### PR TITLE
OKTA-531110 : Fixing flaky test

### DIFF
--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -276,7 +276,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways Mui-focusVisible emotion-43"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx
+++ b/src/v3/test/integration/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx
@@ -68,11 +68,13 @@ describe('flow-unlock-account-email-polling-to-mfa-challenge-authenticator', () 
     await findByText(/Verify with your email/);
 
     /* refresh: 4000 and we poll twice */
-    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(9000);
 
-    await waitFor(async () => {
-      await findByText(/Verify with Security Key or Biometric Authenticator/);
-    });
+    await findByText(
+      /Verify with Security Key or Biometric Authenticator/,
+      undefined,
+      { timeout: 5000 },
+    );
     const switchAuthenticatorEle = await findByTestId('switchAuthenticator');
     await waitFor(() => expect(switchAuthenticatorEle).toHaveFocus());
 

--- a/src/v3/test/integration/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx
+++ b/src/v3/test/integration/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx
@@ -11,6 +11,7 @@
  */
 
 import { HttpRequestClient } from '@okta/okta-auth-js';
+import { waitFor } from '@testing-library/preact';
 import emailPollingResponse from '../../src/mocks/response/idp/idx/challenge/unlock-account-email.json';
 import webauthnChallengeResponse from '../../src/mocks/response/idp/idx/challenge/unlock-account-sms-verify-webauthn.json';
 
@@ -61,15 +62,19 @@ describe('flow-unlock-account-email-polling-to-mfa-challenge-authenticator', () 
       return Promise.reject(new Error('Unknown request'));
     });
     const {
-      container, findByText,
+      container, findByText, findByTestId,
     } = await setup({ mockRequestClient });
 
     await findByText(/Verify with your email/);
 
     /* refresh: 4000 and we poll twice */
-    jest.advanceTimersByTime(9000);
+    jest.advanceTimersByTime(1000);
 
-    await findByText(/Verify with Security Key or Biometric Authenticator/);
+    await waitFor(async () => {
+      await findByText(/Verify with Security Key or Biometric Authenticator/);
+    });
+    const switchAuthenticatorEle = await findByTestId('switchAuthenticator');
+    await waitFor(() => expect(switchAuthenticatorEle).toHaveFocus());
 
     expect(container).toMatchSnapshot();
   });


### PR DESCRIPTION
## Description:
Purpose of this PR is to fix a flaky flow test.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-531110](https://oktainc.atlassian.net/browse/OKTA-531110)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



