### PR TITLE
OKTA-516700 : Security question enroll Combo box with Auto complete selection

### DIFF
--- a/src/v3/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/v3/src/components/Autocomplete/Autocomplete.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  Autocomplete as MuiAutocomplete,
+  AutocompleteRenderInputParams,
+  Box,
+  FormHelperText,
+  InputLabel,
+  TextField,
+} from '@mui/material';
+import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';
+import { h } from 'preact';
+
+import { getMessage } from '../../../../v2/ion/i18nTransformer';
+import { useAutoFocus, useOnChange, useValue } from '../../hooks';
+import {
+  FieldElement, UISchemaElementComponent,
+} from '../../types';
+
+const AutoComplete: UISchemaElementComponent<{
+  uischema: FieldElement
+}> = ({ uischema }) => {
+  const value = useValue(uischema);
+  const onChangeHandler = useOnChange(uischema);
+  const { label, focus } = uischema;
+  const {
+    inputMeta: {
+      // @ts-ignore expose type from auth-js
+      messages = {},
+      name,
+      options,
+    },
+    customOptions,
+  } = uischema.options;
+  const autocompleteProps = {
+    options: (customOptions ?? options)!,
+    getOptionLabel: (opt: IdxOption) => opt.label,
+    autoHighlight: true,
+    autoSelect: true,
+    disableClearable: true,
+    disablePortal: true,
+  };
+  const selectedOption = autocompleteProps.options.find((opt) => opt.value === value) || null;
+  const error = messages?.value?.[0] && getMessage(messages.value[0]);
+  const focusRef = useAutoFocus<HTMLSelectElement>(focus);
+
+  const handleChange = (_: unknown, option: IdxOption | null) => {
+    const newValue = option === null ? '' : option.value as string;
+    onChangeHandler(newValue);
+  };
+
+  return (
+    <Box>
+      <InputLabel htmlFor={name}>{label}</InputLabel>
+      <MuiAutocomplete
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...autocompleteProps}
+        id={name}
+        value={selectedOption}
+        onChange={handleChange}
+        fullWidth
+        renderInput={
+          (params: AutocompleteRenderInputParams) => {
+            // InputLabelProps is incompatible with TextField component, need to exclude it
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { InputLabelProps, inputProps, ...rest } = params;
+            return (
+              <TextField
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...rest}
+                error={error !== undefined}
+                inputProps={{
+                  ...inputProps,
+                  'aria-describedby': error && `${name}-error`,
+                }}
+                inputRef={focusRef}
+              />
+            );
+          }
+        }
+      />
+      {error && (
+        <FormHelperText
+          id={`${name}-error`}
+          role="alert"
+          data-se={`${name}-error`}
+          error
+        >
+          {error}
+        </FormHelperText>
+      )}
+    </Box>
+  );
+};
+
+export default AutoComplete;

--- a/src/v3/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/v3/src/components/Autocomplete/Autocomplete.tsx
@@ -27,7 +27,7 @@ import {
   FieldElement, UISchemaElementComponent,
 } from '../../types';
 
-const AutoComplete: UISchemaElementComponent<{
+const Autocomplete: UISchemaElementComponent<{
   uischema: FieldElement
 }> = ({ uischema }) => {
   const value = useValue(uischema);
@@ -103,4 +103,4 @@ const AutoComplete: UISchemaElementComponent<{
   );
 };
 
-export default AutoComplete;
+export default Autocomplete;

--- a/src/v3/src/components/Autocomplete/index.tsx
+++ b/src/v3/src/components/Autocomplete/index.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import Autocomplete from './Autocomplete';
+
+export default Autocomplete;

--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -14,6 +14,7 @@ import { Input } from '@okta/okta-auth-js';
 
 import { FieldElement, Renderer } from '../../types';
 import AuthenticatorButton from '../AuthenticatorButton';
+import Autocomplete from '../Autocomplete';
 import Button from '../Button';
 import Checkbox from '../Checkbox';
 import Divider from '../Divider';
@@ -176,6 +177,16 @@ export default [
       },
     }: FieldElement) => (Array.isArray(customOptions) || Array.isArray(options)) && format === 'dropdown',
     renderer: Select,
+  },
+  {
+    tester: ({
+      options: {
+        inputMeta: { options } = {} as Input,
+        format,
+        customOptions,
+      },
+    }: FieldElement) => (Array.isArray(customOptions) || Array.isArray(options)) && format === 'autocomplete',
+    renderer: Autocomplete,
   },
   {
     tester: ({ type }) => type === 'Button',

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.ts
@@ -79,7 +79,7 @@ export const transformSecurityQuestionEnroll: IdxStepTransformer = ({ transactio
     label: loc('oie.security.question.questionKey.label', 'login'),
     key: QUESTION_KEY_INPUT_NAME,
     options: {
-      format: 'dropdown',
+      format: 'autocomplete',
       inputMeta: {
         ...(predefinedQuestionOptions?.[0].value as Input[]).find(({ name }) => name === 'questionKey'),
         name: QUESTION_KEY_INPUT_NAME,

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -154,7 +154,7 @@ export interface FieldElement extends UISchemaElement {
   key: string;
   options: {
     inputMeta: Input;
-    format?: string;
+    format?: 'autocomplete' | 'dropdown' | 'radio';
     attributes?: InputAttributes;
     type?: string;
     customOptions?: IdxOption[],

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -1433,144 +1433,71 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                     <div
                       class="MuiBox-root emotion-4"
                     >
-                      <div
-                        class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                      <label
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
+                        for="credentials.questionKey"
                       >
-                        <label
-                          class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                          for="credentials.questionKey"
-                        >
-                          <span
-                            class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                          >
-                            Choose a security question
-                          </span>
-                        </label>
+                        Choose a security question
+                      </label>
+                      <div
+                        class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasPopupIcon emotion-35"
+                      >
                         <div
-                          class="ods-mUkyrD"
+                          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-36"
                         >
-                          <select
-                            class="ods-1B2Zfy"
-                            id="credentials.questionKey"
-                            name="credentials.questionKey"
+                          <div
+                            class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot emotion-37"
                           >
-                            <option
-                              value=""
+                            <input
+                              aria-autocomplete="list"
+                              aria-expanded="false"
+                              aria-invalid="false"
+                              autocapitalize="none"
+                              autocomplete="off"
+                              class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused emotion-38"
+                              id="credentials.questionKey"
+                              role="combobox"
+                              spellcheck="false"
+                              type="text"
                             />
-                            <option
-                              value="disliked_food"
+                            <div
+                              class="MuiAutocomplete-endAdornment emotion-39"
                             >
-                              What is the food you least liked as a child?
-                            </option>
-                            <option
-                              value="name_of_first_plush_toy"
+                              <button
+                                aria-label="Open"
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator emotion-40"
+                                tabindex="-1"
+                                title="Open"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
+                                  data-testid="ArrowDropDownIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7 10l5 5 5-5z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <fieldset
+                              aria-hidden="true"
+                              class="MuiOutlinedInput-notchedOutline emotion-42"
                             >
-                              What is the name of your first stuffed animal?
-                            </option>
-                            <option
-                              value="first_award"
-                            >
-                              What did you earn your first medal or award for?
-                            </option>
-                            <option
-                              value="favorite_security_question"
-                            >
-                              What is your favorite security question?
-                            </option>
-                            <option
-                              value="favorite_toy"
-                            >
-                              What is the toy/stuffed animal you liked the most as a kid?
-                            </option>
-                            <option
-                              value="first_computer_game"
-                            >
-                              What was the first computer game you played?
-                            </option>
-                            <option
-                              value="favorite_movie_quote"
-                            >
-                              What is your favorite movie quote?
-                            </option>
-                            <option
-                              value="first_sports_team_mascot"
-                            >
-                              What was the mascot of the first sports team you played on?
-                            </option>
-                            <option
-                              value="first_music_purchase"
-                            >
-                              What music album or song did you first purchase?
-                            </option>
-                            <option
-                              value="favorite_art_piece"
-                            >
-                              What is your favorite piece of art?
-                            </option>
-                            <option
-                              value="grandmother_favorite_desert"
-                            >
-                              What was your grandmother's favorite dessert?
-                            </option>
-                            <option
-                              value="first_thing_cooked"
-                            >
-                              What was the first thing you learned to cook?
-                            </option>
-                            <option
-                              value="childhood_dream_job"
-                            >
-                              What was your dream job as a child?
-                            </option>
-                            <option
-                              value="place_where_significant_other_was_met"
-                            >
-                              Where did you meet your spouse/significant other?
-                            </option>
-                            <option
-                              value="favorite_vacation_location"
-                            >
-                              Where did you go for your favorite vacation?
-                            </option>
-                            <option
-                              value="new_years_two_thousand"
-                            >
-                              Where were you on New Year's Eve in the year 2000?
-                            </option>
-                            <option
-                              value="favorite_speaker_actor"
-                            >
-                              Who is your favorite speaker/orator?
-                            </option>
-                            <option
-                              value="favorite_book_movie_character"
-                            >
-                              Who is your favorite book/movie character?
-                            </option>
-                            <option
-                              value="favorite_sports_player"
-                            >
-                              Who is your favorite sports player?
-                            </option>
-                          </select>
-                          <span
-                            class="ods-7mdg51"
-                          >
-                            <svg
-                              class="ods-2icygl"
-                              fill="none"
-                              role="presentation"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </span>
+                              <legend
+                                class="emotion-43"
+                              >
+                                <span
+                                  class="notranslate"
+                                >
+                                  ​
+                                </span>
+                              </legend>
+                            </fieldset>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1585,36 +1512,36 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                         >
                           <input
                             aria-invalid="false"
                             autocomplete="off"
-                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                           >
                             <button
                               aria-label="toggle password visibility"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                                 data-testid="VisibilityIcon"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1627,10 +1554,10 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                           </div>
                           <fieldset
                             aria-hidden="true"
-                            class="MuiOutlinedInput-notchedOutline emotion-43"
+                            class="MuiOutlinedInput-notchedOutline emotion-42"
                           >
                             <legend
-                              class="emotion-44"
+                              class="emotion-43"
                             >
                               <span
                                 class="notranslate"
@@ -1647,7 +1574,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                     class="MuiBox-root emotion-12"
                   >
                     <button
-                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-46"
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-56"
                       data-type="save"
                       tabindex="0"
                       type="submit"
@@ -1660,7 +1587,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                   class="MuiBox-root emotion-12"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -1671,7 +1598,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                   class="MuiBox-root emotion-12"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
@@ -1946,144 +1873,71 @@ exports[`authenticator-enroll-security-question predefined question should send 
                     <div
                       class="MuiBox-root emotion-4"
                     >
-                      <div
-                        class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                      <label
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-39"
+                        for="credentials.questionKey"
                       >
-                        <label
-                          class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                          for="credentials.questionKey"
-                        >
-                          <span
-                            class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                          >
-                            Choose a security question
-                          </span>
-                        </label>
+                        Choose a security question
+                      </label>
+                      <div
+                        class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasPopupIcon emotion-40"
+                      >
                         <div
-                          class="ods-mUkyrD"
+                          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-41"
                         >
-                          <select
-                            class="ods-1B2Zfy"
-                            id="credentials.questionKey"
-                            name="credentials.questionKey"
+                          <div
+                            class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot emotion-42"
                           >
-                            <option
-                              value=""
+                            <input
+                              aria-autocomplete="list"
+                              aria-expanded="false"
+                              aria-invalid="false"
+                              autocapitalize="none"
+                              autocomplete="off"
+                              class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused emotion-43"
+                              id="credentials.questionKey"
+                              role="combobox"
+                              spellcheck="false"
+                              type="text"
                             />
-                            <option
-                              value="disliked_food"
+                            <div
+                              class="MuiAutocomplete-endAdornment emotion-44"
                             >
-                              What is the food you least liked as a child?
-                            </option>
-                            <option
-                              value="name_of_first_plush_toy"
+                              <button
+                                aria-label="Open"
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator emotion-45"
+                                tabindex="-1"
+                                title="Open"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-46"
+                                  data-testid="ArrowDropDownIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7 10l5 5 5-5z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <fieldset
+                              aria-hidden="true"
+                              class="MuiOutlinedInput-notchedOutline emotion-47"
                             >
-                              What is the name of your first stuffed animal?
-                            </option>
-                            <option
-                              value="first_award"
-                            >
-                              What did you earn your first medal or award for?
-                            </option>
-                            <option
-                              value="favorite_security_question"
-                            >
-                              What is your favorite security question?
-                            </option>
-                            <option
-                              value="favorite_toy"
-                            >
-                              What is the toy/stuffed animal you liked the most as a kid?
-                            </option>
-                            <option
-                              value="first_computer_game"
-                            >
-                              What was the first computer game you played?
-                            </option>
-                            <option
-                              value="favorite_movie_quote"
-                            >
-                              What is your favorite movie quote?
-                            </option>
-                            <option
-                              value="first_sports_team_mascot"
-                            >
-                              What was the mascot of the first sports team you played on?
-                            </option>
-                            <option
-                              value="first_music_purchase"
-                            >
-                              What music album or song did you first purchase?
-                            </option>
-                            <option
-                              value="favorite_art_piece"
-                            >
-                              What is your favorite piece of art?
-                            </option>
-                            <option
-                              value="grandmother_favorite_desert"
-                            >
-                              What was your grandmother's favorite dessert?
-                            </option>
-                            <option
-                              value="first_thing_cooked"
-                            >
-                              What was the first thing you learned to cook?
-                            </option>
-                            <option
-                              value="childhood_dream_job"
-                            >
-                              What was your dream job as a child?
-                            </option>
-                            <option
-                              value="place_where_significant_other_was_met"
-                            >
-                              Where did you meet your spouse/significant other?
-                            </option>
-                            <option
-                              value="favorite_vacation_location"
-                            >
-                              Where did you go for your favorite vacation?
-                            </option>
-                            <option
-                              value="new_years_two_thousand"
-                            >
-                              Where were you on New Year's Eve in the year 2000?
-                            </option>
-                            <option
-                              value="favorite_speaker_actor"
-                            >
-                              Who is your favorite speaker/orator?
-                            </option>
-                            <option
-                              value="favorite_book_movie_character"
-                            >
-                              Who is your favorite book/movie character?
-                            </option>
-                            <option
-                              value="favorite_sports_player"
-                            >
-                              Who is your favorite sports player?
-                            </option>
-                          </select>
-                          <span
-                            class="ods-7mdg51"
-                          >
-                            <svg
-                              class="ods-2icygl"
-                              fill="none"
-                              role="presentation"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </span>
+                              <legend
+                                class="emotion-48"
+                              >
+                                <span
+                                  class="notranslate"
+                                >
+                                  ​
+                                </span>
+                              </legend>
+                            </fieldset>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -2098,37 +1952,37 @@ exports[`authenticator-enroll-security-question predefined question should send 
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-42"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-39"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-43"
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-42"
                         >
                           <input
                             aria-describedby="credentials.answer-error"
                             aria-invalid="true"
                             autocomplete="off"
-                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-43"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-45"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-55"
                           >
                             <button
                               aria-label="toggle password visibility"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-46"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-56"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-47"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-46"
                                 data-testid="VisibilityIcon"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -2141,10 +1995,10 @@ exports[`authenticator-enroll-security-question predefined question should send 
                           </div>
                           <fieldset
                             aria-hidden="true"
-                            class="MuiOutlinedInput-notchedOutline emotion-48"
+                            class="MuiOutlinedInput-notchedOutline emotion-47"
                           >
                             <legend
-                              class="emotion-49"
+                              class="emotion-48"
                             >
                               <span
                                 class="notranslate"
@@ -2156,7 +2010,7 @@ exports[`authenticator-enroll-security-question predefined question should send 
                         </div>
                       </div>
                       <p
-                        class="MuiFormHelperText-root Mui-error emotion-50"
+                        class="MuiFormHelperText-root Mui-error emotion-60"
                         data-se="credentials.answer-error"
                         id="credentials.answer-error"
                         role="alert"
@@ -2169,7 +2023,7 @@ exports[`authenticator-enroll-security-question predefined question should send 
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-52"
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-62"
                       data-type="save"
                       tabindex="0"
                       type="submit"
@@ -2182,7 +2036,7 @@ exports[`authenticator-enroll-security-question predefined question should send 
                   class="MuiBox-root emotion-17"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -2193,7 +2047,7 @@ exports[`authenticator-enroll-security-question predefined question should send 
                   class="MuiBox-root emotion-17"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
@@ -2439,144 +2293,71 @@ exports[`authenticator-enroll-security-question predefined question should show 
                     <div
                       class="MuiBox-root emotion-4"
                     >
-                      <div
-                        class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                      <label
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
+                        for="credentials.questionKey"
                       >
-                        <label
-                          class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                          for="credentials.questionKey"
-                        >
-                          <span
-                            class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                          >
-                            Choose a security question
-                          </span>
-                        </label>
+                        Choose a security question
+                      </label>
+                      <div
+                        class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasPopupIcon emotion-35"
+                      >
                         <div
-                          class="ods-mUkyrD"
+                          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-36"
                         >
-                          <select
-                            class="ods-1B2Zfy"
-                            id="credentials.questionKey"
-                            name="credentials.questionKey"
+                          <div
+                            class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot emotion-37"
                           >
-                            <option
-                              value=""
+                            <input
+                              aria-autocomplete="list"
+                              aria-expanded="false"
+                              aria-invalid="false"
+                              autocapitalize="none"
+                              autocomplete="off"
+                              class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused emotion-38"
+                              id="credentials.questionKey"
+                              role="combobox"
+                              spellcheck="false"
+                              type="text"
                             />
-                            <option
-                              value="disliked_food"
+                            <div
+                              class="MuiAutocomplete-endAdornment emotion-39"
                             >
-                              What is the food you least liked as a child?
-                            </option>
-                            <option
-                              value="name_of_first_plush_toy"
+                              <button
+                                aria-label="Open"
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator emotion-40"
+                                tabindex="-1"
+                                title="Open"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
+                                  data-testid="ArrowDropDownIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7 10l5 5 5-5z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <fieldset
+                              aria-hidden="true"
+                              class="MuiOutlinedInput-notchedOutline emotion-42"
                             >
-                              What is the name of your first stuffed animal?
-                            </option>
-                            <option
-                              value="first_award"
-                            >
-                              What did you earn your first medal or award for?
-                            </option>
-                            <option
-                              value="favorite_security_question"
-                            >
-                              What is your favorite security question?
-                            </option>
-                            <option
-                              value="favorite_toy"
-                            >
-                              What is the toy/stuffed animal you liked the most as a kid?
-                            </option>
-                            <option
-                              value="first_computer_game"
-                            >
-                              What was the first computer game you played?
-                            </option>
-                            <option
-                              value="favorite_movie_quote"
-                            >
-                              What is your favorite movie quote?
-                            </option>
-                            <option
-                              value="first_sports_team_mascot"
-                            >
-                              What was the mascot of the first sports team you played on?
-                            </option>
-                            <option
-                              value="first_music_purchase"
-                            >
-                              What music album or song did you first purchase?
-                            </option>
-                            <option
-                              value="favorite_art_piece"
-                            >
-                              What is your favorite piece of art?
-                            </option>
-                            <option
-                              value="grandmother_favorite_desert"
-                            >
-                              What was your grandmother's favorite dessert?
-                            </option>
-                            <option
-                              value="first_thing_cooked"
-                            >
-                              What was the first thing you learned to cook?
-                            </option>
-                            <option
-                              value="childhood_dream_job"
-                            >
-                              What was your dream job as a child?
-                            </option>
-                            <option
-                              value="place_where_significant_other_was_met"
-                            >
-                              Where did you meet your spouse/significant other?
-                            </option>
-                            <option
-                              value="favorite_vacation_location"
-                            >
-                              Where did you go for your favorite vacation?
-                            </option>
-                            <option
-                              value="new_years_two_thousand"
-                            >
-                              Where were you on New Year's Eve in the year 2000?
-                            </option>
-                            <option
-                              value="favorite_speaker_actor"
-                            >
-                              Who is your favorite speaker/orator?
-                            </option>
-                            <option
-                              value="favorite_book_movie_character"
-                            >
-                              Who is your favorite book/movie character?
-                            </option>
-                            <option
-                              value="favorite_sports_player"
-                            >
-                              Who is your favorite sports player?
-                            </option>
-                          </select>
-                          <span
-                            class="ods-7mdg51"
-                          >
-                            <svg
-                              class="ods-2icygl"
-                              fill="none"
-                              role="presentation"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </span>
+                              <legend
+                                class="emotion-43"
+                              >
+                                <span
+                                  class="notranslate"
+                                >
+                                  ​
+                                </span>
+                              </legend>
+                            </fieldset>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -2591,37 +2372,37 @@ exports[`authenticator-enroll-security-question predefined question should show 
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
                         >
                           <input
                             aria-describedby="credentials.answer-error"
                             aria-invalid="true"
                             autocomplete="off"
-                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                           >
                             <button
                               aria-label="toggle password visibility"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
                                 data-testid="VisibilityIcon"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -2634,10 +2415,10 @@ exports[`authenticator-enroll-security-question predefined question should show 
                           </div>
                           <fieldset
                             aria-hidden="true"
-                            class="MuiOutlinedInput-notchedOutline emotion-43"
+                            class="MuiOutlinedInput-notchedOutline emotion-42"
                           >
                             <legend
-                              class="emotion-44"
+                              class="emotion-43"
                             >
                               <span
                                 class="notranslate"
@@ -2649,7 +2430,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
                         </div>
                       </div>
                       <p
-                        class="MuiFormHelperText-root Mui-error emotion-45"
+                        class="MuiFormHelperText-root Mui-error emotion-55"
                         data-se="credentials.answer-error"
                         id="credentials.answer-error"
                         role="alert"
@@ -2985,144 +2766,71 @@ exports[`authenticator-enroll-security-question predefined question should show 
                     <div
                       class="MuiBox-root emotion-4"
                     >
-                      <div
-                        class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                      <label
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-39"
+                        for="credentials.questionKey"
                       >
-                        <label
-                          class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                          for="credentials.questionKey"
-                        >
-                          <span
-                            class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                          >
-                            Choose a security question
-                          </span>
-                        </label>
+                        Choose a security question
+                      </label>
+                      <div
+                        class="MuiAutocomplete-root MuiAutocomplete-fullWidth MuiAutocomplete-hasPopupIcon emotion-40"
+                      >
                         <div
-                          class="ods-mUkyrD"
+                          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-41"
                         >
-                          <select
-                            class="ods-1B2Zfy"
-                            id="credentials.questionKey"
-                            name="credentials.questionKey"
+                          <div
+                            class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot emotion-42"
                           >
-                            <option
-                              value=""
+                            <input
+                              aria-autocomplete="list"
+                              aria-expanded="false"
+                              aria-invalid="false"
+                              autocapitalize="none"
+                              autocomplete="off"
+                              class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused emotion-43"
+                              id="credentials.questionKey"
+                              role="combobox"
+                              spellcheck="false"
+                              type="text"
                             />
-                            <option
-                              value="disliked_food"
+                            <div
+                              class="MuiAutocomplete-endAdornment emotion-44"
                             >
-                              What is the food you least liked as a child?
-                            </option>
-                            <option
-                              value="name_of_first_plush_toy"
+                              <button
+                                aria-label="Open"
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator emotion-45"
+                                tabindex="-1"
+                                title="Open"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-46"
+                                  data-testid="ArrowDropDownIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7 10l5 5 5-5z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                            <fieldset
+                              aria-hidden="true"
+                              class="MuiOutlinedInput-notchedOutline emotion-47"
                             >
-                              What is the name of your first stuffed animal?
-                            </option>
-                            <option
-                              value="first_award"
-                            >
-                              What did you earn your first medal or award for?
-                            </option>
-                            <option
-                              value="favorite_security_question"
-                            >
-                              What is your favorite security question?
-                            </option>
-                            <option
-                              value="favorite_toy"
-                            >
-                              What is the toy/stuffed animal you liked the most as a kid?
-                            </option>
-                            <option
-                              value="first_computer_game"
-                            >
-                              What was the first computer game you played?
-                            </option>
-                            <option
-                              value="favorite_movie_quote"
-                            >
-                              What is your favorite movie quote?
-                            </option>
-                            <option
-                              value="first_sports_team_mascot"
-                            >
-                              What was the mascot of the first sports team you played on?
-                            </option>
-                            <option
-                              value="first_music_purchase"
-                            >
-                              What music album or song did you first purchase?
-                            </option>
-                            <option
-                              value="favorite_art_piece"
-                            >
-                              What is your favorite piece of art?
-                            </option>
-                            <option
-                              value="grandmother_favorite_desert"
-                            >
-                              What was your grandmother's favorite dessert?
-                            </option>
-                            <option
-                              value="first_thing_cooked"
-                            >
-                              What was the first thing you learned to cook?
-                            </option>
-                            <option
-                              value="childhood_dream_job"
-                            >
-                              What was your dream job as a child?
-                            </option>
-                            <option
-                              value="place_where_significant_other_was_met"
-                            >
-                              Where did you meet your spouse/significant other?
-                            </option>
-                            <option
-                              value="favorite_vacation_location"
-                            >
-                              Where did you go for your favorite vacation?
-                            </option>
-                            <option
-                              value="new_years_two_thousand"
-                            >
-                              Where were you on New Year's Eve in the year 2000?
-                            </option>
-                            <option
-                              value="favorite_speaker_actor"
-                            >
-                              Who is your favorite speaker/orator?
-                            </option>
-                            <option
-                              value="favorite_book_movie_character"
-                            >
-                              Who is your favorite book/movie character?
-                            </option>
-                            <option
-                              value="favorite_sports_player"
-                            >
-                              Who is your favorite sports player?
-                            </option>
-                          </select>
-                          <span
-                            class="ods-7mdg51"
-                          >
-                            <svg
-                              class="ods-2icygl"
-                              fill="none"
-                              role="presentation"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </span>
+                              <legend
+                                class="emotion-48"
+                              >
+                                <span
+                                  class="notranslate"
+                                >
+                                  ​
+                                </span>
+                              </legend>
+                            </fieldset>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -3137,37 +2845,37 @@ exports[`authenticator-enroll-security-question predefined question should show 
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-42"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-39"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-43"
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-42"
                         >
                           <input
                             aria-describedby="credentials.answer-error"
                             aria-invalid="true"
                             autocomplete="off"
-                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-43"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-45"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-55"
                           >
                             <button
                               aria-label="toggle password visibility"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-46"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-56"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-47"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-46"
                                 data-testid="VisibilityIcon"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -3180,10 +2888,10 @@ exports[`authenticator-enroll-security-question predefined question should show 
                           </div>
                           <fieldset
                             aria-hidden="true"
-                            class="MuiOutlinedInput-notchedOutline emotion-48"
+                            class="MuiOutlinedInput-notchedOutline emotion-47"
                           >
                             <legend
-                              class="emotion-49"
+                              class="emotion-48"
                             >
                               <span
                                 class="notranslate"
@@ -3195,7 +2903,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
                         </div>
                       </div>
                       <p
-                        class="MuiFormHelperText-root Mui-error emotion-50"
+                        class="MuiFormHelperText-root Mui-error emotion-60"
                         data-se="credentials.answer-error"
                         id="credentials.answer-error"
                         role="alert"
@@ -3208,7 +2916,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-52"
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-62"
                       data-type="save"
                       tabindex="0"
                       type="submit"
@@ -3221,7 +2929,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
                   class="MuiBox-root emotion-17"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -3232,7 +2940,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
                   class="MuiBox-root emotion-17"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -2443,26 +2443,26 @@ exports[`authenticator-enroll-security-question predefined question should show 
                     class="MuiBox-root emotion-12"
                   >
                     <button
-                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root Mui-disabled  emotion-47"
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root Mui-disabled  emotion-57"
                       data-type="save"
                       disabled=""
                       tabindex="-1"
                       type="submit"
                     >
                       <div
-                        class="MuiBox-root emotion-48"
+                        class="MuiBox-root emotion-58"
                       >
                         <span
-                          class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-49"
+                          class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-59"
                           role="progressbar"
                           style="width: 1.14285714rem; height: 1.14285714rem;"
                         >
                           <svg
-                            class="MuiCircularProgress-svg emotion-50"
+                            class="MuiCircularProgress-svg emotion-60"
                             viewBox="22 22 44 44"
                           >
                             <circle
-                              class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-51"
+                              class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-61"
                               cx="44"
                               cy="44"
                               fill="none"
@@ -2480,7 +2480,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
                   class="MuiBox-root emotion-12"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-53"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-63"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -2491,7 +2491,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
                   class="MuiBox-root emotion-12"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-53"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-63"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
@@ -65,7 +65,7 @@ describe('authenticator-enroll-security-question', () => {
       const { container, findByText } = await setup({ mockResponse });
 
       await findByText(/Set up security question/);
-      await findByText(/What is the food you least liked/);
+      await findByText('Choose a security question', { selector: 'label' });
       expect(container).toMatchSnapshot();
     });
 
@@ -255,8 +255,8 @@ describe('authenticator-enroll-security-question', () => {
         .toEqual('The security question answer must be at least 4 characters in length');
 
       // switch to predefined question form
-      await user.click(await findByLabelText(/Choose a security question/));
-      await findByLabelText('Choose a security question', { selector: 'select' });
+      await user.click(await findByText('Choose a security question', { selector: 'span' }));
+      await findByText('Choose a security question', { selector: 'label' });
       const restoredAnswerEle = await findByTestId('credentials.answer') as HTMLInputElement;
 
       await user.type(restoredAnswerEle, answer);


### PR DESCRIPTION
## Description:

The purpose of this PR is to change the select dropdown for Security Question enroll from using the Native Select to use MUI's `Autocomplete` which allows search/filter capabilities on the list of pre-defined questions.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-516700](https://oktainc.atlassian.net/browse/OKTA-516700)

### Reviewers:

### Screenshot/Video:

https://user-images.githubusercontent.com/97472729/191846572-5c14f0fe-9b3c-4904-874b-0d557d08335f.mov



### Downstream Monolith Build:



