### PR TITLE
OKTA-532426 : Phone authenticator method descriptions fix

### DIFF
--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -102,7 +102,6 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
   useEffect(() => {
     const formattedPhone = formatPhone(phone, phoneCode, extension);
     onChangeHandler(formattedPhone);
-    setTouched?.(true);
     onValidateHandler?.(setError, formattedPhone);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phoneCode, phone, extension, showExtension]);
@@ -178,6 +177,10 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
             onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
               // Set new phone value without phone code
               setPhone(e.currentTarget.value);
+              // setTimeout needed because touched is being updated before validation
+              setTimeout(() => {
+                setTouched?.(true);
+              }, 0);
             }}
             startAdornment={(
               <InputAdornment

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -68,6 +68,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
   // Sets US as default code
   const [phoneCode, setPhoneCode] = useState(`+${CountryUtil.getCallingCodeForCountry('US')}`);
   const [extension, setExtension] = useState<string>('');
+  const [phoneChanged, setPhoneChanged] = useState<boolean>(false);
   const methodType = data['authenticator.methodType'];
   const showExtension = methodType === 'voice';
   const onChangeHandler = useOnChange(uischema);
@@ -105,6 +106,12 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
     onValidateHandler?.(setError, formattedPhone);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phoneCode, phone, extension, showExtension]);
+
+  useEffect(() => {
+    if (phoneChanged) {
+      setTouched?.(true);
+    }
+  }, [phoneChanged, setTouched]);
 
   const renderExtension = () => (
     showExtension && (
@@ -177,10 +184,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
             onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
               // Set new phone value without phone code
               setPhone(e.currentTarget.value);
-              // setTimeout needed because touched is being updated before validation
-              setTimeout(() => {
-                setTouched?.(true);
-              });
+              setPhoneChanged(true);
             }}
             startAdornment={(
               <InputAdornment

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -180,7 +180,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
               // setTimeout needed because touched is being updated before validation
               setTimeout(() => {
                 setTouched?.(true);
-              }, 0);
+              });
             }}
             startAdornment={(
               <InputAdornment

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
@@ -37,8 +37,8 @@ export const transformPhoneChallenge: IdxStepTransformer = ({ transaction, formB
     reminderElement = {
       type: 'Reminder',
       options: {
-        content: loc('oie.phone.verify.sms.resendText', 'login'),
-        buttonText: loc('email.button.resend', 'login'),
+        content: methodType === 'sms' ? loc('oie.phone.verify.sms.resendText', 'login') : loc('oie.phone.verify.call.resendText', 'login'),
+        buttonText: methodType === 'sms' ? loc('oie.phone.verify.sms.resendLinkText', 'login') : loc('oie.phone.verify.call.resendLinkText', 'login'),
         step: name,
         isActionStep: true,
         actionParams: { resend: true },

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
@@ -32,9 +32,9 @@ export const transformPhoneChallenge: IdxStepTransformer = ({ transaction, formB
   let reminderElement: ReminderElement | undefined;
 
   const resendStep = availableSteps?.find(({ name }) => name?.endsWith('resend'));
+  const smsMethodType = methodType === 'sms';
   if (resendStep) {
     const { name } = resendStep;
-    const smsMethodType = methodType === 'sms';
     reminderElement = {
       type: 'Reminder',
       options: {
@@ -47,9 +47,9 @@ export const transformPhoneChallenge: IdxStepTransformer = ({ transaction, formB
     };
   }
 
-  const sendInfoText = methodType === 'voice'
-    ? loc('mfa.calling', 'login')
-    : loc('oie.phone.verify.sms.codeSentText', 'login');
+  const sendInfoText = smsMethodType
+    ? loc('oie.phone.verify.sms.codeSentText', 'login')
+    : loc('mfa.calling', 'login');
   const phoneInfoText = phoneNumber || loc('oie.phone.alternate.title', 'login');
   const enterCodeInfoText = loc('oie.phone.verify.enterCodeText', 'login');
   const informationalText: DescriptionElement = {

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
@@ -34,11 +34,12 @@ export const transformPhoneChallenge: IdxStepTransformer = ({ transaction, formB
   const resendStep = availableSteps?.find(({ name }) => name?.endsWith('resend'));
   if (resendStep) {
     const { name } = resendStep;
+    const smsMethodType = methodType === 'sms';
     reminderElement = {
       type: 'Reminder',
       options: {
-        content: methodType === 'sms' ? loc('oie.phone.verify.sms.resendText', 'login') : loc('oie.phone.verify.call.resendText', 'login'),
-        buttonText: methodType === 'sms' ? loc('oie.phone.verify.sms.resendLinkText', 'login') : loc('oie.phone.verify.call.resendLinkText', 'login'),
+        content: smsMethodType ? loc('oie.phone.verify.sms.resendText', 'login') : loc('oie.phone.verify.call.resendText', 'login'),
+        buttonText: smsMethodType ? loc('oie.phone.verify.sms.resendLinkText', 'login') : loc('oie.phone.verify.call.resendLinkText', 'login'),
         step: name,
         isActionStep: true,
         actionParams: { resend: true },

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -32,9 +32,9 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, 
   const { phoneNumber } = profile || {};
   const methodType = methods?.[0]?.type;
   const resendStep = availableSteps?.find(({ name }) => name?.endsWith('resend'));
+  const smsMethodType = methodType === 'sms';
   if (resendStep) {
     const { name } = resendStep;
-    const smsMethodType = methodType === 'sms';
     reminderElement = {
       type: 'Reminder',
       options: {
@@ -53,7 +53,7 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, 
       content: loc('oie.phone.enroll.title', 'login'),
     },
   };
-  const sendInfoText = methodType === 'sms'
+  const sendInfoText = smsMethodType
     ? loc('oie.phone.verify.sms.codeSentText', 'login')
     : loc('mfa.calling', 'login');
   const phoneInfoText = phoneNumber || loc('oie.phone.alternate.title', 'login');

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -34,11 +34,12 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, 
   const resendStep = availableSteps?.find(({ name }) => name?.endsWith('resend'));
   if (resendStep) {
     const { name } = resendStep;
+    const smsMethodType = methodType === 'sms';
     reminderElement = {
       type: 'Reminder',
       options: {
-        content: methodType === 'sms' ? loc('oie.phone.verify.sms.resendText', 'login') : loc('oie.phone.verify.call.resendText', 'login'),
-        buttonText: methodType === 'sms' ? loc('oie.phone.verify.sms.resendLinkText', 'login') : loc('oie.phone.verify.call.resendLinkText', 'login'),
+        content: smsMethodType ? loc('oie.phone.verify.sms.resendText', 'login') : loc('oie.phone.verify.call.resendText', 'login'),
+        buttonText: smsMethodType ? loc('oie.phone.verify.sms.resendLinkText', 'login') : loc('oie.phone.verify.call.resendLinkText', 'login'),
         step: name,
         isActionStep: true,
         actionParams: { resend: true },

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -28,14 +28,17 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, 
 
   let reminderElement: ReminderElement | undefined;
 
+  const { methods, profile } = nextStep.relatesTo?.value || {};
+  const { phoneNumber } = profile || {};
+  const methodType = methods?.[0]?.type;
   const resendStep = availableSteps?.find(({ name }) => name?.endsWith('resend'));
   if (resendStep) {
     const { name } = resendStep;
     reminderElement = {
       type: 'Reminder',
       options: {
-        content: loc('oie.phone.verify.sms.resendText', 'login'),
-        buttonText: loc('email.button.resend', 'login'),
+        content: methodType === 'sms' ? loc('oie.phone.verify.sms.resendText', 'login') : loc('oie.phone.verify.call.resendText', 'login'),
+        buttonText: methodType === 'sms' ? loc('oie.phone.verify.sms.resendLinkText', 'login') : loc('oie.phone.verify.call.resendLinkText', 'login'),
         step: name,
         isActionStep: true,
         actionParams: { resend: true },
@@ -49,10 +52,6 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, 
       content: loc('oie.phone.enroll.title', 'login'),
     },
   };
-
-  const { methods, profile } = nextStep.relatesTo?.value || {};
-  const { phoneNumber } = profile || {};
-  const methodType = methods?.[0]?.type;
   const sendInfoText = methodType === 'sms'
     ? loc('oie.phone.verify.sms.codeSentText', 'login')
     : loc('mfa.calling', 'login');

--- a/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
@@ -25,7 +25,7 @@ import { loc, removeFieldLevelMessages } from '../../util';
 import { getUIElementWithName } from '../utils';
 
 export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transaction }) => {
-  const { uischema, dataSchema } = formBag;
+  const { uischema, data, dataSchema } = formBag;
 
   const titleElement: TitleElement = {
     type: 'Title',
@@ -107,31 +107,52 @@ export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transact
     },
   };
 
-  phoneMethodStepper.elements = [
-    {
-      type: UISchemaLayoutType.VERTICAL,
-      elements: [
+  uischema.elements = [
+    titleElement,
+  ];
+
+  if (phoneMethodOptions.length === 1) {
+    const firstOptionMethod = phoneMethodOptions[0].value;
+    data['authenticator.methodType'] = firstOptionMethod;
+    if (firstOptionMethod === 'sms') {
+      uischema.elements = uischema.elements.concat([
         smsInfoTextElement,
         methodTypeRadioEl,
         phoneNumberElement,
         smsStepSubmitButton,
-      ],
-    },
-    {
-      type: UISchemaLayoutType.VERTICAL,
-      elements: [
+      ]);
+    } else {
+      uischema.elements = uischema.elements.concat([
         voiceInfoTextElement,
         methodTypeRadioEl,
         phoneNumberElement,
         voiceStepSubmitButton,
-      ],
-    },
-  ];
+      ]);
+    }
+  } else {
+    phoneMethodStepper.elements = [
+      {
+        type: UISchemaLayoutType.VERTICAL,
+        elements: [
+          smsInfoTextElement,
+          methodTypeRadioEl,
+          phoneNumberElement,
+          smsStepSubmitButton,
+        ],
+      },
+      {
+        type: UISchemaLayoutType.VERTICAL,
+        elements: [
+          voiceInfoTextElement,
+          methodTypeRadioEl,
+          phoneNumberElement,
+          voiceStepSubmitButton,
+        ],
+      },
+    ];
 
-  uischema.elements = [
-    titleElement,
-    phoneMethodStepper,
-  ];
+    uischema.elements.push(phoneMethodStepper);
+  }
 
   // set default dataSchema
   dataSchema.submit = smsStepSubmitButton.options;

--- a/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
@@ -114,7 +114,6 @@ export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transact
   if (phoneMethodOptions.length === 1) {
     const firstOptionMethod = phoneMethodOptions[0].value;
     data['authenticator.methodType'] = firstOptionMethod;
-    
     if (firstOptionMethod === 'sms') {
       uischema.elements = uischema.elements.concat([
         smsInfoTextElement,

--- a/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
@@ -34,7 +34,8 @@ export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transact
     },
   };
 
-  const methodTypeElement = getUIElementWithName('authenticator.methodType', uischema.elements) as FieldElement;
+  const METHOD_TYPE_KEY = 'authenticator.methodType';
+  const methodTypeElement = getUIElementWithName(METHOD_TYPE_KEY, uischema.elements) as FieldElement;
 
   const phoneMethodStepper: StepperLayout = {
     type: UISchemaLayoutType.STEPPER,
@@ -53,7 +54,7 @@ export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transact
 
           setData((prev) => ({
             ...prev,
-            'authenticator.methodType': phoneMethodOptions[stepIndex].value,
+            [METHOD_TYPE_KEY]: phoneMethodOptions[stepIndex].value,
           }));
 
           const stepLayout = phoneMethodStepper.elements[stepIndex];
@@ -64,7 +65,7 @@ export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transact
         const { setData } = widgetContext;
         setData((prev) => ({
           ...prev,
-          'authenticator.methodType': phoneMethodOptions[stepIndex].value,
+          [METHOD_TYPE_KEY]: phoneMethodOptions[stepIndex].value,
         }));
         return phoneMethodOptions[0].value.toString();
       },
@@ -113,7 +114,7 @@ export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transact
 
   if (phoneMethodOptions.length === 1) {
     const firstOptionMethod = phoneMethodOptions[0].value;
-    data['authenticator.methodType'] = firstOptionMethod;
+    data[METHOD_TYPE_KEY] = firstOptionMethod;
     if (firstOptionMethod === 'sms') {
       uischema.elements = uischema.elements.concat([
         smsInfoTextElement,

--- a/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
@@ -114,6 +114,7 @@ export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transact
   if (phoneMethodOptions.length === 1) {
     const firstOptionMethod = phoneMethodOptions[0].value;
     data['authenticator.methodType'] = firstOptionMethod;
+    
     if (firstOptionMethod === 'sms') {
       uischema.elements = uischema.elements.concat([
         smsInfoTextElement,

--- a/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
@@ -35,7 +35,10 @@ export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transact
   };
 
   const METHOD_TYPE_KEY = 'authenticator.methodType';
-  const methodTypeElement = getUIElementWithName(METHOD_TYPE_KEY, uischema.elements) as FieldElement;
+  const methodTypeElement = getUIElementWithName(
+    METHOD_TYPE_KEY,
+    uischema.elements,
+  ) as FieldElement;
 
   const phoneMethodStepper: StepperLayout = {
     type: UISchemaLayoutType.STEPPER,

--- a/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentTransformer.ts
@@ -117,14 +117,12 @@ export const transformPhoneEnrollment: IdxStepTransformer = ({ formBag, transact
     if (firstOptionMethod === 'sms') {
       uischema.elements = uischema.elements.concat([
         smsInfoTextElement,
-        methodTypeRadioEl,
         phoneNumberElement,
         smsStepSubmitButton,
       ]);
     } else {
       uischema.elements = uischema.elements.concat([
         voiceInfoTextElement,
-        methodTypeRadioEl,
         phoneNumberElement,
         voiceStepSubmitButton,
       ]);

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -149,16 +149,16 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                     <fieldset
                       class="MuiFormControl-root emotion-19"
                     >
+                      
                       <div
                         class="MuiFormGroup-root emotion-20"
-                        id="authenticator.methodType"
                         role="radiogroup"
                       >
                         <label
                           class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                         >
                           <span
-                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-22"
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root Mui-focusVisible MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-22"
                           >
                             <input
                               class="PrivateSwitchBase-input emotion-23"
@@ -1741,7 +1741,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                         class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
                         data-se="o-form-explain"
                       >
-                        Enter your phone number to receive a verification code via SMS.
+                        Enter your phone number to receive a verification code via voice call.
                       </p>
                     </div>
                   </div>
@@ -1751,9 +1751,9 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                     <fieldset
                       class="MuiFormControl-root emotion-19"
                     >
+                      
                       <div
                         class="MuiFormGroup-root emotion-20"
-                        id="authenticator.methodType"
                         role="radiogroup"
                       >
                         <label
@@ -3120,7 +3120,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                             Phone number
                           </label>
                           <div
-                            class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-41"
+                            class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-41"
                           >
                             <span
                               class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined emotion-42"
@@ -3132,8 +3132,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                               </p>
                             </span>
                             <input
-                              aria-describedby="authenticator.phoneNumber-error"
-                              aria-invalid="true"
+                              aria-invalid="false"
                               autocomplete="tel-national"
                               class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedStart emotion-44"
                               data-se="authenticator.phoneNumber"
@@ -3156,17 +3155,9 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                               </legend>
                             </fieldset>
                           </div>
-                          <p
-                            class="MuiFormHelperText-root Mui-error emotion-47"
-                            data-se="authenticator.phoneNumber-error"
-                            id="authenticator.phoneNumber-error"
-                            role="alert"
-                          >
-                            This field cannot be left blank
-                          </p>
                         </div>
                         <div
-                          class="MuiBox-root emotion-48"
+                          class="MuiBox-root emotion-47"
                         >
                           <label
                             class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
@@ -3175,11 +3166,11 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                             Extension
                           </label>
                           <div
-                            class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary emotion-50"
+                            class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary emotion-49"
                           >
                             <input
                               autocomplete="tel-extension"
-                              class="MuiOutlinedInput-input MuiInputBase-input emotion-51"
+                              class="MuiOutlinedInput-input MuiInputBase-input emotion-50"
                               data-se="extension"
                               id="phoneExtension"
                               name="extension"
@@ -3208,12 +3199,12 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-55"
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-54"
                       data-type="save"
                       tabindex="0"
                       type="submit"
                     >
-                      Receive a code via SMS
+                      Receive a code via voice call
                     </button>
                   </div>
                 </div>
@@ -3221,7 +3212,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-56"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -3232,7 +3223,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-56"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/authenticator-enroll-data-phone.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-data-phone.test.tsx
@@ -92,7 +92,7 @@ describe('authenticator-enroll-data-phone', () => {
     const methodType = await findByLabelText(/Voice call/);
     await user.click(methodType);
 
-    const submitButton = await findByText('Receive a code via SMS');
+    const submitButton = await findByText('Receive a code via voice call');
     const phoneNumberEle = await findByTestId('authenticator.phoneNumber') as HTMLInputElement;
     const extensionEle = await findByTestId('extension') as HTMLInputElement;
 


### PR DESCRIPTION
## Description:

This PR fixes the phone authenticator so that the text descriptions/instructions reflect the chosen method.  This PR also fixes the issue of the phone authenticator showing a radio button with one option.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-532426](https://oktainc.atlassian.net/browse/OKTA-532426)
- [OKTA-516592](https://oktainc.atlassian.net/browse/OKTA-516592)

### Reviewers:

### Screenshot/Video:
<img width="517" alt="Screen Shot 2022-09-14 at 6 44 42 PM" src="https://user-images.githubusercontent.com/107433508/190298457-d5dcdb45-14fa-4bc0-8b8d-4d1d28a53073.png">
<img width="524" alt="Screen Shot 2022-09-14 at 6 44 51 PM" src="https://user-images.githubusercontent.com/107433508/190298828-c3e0dc47-79d2-472b-a997-b40ffcbd6c77.png">
<img width="467" alt="Screen Shot 2022-09-12 at 9 31 10 PM" src="https://user-images.githubusercontent.com/107433508/190436854-e196be32-5628-4993-9640-115aac54a06f.png">

### Downstream Monolith Build:



