### PR TITLE
OKTA-521316 : Initial implementation for Cant verify link in webAuthN verify flow

### DIFF
--- a/src/v3/src/components/Form/Accordion.tsx
+++ b/src/v3/src/components/Form/Accordion.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  AccordionDetails,
+  AccordionSummary,
+  AccordionSummaryProps,
+  Box,
+  Typography,
+} from '@mui/material';
+import MuiAccordion from '@mui/material/Accordion';
+import { styled } from '@mui/material/styles';
+import { FunctionComponent, h } from 'preact';
+
+import { AccordionLayout } from '../../types';
+// eslint-disable-next-line import/no-cycle
+import Layout from './Layout';
+
+type AccordionProps = {
+  uischema: AccordionLayout;
+};
+
+const StyledAccordionSummary = styled((props: AccordionSummaryProps) => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <AccordionSummary {...props} />
+))(({ theme }) => ({
+  padding: 0,
+  width: 'fit-content',
+  '& .MuiAccordionSummary-content': {
+    margin: 0,
+    color: theme.palette.primary.main,
+    '&:hover': {
+      textDecoration: 'underline',
+      textDecorationColor: theme.palette.primary.main,
+    },
+  },
+}));
+
+const Accordion: FunctionComponent<AccordionProps> = ({ uischema }) => {
+  const { elements } = uischema;
+
+  return (
+    <Box>
+      {
+        elements.map((element) => (
+          <MuiAccordion
+            key={element.key}
+            disableGutters
+            elevation={0}
+          >
+            <StyledAccordionSummary
+              aria-controls={`${element.options.id}-content`}
+              id={`${element.options.id}-header`}
+            >
+              <Typography>{element.options.summary}</Typography>
+            </StyledAccordionSummary>
+            <AccordionDetails sx={{ padding: 0 }}>
+              {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
+              <Layout uischema={element.options.content} />
+            </AccordionDetails>
+          </MuiAccordion>
+        ))
+      }
+    </Box>
+  );
+};
+
+export default Accordion;

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -11,14 +11,8 @@
  */
 
 import {
-  AccordionDetails,
-  AccordionSummary,
-  AccordionSummaryProps,
   Box,
-  Typography,
 } from '@mui/material';
-import MuiAccordion from '@mui/material/Accordion';
-import { styled } from '@mui/material/styles';
 import { FunctionComponent, h } from 'preact';
 
 import {
@@ -31,6 +25,8 @@ import {
   UISchemaLayoutType,
 } from '../../types';
 import { isDevelopmentEnvironment, isTestEnvironment } from '../../util';
+// eslint-disable-next-line import/no-cycle
+import Accordion from './Accordion';
 import renderers from './renderers';
 // eslint-disable-next-line import/no-cycle
 import Stepper from './Stepper';
@@ -44,55 +40,6 @@ const getElementKey = (element: UISchemaElement, index: number): string => {
 
 type LayoutProps = {
   uischema: UISchemaLayout;
-};
-
-type StyledAccordionProps = {
-  uischema: AccordionLayout;
-};
-
-const StyledAccordionSummary = styled((props: AccordionSummaryProps) => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  <AccordionSummary {...props} />
-))(({ theme }) => ({
-  padding: 0,
-  width: 'fit-content',
-  '& .MuiAccordionSummary-content': {
-    margin: 0,
-    color: theme.palette.primary.main,
-    '&:hover': {
-      textDecoration: 'underline',
-      textDecorationColor: theme.palette.primary.main,
-    },
-  },
-}));
-
-const Accordion: FunctionComponent<StyledAccordionProps> = ({ uischema }) => {
-  const { elements } = uischema;
-
-  return (
-    <Box>
-      {
-        elements.map((element) => (
-          <MuiAccordion
-            key={element.key}
-            disableGutters
-            elevation={0}
-          >
-            <StyledAccordionSummary
-              aria-controls={`${element.options.id}-content`}
-              id={`${element.options.id}-header`}
-            >
-              <Typography>{element.options.summary}</Typography>
-            </StyledAccordionSummary>
-            <AccordionDetails sx={{ padding: 0 }}>
-              {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
-              <Layout uischema={element.options.content} />
-            </AccordionDetails>
-          </MuiAccordion>
-        ))
-      }
-    </Box>
-  );
 };
 
 const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -10,10 +10,19 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box } from '@mui/material';
+import {
+  AccordionDetails,
+  AccordionSummary,
+  AccordionSummaryProps,
+  Box,
+  Typography,
+} from '@mui/material';
+import MuiAccordion from '@mui/material/Accordion';
+import { styled } from '@mui/material/styles';
 import { FunctionComponent, h } from 'preact';
 
 import {
+  AccordionLayout,
   FieldElement,
   StepperLayout,
   UISchemaElement,
@@ -26,15 +35,65 @@ import renderers from './renderers';
 // eslint-disable-next-line import/no-cycle
 import Stepper from './Stepper';
 
-type LayoutProps = {
-  uischema: UISchemaLayout;
-};
-
 const getElementKey = (element: UISchemaElement, index: number): string => {
   const defaultKey = [element.type, element.key, index].join('_');
   return element.type === 'Field' && (element as FieldElement).key
     ? [(element as FieldElement).key].join('_')
     : defaultKey;
+};
+
+type LayoutProps = {
+  uischema: UISchemaLayout;
+};
+
+type StyledAccordionProps = {
+  uischema: AccordionLayout;
+};
+
+const StyledAccordionSummary = styled((props: AccordionSummaryProps) => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <AccordionSummary {...props} />
+))(({ theme }) => ({
+  padding: 0,
+  width: 'fit-content',
+  '& .MuiAccordionSummary-content': {
+    // marginLeft: theme.spacing(1),
+    margin: 0,
+    color: theme.palette.primary.main,
+    '&:hover': {
+      textDecoration: 'underline',
+      textDecorationColor: theme.palette.primary.main,
+    },
+  },
+}));
+
+const Accordion: FunctionComponent<StyledAccordionProps> = ({ uischema }) => {
+  const { elements } = uischema;
+
+  return (
+    <Box>
+      {
+        elements.map((element) => (
+          <MuiAccordion
+            key={element.key}
+            disableGutters
+            elevation={0}
+          >
+            <StyledAccordionSummary
+              aria-controls={`${element.options.id}-content`}
+              id={`${element.options.id}-header`}
+            >
+              <Typography>{element.options.summary}</Typography>
+            </StyledAccordionSummary>
+            <AccordionDetails sx={{ padding: 0 }}>
+              {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
+              <Layout uischema={element.options.content} />
+            </AccordionDetails>
+          </MuiAccordion>
+        ))
+      }
+    </Box>
+  );
 };
 
 const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
@@ -58,6 +117,15 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
               <Stepper
                 key={elementKey}
                 uischema={element as StepperLayout}
+              />
+            );
+          }
+
+          if (element.type === UISchemaLayoutType.ACCORDION) {
+            return (
+              <Accordion
+                key={elementKey}
+                uischema={element as AccordionLayout}
               />
             );
           }

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -57,7 +57,6 @@ const StyledAccordionSummary = styled((props: AccordionSummaryProps) => (
   padding: 0,
   width: 'fit-content',
   '& .MuiAccordionSummary-content': {
-    // marginLeft: theme.spacing(1),
     margin: 0,
     color: theme.palette.primary.main,
     '&:hover': {

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -10,9 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {
-  Box,
-} from '@mui/material';
+import { Box } from '@mui/material';
 import { FunctionComponent, h } from 'preact';
 
 import {

--- a/src/v3/src/components/Form/Stepper.tsx
+++ b/src/v3/src/components/Form/Stepper.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { h } from 'preact';
+import { FunctionComponent, h } from 'preact';
 import { useState } from 'preact/hooks';
 
 import { StepperContext } from '../../contexts';
@@ -22,7 +22,7 @@ type StepperProps = {
   uischema: StepperLayout;
 };
 
-const Stepper: any = ({ uischema }: StepperProps) => {
+const Stepper: FunctionComponent<StepperProps> = ({ uischema }) => {
   const { elements, options } = uischema;
   const [stepIndex, setStepIndex] = useState<number | undefined>(() => {
     if (!options?.defaultStepIndex) {

--- a/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
+++ b/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
@@ -50,7 +50,6 @@ describe('WebAuthNControlSubmitControl Tests', () => {
             () => Promise.resolve({}),
           ),
           submitOnLoad: false,
-          showLoadingIndicator: true,
         },
       } as WebAuthNButtonElement,
     };

--- a/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
+++ b/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
@@ -43,8 +43,8 @@ describe('WebAuthNControlSubmitControl Tests', () => {
     props = {
       uischema: {
         type: 'WebAuthNSubmitButton',
+        translations: [{ name: 'label', value: 'Verify', i18nKey: 'some.key' }],
         options: {
-          label: 'Verify',
           step: 'enroll-authenticator',
           onClick: jest.fn().mockImplementation(
             () => Promise.resolve({}),
@@ -67,11 +67,15 @@ describe('WebAuthNControlSubmitControl Tests', () => {
     });
   });
 
-  it('should render webauthn verify button and handle click when known error occurs', async () => {
+  it('should render webauthn verify button and handle click when known error occurs with retry label', async () => {
     props = {
       ...props,
       uischema: {
         ...props.uischema,
+        translations: [
+          ...props.uischema.translations!,
+          { name: 'retry-label', value: 'Retry', i18nKey: 'another.key' },
+        ],
         options: {
           ...props.uischema.options,
           onClick: () => new Promise((resolve, reject) => {
@@ -82,18 +86,19 @@ describe('WebAuthNControlSubmitControl Tests', () => {
         },
       },
     };
-    const { findByTestId } = render(<WebAuthNSubmitButton {...props} />);
+    const { findByTestId, findByText } = render(<WebAuthNSubmitButton {...props} />);
 
     const button = await findByTestId('button');
 
     fireEvent.click(button);
 
-    await waitFor(() => {
+    await waitFor(async () => {
       expect(setMessageMockFn).toHaveBeenLastCalledWith({
         message: 'Operation not allowed',
         class: MessageType.ERROR,
         i18n: { key: 'Operation not allowed' },
       });
+      await findByText(/Retry/);
     });
   });
 

--- a/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.tsx
+++ b/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.tsx
@@ -24,15 +24,21 @@ import {
   UISchemaElementComponent,
   WebAuthNButtonElement,
 } from '../../types';
+import { getTranslation } from '../../util';
 
 const WebAuthNSubmit: UISchemaElementComponent<{
   uischema: WebAuthNButtonElement
 }> = ({ uischema }) => {
+  const { translations = [] } = uischema;
   const { options } = uischema;
+
+  const btnLabel = getTranslation(translations);
+  const btnRetryLabel = getTranslation(translations, 'retry-label');
 
   const { setMessage } = useWidgetContext();
   const onSubmitHandler = useOnSubmit();
   const [waiting, setWaiting] = useState<boolean>(false);
+  const [label, setLabel] = useState<string>(btnLabel!);
 
   const executeNextStep = () => {
     if (options?.showLoadingIndicator) {
@@ -56,6 +62,9 @@ const WebAuthNSubmit: UISchemaElementComponent<{
           class: 'ERROR',
           i18n: { key: message },
         });
+        if (btnRetryLabel) {
+          setLabel(btnRetryLabel);
+        }
       })
       .finally(() => setWaiting(false));
   };
@@ -98,7 +107,7 @@ const WebAuthNSubmit: UISchemaElementComponent<{
               variant="primary"
               wide
             >
-              { options?.label }
+              { label }
             </Button>
           )
       }

--- a/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.tsx
+++ b/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.tsx
@@ -41,9 +41,7 @@ const WebAuthNSubmit: UISchemaElementComponent<{
   const [label, setLabel] = useState<string>(btnLabel!);
 
   const executeNextStep = () => {
-    if (options?.showLoadingIndicator) {
-      setWaiting(true);
-    }
+    setWaiting(true);
     setMessage(undefined);
 
     options?.onClick()

--- a/src/v3/src/mocks/response/idp/idx/authenticator-enroll-webauthn-userverification-required.json
+++ b/src/v3/src/mocks/response/idp/idx/authenticator-enroll-webauthn-userverification-required.json
@@ -1,0 +1,305 @@
+{
+  "stateHandle": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+  "version": "1.0.0",
+  "expiresAt": "2020-02-21T15:29:41.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-authenticator",
+        "href": "http://localhost:3000/idp/idx/challenge/answer",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "credentials",
+            "form": {
+              "value": [
+                {
+                  "name": "clientData",
+                  "label": "Client Data",
+                  "visible": false,
+                  "required": true,
+                  "hint": "webauthn"
+                },
+                {
+                  "name": "attestation",
+                  "label": "Attestation",
+                  "visible": false,
+                  "required": true,
+                  "hint": "webauthn"
+                }
+              ]
+            }
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "relatesTo": ["$.currentAuthenticator"]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "required": true,
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "autwa6eD9o02iBbtv0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              },
+              {
+                "label": "Okta Phone",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1SLH",
+                        "mutable": false,
+                        "required": true
+                    },
+                    {
+                        "name": "methodType",
+                        "required": false,
+                        "options": [
+                            { "label": "SMS", "value": "sms" },
+                            { "label": "VOICE", "value": "voice" }
+                        ]
+                    },
+                    {
+                        "name": "phoneNumber",
+                        "required": false,
+                        "type": "string"
+                    }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[2]"
+              },
+              {
+                "label": "Security Key or Biometric Authenticator (FIDO2)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[1]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1GGG",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[3]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02CqFbzJ_zMGCqXut-1CNXfafiTkh9wGlbFqi9Xupt",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "displayName": "Security Key or Biometric Authenticator (FIDO2)",
+      "catalogKey": "webauthn",
+      "type": "security_key",
+      "key": "webauthn",
+      "id": "aidtheidkwh282hv8g3",
+      "settings": {},
+      "contextualData": {
+        "activationData": {
+          "rp": {
+            "name": "idx"
+          },
+          "user": {
+            "displayName": "test user",
+            "name": "test@okta.com",
+            "id": "00utjm1GstPjCF9Ad0g3"
+          },
+          "pubKeyCredParams": [
+            {
+              "type": "public-key",
+              "alg": -7
+            },
+            {
+              "type": "public-key",
+              "alg": -257
+            }
+          ],
+          "challenge": "zrTo0mMXyCt90mweh2HL",
+          "attestation": "direct",
+          "authenticatorSelection": {
+            "userVerification": "required"
+          },
+          "u2fParams": {
+            "appid": "http://idx.okta1.com:1802"
+          }
+        }
+      }
+    }
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "key": "okta_password",
+        "id": "autwa6eD9o02iBbtv0g1",
+        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+      },
+      {
+        "type": "security_key",
+        "key": "custom_otp",
+        "id": "chf1k6lWANK11wvVk0g4",
+        "displayName": "Custom OTP",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      },
+      {
+        "displayName": "yubikey",
+        "type": "security_key",
+        "key": "webauthn",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "aidtheidkwh282hv8g3",
+        "credentialId": "hpxQXbu5R5Y2JMqpvtE9Oo9FdwO6z2kMR-ZQkAb6p6GSguXQ57oVXKvpVHT2fyCR_m2EL1vIgszxi00kyFIX6w"
+      },
+      {
+        "displayName": "MacBook Touch ID",
+        "type": "security_key",
+        "key": "webauthn",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "fwftheidkwh282hv8g3",
+        "credentialId": "7Ag2iWUqfz0SanWDj-ZZ2fpDsgiEDt_08O1VSSRZHpgkUS1zhLSyWYDrxXXB5VE_w1iiqSvPaRgXcmG5rPwB-w"
+      }]
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "key": "okta_password",
+        "authenticatorId": "autwa6eD9o02iBbtv0g3",
+        "id": "password-enroll-id-123"
+      },
+      {
+        "displayName": "Security Key or Biometric Authenticator (FIDO2)",
+        "type": "security_key",
+        "key": "webauthn",
+        "authenticatorid": "aidtheidkwh282hv8g3",
+        "id": "webauthn-enroll-id-123"
+      },
+      {
+        "displayName": "Okta Phone",
+        "type": "phone",
+        "key": "phone_number",
+        "authenticatorId": "aid568g3mXgtID0X1SLH",
+        "id": "phone-enroll-id-123"
+      },
+      {
+        "displayName": "Okta Security Question",
+        "type": "security_question",
+        "key": "security_question",
+        "authenticatorId": "aid568g3mXgtID0X1GGG",
+        "id": "security-question-enroll-id-123"
+      }
+    ]
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u12iwg7zlRVxEQU0g4",
+      "identifier": "testUser@okta.com"
+    }
+  }
+}

--- a/src/v3/src/transformer/i18n/transform.ts
+++ b/src/v3/src/transformer/i18n/transform.ts
@@ -20,6 +20,7 @@ import { transformInputPassword } from './transformInputPassword';
 import { transformPasscodeHint } from './transformPasscodeHint';
 import { transformPhoneAuthenticator } from './transformPhoneAuthenticator';
 import { transformQRCode } from './transformQRCode';
+import { transformWebAuthNSubmitButton } from './transformWebAuthNSubmitButton';
 
 export const transformI18n: TransformStepFnWithOptions = (options) => (formbag) => flow(
   transformField(options),
@@ -29,4 +30,5 @@ export const transformI18n: TransformStepFnWithOptions = (options) => (formbag) 
   transformQRCode,
   transformIdentifierHint(options),
   transformPasscodeHint(options),
+  transformWebAuthNSubmitButton(options),
 )(formbag);

--- a/src/v3/src/transformer/i18n/transformWebAuthNSubmitButton.ts
+++ b/src/v3/src/transformer/i18n/transformWebAuthNSubmitButton.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IDX_STEP } from '../../constants';
+import {
+  TransformStepFnWithOptions,
+} from '../../types';
+import { traverseLayout } from '../util';
+import { addTranslation } from './util';
+
+export const transformWebAuthNSubmitButton: TransformStepFnWithOptions = ({
+  transaction,
+}) => (
+  formbag,
+) => {
+  const { uischema } = formbag;
+
+  traverseLayout({
+    layout: uischema,
+    predicate: (element) => element.type === 'WebAuthNSubmitButton',
+    callback: (element) => {
+      const { nextStep: { name } = {} } = transaction;
+      if (name === IDX_STEP.ENROLL_AUTHENTICATOR) {
+        addTranslation({
+          element,
+          name: 'label',
+          i18nKey: 'oie.enroll.webauthn.save',
+        });
+      } else {
+        addTranslation({
+          element,
+          name: 'label',
+          i18nKey: 'mfa.challenge.verify',
+        });
+        addTranslation({
+          element,
+          name: 'retry-label',
+          i18nKey: 'retry',
+        });
+      }
+    },
+  });
+
+  return formbag;
+};

--- a/src/v3/src/transformer/selectAuthenticator/utils.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.ts
@@ -218,7 +218,7 @@ const formatAuthenticatorOptions = (
           authenticatorKey,
           isEnroll,
         ),
-        usageDescription: getUsageDescription(option),
+        usageDescription: isEnroll && getUsageDescription(option),
         // @ts-ignore logoUri missing from interface
         logoUri: authenticator.logoUri,
         actionParams: {

--- a/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
@@ -100,7 +100,7 @@ Object {
         "options": Object {
           "onClick": [Function],
           "step": "challenge-authenticator",
-          "submitOnLoad": true,
+          "submitOnLoad": false,
         },
         "type": "WebAuthNSubmitButton",
       },
@@ -162,7 +162,7 @@ Object {
 }
 `;
 
-exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should render title, description, button, and callout elements when WebAuthN API is available 1`] = `
+exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should render title, description, button, and callout elements when WebAuthN API is available in Safari Browser 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {},
@@ -317,7 +317,7 @@ Object {
 }
 `;
 
-exports[`WebAuthN Transformer Tests WebAuthN Enroll Tests should render title, description, button, and callout elements when WebAuthN API is available 1`] = `
+exports[`WebAuthN Transformer Tests WebAuthN Enroll Tests should render title, description, button, and callout elements when WebAuthN API is available on MS Edge browser 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {},

--- a/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
@@ -1,0 +1,363 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should only render title and description elements when WebAuthN API is not available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {},
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.verify.webauth.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.webauthn.error.not.supported",
+        },
+        "type": "Description",
+      },
+      Object {
+        "elements": Array [
+          Object {
+            "key": "cant-verify",
+            "options": Object {
+              "content": Object {
+                "elements": Array [
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.title",
+                      "level": 6,
+                      "visualLevel": 3,
+                    },
+                    "type": "Heading",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description1",
+                    },
+                    "type": "Description",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description2",
+                    },
+                    "type": "Description",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.security.key.title",
+                      "level": 6,
+                      "visualLevel": 3,
+                    },
+                    "type": "Heading",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.security.key.description",
+                    },
+                    "type": "Description",
+                  },
+                ],
+                "type": "VerticalLayout",
+              },
+              "id": "cant-verify",
+              "summary": "oie.verify.webauthn.cant.verify",
+            },
+            "type": "AccordionPanel",
+          },
+        ],
+        "type": "Accordion",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should render title, description and button elements when WebAuthN API is available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {},
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.verify.webauth.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.verify.webauthn.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "onClick": [Function],
+          "step": "challenge-authenticator",
+          "submitOnLoad": true,
+        },
+        "type": "WebAuthNSubmitButton",
+      },
+      Object {
+        "elements": Array [
+          Object {
+            "key": "cant-verify",
+            "options": Object {
+              "content": Object {
+                "elements": Array [
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.title",
+                      "level": 6,
+                      "visualLevel": 3,
+                    },
+                    "type": "Heading",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description1",
+                    },
+                    "type": "Description",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description2",
+                    },
+                    "type": "Description",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.security.key.title",
+                      "level": 6,
+                      "visualLevel": 3,
+                    },
+                    "type": "Heading",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.security.key.description",
+                    },
+                    "type": "Description",
+                  },
+                ],
+                "type": "VerticalLayout",
+              },
+              "id": "cant-verify",
+              "summary": "oie.verify.webauthn.cant.verify",
+            },
+            "type": "AccordionPanel",
+          },
+        ],
+        "type": "Accordion",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should render title, description, button, and callout elements when WebAuthN API is available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {},
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.verify.webauth.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.verify.webauthn.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.verify.webauthn.uv.required.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "onClick": [Function],
+          "step": "challenge-authenticator",
+          "submitOnLoad": false,
+        },
+        "type": "WebAuthNSubmitButton",
+      },
+      Object {
+        "elements": Array [
+          Object {
+            "key": "cant-verify",
+            "options": Object {
+              "content": Object {
+                "elements": Array [
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.title",
+                      "level": 6,
+                      "visualLevel": 3,
+                    },
+                    "type": "Heading",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description1",
+                    },
+                    "type": "Description",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description2",
+                    },
+                    "type": "Description",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.security.key.title",
+                      "level": 6,
+                      "visualLevel": 3,
+                    },
+                    "type": "Heading",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.security.key.description",
+                    },
+                    "type": "Description",
+                  },
+                ],
+                "type": "VerticalLayout",
+              },
+              "id": "cant-verify",
+              "summary": "oie.verify.webauthn.cant.verify",
+            },
+            "type": "AccordionPanel",
+          },
+        ],
+        "type": "Accordion",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`WebAuthN Transformer Tests WebAuthN Enroll Tests should only render title and description elements when WebAuthN API is not available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {},
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.webauthn.error.not.supported",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`WebAuthN Transformer Tests WebAuthN Enroll Tests should render title, description and button elements when WebAuthN API is available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {},
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.instructions.edge",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "onClick": [Function],
+          "step": "enroll-authenticator",
+          "submitOnLoad": false,
+        },
+        "type": "WebAuthNSubmitButton",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`WebAuthN Transformer Tests WebAuthN Enroll Tests should render title, description, button, and callout elements when WebAuthN API is available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {},
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.instructions.edge",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.uv.required.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "onClick": [Function],
+          "step": "enroll-authenticator",
+          "submitOnLoad": false,
+        },
+        "type": "WebAuthNSubmitButton",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
@@ -100,8 +100,6 @@ describe('WebAuthN Transformer Tests', () => {
         .toBe('oie.enroll.webauthn.save');
       expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options?.submitOnLoad)
         .toBe(true);
-      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement)
-        .options?.showLoadingIndicator).toBe(true);
     });
   });
 
@@ -170,8 +168,6 @@ describe('WebAuthN Transformer Tests', () => {
         .toBe('mfa.challenge.verify');
       expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options?.submitOnLoad)
         .toBe(true);
-      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement)
-        .options?.showLoadingIndicator).toBe(true);
     });
   });
 });

--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
@@ -10,24 +10,34 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { ActivationData, ChallengeData, IdxAuthenticator } from '@okta/okta-auth-js';
 import { IDX_STEP } from 'src/constants';
 import { getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  DescriptionElement,
   FormBag,
-  TitleElement,
   UISchemaLayoutType,
-  WebAuthNButtonElement,
   WidgetProps,
 } from 'src/types';
 
 import { transformWebAuthNAuthenticator } from '.';
+
+let mockIsEdgeBrowser = false;
+let mockIsSafariBrowser = false;
+jest.mock('../../../../util/BrowserFeatures', () => ({
+  isEdge: () => jest.fn().mockImplementation(() => mockIsEdgeBrowser),
+  isSafari: jest.fn().mockImplementation(() => mockIsSafariBrowser),
+}));
 
 describe('WebAuthN Transformer Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const widgetProps: WidgetProps = {};
   let formBag: FormBag;
   let mockCredentialsContainer: CredentialsContainer;
+
+  beforeEach(() => {
+    mockIsEdgeBrowser = false;
+    mockIsSafariBrowser = false;
+  });
 
   afterAll(() => {
     jest.restoreAllMocks();
@@ -36,7 +46,7 @@ describe('WebAuthN Transformer Tests', () => {
   describe('WebAuthN Enroll Tests', () => {
     beforeEach(() => {
       formBag = {
-        dataSchema: {},
+        dataSchema: {} as any,
         schema: {},
         uischema: {
           type: UISchemaLayoutType.VERTICAL,
@@ -59,12 +69,7 @@ describe('WebAuthN Transformer Tests', () => {
 
       // Verify added elements
       expect(updatedFormBag.uischema.elements.length).toBe(2);
-      expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-        .toBe('oie.enroll.webauthn.title');
-      expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-        .toBe('webauthn.biometric.error.factorNotSupported');
+      expect(updatedFormBag).toMatchSnapshot();
     });
 
     it('should render title, description and button elements when WebAuthN API is available', () => {
@@ -86,27 +91,48 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(3);
-      expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-        .toBe('oie.enroll.webauthn.title');
-      expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-        .toBe('oie.enroll.webauthn.instructions');
-      expect(updatedFormBag.uischema.elements[2]?.type).toBe('WebAuthNSubmitButton');
-      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options?.onClick)
-        .not.toBeUndefined();
-      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options?.label)
-        .toBe('oie.enroll.webauthn.save');
-      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options?.submitOnLoad)
-        .toBe(true);
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect(updatedFormBag).toMatchSnapshot();
+    });
+
+    it('should render title, description, button, and callout elements when WebAuthN API is available', () => {
+      transaction.nextStep!.relatesTo = {
+        value: {
+          contextualData: {
+            activationData: {
+              authenticatorSelection: { userVerification: 'required' },
+            } as unknown as ActivationData,
+          },
+        } as unknown as IdxAuthenticator,
+      };
+      mockIsEdgeBrowser = true;
+      mockCredentialsContainer = {
+        create: jest.fn().mockImplementationOnce(
+          () => Promise.resolve({}),
+        ),
+        get: jest.fn().mockImplementationOnce(
+          () => Promise.resolve({}),
+        ),
+        preventSilentAccess: jest.fn(),
+        store: jest.fn(),
+      };
+      const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+      navigatorCredentials.mockReturnValue(
+        { credentials: mockCredentialsContainer } as unknown as Navigator,
+      );
+
+      const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
+
+      // Verify added elements
+      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect(updatedFormBag).toMatchSnapshot();
     });
   });
 
   describe('WebAuthN Challenge Tests', () => {
     beforeEach(() => {
       formBag = {
-        dataSchema: {},
+        dataSchema: {} as any,
         schema: {},
         uischema: {
           type: UISchemaLayoutType.VERTICAL,
@@ -127,13 +153,8 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(2);
-      expect((updatedFormBag.uischema.elements[0] as TitleElement).type).toBe('Title');
-      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-        .toBe('oie.enroll.webauthn.title');
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).type).toBe('Description');
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-        .toBe('webauthn.biometric.error.factorNotSupported');
+      expect(updatedFormBag.uischema.elements.length).toBe(3);
+      expect(updatedFormBag).toMatchSnapshot();
     });
 
     it('should render title, description and button elements when WebAuthN API is available', () => {
@@ -154,20 +175,42 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(3);
-      expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-        .toBe('oie.enroll.webauthn.title');
-      expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-        .toBe('oie.verify.webauthn.instructions');
-      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).type).toBe('WebAuthNSubmitButton');
-      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options?.onClick)
-        .not.toBeUndefined();
-      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options?.label)
-        .toBe('mfa.challenge.verify');
-      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options?.submitOnLoad)
-        .toBe(true);
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect(updatedFormBag).toMatchSnapshot();
+    });
+
+    it('should render title, description, button, and callout elements when WebAuthN API is available', () => {
+      transaction.nextStep!.relatesTo = {
+        value: {
+          contextualData: {
+            challengeData: {
+              userVerification: 'required',
+            } as unknown as ChallengeData,
+          },
+        } as unknown as IdxAuthenticator,
+      };
+      // mockIsSafariBrowser.mockReturnValue(true);
+      mockIsSafariBrowser = true;
+      mockCredentialsContainer = {
+        create: jest.fn().mockImplementationOnce(
+          () => Promise.resolve({}),
+        ),
+        get: jest.fn().mockImplementationOnce(
+          () => Promise.resolve({}),
+        ),
+        preventSilentAccess: jest.fn(),
+        store: jest.fn(),
+      };
+      const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+      navigatorCredentials.mockReturnValue(
+        { credentials: mockCredentialsContainer } as unknown as Navigator,
+      );
+
+      const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
+
+      // Verify added elements
+      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect(updatedFormBag).toMatchSnapshot();
     });
   });
 });

--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
@@ -24,8 +24,8 @@ import { transformWebAuthNAuthenticator } from '.';
 let mockIsEdgeBrowser = false;
 let mockIsSafariBrowser = false;
 jest.mock('../../../../util/BrowserFeatures', () => ({
-  isEdge: () => jest.fn().mockImplementation(() => mockIsEdgeBrowser),
-  isSafari: jest.fn().mockImplementation(() => mockIsSafariBrowser),
+  isEdge: () => jest.fn().mockReturnValue(mockIsEdgeBrowser),
+  isSafari: () => jest.fn().mockReturnValue(mockIsSafariBrowser),
 }));
 
 describe('WebAuthN Transformer Tests', () => {
@@ -74,12 +74,8 @@ describe('WebAuthN Transformer Tests', () => {
 
     it('should render title, description and button elements when WebAuthN API is available', () => {
       mockCredentialsContainer = {
-        create: jest.fn().mockImplementationOnce(
-          () => Promise.resolve({}),
-        ),
-        get: jest.fn().mockImplementationOnce(
-          () => Promise.resolve({}),
-        ),
+        create: jest.fn().mockResolvedValue({}),
+        get: jest.fn().mockResolvedValue({}),
         preventSilentAccess: jest.fn(),
         store: jest.fn(),
       };
@@ -95,7 +91,7 @@ describe('WebAuthN Transformer Tests', () => {
       expect(updatedFormBag).toMatchSnapshot();
     });
 
-    it('should render title, description, button, and callout elements when WebAuthN API is available', () => {
+    it('should render title, description, button, and callout elements when WebAuthN API is available on MS Edge browser', () => {
       transaction.nextStep!.relatesTo = {
         value: {
           contextualData: {
@@ -107,12 +103,8 @@ describe('WebAuthN Transformer Tests', () => {
       };
       mockIsEdgeBrowser = true;
       mockCredentialsContainer = {
-        create: jest.fn().mockImplementationOnce(
-          () => Promise.resolve({}),
-        ),
-        get: jest.fn().mockImplementationOnce(
-          () => Promise.resolve({}),
-        ),
+        create: jest.fn().mockResolvedValue({}),
+        get: jest.fn().mockResolvedValue({}),
         preventSilentAccess: jest.fn(),
         store: jest.fn(),
       };
@@ -159,12 +151,8 @@ describe('WebAuthN Transformer Tests', () => {
 
     it('should render title, description and button elements when WebAuthN API is available', () => {
       mockCredentialsContainer = {
-        create: jest.fn().mockImplementationOnce(
-          () => Promise.resolve({}),
-        ),
-        get: jest.fn().mockImplementationOnce(
-          () => Promise.resolve({}),
-        ),
+        create: jest.fn().mockResolvedValue({}),
+        get: jest.fn().mockResolvedValue({}),
         preventSilentAccess: jest.fn(),
         store: jest.fn(),
       };
@@ -179,7 +167,7 @@ describe('WebAuthN Transformer Tests', () => {
       expect(updatedFormBag).toMatchSnapshot();
     });
 
-    it('should render title, description, button, and callout elements when WebAuthN API is available', () => {
+    it('should render title, description, button, and callout elements when WebAuthN API is available in Safari Browser', () => {
       transaction.nextStep!.relatesTo = {
         value: {
           contextualData: {
@@ -189,15 +177,10 @@ describe('WebAuthN Transformer Tests', () => {
           },
         } as unknown as IdxAuthenticator,
       };
-      // mockIsSafariBrowser.mockReturnValue(true);
       mockIsSafariBrowser = true;
       mockCredentialsContainer = {
-        create: jest.fn().mockImplementationOnce(
-          () => Promise.resolve({}),
-        ),
-        get: jest.fn().mockImplementationOnce(
-          () => Promise.resolve({}),
-        ),
+        create: jest.fn().mockResolvedValue({}),
+        get: jest.fn().mockResolvedValue({}),
         preventSilentAccess: jest.fn(),
         store: jest.fn(),
       };

--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
@@ -178,8 +178,7 @@ export const transformWebAuthNAuthenticator: IdxStepTransformer = ({ transaction
         onClick: name === IDX_STEP.ENROLL_AUTHENTICATOR
           ? () => webAuthNEnrollmentHandler(transaction)
           : () => webAuthNAuthenticationHandler(transaction),
-        submitOnLoad: true,
-        showLoadingIndicator: true,
+        submitOnLoad: !BrowserFeatures.isSafari(),
       },
     };
     uischema.elements.unshift(submitButtonEle);

--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
@@ -178,7 +178,7 @@ export const transformWebAuthNAuthenticator: IdxStepTransformer = ({ transaction
         onClick: name === IDX_STEP.ENROLL_AUTHENTICATOR
           ? () => webAuthNEnrollmentHandler(transaction)
           : () => webAuthNAuthenticationHandler(transaction),
-        submitOnLoad: !BrowserFeatures.isSafari(),
+        submitOnLoad: name === IDX_STEP.CHALLENGE_AUTHENTICATOR && !BrowserFeatures.isSafari(),
       },
     };
     uischema.elements.unshift(submitButtonEle);

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -196,7 +196,6 @@ export interface WebAuthNButtonElement extends UISchemaElement {
     onClick: (() => Promise<WebAuthNEnrollmentPayload>)
     | (() => Promise<WebAuthNVerificationPayload>)
     submitOnLoad?: boolean;
-    showLoadingIndicator?: boolean;
   };
 }
 

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -113,7 +113,7 @@ export interface UISchemaElement {
 
 export interface UISchemaLayout {
   type: UISchemaLayoutType;
-  elements: (UISchemaElement | UISchemaLayout | StepperLayout)[];
+  elements: (UISchemaElement | UISchemaLayout | StepperLayout | AccordionLayout)[];
   options?: {
     onClick?: ClickHandler;
   }
@@ -132,6 +132,7 @@ export enum UISchemaLayoutType {
   HORIZONTAL = 'HorizontalLayout',
   VERTICAL = 'VerticalLayout',
   STEPPER = 'Stepper',
+  ACCORDION = 'Accordion',
 }
 
 export function isUISchemaLayoutType(type: string): boolean {
@@ -191,7 +192,6 @@ export interface AuthenticatorButtonElement extends UISchemaElement {
 export interface WebAuthNButtonElement extends UISchemaElement {
   type: 'WebAuthNSubmitButton';
   options: {
-    label: string;
     step: string;
     onClick: (() => Promise<WebAuthNEnrollmentPayload>)
     | (() => Promise<WebAuthNVerificationPayload>)
@@ -281,6 +281,15 @@ export interface LinkElement extends UISchemaElement {
   };
 }
 
+export interface AccordionPanelElement extends UISchemaElement {
+  type: 'AccordionPanel',
+  options: {
+    id: string;
+    summary: string;
+    content: UISchemaLayout;
+  };
+}
+
 export interface ImageWithTextElement extends UISchemaElement {
   type: 'ImageWithText';
   options: {
@@ -335,6 +344,11 @@ export interface StepperLayout {
   options?: {
     defaultStepIndex: () => number;
   }
+}
+
+export interface AccordionLayout {
+  type: UISchemaLayoutType.ACCORDION;
+  elements: AccordionPanelElement[];
 }
 
 export interface StepperButtonElement {

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -146,15 +146,137 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
                       data-se="o-form-explain"
                     >
-                      Security key or biometric authenticator is not supported on this browser. Select another factor or contact your admin for assistance.
+                      Security key or biometric authenticator is not supported on this browser. Contact your admin for assistance.
                     </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded emotion-18"
+                  >
+                    <div
+                      aria-controls="cant-verify-content"
+                      aria-expanded="false"
+                      class="MuiButtonBase-root MuiAccordionSummary-root emotion-19"
+                      id="cant-verify-header"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <div
+                        class="MuiAccordionSummary-content emotion-20"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-21"
+                        >
+                          Can't verify?
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden emotion-22"
+                      style="min-height: 0px;"
+                    >
+                      <div
+                        class="MuiCollapse-wrapper MuiCollapse-vertical emotion-23"
+                      >
+                        <div
+                          class="MuiCollapse-wrapperInner MuiCollapse-vertical emotion-24"
+                        >
+                          <div
+                            aria-labelledby="cant-verify-header"
+                            class="MuiAccordion-region"
+                            id="cant-verify-content"
+                            role="region"
+                          >
+                            <div
+                              class="MuiAccordionDetails-root emotion-25"
+                            >
+                              <div
+                                class="MuiBox-root emotion-10"
+                              >
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-28"
+                                  >
+                                    <h3
+                                      class="MuiTypography-root MuiTypography-h6 emotion-29"
+                                    >
+                                      Are you trying to use a biometric authenticator?
+                                    </h3>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      Biometric authenticators (fingerprint, face recognition, PIN) will only work on the same device on which they were set up.
+                                    </p>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      If available, set up another security method on the device you used to set up your biometric authenticator.
+                                    </p>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-28"
+                                  >
+                                    <h3
+                                      class="MuiTypography-root MuiTypography-h6 emotion-29"
+                                    >
+                                      Are you trying to use a security key?
+                                    </h3>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      If you have set up a security key, insert it in a USB port when prompted by the browser and tap on the button or gold disk. Security keys can work on multiple devices.
+                                    </p>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -165,7 +287,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
@@ -351,10 +473,132 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                   </div>
                 </div>
                 <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded emotion-20"
+                  >
+                    <div
+                      aria-controls="cant-verify-content"
+                      aria-expanded="false"
+                      class="MuiButtonBase-root MuiAccordionSummary-root emotion-21"
+                      id="cant-verify-header"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <div
+                        class="MuiAccordionSummary-content emotion-22"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-23"
+                        >
+                          Can't verify?
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden emotion-24"
+                      style="min-height: 0px;"
+                    >
+                      <div
+                        class="MuiCollapse-wrapper MuiCollapse-vertical emotion-25"
+                      >
+                        <div
+                          class="MuiCollapse-wrapperInner MuiCollapse-vertical emotion-26"
+                        >
+                          <div
+                            aria-labelledby="cant-verify-header"
+                            class="MuiAccordion-region"
+                            id="cant-verify-content"
+                            role="region"
+                          >
+                            <div
+                              class="MuiAccordionDetails-root emotion-27"
+                            >
+                              <div
+                                class="MuiBox-root emotion-10"
+                              >
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-30"
+                                  >
+                                    <h3
+                                      class="MuiTypography-root MuiTypography-h6 emotion-31"
+                                    >
+                                      Are you trying to use a biometric authenticator?
+                                    </h3>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      Biometric authenticators (fingerprint, face recognition, PIN) will only work on the same device on which they were set up.
+                                    </p>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      If available, set up another security method on the device you used to set up your biometric authenticator.
+                                    </p>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-30"
+                                  >
+                                    <h3
+                                      class="MuiTypography-root MuiTypography-h6 emotion-31"
+                                    >
+                                      Are you trying to use a security key?
+                                    </h3>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      If you have set up a security key, insert it in a USB port when prompted by the browser and tap on the button or gold disk. Security keys can work on multiple devices.
+                                    </p>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-45"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -365,7 +609,329 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-45"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`authenticator-verification-webauthn should render form with required user verification in safari browser 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-webauthn authCoinOverlay MuiBox-root emotion-4"
+            >
+              <svg
+                aria-labelledby="authCoinWebauthnAuthenticator"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="authCoinWebauthnAuthenticator"
+                >
+                  Security Key or Biometric Authenticator
+                </title>
+                <path
+                  class="siwFillBg"
+                  clip-rule="evenodd"
+                  d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                  fill="#F5F5F6"
+                  fill-rule="evenodd"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M24 17V9h-9v8h-3v15.5a2.5 2.5 0 0 0 2.5 2.5h6.34a8.58 8.58 0 0 1-.38-1H14.5a1.5 1.5 0 0 1-1.5-1.5V18h13v3.84a8.58 8.58 0 0 1 1-.38V17h-3Zm-8 0v-7h7v7h-7Z"
+                  fill="#00297A"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M19.5 25a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
+                  fill="#00297A"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M30 40a9 9 0 1 1 9-9 9.01 9.01 0 0 1-9 9Zm0-17a8 8 0 1 0 8 8 8.009 8.009 0 0 0-8-8Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M32.084 36.019a.472.472 0 0 1-.319-.112.501.501 0 0 1-.159-.532c.43-1.389 1.274-4.787-.119-6.352a1.962 1.962 0 0 0-1.946-.6 1.93 1.93 0 0 0-1.387 2.354c.007.024.666 2.823-.966 4.55a.5.5 0 1 1-.727-.685c1.24-1.314.728-3.6.723-3.622a2.933 2.933 0 0 1 2.106-3.566 2.977 2.977 0 0 1 2.944.906c1.67 1.875.922 5.386.328 7.312a.5.5 0 0 1-.478.347Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M28.63 37.25a.5.5 0 0 1-.359-.849c2.235-2.3 1.345-5.782 1.336-5.817a.5.5 0 0 1 .966-.259c.045.165 1.052 4.067-1.586 6.774a.5.5 0 0 1-.358.151Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M34.88 35.2a.5.5 0 0 1-.488-.612c.493-2.2.716-5.235-1.03-7.2a4.508 4.508 0 0 0-4.455-1.357 4.416 4.416 0 0 0-2.72 2.069 4.2 4.2 0 0 0-.468 3.2 3.1 3.1 0 0 1-.355 2.347.5.5 0 1 1-.728-.685 2.37 2.37 0 0 0 .11-1.434 5.174 5.174 0 0 1 .577-3.939 5.42 5.42 0 0 1 3.333-2.518 5.524 5.524 0 0 1 5.453 1.66c1.628 1.832 2.051 4.551 1.257 8.082a.5.5 0 0 1-.487.387Z"
+                  fill="#A7B5EC"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+              style="max-width: 100%; word-break: break-word;"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                      data-se="o-form-head"
+                    >
+                      Verify with Security Key or Biometric Authenticator
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                      data-se="o-form-explain"
+                    >
+                      You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="ods-4o5zYQ ods-2NLKpK ods-5E7TSu ods-6GYpAv ods-6Tybtd"
+                      data-se="button"
+                    >
+                      <span
+                        class="ods-IkfPY2"
+                      >
+                        Verify
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded emotion-20"
+                  >
+                    <div
+                      aria-controls="cant-verify-content"
+                      aria-expanded="false"
+                      class="MuiButtonBase-root MuiAccordionSummary-root emotion-21"
+                      id="cant-verify-header"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <div
+                        class="MuiAccordionSummary-content emotion-22"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-23"
+                        >
+                          Can't verify?
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden emotion-24"
+                      style="min-height: 0px;"
+                    >
+                      <div
+                        class="MuiCollapse-wrapper MuiCollapse-vertical emotion-25"
+                      >
+                        <div
+                          class="MuiCollapse-wrapperInner MuiCollapse-vertical emotion-26"
+                        >
+                          <div
+                            aria-labelledby="cant-verify-header"
+                            class="MuiAccordion-region"
+                            id="cant-verify-content"
+                            role="region"
+                          >
+                            <div
+                              class="MuiAccordionDetails-root emotion-27"
+                            >
+                              <div
+                                class="MuiBox-root emotion-10"
+                              >
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-30"
+                                  >
+                                    <h3
+                                      class="MuiTypography-root MuiTypography-h6 emotion-31"
+                                    >
+                                      Are you trying to use a biometric authenticator?
+                                    </h3>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      Biometric authenticators (fingerprint, face recognition, PIN) will only work on the same device on which they were set up.
+                                    </p>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      If available, set up another security method on the device you used to set up your biometric authenticator.
+                                    </p>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-30"
+                                  >
+                                    <h3
+                                      class="MuiTypography-root MuiTypography-h6 emotion-31"
+                                    >
+                                      Are you trying to use a security key?
+                                    </h3>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      If you have set up a security key, insert it in a USB port when prompted by the browser and tap on the button or gold disk. Security keys can work on multiple devices.
+                                    </p>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-45"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-45"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -146,15 +146,137 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
                       data-se="o-form-explain"
                     >
-                      Security key or biometric authenticator is not supported on this browser. Select another factor or contact your admin for assistance.
+                      Security key or biometric authenticator is not supported on this browser. Contact your admin for assistance.
                     </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded emotion-18"
+                  >
+                    <div
+                      aria-controls="cant-verify-content"
+                      aria-expanded="false"
+                      class="MuiButtonBase-root MuiAccordionSummary-root emotion-19"
+                      id="cant-verify-header"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <div
+                        class="MuiAccordionSummary-content emotion-20"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-21"
+                        >
+                          Can't verify?
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden emotion-22"
+                      style="min-height: 0px;"
+                    >
+                      <div
+                        class="MuiCollapse-wrapper MuiCollapse-vertical emotion-23"
+                      >
+                        <div
+                          class="MuiCollapse-wrapperInner MuiCollapse-vertical emotion-24"
+                        >
+                          <div
+                            aria-labelledby="cant-verify-header"
+                            class="MuiAccordion-region"
+                            id="cant-verify-content"
+                            role="region"
+                          >
+                            <div
+                              class="MuiAccordionDetails-root emotion-25"
+                            >
+                              <div
+                                class="MuiBox-root emotion-10"
+                              >
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-28"
+                                  >
+                                    <h3
+                                      class="MuiTypography-root MuiTypography-h6 emotion-29"
+                                    >
+                                      Are you trying to use a biometric authenticator?
+                                    </h3>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      Biometric authenticators (fingerprint, face recognition, PIN) will only work on the same device on which they were set up.
+                                    </p>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      If available, set up another security method on the device you used to set up your biometric authenticator.
+                                    </p>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-28"
+                                  >
+                                    <h3
+                                      class="MuiTypography-root MuiTypography-h6 emotion-29"
+                                    >
+                                      Are you trying to use a security key?
+                                    </h3>
+                                  </div>
+                                </div>
+                                <div
+                                  class="MuiBox-root emotion-11"
+                                >
+                                  <div
+                                    class="MuiBox-root emotion-12"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                                      data-se="o-form-explain"
+                                    >
+                                      If you have set up a security key, insert it in a USB port when prompted by the browser and tap on the button or gold disk. Security keys can work on multiple devices.
+                                    </p>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -165,7 +287,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -346,7 +346,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
                       data-se="o-form-explain"
                     >
-                      Security key or biometric authenticator is not supported on this browser. Select another factor or contact your admin for assistance.
+                      Security key or biometric authenticator is not supported on this browser. Contact your admin for assistance.
                     </p>
                   </div>
                 </div>
@@ -366,6 +366,220 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`webauthn-enroll should render form with user verification and edge browser callouts 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-webauthn authCoinOverlay MuiBox-root emotion-4"
+            >
+              <svg
+                aria-labelledby="authCoinWebauthnAuthenticator"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="authCoinWebauthnAuthenticator"
+                >
+                  Security Key or Biometric Authenticator
+                </title>
+                <path
+                  class="siwFillBg"
+                  clip-rule="evenodd"
+                  d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                  fill="#F5F5F6"
+                  fill-rule="evenodd"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M24 17V9h-9v8h-3v15.5a2.5 2.5 0 0 0 2.5 2.5h6.34a8.58 8.58 0 0 1-.38-1H14.5a1.5 1.5 0 0 1-1.5-1.5V18h13v3.84a8.58 8.58 0 0 1 1-.38V17h-3Zm-8 0v-7h7v7h-7Z"
+                  fill="#00297A"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M19.5 25a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
+                  fill="#00297A"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M30 40a9 9 0 1 1 9-9 9.01 9.01 0 0 1-9 9Zm0-17a8 8 0 1 0 8 8 8.009 8.009 0 0 0-8-8Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M32.084 36.019a.472.472 0 0 1-.319-.112.501.501 0 0 1-.159-.532c.43-1.389 1.274-4.787-.119-6.352a1.962 1.962 0 0 0-1.946-.6 1.93 1.93 0 0 0-1.387 2.354c.007.024.666 2.823-.966 4.55a.5.5 0 1 1-.727-.685c1.24-1.314.728-3.6.723-3.622a2.933 2.933 0 0 1 2.106-3.566 2.977 2.977 0 0 1 2.944.906c1.67 1.875.922 5.386.328 7.312a.5.5 0 0 1-.478.347Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M28.63 37.25a.5.5 0 0 1-.359-.849c2.235-2.3 1.345-5.782 1.336-5.817a.5.5 0 0 1 .966-.259c.045.165 1.052 4.067-1.586 6.774a.5.5 0 0 1-.358.151Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M34.88 35.2a.5.5 0 0 1-.488-.612c.493-2.2.716-5.235-1.03-7.2a4.508 4.508 0 0 0-4.455-1.357 4.416 4.416 0 0 0-2.72 2.069 4.2 4.2 0 0 0-.468 3.2 3.1 3.1 0 0 1-.355 2.347.5.5 0 1 1-.728-.685 2.37 2.37 0 0 0 .11-1.434 5.174 5.174 0 0 1 .577-3.939 5.42 5.42 0 0 1 3.333-2.518 5.524 5.524 0 0 1 5.453 1.66c1.628 1.832 2.051 4.551 1.257 8.082a.5.5 0 0 1-.487.387Z"
+                  fill="#A7B5EC"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester5@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+              style="max-width: 100%; word-break: break-word;"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                      data-se="o-form-head"
+                    >
+                      Set up security key or biometric authenticator
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                      data-se="o-form-explain"
+                    >
+                      You will be prompted to register a security key or biometric authenticator (Windows Hello, Touch ID, Face ID, etc.). Follow the instructions to complete set up.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-16"
+                      data-se="o-form-explain"
+                    >
+                      Note: If you are enrolling a security key and Windows Hello or PIN is enabled, you will need to select 'Cancel' in the prompt before continuing.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="ods-4o5zYQ ods-2NLKpK ods-5E7TSu ods-6GYpAv ods-6Tybtd"
+                      data-se="button"
+                    >
+                      <span
+                        class="ods-IkfPY2"
+                      >
+                        Set up
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/authenticator-verification-webauthn.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-webauthn.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import mockResponseWithRequiredUserVerification from '@okta/mocks/data/idp/idx/authenticator-verification-webauthn.json';
 import { setup, getMockCredentialsResponse } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/challenge/unlock-account-email-verify-webauthn.json';
@@ -23,9 +24,29 @@ describe('authenticator-verification-webauthn', () => {
           create: jest.fn(),
           get: jest.fn().mockResolvedValue(getMockCredentialsResponse()),
         },
+        userAgent: '',
       } as unknown as Navigator,
     );
     const { container, findByText } = await setup({ mockResponse });
+    await findByText(/Verify with Security Key or Biometric Authenticator/);
+    await findByText(/You will be prompted to use a security key or biometric verification/);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render form with required user verification in safari browser', async () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      {
+        credentials: {
+          create: jest.fn(),
+          get: jest.fn().mockResolvedValue(getMockCredentialsResponse()),
+        },
+        userAgent: 'safari',
+      } as unknown as Navigator,
+    );
+    const { container, findByText } = await setup({
+      mockResponse: mockResponseWithRequiredUserVerification,
+    });
     await findByText(/Verify with Security Key or Biometric Authenticator/);
     await findByText(/You will be prompted to use a security key or biometric verification/);
     expect(container).toMatchSnapshot();
@@ -36,11 +57,12 @@ describe('authenticator-verification-webauthn', () => {
     navigatorCredentials.mockReturnValue(
       {
         credentials: undefined,
+        userAgent: '',
       } as unknown as Navigator,
     );
     const { container, findByText } = await setup({ mockResponse });
     await findByText(/Verify with Security Key or Biometric Authenticator/);
-    await findByText(/Security key or biometric authenticator is not supported on this browser./);
+    await findByText(/Security key or biometric authenticator is not supported on this browser. Contact your admin for assistance./);
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/v3/test/integration/webauthn-enroll.test.tsx
+++ b/src/v3/test/integration/webauthn-enroll.test.tsx
@@ -13,6 +13,7 @@
 import { setup, getMockCredentialsResponse } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/credential/enroll/webauthn-enroll-mfa.json';
+import mockResponseWithRequiredUserVerification from '../../src/mocks/response/idp/idx/authenticator-enroll-webauthn-userverification-required.json';
 
 describe('webauthn-enroll', () => {
   let mockCredentialsContainer: CredentialsContainer | undefined;
@@ -33,9 +34,21 @@ describe('webauthn-enroll', () => {
   it('should render form', async () => {
     const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
     navigatorCredentials.mockReturnValue(
-      { credentials: mockCredentialsContainer } as unknown as Navigator,
+      { credentials: mockCredentialsContainer, userAgent: '' } as unknown as Navigator,
     );
     const { container, findByText } = await setup({ mockResponse });
+    await findByText(/Set up security key or biometric authenticator/);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render form with user verification and edge browser callouts', async () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { credentials: mockCredentialsContainer, userAgent: 'edge' } as unknown as Navigator,
+    );
+    const { container, findByText } = await setup({
+      mockResponse: mockResponseWithRequiredUserVerification,
+    });
     await findByText(/Set up security key or biometric authenticator/);
     expect(container).toMatchSnapshot();
   });
@@ -43,13 +56,13 @@ describe('webauthn-enroll', () => {
   it('should render form when Credentials API is not available', async () => {
     const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
     navigatorCredentials.mockReturnValue(
-      { credentials: undefined } as unknown as Navigator,
+      { credentials: undefined, userAgent: '' } as unknown as Navigator,
     );
 
     const { container, findByText } = await setup({ mockResponse });
 
     await findByText(/Set up security key or biometric authenticator/);
-    await findByText(/Security key or biometric authenticator is not supported on this browser. Select another factor or contact your admin for assistance./);
+    await findByText(/Security key or biometric authenticator is not supported on this browser. Contact your admin for assistance./);
 
     expect(container).toMatchSnapshot();
   });
@@ -57,7 +70,7 @@ describe('webauthn-enroll', () => {
   it('should send correct payload', async () => {
     const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
     navigatorCredentials.mockReturnValue(
-      { credentials: mockCredentialsContainer } as unknown as Navigator,
+      { credentials: mockCredentialsContainer, userAgent: '' } as unknown as Navigator,
     );
 
     const {


### PR DESCRIPTION
## Description:

The purpose of this PR is to add the missing `Can't verify` link and content to the WebAuthN Challenge flow.

There is also an additional small fix included in this for Authenticator usage text: [OKTA-530979](https://oktainc.atlassian.net/browse/OKTA-530979) (removes the usage text for verification flows).

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521316](https://oktainc.atlassian.net/browse/OKTA-521316)

### Reviewers:

### Screenshot/Video:


https://user-images.githubusercontent.com/97472729/188984978-c574368b-966a-441d-b906-35a29b4b9e74.mov


### Downstream Monolith Build:



