### PR TITLE
Fix english leak test

### DIFF
--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -60,7 +60,8 @@ const I18N_OVERRIDE_MAPPINGS = {
   'select-authenticator-unlock-account.identifier': 'primaryauth.username.placeholder',
   'identify.credentials.passcode': 'primaryauth.password.placeholder',
   'identify.rememberMe': 'oie.remember',
-
+  'enroll-profile.userProfile.rememberMe': 'oie.remember',
+  
   'identify-recovery.identifier': 'password.forgot.email.or.username.placeholder',
 
   'select-authenticator-enroll.authenticator.duo': 'factor.duo',
@@ -359,8 +360,10 @@ const updateLabelForUiSchema = (remediation, uiSchema) => {
         if (o.authenticatorKey === AUTHENTICATOR_KEY.OV && methodType) {
           i18nPathOption = `${i18nPathOption}.${methodType}`;
         }
-      } else if (o.value !== undefined) { // value could be string or number or undefined.
+      } else if (typeof o.value === 'string' || typeof o.value === 'number') { // value could be string, number, object or undefined.
         i18nPathOption = `${i18nPath}.${o.value}`;
+      } else {
+        i18nPathOption = i18nPath;
       }
       Logger.info('\t 4: ', i18nPathOption);
       o.label = getI18NValue(i18nPathOption, o.label);

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -58,7 +58,9 @@ export default class BasePageObject {
       window.addEventListener('submit', function(e) {
         if (!toUrls || toUrls.includes(e.target.action)) {
           e.preventDefault();
+          return;
         }
+        console.log('WARNING! allowing redirect:', e.target.action);
       });
     })(toUrls);
   }

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -50,15 +50,6 @@ const mocksWithAlert = [
   'success-with-interaction-code.json'
 ];
 
-const mocksWithPreventRedirect = [
-  'identify-with-only-one-third-party-idp-app-user.json',
-  'error-with-failure-redirect.json'
-];
-const mocksWithoutInitialRender = [
-  'success-with-interaction-code.json',
-  'error-with-failure-redirect.json'
-];
-
 const parseMockData = () => {
   // parse mocks folder
   const mocks = [];
@@ -137,28 +128,30 @@ const setUpResponse = (filePath) => {
 
 async function setup(t, locale, fileName) {
   const withInteractionCodeFlow = mocksWithInteractionCodeFlow.includes(fileName);
-  const preventInitialRender = mocksWithoutInitialRender.includes(fileName);
   const withAlert = mocksWithAlert.includes(fileName);
   const options = withInteractionCodeFlow ? optionsForInteractionCodeFlow : {};
-  const preventRedirect = mocksWithPreventRedirect.includes(fileName);
-  
   const widgetView = new PageObject(t);
-  if (preventInitialRender) {
-    await widgetView.navigateToPage({ render: false });
-  } else {
-    await widgetView.navigateToPage();
-  }
+  
+  // Navigate to the page but do not render the widget yet
+  await widgetView.navigateToPage({ render: false });
+
   if (withInteractionCodeFlow) {
     await widgetView.mockCrypto();
   }
+
   if (withAlert) {
     await t.setNativeDialogHandler(() => true);
   }
-  if (preventRedirect) {
-    await widgetView.preventRedirect([
-      'http://localhost:3000/error.html'
-    ]);
-  }
+
+  // Prevent redirects
+  await widgetView.preventRedirect([
+    // TODO: are there *any* allowed redirects?
+    'http://localhost:3000/error.html',
+    'http://localhost:3000/sso/idps/facebook-idp-id-123',
+    'https://okta.mtls.okta.com/sso/idps/mtlsidp',
+    'http://localhost:3000/app/UserHome'
+  ]);
+  
   await renderWidget({
     ...options,
     'language': locale

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -26,6 +26,7 @@ const ignoredMocks = [
   'enroll-profile-all-base-attributes.json', // No english leaks on UI. Country and timezone dropdown values are not localized OKTA-454630
   'error-custom-access-denied-success-redirect.json', // custom message
   'error-identify-access-denied-custom-message.json', // custom message
+  'enroll-profile-new-boolean-fields', // custom registration fields
 ];
 
 const optionsForInteractionCodeFlow = {

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -26,11 +26,10 @@ const ignoredMocks = [
   'enroll-profile-all-base-attributes.json', // No english leaks on UI. Country and timezone dropdown values are not localized OKTA-454630
   'error-custom-access-denied-success-redirect.json', // custom message
   'error-identify-access-denied-custom-message.json', // custom message
-  'enroll-profile-new-boolean-fields', // custom registration fields
-  'identify-with-only-one-third-party-idp-app-user', // redirect-idp
+  'enroll-profile-new-boolean-fields.json', // custom registration fields
 
   // OKTA-535435 "Sign me out of all other devices." (enroll-authenticator.okta_password.credentials.revokeSessions) has no entry in login.properties
-  'authenticator-enroll-password',
+  'authenticator-enroll-password.json',
 ];
 
 const optionsForInteractionCodeFlow = {
@@ -52,7 +51,7 @@ const mocksWithAlert = [
 ];
 
 const mocksWithPreventRedirect = [
-  'identify-with-only-one-third-party-idp-app-use',
+  'identify-with-only-one-third-party-idp-app-user.json',
   'error-with-failure-redirect.json'
 ];
 const mocksWithoutInitialRender = [

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -27,6 +27,10 @@ const ignoredMocks = [
   'error-custom-access-denied-success-redirect.json', // custom message
   'error-identify-access-denied-custom-message.json', // custom message
   'enroll-profile-new-boolean-fields', // custom registration fields
+  'identify-with-only-one-third-party-idp-app-user', // redirect-idp
+
+  // OKTA-535435 "Sign me out of all other devices." (enroll-authenticator.okta_password.credentials.revokeSessions) has no entry in login.properties
+  'authenticator-enroll-password',
 ];
 
 const optionsForInteractionCodeFlow = {


### PR DESCRIPTION
## Description:
- Fixes an english leak with `enroll-profile-new-checkbox` by adding an alias in i18nTransformer
- Adds english leak test exceptions for: 
  - enroll-profile-new-boolean-fields.json
  - authenticator-enroll-password.json ( OKTA-535435 )
- Fixes race condition in test where widget was rendered before mocks/intercepts are in place
- Always block redirects
  - adds additional URLs to redirect block list
  - adds console warning if redirect URL is not in the list


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-535209](https://oktainc.atlassian.net/browse/OKTA-535209)

### Reviewers:
@fangshi-okta @haoyuli-okta 


