### PR TITLE
OKTA-535513 : Disable Auth button and Link on loading 

### DIFF
--- a/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
+++ b/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
@@ -53,7 +53,7 @@ const AuthenticatorButton: UISchemaElementComponent<{
     },
   } = uischema;
   const label = getTranslation(translations!, 'label');
-  const { dataSchemaRef, data } = useWidgetContext();
+  const { dataSchemaRef, data, loading } = useWidgetContext();
   const onSubmitHandler = useOnSubmit();
   const onValidationHandler = useOnSubmitValidation();
   const focusRef = useAutoFocus<HTMLButtonElement>(focus);
@@ -95,6 +95,7 @@ const AuthenticatorButton: UISchemaElementComponent<{
       onClick={onClick}
       onKeyPress={onClick}
       ref={focusRef}
+      disabled={loading}
     >
       { authenticationKey && (
         <Box data-se="authenticator-icon">

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -13,12 +13,16 @@
 import { Link as LinkMui } from '@mui/material';
 import { h } from 'preact';
 
+import { useWidgetContext } from '../../contexts';
 import { useAutoFocus, useOnSubmit } from '../../hooks';
 import { ClickHandler, LinkElement, UISchemaElementComponent } from '../../types';
 
 const Link: UISchemaElementComponent<{
   uischema: LinkElement
 }> = ({ uischema }) => {
+  const {
+    loading,
+  } = useWidgetContext();
   const {
     options: {
       label,
@@ -37,11 +41,13 @@ const Link: UISchemaElementComponent<{
   const onClick: ClickHandler = async (e) => {
     e.preventDefault();
 
-    onSubmitHandler({
-      params: actionParams,
-      isActionStep,
-      step,
-    });
+    if (!loading) {
+      onSubmitHandler({
+        params: actionParams,
+        isActionStep,
+        step,
+      });
+    }
   };
   const onMouseDown: ClickHandler = (e) => { e.preventDefault(); };
 

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -41,13 +41,15 @@ const Link: UISchemaElementComponent<{
   const onClick: ClickHandler = async (e) => {
     e.preventDefault();
 
-    if (!loading) {
-      onSubmitHandler({
-        params: actionParams,
-        isActionStep,
-        step,
-      });
+    if (loading) {
+      return;
     }
+
+    onSubmitHandler({
+      params: actionParams,
+      isActionStep,
+      step,
+    });
   };
   const onMouseDown: ClickHandler = (e) => { e.preventDefault(); };
 

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
@@ -29,6 +29,12 @@ jest.mock('../../hooks', () => ({
   useOnSubmit: () => mockSubmitHook,
 }));
 
+jest.mock('../../contexts', () => ({
+  useWidgetContext: () => ({
+    loading: jest.fn().mockReturnValue(false)(),
+  }),
+}));
+
 describe('ReminderPrompt', () => {
   beforeEach(() => {
     mockSubmitHook.mockRestore();

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -29,7 +29,7 @@ const ReminderPrompt: UISchemaElementComponent<{
   uischema: ReminderElement
 }> = ({ uischema }) => {
   const {
-    loading = false,
+    loading,
   } = useWidgetContext();
   const {
     content,

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -18,6 +18,7 @@ import {
 import { h } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
+import { useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';
 import { ReminderElement, UISchemaElementComponent } from '../../types';
 import TextWithHtml from '../TextWithHtml';
@@ -27,6 +28,9 @@ export const DEFAULT_TIMEOUT_MS = 30_000;
 const ReminderPrompt: UISchemaElementComponent<{
   uischema: ReminderElement
 }> = ({ uischema }) => {
+  const {
+    loading = false,
+  } = useWidgetContext();
   const {
     content,
     step,
@@ -64,6 +68,9 @@ const ReminderPrompt: UISchemaElementComponent<{
   }, []);
 
   const resendHandler = async () => {
+    if (loading) {
+      return;
+    }
     startTimer();
 
     await onSubmitHandler({ step, isActionStep, params: actionParams });

--- a/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
+++ b/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
@@ -25,7 +25,7 @@ const TextWithHtml: UISchemaElementComponent<{
   uischema: TextWithHtmlElement
 }> = ({ uischema }) => {
   const {
-    loading = false,
+    loading,
   } = useWidgetContext();
   const {
     content,

--- a/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
+++ b/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
@@ -13,6 +13,7 @@
 import { Box } from '@mui/material';
 import { h } from 'preact';
 
+import { useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';
 import {
   ClickHandler,
@@ -23,6 +24,9 @@ import {
 const TextWithHtml: UISchemaElementComponent<{
   uischema: TextWithHtmlElement
 }> = ({ uischema }) => {
+  const {
+    loading = false,
+  } = useWidgetContext();
   const {
     content,
     actionParams,
@@ -36,6 +40,10 @@ const TextWithHtml: UISchemaElementComponent<{
   const onMouseDown: ClickHandler = (e) => { e.preventDefault(); };
   const handleClick = async (e: Event) => {
     e.preventDefault();
+
+    if (loading) {
+      return;
+    }
 
     // only submit when className matches
     if ((e.target as HTMLElement).className.includes(contentClassname)) {

--- a/src/v3/test/integration/authenticator-enroll-select-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-select-authenticator.test.tsx
@@ -51,6 +51,18 @@ describe('authenticator-enroll-select-authenticator', () => {
         },
       );
     });
+
+    it('should only send api request once when double clicked', async () => {
+      const {
+        authClient,
+        user,
+        findByTestId,
+      } = await setup({ mockResponse });
+
+      const authenticatorButton = await findByTestId('google_otp');
+      await user.dblClick(authenticatorButton);
+      expect(authClient.options.httpRequestClient).toHaveBeenCalledTimes(1);
+    });
   });
 
   // TODO: Additional tests and flows can be added when testing monolith scenarios

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -345,4 +345,17 @@ describe('identify-with-password', () => {
 
     expect(authClient.options.httpRequestClient).toHaveBeenCalledTimes(1);
   });
+
+  it('should only send one api request when forgot password link is double clicked', async () => {
+    const {
+      findByText,
+      user,
+      authClient,
+    } = await setup({ mockResponse });
+
+    const cancelLink = await findByText(/Forgot password?/);
+
+    await user.dblClick(cancelLink);
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Description:

This PR adds to https://github.com/okta/okta-signin-widget/pull/2800 and is for disabling the Authenticator buttons and Links while the widget is loading.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-535513](https://oktainc.atlassian.net/browse/OKTA-535513)

### Reviewers:

### Screenshot/Video:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/107433508/191866788-1e3c961a-6aaf-4906-89e0-9e6f2fee358b.png">

### Downstream Monolith Build:



