### PR TITLE
Self service unlock flow with email magic link

### DIFF
--- a/test/e2e/features/self-service-unlock.feature
+++ b/test/e2e/features/self-service-unlock.feature
@@ -1,0 +1,16 @@
+Feature: Self Service Recovery
+
+  Background:
+    Given an App configured to use interaction code flow
+    And a User named "testuser" exists in the org
+
+  Scenario: User resets password using magic link
+    Given user opens the login page
+    When user logs in with username and wrong password 10 times
+    And user is locked out
+    And user clicks unlock account
+    And user submits their email
+    Then user is challenged for email code
+    And user clicks send email
+    And user clicks magic link
+    Then user sees the tokens on the page

--- a/test/e2e/features/self-service-unlock.feature
+++ b/test/e2e/features/self-service-unlock.feature
@@ -1,16 +1,18 @@
-Feature: Self Service Recovery
+Feature: Self Service Unlock
 
   Background:
     Given an App configured to use interaction code flow
     And a User named "testuser" exists in the org
 
-  Scenario: User resets password using magic link
+  Scenario: User unlocks account using magic link
     Given user opens the login page
-    When user logs in with username and wrong password 10 times
-    And user is locked out
-    And user clicks unlock account
-    And user submits their email
+    When user logs in with username and wrong password 5 times
+    Then user is locked out
+    When user clicks unlock account
+    And user submits their email to unlock
     Then user is challenged for email code
     And user clicks send email
-    And user clicks magic link
+    And user clicks the unlock account magic link
+    Then user account is unlocked
+    And user enters passowrd to unlock
     Then user sees the tokens on the page

--- a/test/e2e/page-objects/primary-auth-oie.page.js
+++ b/test/e2e/page-objects/primary-auth-oie.page.js
@@ -5,11 +5,11 @@ class PrimaryAuthOIEPage {
 
   get forgotPassword() { return $('.siw-main-view.identify-recovery.forgot-password'); }
   get forgotPasswordButton() { return $('[data-se="forgot-password"]'); }
+  get unlockButton() {return $('[data-se="unlock"]');}
   get nextButton() { return $('[value="Next"]'); }
   get signupForm() { return $('.siw-main-view.enroll-profile.registration'); }
   get signupLink() { return $('a[data-se="enroll"]'); }
   get unlockAccountForm() { return $('.siw-main-view.select-authenticator-unlock-account'); }
-
   get primaryAuthForm() { return $('.siw-main-view.primary-auth'); }
   get identifierField() { return $('input[name="identifier"]'); }
   get passwordField() { return $('input[name="credentials.passcode"]'); }
@@ -37,6 +37,10 @@ class PrimaryAuthOIEPage {
 
   async clickForgotPasswordButton() {
     await this.forgotPasswordButton.click();
+  }
+
+  async clickUnlockButton() {
+    await this.unlockButton.click();
   }
 
   async clickSignUpLink() {

--- a/test/e2e/page-objects/test-app.page.js
+++ b/test/e2e/page-objects/test-app.page.js
@@ -1,4 +1,5 @@
 import { waitForLoad } from '../util/waitUtil';
+import PrimaryAuthPage  from './primary-auth.page';
 
 const { WIDGET_TEST_SERVER } = process.env;
 
@@ -9,7 +10,6 @@ class TestAppPage {
   get code() { return $('#code-container'); }
   get cspErrors() { return $('#csp-errors-container'); }
   get oidcError() { return $('#oidc-error-container'); }
-
   // widget general elements
   get widgetTitle() { return $('[data-se="o-form-head"]'); }
   get submit() { return $('[data-type="save"]'); }
@@ -113,6 +113,12 @@ class TestAppPage {
     await waitForLoad(this.cspErrors);
     await this.cspErrors.then(el => el.getText()).then(txt => {
       expect(txt).toEqual(expectedError);
+    });
+  }
+
+  async assertWidgetUnableToSignin() {
+    await PrimaryAuthPage.errorBox.then(el => el.getText()).then(txt => {
+      expect(txt).toBe('Unable to sign in');
     });
   }
 

--- a/test/e2e/page-objects/unlock.page.js
+++ b/test/e2e/page-objects/unlock.page.js
@@ -1,0 +1,31 @@
+
+class UnlockPage {
+  get identifierField() { return $('input[name="identifier"]'); }
+  get emailSelectButton() { return $('div[data-se="okta_email"]'); }
+  get passwordField() { return $('input[name="credentials.passcode"]'); }
+  get verifyButton() { return $('input[type="submit"]'); }
+  get unlockPageMessage() { return $('div[class="ion-messages-container"]');}
+  async selectEmailToUnlock() {
+    this.emailSelectButton.Select();
+  }
+  async enterUserEmailToUnlock(userEmail) {
+    await this.identifierField.setValue(userEmail);
+    await this.emailSelectButton.click();
+    await browser.pause(1000);
+  }
+  async enterPasswordAndVerify(userPassword) {
+    await this.passwordField.setValue(userPassword);
+    await this.verifyButton.isClickable().then((clickable) => {
+      if(clickable) {
+        this.verifyButton.click();
+      }
+    });
+  }
+  async assertUnlockMessage() {
+    await this.unlockPageMessage.then(el => el.getText()).then(txt => {
+      expect(txt).toBe('Account successfully unlocked! Verify your account with a security method to continue.');
+    });
+  }
+
+}
+export default new UnlockPage();

--- a/test/e2e/steps/then.ts
+++ b/test/e2e/steps/then.ts
@@ -22,6 +22,7 @@ import ResetPasswordPage from '../page-objects/reset-password.page';
 import EnrollPasswordPage from '../page-objects/enroll-password-authenticator.page';
 import EnrollPhonePage from '../page-objects/enroll-phone-authenticator.page';
 import VerifyPhoneAuthenticatorPage from '../page-objects/verify-phone-authenticator.page';
+import UnlockPage from '../page-objects/unlock.page.js';
 
 Then(
   /^user sees the tokens on the page$/,
@@ -95,6 +96,19 @@ Then(
   async function() {
     return await PrimaryAuthPage.waitForUnlockAccountForm();
   }
+);
+Then(
+  /^user is locked out$/,
+  async function() {
+      return await TestAppPage.assertWidgetUnableToSignin();
+  }
+);
+
+Then(
+    /^user account is unlocked$/,
+    async function() {
+        return await UnlockPage.assertUnlockMessage();
+    }
 );
 
 Then(

--- a/test/e2e/steps/when.ts
+++ b/test/e2e/steps/when.ts
@@ -23,6 +23,7 @@ import ResetPasswordPage from '../page-objects/reset-password.page';
 import RegistrationPage from '../page-objects/registration.page';
 import EnrollPhonePage from '../page-objects/enroll-phone-authenticator.page';
 import VerifyPhoneAuthenticatorPage from '../page-objects/verify-phone-authenticator.page';
+import UnlockPage from '../page-objects/unlock.page.js'
 
 When(
   /^user logs in with username and password$/,
@@ -30,6 +31,20 @@ When(
   async function(this: ActionContext) {
     return await PrimaryAuthPage.login(this.credentials.emailAddress, this.credentials.password);
   }
+);
+
+When(
+    /^user logs in with username and wrong password 5 times$/,
+    async function() {
+        let n=0;
+        while(n<5) {
+            await waitForLoad(TestAppPage.widget);
+            await PrimaryAuthPage.login(this.credentials.emailAddress, "userR1234");
+            await browser.pause(1000);
+            n++;
+        }
+        return
+    }
 );
 
 When(
@@ -111,6 +126,28 @@ When(
 );
 
 When(
+  /^user clicks unlock account$/,
+  async function() {
+    await PrimaryAuthPage.clickUnlockButton();
+    await browser.pause(1000)
+  }
+)
+
+When(
+    /^user selects email to unlock account$/,
+    async function() {
+        await UnlockPage.selectEmailToUnlock();
+    }
+);
+
+When (
+    /^user enters passowrd to unlock$/,
+    async function() {
+        await UnlockPage.enterPasswordAndVerify(this.credentials.password);
+}
+);
+
+When(
   /^user clicks the email magic link$/,
   async function() {
     const emailMagicLink = await this.a18nClient.getEmailMagicLink(this.credentials.profileId);
@@ -154,11 +191,26 @@ When(
 );
 
 When(
+    /^user submits their email to unlock$/,
+    async function() {
+        return await UnlockPage.enterUserEmailToUnlock(this.credentials.emailAddress);
+    }
+);
+
+When(
   /^user clicks the password reset magic link$/,
   async function() {
     const passwordResetMagicLink = await this.a18nClient.getPasswordResetMagicLink(this.credentials.profileId);
     await browser.url(passwordResetMagicLink);
   }
+);
+
+When(
+    /^user clicks the unlock account magic link$/,
+    async function() {
+        const unlockAccountLink = await this.a18nClient.getUnlockAccountLink(this.credentials.profileId);
+        await browser.url(unlockAccountLink);
+    }
 );
 
 When(

--- a/test/e2e/support/a18nClient.ts
+++ b/test/e2e/support/a18nClient.ts
@@ -128,6 +128,22 @@ export default class A18nClient {
     return url;
   }
 
+  async getUnlockAccountLink(profileId: string) {
+    let retryAttemptsRemaining = 5;
+    let response;
+    while (!response?.content && retryAttemptsRemaining > 0) {
+      await waitForOneSecond();
+      response = await this.getOnURL(LATEST_EMAIL_URL.replace(':profileId', profileId)) as Record<string, string>;
+      --retryAttemptsRemaining;
+    }
+    const match = response?.content?.match(/<a id="unlock-account-link" href="(?<url>\S+)"/);
+    const url = match?.groups?.url;
+    if (!url) {
+      throw new Error('Unable to retrieve unlock account link from email.');
+    }
+    return url;
+  }
+
   private async deleteOnProtectedURL(url: string): Promise<string|never>{
     try {
       const response =  await fetch(url, {


### PR DESCRIPTION
## Description:
This pr addresses the e2e flow for SSU using new magic link experience.
The test creates a user and enters the user name with wrong password 5 times to intentionally lockout user
Then sends email to the user email id 
Clicks on the magic link
Asserts that account successfully unlocked message is displayed
Enters password and verifies tokens are redeemed for the user.

## PR Checklist

- [ X] Have you verified the basic functionality for this change?
- [ X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

okta-523227
### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



