### PR TITLE
OKTA-526392 hide widget version from UI

### DIFF
--- a/src/v3/src/OktaSignIn/index.ts
+++ b/src/v3/src/OktaSignIn/index.ts
@@ -34,6 +34,8 @@ export type RenderErrorCallback = {
 export type RenderResult = JsonObject;
 export type Tokens = JsonObject;
 
+console.debug(`${VERSION}-g${COMMITHASH.substring(0, 7)}`);
+
 export default class OktaSignIn {
   /**
    * Version string

--- a/src/v3/src/components/AuthContent/AuthContent.tsx
+++ b/src/v3/src/components/AuthContent/AuthContent.tsx
@@ -13,8 +13,6 @@
 import { Box } from '@mui/material';
 import { FunctionComponent, h } from 'preact';
 
-const version = `${VERSION}-g${COMMITHASH.substring(0, 7)}`;
-
 const AuthContent: FunctionComponent = ({ children }) => (
   <Box
     display="flex"
@@ -28,13 +26,6 @@ const AuthContent: FunctionComponent = ({ children }) => (
     marginBottom={3}
   >
     { children }
-    {
-      process.env.NODE_ENV !== 'test' && (
-        <code aria-hidden>
-          { version }
-        </code>
-      )
-    }
   </Box>
 );
 


### PR DESCRIPTION
## Description:

Hides the version from the widget footer and prints using `console.debug` in `OktaSignIn` instead.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-526392](https://oktainc.atlassian.net/browse/OKTA-526392)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



