### PR TITLE
OKTA-525951 : Adjusting message spacing for focus offset and border

### DIFF
--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -111,6 +111,12 @@ const ReminderPrompt: UISchemaElementComponent<{
       <Alert
         severity="warning"
         variant="infobox"
+        sx={{
+          '& .MuiAlert-message': {
+            paddingLeft: '3px',
+            paddingBottom: '1px',
+          },
+        }}
       >
         {renderAlertContent()}
         {renderActionLink()}

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -112,9 +112,9 @@ const ReminderPrompt: UISchemaElementComponent<{
         severity="warning"
         variant="infobox"
         sx={{
+          // Allows the focus outline to not be cut off
           '& .MuiAlert-message': {
-            paddingLeft: '3px',
-            paddingBottom: '1px',
+            overflow: 'visible',
           },
         }}
       >


### PR DESCRIPTION
## Description:
Purpose of this PR is to adjust the space between the message and the container to account for focus border width and offset.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:
**Before:** 
<img width="512" alt="image" src="https://user-images.githubusercontent.com/97472729/191289586-e62b9f41-f474-4ebf-96fe-1b683749897c.png">

**After:**
<img width="505" alt="image" src="https://user-images.githubusercontent.com/97472729/191289195-d49a4837-7945-46f0-b4bc-34f1ba83c45b.png">


### Downstream Monolith Build:



