### PR TITLE
OKTA 534363 : Back to sign in link in dashboard fix

### DIFF
--- a/src/v3/test/integration/error-session-expired.test.tsx
+++ b/src/v3/test/integration/error-session-expired.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { waitFor } from '@testing-library/preact';
+import { queryByText, waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/error-session-expired.json';
@@ -57,5 +57,19 @@ describe('error-session-expired', () => {
     await findByText(/You have been logged out due to inactivity. Refresh or return to the sign in screen./);
     const cancelLink = await findByText(/Back to sign in/);
     await waitFor(() => expect(cancelLink).toHaveFocus());
+  });
+
+  it('should not show "Back to sign in" link when hideSignOutLinkInMFA flag is true', async () => {
+    const { findByText, container } = await setup({
+      mockResponse,
+      widgetOptions: {
+        features: {
+          hideSignOutLinkInMFA: true,
+        },
+      },
+    });
+    await findByText(/You have been logged out due to inactivity. Refresh or return to the sign in screen./);
+    const cancelLink = queryByText(container as HTMLElement, /Back to sign in/);
+    expect(cancelLink).toBeNull();
   });
 });


### PR DESCRIPTION
## Description:

This PR fixes the issue where the "Back to sign in" link displays in a session expired error while enrolling an authenticator inside the dashboard.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-534363](https://oktainc.atlassian.net/browse/OKTA-534363)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



