### PR TITLE
OKTA-531320 : Adding hidden input field for username to assist password managers

### DIFF
--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -18,6 +18,7 @@ import Button from '../Button';
 import Checkbox from '../Checkbox';
 import Divider from '../Divider';
 import Heading from '../Heading';
+import HiddenInput from '../HiddenInput';
 import ImageWithText from '../ImageWithText';
 import InfoBox from '../InfoBox';
 import InformationalText from '../InformationalText';
@@ -96,6 +97,10 @@ export default [
   {
     tester: ({ type }) => type === 'WebAuthNSubmitButton',
     renderer: WebAuthNSubmitButton,
+  },
+  {
+    tester: ({ type }) => type === 'HiddenInput',
+    renderer: HiddenInput,
   },
   {
     tester: (uischema: FieldElement) => {

--- a/src/v3/src/components/HiddenInput/HiddenInput.tsx
+++ b/src/v3/src/components/HiddenInput/HiddenInput.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { h } from 'preact';
+
+import {
+  HiddenInputElement,
+  UISchemaElementComponent,
+} from '../../types';
+
+const InputText: UISchemaElementComponent<{ uischema: HiddenInputElement }> = ({
+  uischema,
+}) => {
+  const { name, value } = uischema.options;
+
+  return (
+    <input
+      type="text"
+      // Can't use hidden types otherwise browser plugins (i.e. Password Managers) will ignore
+      style={{ display: 'none' }}
+      id={name}
+      name={name}
+      value={value}
+    />
+  );
+};
+
+export default InputText;

--- a/src/v3/src/components/HiddenInput/index.tsx
+++ b/src/v3/src/components/HiddenInput/index.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import HiddenInput from './HiddenInput';
+
+export default HiddenInput;

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -112,7 +112,7 @@ const ReminderPrompt: UISchemaElementComponent<{
         severity="warning"
         variant="infobox"
         sx={{
-          // Allows the focus outline to not be cut off
+          // TODO: OKTA-534606 - switch to ODS component which has this fix
           '& .MuiAlert-message': {
             overflow: 'visible',
           },

--- a/src/v3/src/mocks/scenario/identify-with-username.ts
+++ b/src/v3/src/mocks/scenario/identify-with-username.ts
@@ -36,7 +36,30 @@ scenario('identify-with-username', (rest) => ([
     );
   }),
   rest.post('*/idp/idx/identify', async (req, res, ctx) => {
-    const { default: body } = await import('../response/idp/idx/introspect/identify-with-username.json');
+    const { default: body } = await import('../response/idp/idx/identify/authenticator-verification-password.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  rest.post('*/idp/idx/challenge/answer', async (req, res, ctx) => {
+    const { default: body } = await import('../response/idp/idx/challenge/answer/default.json');
+    return res.once(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // get oauth2 token
+  rest.post('*/oauth2/default/v1/token', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/v1/token/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // get oauth2 keys
+  rest.get('*/oauth2/default/v1/keys', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/v1/keys/default.json');
     return res(
       ctx.status(200),
       ctx.json(body),

--- a/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
+++ b/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
@@ -14,6 +14,7 @@ import { PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS } from '../../constants';
 import {
   FieldElement,
   FormBag,
+  HiddenInputElement,
   IdxMessageWithName,
   IdxStepTransformer,
   PasswordRequirementsElement,
@@ -119,12 +120,18 @@ export const transformEnrollPasswordAuthenticator: IdxStepTransformer = ({
     },
   };
 
+  const userInfo = getUserInfo(transaction);
   uischema.elements = [
     titleElement,
     ...(Object.keys(passwordSettings)?.length > 0
       ? [passwordRequirementsElement]
       : []
     ),
+    {
+      type: 'HiddenInput',
+      noMargin: true,
+      options: { name: 'username', value: userInfo.identifier },
+    } as HiddenInputElement,
     passwordElement,
     confirmPasswordElement,
   ];

--- a/src/v3/src/transformer/password/transformPasswordChallenge.ts
+++ b/src/v3/src/transformer/password/transformPasswordChallenge.ts
@@ -13,10 +13,11 @@
 import {
   ButtonElement,
   ButtonType,
+  HiddenInputElement,
   IdxStepTransformer,
   TitleElement,
 } from '../../types';
-import { loc } from '../../util';
+import { getUserInfo, loc } from '../../util';
 
 export const transformPasswordChallenge: IdxStepTransformer = ({ formBag, transaction }) => {
   const { uischema } = formBag;
@@ -35,6 +36,12 @@ export const transformPasswordChallenge: IdxStepTransformer = ({ formBag, transa
     },
   };
 
+  const userInfo = getUserInfo(transaction);
+  uischema.elements.unshift({
+    type: 'HiddenInput',
+    noMargin: true,
+    options: { name: 'username', value: userInfo.identifier },
+  } as HiddenInputElement);
   uischema.elements.unshift(titleElement);
   uischema.elements.push(submitBtnElement);
 

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -386,6 +386,11 @@ export interface RedirectElement extends UISchemaElement {
   options: { url: string; },
 }
 
+export interface HiddenInputElement extends UISchemaElement {
+  type: 'HiddenInput';
+  options: { name: string; value: string | number };
+}
+
 type ValidateFunction = (data: FormBag['data']) => IdxMessageWithName[] | undefined;
 
 export interface DataSchema {

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -388,7 +388,7 @@ export interface RedirectElement extends UISchemaElement {
 
 export interface HiddenInputElement extends UISchemaElement {
   type: 'HiddenInput';
-  options: { name: string; value: string | number };
+  options: { name: string; value: string; };
 }
 
 type ValidateFunction = (data: FormBag['data']) => IdxMessageWithName[] | undefined;

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -117,6 +117,16 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   </div>
                 </div>
                 <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <input
+                    id="username"
+                    name="username"
+                    style="display: none;"
+                    type="text"
+                  />
+                </div>
+                <div
                   class="MuiBox-root emotion-11"
                 >
                   <div
@@ -126,36 +136,36 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-18"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-19"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-19"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-20"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-20"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-21"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-21"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-22"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-22"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-23"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -168,10 +178,10 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-23"
+                          class="MuiOutlinedInput-notchedOutline emotion-24"
                         >
                           <legend
-                            class="emotion-24"
+                            class="emotion-25"
                           >
                             <span
                               class="notranslate"
@@ -194,36 +204,36 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-18"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-19"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-19"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-20"
                           data-se="confirmPassword"
                           id="confirmPassword"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-20"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-21"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-21"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-22"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-22"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-23"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -236,10 +246,10 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-23"
+                          class="MuiOutlinedInput-notchedOutline emotion-24"
                         >
                           <legend
-                            class="emotion-24"
+                            class="emotion-25"
                           >
                             <span
                               class="notranslate"
@@ -256,7 +266,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-37"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-38"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -268,7 +278,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -325,6 +325,16 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   </div>
                 </div>
                 <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <input
+                    id="generated"
+                    name="username"
+                    style="display: none;"
+                    type="text"
+                  />
+                </div>
+                <div
                   class="MuiBox-root emotion-11"
                 >
                   <div
@@ -334,36 +344,36 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-36"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-39"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-40"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -376,10 +386,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                          class="MuiOutlinedInput-notchedOutline emotion-42"
                         >
                           <legend
-                            class="emotion-42"
+                            class="emotion-43"
                           >
                             <span
                               class="notranslate"
@@ -402,36 +412,36 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-36"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-39"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-40"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -444,10 +454,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                          class="MuiOutlinedInput-notchedOutline emotion-42"
                         >
                           <legend
-                            class="emotion-42"
+                            class="emotion-43"
                           >
                             <span
                               class="notranslate"
@@ -464,7 +474,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-55"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-56"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -476,7 +486,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -487,7 +497,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -325,6 +325,16 @@ exports[`authenticator-expired-password should render form 1`] = `
                   </div>
                 </div>
                 <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <input
+                    id="generated"
+                    name="username"
+                    style="display: none;"
+                    type="text"
+                  />
+                </div>
+                <div
                   class="MuiBox-root emotion-11"
                 >
                   <div
@@ -334,36 +344,36 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-36"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-39"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-40"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -376,10 +386,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                          class="MuiOutlinedInput-notchedOutline emotion-42"
                         >
                           <legend
-                            class="emotion-42"
+                            class="emotion-43"
                           >
                             <span
                               class="notranslate"
@@ -402,36 +412,36 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-36"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-39"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-40"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -444,10 +454,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                          class="MuiOutlinedInput-notchedOutline emotion-42"
                         >
                           <legend
-                            class="emotion-42"
+                            class="emotion-43"
                           >
                             <span
                               class="notranslate"
@@ -464,7 +474,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-55"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-56"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -476,7 +486,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -450,6 +450,16 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   </div>
                 </div>
                 <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <input
+                    id="generated"
+                    name="username"
+                    style="display: none;"
+                    type="text"
+                  />
+                </div>
+                <div
                   class="MuiBox-root emotion-11"
                 >
                   <div
@@ -459,36 +469,36 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-48"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-49"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-50"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-51"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-52"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-52"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-53"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -501,10 +511,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-53"
+                          class="MuiOutlinedInput-notchedOutline emotion-54"
                         >
                           <legend
-                            class="emotion-54"
+                            class="emotion-55"
                           >
                             <span
                               class="notranslate"
@@ -527,36 +537,36 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-48"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-49"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-50"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-51"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-52"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-52"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-53"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -569,10 +579,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-53"
+                          class="MuiOutlinedInput-notchedOutline emotion-54"
                         >
                           <legend
-                            class="emotion-54"
+                            class="emotion-55"
                           >
                             <span
                               class="notranslate"
@@ -589,7 +599,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-67"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-68"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -601,7 +611,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-69"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-70"
                     tabindex="0"
                     type="button"
                   >
@@ -612,7 +622,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-71"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-72"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -325,6 +325,16 @@ exports[`authenticator-reset-password should render form 1`] = `
                   </div>
                 </div>
                 <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <input
+                    id="generated"
+                    name="username"
+                    style="display: none;"
+                    type="text"
+                  />
+                </div>
+                <div
                   class="MuiBox-root emotion-11"
                 >
                   <div
@@ -334,36 +344,36 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-36"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-39"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-40"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -376,10 +386,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                          class="MuiOutlinedInput-notchedOutline emotion-42"
                         >
                           <legend
-                            class="emotion-42"
+                            class="emotion-43"
                           >
                             <span
                               class="notranslate"
@@ -402,36 +412,36 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-36"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-39"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-40"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -444,10 +454,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                          class="MuiOutlinedInput-notchedOutline emotion-42"
                         >
                           <legend
-                            class="emotion-42"
+                            class="emotion-43"
                           >
                             <span
                               class="notranslate"
@@ -464,7 +474,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-55"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-56"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -476,7 +486,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
@@ -818,6 +828,16 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   </div>
                 </div>
                 <div
+                  class="MuiBox-root emotion-4"
+                >
+                  <input
+                    id="generated"
+                    name="username"
+                    style="display: none;"
+                    type="text"
+                  />
+                </div>
+                <div
                   class="MuiBox-root emotion-11"
                 >
                   <div
@@ -827,36 +847,36 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-36"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-39"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-40"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -869,10 +889,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                          class="MuiOutlinedInput-notchedOutline emotion-42"
                         >
                           <legend
-                            class="emotion-42"
+                            class="emotion-43"
                           >
                             <span
                               class="notranslate"
@@ -895,36 +915,36 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-36"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-39"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-40"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -937,10 +957,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                          class="MuiOutlinedInput-notchedOutline emotion-42"
                         >
                           <legend
-                            class="emotion-42"
+                            class="emotion-43"
                           >
                             <span
                               class="notranslate"
@@ -957,7 +977,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-55"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-56"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -969,7 +989,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >


### PR DESCRIPTION
## Description:
The purpose of this PR is to enable password managers to be able to read and pre-populate the username field when the SIW is in the identifier first flow.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-531320](https://oktainc.atlassian.net/browse/OKTA-531320)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



