### PR TITLE
OKTA-501772 : Autocomplete implementation for OTP codes

### DIFF
--- a/src/v3/src/transformer/field/attributes.test.ts
+++ b/src/v3/src/transformer/field/attributes.test.ts
@@ -47,18 +47,50 @@ describe('Attributes transformer', () => {
     expect(transformer(formfield)).toEqual(result);
   });
 
-  it('should return uischema object with options.attributes.autocomplete === "one-time-code" if formfield.name === "passcode" & secret property doesnt exist in ion object', () => {
+  it('should return uischema object with options.attributes.autocomplete === "one-time-code" and options.attributes.inputmode === "numeric" if formfield.name === "passcode" & secret property doesnt exist in ion object when on ios device', () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { userAgent: 'iPhone' } as unknown as Navigator,
+    );
     const formfield: Input = { name: 'credentials.passcode' };
 
-    const result = { attributes: { autocomplete: 'one-time-code' } };
+    const result = { attributes: { autocomplete: 'one-time-code', inputmode: 'numeric' } };
 
     expect(transformer(formfield)).toEqual(result);
   });
 
-  it('should return uischema object with options.attributes.autocomplete === "one-time-code" if formfield.name === "totp" is present in ion object', () => {
+  it('should return uischema object with options.attributes.autocomplete === "off" if formfield.name === "passcode" & secret property doesnt exist in ion object when on desktop', () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { userAgent: 'Mozilla' } as unknown as Navigator,
+    );
+    const formfield: Input = { name: 'credentials.passcode' };
+
+    const result = { attributes: { autocomplete: 'off', inputmode: 'numeric' } };
+
+    expect(transformer(formfield)).toEqual(result);
+  });
+
+  it('should return uischema object with options.attributes.autocomplete === "one-time-code" if formfield.name === "totp" is present in ion object when on ios device', () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { userAgent: 'iPhone' } as unknown as Navigator,
+    );
     const formfield: Input = { name: 'totp' };
 
-    const result = { attributes: { autocomplete: 'one-time-code' } };
+    const result = { attributes: { autocomplete: 'one-time-code', inputmode: 'numeric' } };
+
+    expect(transformer(formfield)).toEqual(result);
+  });
+
+  it('should return uischema object with options.attributes.autocomplete === "off" if formfield.name === "totp" is present in ion object when on desktop', () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { userAgent: 'Mozilla' } as unknown as Navigator,
+    );
+    const formfield: Input = { name: 'totp' };
+
+    const result = { attributes: { autocomplete: 'off', inputmode: 'numeric' } };
 
     expect(transformer(formfield)).toEqual(result);
   });
@@ -66,7 +98,7 @@ describe('Attributes transformer', () => {
   it('should return uischema object with options.attributes.autocomplete === "tel-national" if formfield.name === "phoneNumber" is present in ion object', () => {
     const formfield: Input = { name: 'phoneNumber' };
 
-    const result = { attributes: { autocomplete: 'tel-national' } };
+    const result = { attributes: { autocomplete: 'tel-national', inputmode: 'tel' } };
 
     expect(transformer(formfield)).toEqual(result);
   });

--- a/src/v3/src/transformer/field/attributes.ts
+++ b/src/v3/src/transformer/field/attributes.ts
@@ -41,10 +41,10 @@ const inputModeValueMap = new Map<string, InputModeValue>([
 ]);
 
 const getKeyFromMap = (
-  map: Map<string, AutoCompleteValue> | Map<string, InputModeValue>,
+  map: Map<string, unknown>,
   inputName: string,
 ): string | undefined => {
-  let isMatch;
+  let isMatch: string | undefined;
   map.forEach((_, key: string) => {
     if (inputName.match(key)?.length) {
       isMatch = key;
@@ -59,15 +59,9 @@ const autocompleteValueTransformer = (input: Input): AutoCompleteValue | null =>
     return autocompleteValueMap.get('password') ?? null;
   }
   const key = getKeyFromMap(autocompleteValueMap, input.name);
-  if (!key) {
-    return null;
-  }
-  const autocompleteValue = autocompleteValueMap.get(key) ?? null;
+  const autocompleteValue = key ? autocompleteValueMap.get(key) ?? null : null;
   // If not on iOS or Android, disable autocomplete for otp
-  if (autocompleteValue === 'one-time-code' && !isAndroidOrIOS()) {
-    return 'off';
-  }
-  return autocompleteValue;
+  return autocompleteValue === 'one-time-code' && !isAndroidOrIOS() ? 'off' : autocompleteValue;
 };
 
 const inputModeValueTransformer = (input: Input): InputModeValue | null => {
@@ -76,10 +70,7 @@ const inputModeValueTransformer = (input: Input): InputModeValue | null => {
     return null;
   }
   const key = getKeyFromMap(inputModeValueMap, input.name);
-  if (key) {
-    return inputModeValueMap.get(key) ?? null;
-  }
-  return null;
+  return key ? inputModeValueMap.get(key) ?? null : null;
 };
 
 export const transformer = (input: Input): Result | null => {
@@ -89,6 +80,8 @@ export const transformer = (input: Input): Result | null => {
     attributes.autocomplete = autocompleteValue;
   }
 
+  // Inputmode is used to optimize the mobile virtual keyboard based on the type of content entered
+  // See https://web.dev/sms-otp-form/#inputmode=numeric
   const inputModeValue = inputModeValueTransformer(input);
   if (inputModeValue) {
     attributes.inputmode = inputModeValue;

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -51,8 +51,16 @@ export type AutoCompleteValue = 'username'
 | 'email'
 | 'off';
 
+export type InputModeValue = 'numeric'
+| 'decimal'
+| 'tel'
+| 'email'
+| 'url'
+| 'search';
+
 export type InputAttributes = {
   autocomplete?: AutoCompleteValue;
+  inputmode?: InputModeValue;
 };
 
 // flat params

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -1535,6 +1535,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                               class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedStart emotion-44"
                               data-se="authenticator.phoneNumber"
                               id="authenticator.phoneNumber"
+                              inputmode="tel"
                               name="authenticator.phoneNumber"
                               type="tel"
                             />
@@ -3137,6 +3138,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                               class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedStart emotion-44"
                               data-se="authenticator.phoneNumber"
                               id="authenticator.phoneNumber"
+                              inputmode="tel"
                               name="authenticator.phoneNumber"
                               type="tel"
                             />

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -495,10 +495,11 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                       >
                         <input
                           aria-invalid="false"
-                          autocomplete="one-time-code"
+                          autocomplete="off"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           type="text"
                         />
@@ -1049,10 +1050,11 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       >
                         <input
                           aria-invalid="false"
-                          autocomplete="one-time-code"
+                          autocomplete="off"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           type="text"
                         />

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -174,10 +174,11 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     >
                       <input
                         aria-invalid="false"
-                        autocomplete="one-time-code"
+                        autocomplete="off"
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-25"
                         data-se="credentials.passcode"
                         id="credentials.passcode"
+                        inputmode="numeric"
                         name="credentials.passcode"
                         type="text"
                       />

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -174,10 +174,11 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     >
                       <input
                         aria-invalid="false"
-                        autocomplete="one-time-code"
+                        autocomplete="off"
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-25"
                         data-se="credentials.passcode"
                         id="credentials.passcode"
+                        inputmode="numeric"
                         name="credentials.passcode"
                         type="text"
                       />

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -531,10 +531,11 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                       >
                         <input
                           aria-invalid="false"
-                          autocomplete="one-time-code"
+                          autocomplete="off"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-23"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           type="text"
                         />
@@ -772,10 +773,11 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                         <input
                           aria-describedby="credentials.passcode-error"
                           aria-invalid="true"
-                          autocomplete="one-time-code"
+                          autocomplete="off"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-28"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           type="text"
                         />
@@ -1072,10 +1074,11 @@ exports[`authenticator-verification-email renders correct form should display re
                         <input
                           aria-describedby="credentials.passcode-error"
                           aria-invalid="true"
-                          autocomplete="one-time-code"
+                          autocomplete="off"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-35"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           type="text"
                         />

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -1240,3 +1240,215 @@ exports[`authenticator-verification-email renders correct form should render ses
   </div>
 </div>
 `;
+
+exports[`authenticator-verification-email should have autocomplete attribute on otp input element when in ios browser 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-4"
+            >
+              <svg
+                aria-labelledby="authCoinEmailAuthenticator"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="authCoinEmailAuthenticator"
+                >
+                  Email Authentication
+                </title>
+                <circle
+                  class="siwFillBg"
+                  cx="24"
+                  cy="24"
+                  fill="#F5F5F6"
+                  r="24"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M32 18v1h5.3L32 24.29v1.42l6-6.01v12.8a1.5 1.5 0 0 1-1.5 1.5h-17a1.5 1.5 0 0 1-1.5-1.5V31h-1v1.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V18h-7Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M9 13v14.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V13H9Zm20.293 1-8.81 8.81L10.794 14h18.499ZM28.5 29h-17a1.5 1.5 0 0 1-1.5-1.5V14.63l10.517 9.56L30 14.707V27.5a1.5 1.5 0 0 1-1.5 1.5Z"
+                  fill="#00297A"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  firstname.lastname@example.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+              style="max-width: 100%; word-break: break-word;"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  />
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-14"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-15"
+                        data-se="o-form-head"
+                      >
+                        Verify with your email
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-14"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-18"
+                        data-se="o-form-explain"
+                      >
+                        We sent an email to f****************e@example.com. Click the verification link in your email to continue or enter the code below.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                        for="credentials.passcode"
+                      >
+                        Enter Code
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused emotion-22"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="one-time-code"
+                          class="MuiOutlinedInput-input MuiInputBase-input emotion-23"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          inputmode="numeric"
+                          name="credentials.passcode"
+                          type="text"
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-24"
+                        >
+                          <legend
+                            class="emotion-25"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-27"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -219,10 +219,11 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     >
                       <input
                         aria-invalid="false"
-                        autocomplete="one-time-code"
+                        autocomplete="off"
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-21"
                         data-se="credentials.passcode"
                         id="credentials.passcode"
+                        inputmode="numeric"
                         name="credentials.passcode"
                         type="text"
                       />

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -1,5 +1,204 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`authenticator-verification-okta-verify-totp should have autocomplete attribute on totp input element when in ios browser 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-4"
+            >
+              <svg
+                aria-labelledby="authCoinOktaVerifyAuthenticator"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="authCoinOktaVerifyAuthenticator"
+                >
+                  Okta Verify
+                </title>
+                <circle
+                  class="siwFillBg"
+                  cx="24"
+                  cy="24"
+                  fill="#F5F5F6"
+                  r="24"
+                />
+                <path
+                  class="siwFillPrimary"
+                  clip-rule="evenodd"
+                  d="M32.872 22.853a8.947 8.947 0 1 1-2.288-4.91L24 24.498l-3.205-3.19c-.482-.48-1.322-.48-1.804 0a1.26 1.26 0 0 0-.374.898c0 .34.133.659.374.898l4.107 4.09c.24.239.561.371.902.371.336 0 .664-.136.902-.372L38.636 13.52a18.089 18.089 0 0 0-1.634-1.967A17.947 17.947 0 0 0 24 6C14.059 6 6 14.059 6 24s8.059 18 18 18 18-8.059 18-18c0-2.972-.722-5.775-1.998-8.245l-7.13 7.098Z"
+                  fill="#00297A"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@icloud.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+              style="max-width: 100%; word-break: break-word;"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                      data-se="o-form-head"
+                    >
+                      Enter a code
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      for="credentials.totp"
+                    >
+                      Enter code from Okta Verify app
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="one-time-code"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
+                        data-se="credentials.totp"
+                        id="credentials.totp"
+                        inputmode="numeric"
+                        name="credentials.totp"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-19"
+                      >
+                        <legend
+                          class="emotion-20"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-22"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Verify
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
 <div>
   <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -130,10 +130,11 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     >
                       <input
                         aria-invalid="false"
-                        autocomplete="one-time-code"
+                        autocomplete="off"
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
                         data-se="credentials.totp"
                         id="credentials.totp"
+                        inputmode="numeric"
                         name="credentials.totp"
                         type="text"
                       />

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -174,10 +174,11 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     >
                       <input
                         aria-invalid="false"
-                        autocomplete="one-time-code"
+                        autocomplete="off"
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-25"
                         data-se="credentials.passcode"
                         id="credentials.passcode"
+                        inputmode="numeric"
                         name="credentials.passcode"
                         type="text"
                       />

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`enroll-profile-new should render form 1`] = `
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-13"
                         data-se="userProfile.email"
                         id="userProfile.email"
+                        inputmode="email"
                         name="userProfile.email"
                         type="text"
                       />

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -621,6 +621,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
                         data-se="email"
                         id="email"
+                        inputmode="email"
                         name="email"
                         type="text"
                       />
@@ -3304,6 +3305,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                             class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedStart emotion-23"
                             data-se="phoneNumber"
                             id="phoneNumber"
+                            inputmode="tel"
                             name="phoneNumber"
                             type="tel"
                           />

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -134,6 +134,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
                         data-se="email"
                         id="email"
+                        inputmode="email"
                         name="email"
                         type="text"
                       />

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1401,6 +1401,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                             class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedStart emotion-23"
                             data-se="phoneNumber"
                             id="phoneNumber"
+                            inputmode="tel"
                             name="phoneNumber"
                             type="tel"
                           />

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -237,4 +237,32 @@ describe('authenticator-verification-email', () => {
       }),
     );
   });
+
+  it('should have autocomplete attribute on otp input element when in ios browser', async () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { userAgent: 'iPhone' } as unknown as Navigator,
+    );
+    const {
+      container,
+      user,
+      findByText,
+      findByTestId,
+    } = await setup({
+      mockResponse: authenticatorVerificationEmail,
+    });
+
+    await findByText(/Verify with your email/);
+    await findByText(/We sent an email to/);
+
+    const nextPageBtn = await findByText(/Enter a code from the email instead/);
+
+    await user.click(nextPageBtn);
+    await findByText(/Enter Code/);
+
+    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+
+    expect(codeEle.getAttribute('autocomplete')).toBe('one-time-code');
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
@@ -43,4 +43,21 @@ describe('authenticator-verification-okta-verify-totp', () => {
       }),
     );
   });
+
+  it('should have autocomplete attribute on totp input element when in ios browser', async () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { userAgent: 'iPhone' } as unknown as Navigator,
+    );
+    const {
+      container, findByTestId, findByText,
+    } = await setup({ mockResponse });
+
+    await findByText(/Enter a code/);
+
+    const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;
+
+    expect(otpEle.getAttribute('autocomplete')).toBe('one-time-code');
+    expect(container).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Description:
The purpose of this PR is to ensure the OTP code fields do not suggest an autocomplete value in web browsers. Given how mobile devices work (i.e. when a text message is sent the mobile browser auto suggests the code from the text, I limited the disabling of autocomplete only to desktop browsers and excluded ios/android).


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-501772](https://oktainc.atlassian.net/browse/OKTA-501772)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



