### PR TITLE
Disabled countdown so that only 1 request to /idp/idx/challenge/poll is sent

### DIFF
--- a/src/v1/controllers/PollController.js
+++ b/src/v1/controllers/PollController.js
@@ -60,10 +60,11 @@ export default FormController.extend({
           }
           this.$('.okta-waiting-spinner').hide();
           let factorPollingIntervalSeconds = Math.ceil(resp.transaction.profile.refresh / 1000);
-          this._startCountDown(factorPollingIntervalSeconds);
+          // this._startCountDown(factorPollingIntervalSeconds);
         })
         .catch(() => {
           this._stopCountDown();
+          // TODO: if TimeoutException, then call poll() again
         });
     },
 
@@ -111,7 +112,8 @@ export default FormController.extend({
       this.transactionObject = options.appState.get('transaction');
       this.factorPollingIntervalSeconds = Math.ceil(this.transactionObject.transaction.profile.refresh / 1000);
       this._updateTitle(this.factorPollingIntervalSeconds);
-      this._startCountDown(this.factorPollingIntervalSeconds);
+      // this._startCountDown(this.factorPollingIntervalSeconds);
+      this._checkStatus();
     },
   },
 


### PR DESCRIPTION
## Description:
As part of hackathon project (https://devpost.team/okta/projects/655), the countDown is disabled so that SIW hits the /idp/idx/challenge/poll endpoint only once for redirect flow.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



