### PR TITLE
OKTA-534967 : Authenticator button description fix

### DIFF
--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -13,6 +13,7 @@
 import { Input } from '@okta/okta-auth-js';
 import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';
 import { AUTHENTICATOR_ENROLLMENT_DESCR_KEY_MAP, AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
+import { ButtonType } from 'src/types';
 
 import {
   getAuthenticatorEnrollButtonElements,
@@ -41,6 +42,10 @@ describe('Select Authenticator Utility Tests', () => {
           options: {
             key: AUTHENTICATOR_KEY.OV,
             ctaLabel: 'oie.verify.authenticator.button.text',
+            includeData: true,
+            includeImmutableData: false,
+            step: 'select-authenticator-enroll',
+            type: ButtonType.BUTTON,
             actionParams: {
               'authenticator.methodType': options[0].value,
             },
@@ -52,6 +57,10 @@ describe('Select Authenticator Utility Tests', () => {
           options: {
             key: AUTHENTICATOR_KEY.OV,
             ctaLabel: 'oie.verify.authenticator.button.text',
+            includeData: true,
+            includeImmutableData: false,
+            step: 'select-authenticator-enroll',
+            type: ButtonType.BUTTON,
             actionParams: {
               'authenticator.methodType': options[1].value,
             },
@@ -151,6 +160,38 @@ describe('Select Authenticator Utility Tests', () => {
           .toBe('oie.verify.authenticator.button.text');
         expect(currentOption?.options.description)
           .toBe(option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE ? mockPhoneNumber : undefined);
+      });
+    });
+
+    it('should return authenticator buttons with multiple enrolled phone number security methods with correct description', () => {
+      const options: IdxOption[] = [
+        { key: AUTHENTICATOR_KEY.PHONE, phoneNumber: '2XXXXXX123' },
+        { key: AUTHENTICATOR_KEY.PHONE, phoneNumber: '2XXXXXX321' },
+      ]
+        .map((obj) => {
+          const option = {
+            label: obj.key,
+            value: [{ name: 'methodType', value: obj.key }],
+            relatesTo: {
+              id: '',
+              type: '',
+              methods: [{ type: '' }],
+              displayName: '',
+              key: obj.key,
+              profile: { phoneNumber: obj.phoneNumber },
+            },
+          };
+          return option;
+        });
+      const authenticatorOptionValues = getAuthenticatorVerifyButtonElements(options, stepName);
+
+      options.forEach((option, index) => {
+        const currentOption = authenticatorOptionValues[index];
+        expect(currentOption?.options.key).toBe(option.relatesTo?.key);
+        expect(currentOption?.label).toBe(option.label);
+        expect(currentOption?.options.ctaLabel)
+          .toBe('oie.verify.authenticator.button.text');
+        expect(currentOption?.options.description).toBe(option.relatesTo?.profile?.phoneNumber);
       });
     });
 

--- a/src/v3/src/transformer/selectAuthenticator/utils.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.ts
@@ -21,13 +21,6 @@ import {
 import { ActionParams, AuthenticatorButtonElement, ButtonType } from '../../types';
 import { loc } from '../../util';
 
-const getAuthenticatorOption = (
-  options: IdxOption[],
-  authenticatorKey: string,
-): IdxOption | undefined => options?.find(
-  ({ relatesTo }) => relatesTo?.key === authenticatorKey,
-);
-
 export const getOptionValue = (
   inputs: Input[],
   key: string,
@@ -48,7 +41,7 @@ const buildOktaVerifyOptions = (
   step: string,
   isEnroll?: boolean,
 ): AuthenticatorButtonElement[] => {
-  const ovRemediation = getAuthenticatorOption(options, AUTHENTICATOR_KEY.OV);
+  const ovRemediation = options.find((option) => option.relatesTo?.key === AUTHENTICATOR_KEY.OV);
   const id = (ovRemediation?.value as Input[])?.find(({ name }) => name === 'id')?.value;
   const methodType = (ovRemediation?.value as Input[])?.find(({ name }) => name === 'methodType');
   if (!methodType || !methodType.options?.length) {
@@ -87,7 +80,7 @@ const buildOktaVerifyOptions = (
 };
 
 const getAuthenticatorDescriptionParams = (
-  options: IdxOption[],
+  option: IdxOption,
   authenticatorKey: string,
   isEnroll?: boolean,
 ): string[] | undefined => {
@@ -103,31 +96,20 @@ const getAuthenticatorDescriptionParams = (
 
   switch (authenticatorKey) {
     case AUTHENTICATOR_KEY.ON_PREM: {
-      const vendorName = getAuthenticatorOption(
-        options,
-        authenticatorKey,
-      )?.relatesTo?.displayName || loc('oie.on_prem.authenticator.default.vendorName', 'login');
+      const vendorName = option.relatesTo?.displayName
+        || loc('oie.on_prem.authenticator.default.vendorName', 'login');
       return [vendorName];
     }
     case AUTHENTICATOR_KEY.IDP: {
-      const idpName = getAuthenticatorOption(
-        options,
-        authenticatorKey,
-      )?.relatesTo?.displayName || '';
+      const idpName = option.relatesTo?.displayName || '';
       return [idpName];
     }
     case AUTHENTICATOR_KEY.CUSTOM_APP: {
-      const customAppName = getAuthenticatorOption(
-        options,
-        authenticatorKey,
-      )?.label || '';
+      const customAppName = option.label || '';
       return [customAppName];
     }
     case AUTHENTICATOR_KEY.SYMANTEC_VIP: {
-      const appName = getAuthenticatorOption(
-        options,
-        authenticatorKey,
-      )?.relatesTo?.displayName || '';
+      const appName = option.relatesTo?.displayName || '';
       return [appName];
     }
     default:
@@ -136,7 +118,7 @@ const getAuthenticatorDescriptionParams = (
 };
 
 const getAuthenticatorDescription = (
-  options: IdxOption[],
+  option: IdxOption,
   authenticatorKey: string,
   isEnroll?: boolean,
 ): string | undefined => {
@@ -144,7 +126,7 @@ const getAuthenticatorDescription = (
     return undefined;
   }
   const descrParams = getAuthenticatorDescriptionParams(
-    options,
+    option,
     authenticatorKey,
     isEnroll,
   );
@@ -153,17 +135,11 @@ const getAuthenticatorDescription = (
   }
 
   if (authenticatorKey === AUTHENTICATOR_KEY.PHONE) {
-    return getAuthenticatorOption(
-      options,
-      authenticatorKey,
-    )?.relatesTo?.profile?.phoneNumber as string || undefined;
+    return option.relatesTo?.profile?.phoneNumber as string || undefined;
   }
 
   if (authenticatorKey === AUTHENTICATOR_KEY.CUSTOM_APP) {
-    return getAuthenticatorOption(
-      options,
-      authenticatorKey,
-    )?.relatesTo?.displayName as string || undefined;
+    return option.relatesTo?.displayName as string || undefined;
   }
 
   if (authenticatorKey === AUTHENTICATOR_KEY.OV) {
@@ -214,7 +190,7 @@ const formatAuthenticatorOptions = (
           ? loc('oie.enroll.authenticator.button.text', 'login')
           : loc('oie.verify.authenticator.button.text', 'login'),
         description: getAuthenticatorDescription(
-          options,
+          option,
           authenticatorKey,
           isEnroll,
         ),

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -593,7 +593,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-54"
                         data-se="authenticator-button-description"
                       >
-                        +1 XXX-XXX-5309
+                        +1 XXX-XXX-5310
                       </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"


### PR DESCRIPTION
## Description:

The purpose of this PR is to fix an issue with the description of Authenticator buttons when there are different authenticators (sharing the same key but an alternate description is required). 

i.e. When someone sets up a phone authenticator with 2 different phone numbers, previously the logic just retrieved the description for the first found phone number entry instead of it being distinct based on each individual authenticator.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-534967](https://oktainc.atlassian.net/browse/OKTA-534967)

### Reviewers:

### Screenshot/Video:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/97472729/191991626-797a2410-7804-460c-810a-519a55e7446c.png">


### Downstream Monolith Build:



