### PR TITLE
OKTA-521312 : Implementing logic to disable autocomplete for security question

### DIFF
--- a/src/v3/src/transformer/field/attributes.ts
+++ b/src/v3/src/transformer/field/attributes.ts
@@ -28,6 +28,8 @@ const autocompleteValueMap = new Map<string, AutoCompleteValue>([
   ['firstName', 'given-name'],
   ['lastName', 'family-name'],
   ['email', 'email'],
+  ['question', 'off'],
+  ['answer', 'off'],
 ]);
 
 const getKeyFromMap = (

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -48,7 +48,8 @@ export type AutoCompleteValue = 'username'
 | 'tel-national'
 | 'given-name'
 | 'family-name'
-| 'email';
+| 'email'
+| 'off';
 
 export type InputAttributes = {
   autocomplete?: AutoCompleteValue;

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -270,6 +270,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                         <input
                           aria-describedby="credentials.question-error"
                           aria-invalid="true"
+                          autocomplete="off"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-41"
                           data-se="credentials.question"
                           id="credentials.question"
@@ -653,6 +654,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       >
                         <input
                           aria-invalid="false"
+                          autocomplete="off"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-36"
                           data-se="credentials.question"
                           id="credentials.question"
@@ -1057,6 +1059,7 @@ exports[`authenticator-enroll-security-question custom question should show fiel
                       >
                         <input
                           aria-invalid="false"
+                          autocomplete="off"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-41"
                           data-se="credentials.question"
                           id="credentials.question"
@@ -1592,6 +1595,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                         >
                           <input
                             aria-invalid="false"
+                            autocomplete="off"
                             class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
                             data-se="credentials.answer"
                             id="credentials.answer"
@@ -2105,6 +2109,7 @@ exports[`authenticator-enroll-security-question predefined question should send 
                           <input
                             aria-describedby="credentials.answer-error"
                             aria-invalid="true"
+                            autocomplete="off"
                             class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
                             data-se="credentials.answer"
                             id="credentials.answer"
@@ -2597,6 +2602,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
                           <input
                             aria-describedby="credentials.answer-error"
                             aria-invalid="true"
+                            autocomplete="off"
                             class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
                             data-se="credentials.answer"
                             id="credentials.answer"
@@ -3118,6 +3124,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
                           <input
                             aria-describedby="credentials.answer-error"
                             aria-invalid="true"
+                            autocomplete="off"
                             class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
                             data-se="credentials.answer"
                             id="credentials.answer"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                       >
                         <input
                           aria-invalid="false"
+                          autocomplete="off"
                           class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-19"
                           data-se="credentials.answer"
                           id="credentials.answer"


### PR DESCRIPTION
## Description:
The purpose of this PR is to disable the browser's autocomplete feature from suggesting passwords on security question (custom question) nor answer field(s). 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521312](https://oktainc.atlassian.net/browse/OKTA-521312)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



