### PR TITLE
OKTA-521313 : Trim whitespace from numeric type fields

### DIFF
--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -66,7 +66,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       return null;
     };
 
-    const { fieldsToExclude } = dataSchemaRef.current!;
+    const { fieldsToExclude, fieldsToTrim } = dataSchemaRef.current!;
 
     const immutableData = getImmutableData(currTransaction!, step);
 
@@ -74,6 +74,13 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
 
     let payload: IdxActionParams = {};
     if (includeData) {
+      Object.keys(data)
+        .filter((key) => fieldsToTrim.includes(key))
+        .forEach((key) => {
+          if (typeof data[key] === 'string') {
+            data[key] = (data[key] as string).trim();
+          }
+        });
       payload = merge(payload, omit(data, fieldsToExclude(data)));
     }
     if (params) {

--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -101,6 +101,10 @@ export const transformStepInputs = (
           },
         };
         acc.dataSchema.fieldsToValidate.push(name);
+        // Of the required fields, trim appropriately
+        if (uischema.options.attributes?.inputmode === 'numeric') {
+          acc.dataSchema.fieldsToTrim.push(name);
+        }
       }
 
       return acc;

--- a/src/v3/src/transformer/main.ts
+++ b/src/v3/src/transformer/main.ts
@@ -59,6 +59,7 @@ export const transformIdxTransaction = (options: TransformationOptions): FormBag
     },
     data: {},
     dataSchema: {
+      fieldsToTrim: [],
       fieldsToValidate: [],
       fieldsToExclude: () => ([]),
     },

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -34,6 +34,7 @@ export type FormBag = {
   // temp schema bag to handle client validation and form submission
   dataSchema: GeneralDataSchemaBag & {
     submit: ActionOptions;
+    fieldsToTrim: string[];
     fieldsToValidate: string[];
     fieldsToExclude: (data: FormBag['data']) => string[];
   }

--- a/src/v3/test/integration/authenticator-enroll-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-google-authenticator.test.tsx
@@ -66,7 +66,7 @@ describe('authenticator-enroll-google-authenticator', () => {
     );
   });
 
-  it('should send correct payload when otp is padded with spaces', async () => {
+  it('should send correct payload when otp is padded with white spaces', async () => {
     const {
       authClient, user, findByText, findByTestId,
     } = await setup({ mockResponse });
@@ -79,6 +79,54 @@ describe('authenticator-enroll-google-authenticator', () => {
     const otpWithSpaces = `${otp}  `;
     await user.type(codeEl, otpWithSpaces);
     expect(codeEl.value).toEqual(otpWithSpaces);
+
+    const submitButton = await findByText('Verify', { selector: 'button' });
+    await user.click(submitButton);
+
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
+        credentials: { passcode: otp },
+      }),
+    );
+  });
+
+  it('should send correct payload when otp is padded with tab spaces', async () => {
+    const {
+      authClient, user, findByText, findByTestId,
+    } = await setup({ mockResponse });
+    const nextButton = await findByText(/Next/);
+    await user.click(nextButton);
+    await findByText(/Enter code displayed from application/);
+
+    const codeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const otp = '123456';
+    const otpWithTabSpaces = `\t${otp}\t\t`;
+    await user.type(codeEl, otpWithTabSpaces);
+    expect(codeEl.value).toEqual(otpWithTabSpaces);
+
+    const submitButton = await findByText('Verify', { selector: 'button' });
+    await user.click(submitButton);
+
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
+        credentials: { passcode: otp },
+      }),
+    );
+  });
+
+  it('should send correct payload when otp is padded with return characters', async () => {
+    const {
+      authClient, user, findByText, findByTestId,
+    } = await setup({ mockResponse });
+    const nextButton = await findByText(/Next/);
+    await user.click(nextButton);
+    await findByText(/Enter code displayed from application/);
+
+    const codeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const otp = '123456';
+    const otpWithReturnSpaces = `\r${otp}\r`;
+    await user.type(codeEl, otpWithReturnSpaces);
+    expect(codeEl.value).toEqual(otp);
 
     const submitButton = await findByText('Verify', { selector: 'button' });
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-enroll-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-google-authenticator.test.tsx
@@ -65,4 +65,28 @@ describe('authenticator-enroll-google-authenticator', () => {
       }),
     );
   });
+
+  it('should send correct payload when otp is padded with spaces', async () => {
+    const {
+      authClient, user, findByText, findByTestId,
+    } = await setup({ mockResponse });
+    const nextButton = await findByText(/Next/);
+    await user.click(nextButton);
+    await findByText(/Enter code displayed from application/);
+
+    const codeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const otp = '123456';
+    const otpWithSpaces = '123456  ';
+    await user.type(codeEl, otpWithSpaces);
+    expect(codeEl.value).toEqual(otpWithSpaces);
+
+    const submitButton = await findByText('Verify', { selector: 'button' });
+    await user.click(submitButton);
+
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
+        credentials: { passcode: otp },
+      }),
+    );
+  });
 });

--- a/src/v3/test/integration/authenticator-enroll-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-google-authenticator.test.tsx
@@ -76,7 +76,7 @@ describe('authenticator-enroll-google-authenticator', () => {
 
     const codeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
     const otp = '123456';
-    const otpWithSpaces = '123456  ';
+    const otpWithSpaces = `${otp}  `;
     await user.type(codeEl, otpWithSpaces);
     expect(codeEl.value).toEqual(otpWithSpaces);
 

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -238,6 +238,40 @@ describe('authenticator-verification-email', () => {
     );
   });
 
+  it('should send correct payload when otp is padded with spaces', async () => {
+    const {
+      authClient,
+      user,
+      findByText,
+      findByTestId,
+    } = await setup({
+      mockResponse: authenticatorVerificationEmail,
+    });
+
+    await findByText(/Verify with your email/);
+    await findByText(/We sent an email to/);
+
+    const nextPageBtn = await findByText(/Enter a code from the email instead/);
+
+    await user.click(nextPageBtn);
+    await findByText(/Enter Code/);
+
+    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const submitButton = await findByText('Verify', { selector: 'button' });
+
+    const verificationCode = '123456';
+    const verificationCodewithSpaces = '  123456';
+    await user.type(codeEle, verificationCodewithSpaces);
+    expect(codeEle.value).toEqual(verificationCodewithSpaces);
+    await user.click(submitButton);
+
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
+        credentials: { passcode: verificationCode },
+      }),
+    );
+  });
+
   it('should have autocomplete attribute on otp input element when in ios browser', async () => {
     const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
     navigatorCredentials.mockReturnValue(

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -238,7 +238,7 @@ describe('authenticator-verification-email', () => {
     );
   });
 
-  it('should send correct payload when otp is padded with spaces', async () => {
+  it('should send correct payload when otp is padded with new line breaks', async () => {
     const {
       authClient,
       user,
@@ -260,9 +260,9 @@ describe('authenticator-verification-email', () => {
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const otp = '123456';
-    const verificationCodewithSpaces = `  ${otp}`;
-    await user.type(codeEle, verificationCodewithSpaces);
-    expect(codeEle.value).toEqual(verificationCodewithSpaces);
+    const otpWithNewLineBreak = `\n${otp}\n\n\n`;
+    await user.type(codeEle, otpWithNewLineBreak);
+    expect(codeEle.value).toBe(otp);
     await user.click(submitButton);
 
     expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -259,15 +259,15 @@ describe('authenticator-verification-email', () => {
     const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
-    const verificationCode = '123456';
-    const verificationCodewithSpaces = '  123456';
+    const otp = '123456';
+    const verificationCodewithSpaces = `  ${otp}`;
     await user.type(codeEle, verificationCodewithSpaces);
     expect(codeEle.value).toEqual(verificationCodewithSpaces);
     await user.click(submitButton);
 
     expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
       ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
-        credentials: { passcode: verificationCode },
+        credentials: { passcode: otp },
       }),
     );
   });

--- a/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
@@ -59,14 +59,14 @@ describe('authenticator-verification-google-authenticator', () => {
     const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
-    const verificationCode = '123456';
-    const verificationCodeWithSpaces = '  123456 ';
+    const otp = '123456';
+    const verificationCodeWithSpaces = `  ${otp} `;
     await user.type(codeEle, verificationCodeWithSpaces);
     expect(codeEle.value).toEqual(verificationCodeWithSpaces);
     await user.click(submitButton);
     expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
       ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
-        credentials: { passcode: verificationCode },
+        credentials: { passcode: otp },
       }),
     );
   });

--- a/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
@@ -44,4 +44,30 @@ describe('authenticator-verification-google-authenticator', () => {
       }),
     );
   });
+
+  it('should send correct payload when otp is padded with spaces', async () => {
+    const {
+      authClient,
+      user,
+      findByText,
+      findByTestId,
+    } = await setup({ mockResponse });
+
+    await findByText(/Verify with Google Authenticator/);
+    await findByText(/Enter the temporary code generated in your Google Authenticator app/);
+
+    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const submitButton = await findByText('Verify', { selector: 'button' });
+
+    const verificationCode = '123456';
+    const verificationCodeWithSpaces = '  123456 ';
+    await user.type(codeEle, verificationCodeWithSpaces);
+    expect(codeEle.value).toEqual(verificationCodeWithSpaces);
+    await user.click(submitButton);
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
+        credentials: { passcode: verificationCode },
+      }),
+    );
+  });
 });

--- a/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
@@ -44,6 +44,30 @@ describe('authenticator-verification-okta-verify-totp', () => {
     );
   });
 
+  it('should send correct payload when totp is padded with spaces', async () => {
+    const {
+      authClient, user, findByTestId, findByText,
+    } = await setup({ mockResponse });
+
+    await findByText(/Enter a code/);
+
+    const submitButton = await findByText('Verify', { selector: 'button' });
+    const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;
+
+    const totp = '123456';
+    const totpWithSpaces = '   123456   ';
+    await user.type(otpEle, totpWithSpaces);
+
+    expect(otpEle.value).toEqual(totpWithSpaces);
+
+    await user.click(submitButton);
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
+        credentials: { totp },
+      }),
+    );
+  });
+
   it('should have autocomplete attribute on totp input element when in ios browser', async () => {
     const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
     navigatorCredentials.mockReturnValue(

--- a/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
@@ -44,7 +44,7 @@ describe('authenticator-verification-okta-verify-totp', () => {
     );
   });
 
-  it('should send correct payload when totp is padded with spaces', async () => {
+  it('should send correct payload when totp is padded with non-breaking spaces', async () => {
     const {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
@@ -55,10 +55,10 @@ describe('authenticator-verification-okta-verify-totp', () => {
     const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;
 
     const totp = '123456';
-    const totpWithSpaces = `   ${totp}   `;
-    await user.type(otpEle, totpWithSpaces);
+    const totpWithNonBreakingSpaces = `\u00A0${totp}\u00A0`;
+    await user.type(otpEle, totpWithNonBreakingSpaces);
 
-    expect(otpEle.value).toEqual(totpWithSpaces);
+    expect(otpEle.value).toEqual(totpWithNonBreakingSpaces);
 
     await user.click(submitButton);
     expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(

--- a/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
@@ -55,7 +55,7 @@ describe('authenticator-verification-okta-verify-totp', () => {
     const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;
 
     const totp = '123456';
-    const totpWithSpaces = '   123456   ';
+    const totpWithSpaces = `   ${totp}   `;
     await user.type(otpEle, totpWithSpaces);
 
     expect(otpEle.value).toEqual(totpWithSpaces);

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -250,6 +250,32 @@ describe('identify-with-password', () => {
       );
     });
 
+    it('should not remove padded spaces from password', async () => {
+      const {
+        authClient, user, findByTestId, findByText,
+      } = await setup({ mockResponse });
+
+      const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+      const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+      const submitButton = await findByText('Sign in', { selector: 'button' });
+
+      const password = '   fake-password   ';
+      await user.type(usernameEl, 'testuser@okta.com');
+      expect(usernameEl.value).toEqual('testuser@okta.com');
+      await user.type(passwordEl, password);
+      expect(passwordEl.value).toEqual(password);
+      await user.click(submitButton);
+
+      expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+        ...createAuthJsPayloadArgs('POST', 'idp/idx/identify', {
+          identifier: 'testuser@okta.com',
+          credentials: {
+            passcode: password,
+          },
+        }),
+      );
+    });
+
     it('with required fields + optional fields', async () => {
       const {
         authClient, user, findByTestId, findByText,


### PR DESCRIPTION
## Description:

The purpose of this PR is to trim any whitespace from numeric fields (specifically, OTP code fields).

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521313](https://oktainc.atlassian.net/browse/OKTA-521313)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



