### PR TITLE
Auto-select first radio button in OV enrollment options

### DIFF
--- a/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
@@ -16,6 +16,8 @@ const Body = BaseForm.extend({
     channelField.options = _.filter(channelField?.options, (option) =>
       option.value !== this.options.appState.get('currentAuthenticator')?.contextualData?.selectedChannel);
     channelField.value = channelField.options[0]?.value;
+    channelField.sublabel = null;
+    this.model.set('authenticator.channel', channelField.value);
     const description = {
       View: loc('oie.enroll.okta_verify.select.channel.description', 'login'),
       selector: '.o-form-fieldset-container',

--- a/test/unit/spec/v2/view-builder/views/SelectEnrollmentChannelOktaVerifyView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/SelectEnrollmentChannelOktaVerifyView_spec.js
@@ -1,0 +1,78 @@
+import SelectEnrollmentChannelOktaVerifyView from 'v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView';
+import { Model } from 'okta';
+import { BaseForm } from 'v2/view-builder/internals';
+import AppState from 'v2/models/AppState';
+import Settings from 'models/Settings';
+
+describe('v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView', function() {
+  const QRCODE = 'qrcode';
+  const EMAIL = 'email';
+  const TEXT = 'sms';
+  let testContext;
+  let schema;
+
+  beforeEach(function() {
+    testContext = {};
+    testContext.init = (channel) => {
+      const appState = new AppState({
+        currentAuthenticator: {
+          contextualData: {
+            selectedChannel: channel
+          }
+        },
+        idx: {
+          neededToProceed: []
+        }
+      }, {});
+      const settings = new Settings({
+        baseUrl: 'http://localhost:3000',
+      });
+      testContext.view = new SelectEnrollmentChannelOktaVerifyView({
+        appState,
+        settings,
+        currentViewState: {},
+        model: new Model({
+          'authenticator.channel': channel
+        }),
+      });
+      testContext.view.render();
+    };
+    schema = [
+      {
+        name: 'authenticator.channel',
+        options: [
+          { label: 'Scan a QR code', value: QRCODE },
+          { label: 'Email me a setup link', value: EMAIL },
+          { label: 'Text me a setup link', value: TEXT }
+        ],
+        value: QRCODE,
+        type: 'radio'
+      }
+    ];
+  });
+  afterEach(function() {
+    jest.resetAllMocks();
+  });
+
+  it('If previous channel is qrcode, then selected channel should be email', function() {
+    jest.spyOn(BaseForm.prototype.getUISchema, 'apply').mockReturnValue(schema);
+    testContext.init(QRCODE);
+
+    expect(testContext.view.model.get('authenticator.channel')).toEqual(EMAIL);
+  });
+
+  it('If previous channel is email, then selected channel should be qrcode', function() {
+    jest.spyOn(BaseForm.prototype.getUISchema, 'apply').mockReturnValue(schema);
+    testContext.init(EMAIL);
+
+    expect(testContext.view.model.get('authenticator.channel')).toEqual(QRCODE);
+  });
+
+  it('If previous channel is sms, then selected channel should be qrcode', function() {
+    jest.spyOn(BaseForm.prototype.getUISchema, 'apply').mockReturnValue(schema);
+    testContext.init(TEXT);
+
+    expect(testContext.view.model.get('authenticator.channel')).toEqual(QRCODE);
+  });
+
+});


### PR DESCRIPTION
## Description:

- Auto-select first radio button in OV enrollment options
- Remove 'Optional' text
- [New PR](https://github.com/okta/okta-signin-widget/pull/2843) was created for this task, due to branch issues when merging. Needed to merge into 6.8 instead of master, but this PR was rebased off of master, so the commit history didn't line up properly. The new PR was rebased off of 6.8.
## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-491322](https://oktainc.atlassian.net/browse/OKTA-491322)

### Reviewers:
@okta/device-platform 

### Screenshot/Video:

https://user-images.githubusercontent.com/86258428/190716802-9632b946-8ccd-426b-b7df-59aeb335a113.mov

### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-4f4925d-633517e4&page=1&pageSize=6&tab=main

