### PR TITLE
OKTA-516607 : Widget vertical position height fix

### DIFF
--- a/src/v3/src/components/AuthContainer/AuthContainer.tsx
+++ b/src/v3/src/components/AuthContainer/AuthContainer.tsx
@@ -11,11 +11,13 @@
  */
 
 import { Box, useMediaQuery } from '@mui/material';
+import classNames from 'classnames';
 import { FunctionComponent, h } from 'preact';
 
 import style from './style.css';
 
 const AuthContainer: FunctionComponent = ({ children }) => {
+  const classes = classNames('auth-container', 'main-container', style.mainViewContainer);
   const isMobileWidth = useMediaQuery('screen and (max-width: 391px)');
   return (
     <Box
@@ -24,7 +26,7 @@ const AuthContainer: FunctionComponent = ({ children }) => {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      className={style.mainViewContainer}
+      className={classes}
       data-version={VERSION}
       data-commit={COMMITHASH}
     >

--- a/src/v3/src/components/AuthContainer/AuthContainer.tsx
+++ b/src/v3/src/components/AuthContainer/AuthContainer.tsx
@@ -11,13 +11,11 @@
  */
 
 import { Box, useMediaQuery } from '@mui/material';
-import classNames from 'classnames';
 import { FunctionComponent, h } from 'preact';
 
 import style from './style.css';
 
 const AuthContainer: FunctionComponent = ({ children }) => {
-  const classes = classNames('auth-container', 'main-container', style.mainViewContainer);
   const isMobileWidth = useMediaQuery('screen and (max-width: 391px)');
   return (
     <Box
@@ -26,7 +24,7 @@ const AuthContainer: FunctionComponent = ({ children }) => {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      className={classes}
+      className={style.mainViewContainer}
       data-version={VERSION}
       data-commit={COMMITHASH}
     >

--- a/src/v3/src/components/AuthContainer/style.css
+++ b/src/v3/src/components/AuthContainer/style.css
@@ -5,6 +5,11 @@
 
 .mainViewContainer {
   min-width: 100%;
-  /* To prevent overflow scroll */
-  min-height: 98vh; 
+  margin: 100px auto 8px;
+}
+
+@media only screen and (max-device-width: 750px) {
+  .mainViewContainer {
+    margin-top: 0;
+  }
 }

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -286,7 +286,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     >
       {/* Note that we need two theme providers until we fully migrate to odyssey-mui */}
       <MuiThemeProvider theme={mapMuiThemeFromBrand(brandColors)}>
-        <ScopedCssBaseline>
+        {/* the style is to allow the widget to inherit the parent's bg color */}
+        <ScopedCssBaseline sx={{ backgroundColor: 'inherit' }}>
           <ThemeProvider theme={mapThemeFromBrand(brandColors)}>
             <AuthContainer>
               <AuthHeader


### PR DESCRIPTION
## Description:

This PR fixes the issue of the Sign in widget appearing too low on the page.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-516607](https://oktainc.atlassian.net/browse/OKTA-516607)

### Reviewers:

### Screenshot/Video:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/107433508/191346763-c1f5d6f0-6b79-44e4-917d-8b3b35b704fa.png">

### Downstream Monolith Build:



