### PR TITLE
OKTA-530556 : Password validation against username implementation

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -286,7 +286,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     >
       {/* Note that we need two theme providers until we fully migrate to odyssey-mui */}
       <MuiThemeProvider theme={mapMuiThemeFromBrand(brandColors)}>
-        <ScopedCssBaseline>
+        {/* the style is to allow the widget to inherit the parent's bg color */}
+        <ScopedCssBaseline sx={{ backgroundColor: 'inherit' }}>
           <ThemeProvider theme={mapThemeFromBrand(brandColors)}>
             <AuthContainer>
               <AuthHeader

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -286,8 +286,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     >
       {/* Note that we need two theme providers until we fully migrate to odyssey-mui */}
       <MuiThemeProvider theme={mapMuiThemeFromBrand(brandColors)}>
-        {/* the style is to allow the widget to inherit the parent's bg color */}
-        <ScopedCssBaseline sx={{ backgroundColor: 'inherit' }}>
+        <ScopedCssBaseline>
           <ThemeProvider theme={mapThemeFromBrand(brandColors)}>
             <AuthContainer>
               <AuthHeader

--- a/src/v3/src/util/passwordUtils.test.ts
+++ b/src/v3/src/util/passwordUtils.test.ts
@@ -205,9 +205,9 @@ describe('PasswordUtils Tests', () => {
     userInfo = { identifier: 'tester.user+123@okta.com' };
 
     expect(validatePassword('tester.user', userInfo, { complexity: { excludeUsername: true } })?.excludeUsername)
-      .toEqual(true);
+      .toEqual(false);
     expect(validatePassword('tester.user@okta.com', userInfo, { complexity: { excludeUsername: true } })?.excludeUsername)
-      .toEqual(true);
+      .toEqual(false);
     expect(validatePassword('tester.user+123@okta.com', userInfo, { complexity: { excludeUsername: true } })?.excludeUsername)
       .toEqual(false);
     expect(validatePassword('tester.user', userInfo, { complexity: { excludeUsername: false } })?.excludeUsername)
@@ -216,6 +216,13 @@ describe('PasswordUtils Tests', () => {
       .toEqual(true);
     expect(validatePassword('tester.user+123@okta.com', userInfo, { complexity: { excludeUsername: false } })?.excludeUsername)
       .toEqual(true);
+
+    userInfo = { identifier: 'testeruser@okta.com' };
+
+    expect(validatePassword('testeruser', userInfo, { complexity: { excludeUsername: true } })?.excludeUsername)
+      .toEqual(false);
+    expect(validatePassword('okta', userInfo, { complexity: { excludeUsername: true } })?.excludeUsername)
+      .toEqual(false);
   });
 
   it('should validate excludeFirstName', () => {

--- a/src/v3/src/util/passwordUtils.ts
+++ b/src/v3/src/util/passwordUtils.ts
@@ -97,6 +97,10 @@ const excludeAttributeValidator = (
   return true;
 };
 
+/**
+ * This mimics backend logic for validating if password contains username
+ * @see {@link https://github.com/okta/okta-core/blob/master/components/platform/policy/impl/src/main/java/com/saasure/core/services/auth/password/impl/PasswordPolicyVerificationHelperImpl.java#L241-L250}
+ */
 const excludeUsernameValidator = (
   password: string,
   ruleVal: unknown,
@@ -106,7 +110,6 @@ const excludeUsernameValidator = (
     return true;
   }
   const usernameParts = getParts(userInfo.identifier);
-  // This mimics backend logic see: okta-core - PasswordPolicyVerificationHelperImpl.java#L241-L250
   // if any parts of username is included in password return false (meaning invalid)
   return usernameParts.every(
     (part) => excludeAttributeValidator(password, ruleVal as boolean, part),

--- a/src/v3/src/util/passwordUtils.ts
+++ b/src/v3/src/util/passwordUtils.ts
@@ -55,15 +55,15 @@ const minSymbolValidator = (password: string, limit: unknown): boolean => (
 
 const escapeRegExp = (input: string): string => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-/*
-* Copied from backend logic
-* See: okta-core - PasswordUtil.java#L72-L97
+/**
+* Breaks apart a string based on a set of delimiters for (Copied from okta-core password validation logic)
+* @see {@link https://github.com/okta/okta-core/blob/master/components/framework/security/api/src/main/java/com/saasure/framework/security/password/PasswordUtil.java#L72-L97}
 */
 const getParts = (attributeVal: string): string[] => {
   const MIN_PARTS_LENGTH = 4;
   const parts: string[] = [];
   const delimiters = new Set<string>([',', '.', '-', '_', '#', '@']);
-  const characters = attributeVal.split('');
+  const characters = Array.from(attributeVal);
   let combinedStringArr: string[] = [];
 
   characters.forEach((character) => {

--- a/src/v3/src/util/passwordUtils.ts
+++ b/src/v3/src/util/passwordUtils.ts
@@ -55,6 +55,37 @@ const minSymbolValidator = (password: string, limit: unknown): boolean => (
 
 const escapeRegExp = (input: string): string => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+/*
+* Copied from backend logic
+* See: okta-core - PasswordUtil.java#L72-L97
+*/
+const getParts = (attributeVal: string): string[] => {
+  const MIN_PARTS_LENGTH = 4;
+  const parts: string[] = [];
+  const delimiters = new Set<string>([',', '.', '-', '_', '#', '@']);
+  const characters = attributeVal.split('');
+  let combinedStringArr: string[] = [];
+
+  characters.forEach((character) => {
+    if (delimiters.has(character)) {
+      // Parts must be at least MinPartsLength long
+      if (combinedStringArr.length >= MIN_PARTS_LENGTH) {
+        parts.push(combinedStringArr.join(''));
+      }
+      // Start a new part
+      combinedStringArr = [];
+    } else {
+      combinedStringArr.push(character);
+    }
+  });
+
+  if (combinedStringArr.length >= MIN_PARTS_LENGTH) {
+    parts.push(combinedStringArr.join(''));
+  }
+
+  return parts;
+};
+
 const excludeAttributeValidator = (
   password: string,
   ruleEnabled: boolean,
@@ -70,11 +101,17 @@ const excludeUsernameValidator = (
   password: string,
   ruleVal: unknown,
   userInfo: UserInfo,
-): boolean => (
-  !userInfo.identifier
-    ? true
-    : excludeAttributeValidator(password, ruleVal as boolean, userInfo.identifier)
-);
+): boolean => {
+  if (!userInfo.identifier) {
+    return true;
+  }
+  const usernameParts = getParts(userInfo.identifier);
+  // This mimics backend logic see: okta-core - PasswordPolicyVerificationHelperImpl.java#L241-L250
+  // if any parts of username is included in password return false (meaning invalid)
+  return usernameParts.every(
+    (part) => excludeAttributeValidator(password, ruleVal as boolean, part),
+  );
+};
 
 const excludeFirstNameValidator = (
   password: string,


### PR DESCRIPTION
## Description:
Purpose of this is to validate the new password against parts of the username.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-530556](https://oktainc.atlassian.net/browse/OKTA-530556)

### Reviewers:

### Screenshot/Video:
Full username:
<img width="469" alt="image" src="https://user-images.githubusercontent.com/97472729/190832306-191c5271-caa7-44ac-bdc1-00f39bea5355.png">

Partial:
<img width="457" alt="image" src="https://user-images.githubusercontent.com/97472729/190832329-02330fe4-a4b2-4d62-9ef5-852e8e8b5e49.png">

<img width="452" alt="image" src="https://user-images.githubusercontent.com/97472729/190832366-4085d248-0455-4693-9162-3bc87b4d3bbe.png">

### Downstream Monolith Build:



