### PR TITLE
OKTA-534547 : Invalid username error handling fix

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -43,8 +43,8 @@ import {
   WidgetProps,
 } from '../../types';
 import {
+  areTransactionsEqual,
   buildAuthCoinProps,
-  getAuthenticatorKey,
   getLanguageCode,
   isAndroidOrIOS,
   isAuthClientSet,
@@ -228,13 +228,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
      * But if for some reason the keys are the same between them, we perform a last ditch check
      * against the current authenticator's ID, which should always be unique between challenges
     */
-    const pollingTxAuthKey = getAuthenticatorKey(pollingTransaction);
-    const currentTxAuthKey = getAuthenticatorKey(idxTransaction);
-    const pollingTxAuthId = pollingTransaction.context.currentAuthenticator?.value?.id;
-    const currentTxAuthId = idxTransaction.context.currentAuthenticator?.value?.id;
-    if (pollingTransaction.nextStep?.name !== idxTransaction.nextStep?.name
-        || pollingTxAuthKey !== currentTxAuthKey
-        || pollingTxAuthId !== currentTxAuthId) {
+    if (!areTransactionsEqual(idxTransaction, pollingTransaction)) {
       setIdxTransaction(pollingTransaction);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -17,7 +17,13 @@ import { useCallback } from 'preact/hooks';
 
 import { IDX_STEP } from '../constants';
 import { useWidgetContext } from '../contexts';
-import { getImmutableData, loc, toNestedObject } from '../util';
+import { MessageType } from '../types';
+import {
+  areTransactionsEqual,
+  getImmutableData,
+  loc,
+  toNestedObject,
+} from '../util';
 
 type OnSubmitHandlerOptions = {
   includeData?: boolean;
@@ -104,7 +110,11 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     try {
       const newTransaction = await fn(payload);
       setIdxTransaction(newTransaction);
-      const isClientTransaction = !newTransaction.requestDidSucceed;
+      const transactionHasWarning = (newTransaction.messages || [])?.some(
+        (message) => message.class === MessageType.WARNING.toString(),
+      );
+      const isClientTransaction = !newTransaction.requestDidSucceed
+        || (areTransactionsEqual(currTransaction, newTransaction) && transactionHasWarning);
       setIsClientTransaction(isClientTransaction);
       if (isClientTransaction
           && !newTransaction.messages?.length

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -110,7 +110,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     try {
       const newTransaction = await fn(payload);
       setIdxTransaction(newTransaction);
-      const transactionHasWarning = (newTransaction.messages || [])?.some(
+      const transactionHasWarning = (newTransaction.messages || []).some(
         (message) => message.class === MessageType.WARNING.toString(),
       );
       const isClientTransaction = !newTransaction.requestDidSucceed

--- a/src/v3/src/mocks/response/idp/idx/identify/error-invalid-username.json
+++ b/src/v3/src/mocks/response/idp/idx/identify/error-invalid-username.json
@@ -1,0 +1,188 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02.id.LIXBfLYzLfIGVMA0N7dDhhSB263Wp7OSR2mshFZv",
+  "expiresAt": "2022-09-26T17:16:21.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": ["create-form"],
+        "name": "identify",
+        "href": "http://localhost:3000/idp/idx/identify",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          { "name": "identifier", "label": "Username", "required": true },
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                { "name": "passcode", "label": "Password", "secret": true }
+              ]
+            },
+            "required": true
+          },
+          {
+            "name": "rememberMe",
+            "type": "boolean",
+            "label": "Remember this device"
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.LIXBfLYzLfIGVMA0N7dDhhSB263Wp7OSR2mshFZv",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": ["create-form"],
+        "name": "launch-authenticator",
+        "relatesTo": ["authenticatorChallenge"],
+        "href": "http://localhost:3000/idp/idx/authenticators/okta-verify/launch",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.LIXBfLYzLfIGVMA0N7dDhhSB263Wp7OSR2mshFZv",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": ["create-form"],
+        "name": "select-enroll-profile",
+        "href": "http://localhost:3000/idp/idx/enroll",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.LIXBfLYzLfIGVMA0N7dDhhSB263Wp7OSR2mshFZv",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": ["create-form"],
+        "name": "unlock-account",
+        "href": "http://localhost:3000/idp/idx/unlock-account",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.LIXBfLYzLfIGVMA0N7dDhhSB263Wp7OSR2mshFZv",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "There is no account with the Username testeruser@okta1.com.",
+        "i18n": { "key": "idx.unknown.user", "params": [] },
+        "class": "WARNING"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "recover": {
+        "rel": ["create-form"],
+        "name": "recover",
+        "href": "http://localhost:3000/idp/idx/recover",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.LIXBfLYzLfIGVMA0N7dDhhSB263Wp7OSR2mshFZv",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      "type": "password",
+      "key": "okta_password",
+      "id": "aut2h3ffszv3me6O31d7",
+      "displayName": "Password",
+      "methods": [{ "type": "password" }]
+    }
+  },
+  "user": { "type": "object", "value": { "identifier": "testeruser@okta1.com" } },
+  "cancel": {
+    "rel": ["create-form"],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02.id.LIXBfLYzLfIGVMA0N7dDhhSB263Wp7OSR2mshFZv",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "SIW Next",
+      "id": "0oa2h3j3ysoR3eHN11d7"
+    }
+  },
+  "authenticatorChallenge": {
+    "type": "object",
+    "value": {
+      "challengeMethod": "CUSTOM_URI",
+      "href": "com-okta-authenticator:/deviceChallenge?challengeRequest=eyJraWQiOiJNd2lINFJ2SFpSa0pvUFJVWkZwcWZzdzU4dWdqNjdaYWlGLW9DNFpuT2VzIiwidHlwIjoib2t0YS1kZXZpY2ViaW5kK2p3dCIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJodHRwczovL29pZS00Njk1NDYyLm9rdGFwcmV2aWV3LmNvbSIsImF1ZCI6Im9rdGEuNjNjMDgxZGItMWYxMy01MDg0LTg4MmYtZTc5ZTFlNWUyZGE3IiwiZXhwIjoxNjY0MTk5MDc2LCJpYXQiOjE2NjQxOTg3NzYsImp0aSI6ImZ0ZndYOEt0c0cxQkkyTDBRZWdQZWZrd3luaHVfc2NKZmwiLCJub25jZSI6IkJkRHphejF5R2Q5V1QxZmxOZ0lFIiwidHJhbnNhY3Rpb25JZCI6ImZ0ZndYOEt0c0cxQkkyTDBRZWdQZWZrd3luaHVfc2NKZmwiLCJzaWduYWxzIjpbImlkIiwiZGlzcGxheU5hbWUiLCJwbGF0Zm9ybSIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwib3NWZXJzaW9uIiwic2VyaWFsTnVtYmVyIiwidWRpZCIsInNpZCIsImltZWkiLCJtZWlkIiwidHBtUHVibGljS2V5SGFzaCIsInNlY3VyZUhhcmR3YXJlUHJlc2VudCIsImRldmljZUF0dGVzdGF0aW9uIiwiZGV2aWNlSW50ZWdyaXR5Iiwic2NyZWVuTG9ja1R5cGUiLCJkaXNrRW5jcnlwdGlvblR5cGUiLCJjbGllbnRJbnN0YW5jZUJ1bmRsZUlkIiwiY2xpZW50SW5zdGFuY2VEZXZpY2VTZGtWZXJzaW9uIiwiY2xpZW50SW5zdGFuY2VJZCIsImNsaWVudEluc3RhbmNlVmVyc2lvbiJdLCJ2ZXJpZmljYXRpb25VcmkiOiJodHRwczovL29pZS00Njk1NDYyLm9rdGFwcmV2aWV3LmNvbS9pZHAvYXV0aGVudGljYXRvcnMvYXV0MmgzZmZ0NHk5cERQQ1MxZDcvdHJhbnNhY3Rpb25zL2Z0ZndYOEt0c0cxQkkyTDBRZWdQZWZrd3luaHVfc2NKZmwvdmVyaWZ5IiwiY2FTdWJqZWN0TmFtZXMiOltdLCJtZG1BdHRlc3RhdGlvbklzc3VlcnMiOltdLCJrZXlUeXBlIjoicHJvb2ZPZlBvc3Nlc3Npb24iLCJrZXlUeXBlcyI6WyJ1c2VyVmVyaWZpY2F0aW9uIiwicHJvb2ZPZlBvc3Nlc3Npb24iXSwiZmFjdG9yVHlwZSI6InNpZ25lZF9ub25jZSIsIm9yZ0lkIjoiMDBvMmgzZmZvYVR3S1cwRU0xZDciLCJhcHBJbnN0YW5jZU5hbWUiOiJTSVcgTmV4dCIsIm1ldGhvZCI6InNpZ25lZF9ub25jZSIsInJlcXVlc3RSZWZlcnJlciI6Imh0dHBzOi8vb2llLTQ2OTU0NjIub2t0YXByZXZpZXcuY29tIiwidXNlck1lZGlhdGlvbiI6IlJFUVVJUkVEIiwidXNlclZlcmlmaWNhdGlvbiI6IlBSRUZFUlJFRCIsInZlciI6MH0.ny-tOaJAS_-o3E9enescqREvoOMJ8-0uvQbvCv2pq5YaUUkNyTQyAf6FNC8EHzvRosk-mYpfyIcC5Aiz6SS34kDWI6U2ceMxVzTkdolmxR-1C9gMrwolOkebqAKniVRznRUMqrpZcYAfCUQoTK2dAB393Lr-DF-y8wY2WuW2UATGD1XK0DTeqgaKEyDzFVpdx-YqyvFUdR2BFkRhaUyRc6J3Pu46unNoVAbRqc1VlUYF_Qxu2-akfTOrQkh31Xhn_y1HPV-ZN6pXEeI1QCS1xHwfRqAMJw17F0XL_k8cTiBLdABdNYmBbnD3-ocVXpbcdCA6JWbk4RiQV1KBtyahUw",
+      "downloadHref": "https://apps.apple.com/us/app/okta-verify/id490179405"
+    }
+  },
+  "authentication": {
+    "type": "object",
+    "value": {
+      "protocol": "OAUTH2.0",
+      "issuer": {
+        "id": "aus2h3f9n6mV9Rynu1d7",
+        "name": "default",
+        "uri": "http://localhost:3000/oauth2/default"
+      },
+      "request": {
+        "max_age": -1,
+        "scope": "openid profile email",
+        "response_type": "code",
+        "redirect_uri": "http://localhost:3000/login/callback",
+        "state": "ab7azU3hplpqX7sZvdhxMhyshYnA4apkpubwAknfcTL2WeNqvRYVUZoeH9GXRYt3",
+        "code_challenge_method": "S256",
+        "code_challenge": "tABD8EVLKzIIOrK1DLB_mAbgYWarUwTH6zAU4hmLZvo",
+        "response_mode": "query"
+      }
+    }
+  }
+}

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -111,21 +111,18 @@ export const areTransactionsEqual = (
   tx1: IdxTransaction | undefined,
   tx2: IdxTransaction | undefined,
 ): boolean => {
-  const tx1NextStepName = tx1?.nextStep?.name;
-  const tx2NextStepName = tx2?.nextStep?.name;
-  const tx1AuthKey = tx1 && getAuthenticatorKey(tx1);
-  const tx2AuthKey = tx2 && getAuthenticatorKey(tx2);
-  const tx1AuthId = tx1?.context.currentAuthenticator?.value?.id;
-  const tx2AuthId = tx2?.context.currentAuthenticator?.value?.id;
-
-  if (tx1NextStepName !== tx2NextStepName) {
+  if (tx1?.nextStep?.name !== tx2?.nextStep?.name) {
     return false;
   }
 
+  const tx1AuthKey = tx1 && getAuthenticatorKey(tx1);
+  const tx2AuthKey = tx2 && getAuthenticatorKey(tx2);
   if (tx1AuthKey !== tx2AuthKey) {
     return false;
   }
 
+  const tx1AuthId = tx1?.context.currentAuthenticator?.value?.id;
+  const tx2AuthId = tx2?.context.currentAuthenticator?.value?.id;
   if (tx1AuthId !== tx2AuthId) {
     return false;
   }

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -118,7 +118,17 @@ export const areTransactionsEqual = (
   const tx1AuthId = tx1?.context.currentAuthenticator?.value?.id;
   const tx2AuthId = tx2?.context.currentAuthenticator?.value?.id;
 
-  return tx1NextStepName === tx2NextStepName
-    && tx1AuthKey === tx2AuthKey
-    && tx1AuthId === tx2AuthId;
+  if (tx1NextStepName !== tx2NextStepName) {
+    return false;
+  }
+
+  if (tx1AuthKey !== tx2AuthKey) {
+    return false;
+  }
+
+  if (tx1AuthId !== tx2AuthId) {
+    return false;
+  }
+
+  return true;
 };

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -106,3 +106,19 @@ export const hasMinAuthenticatorOptions = (
 export const isAuthClientSet = (
   props: WidgetProps,
 ): props is RequiredKeys<WidgetProps, 'authClient'> => !!props.authClient;
+
+export const areTransactionsEqual = (
+  tx1: IdxTransaction | undefined,
+  tx2: IdxTransaction | undefined,
+): boolean => {
+  const tx1NextStepName = tx1?.nextStep?.name;
+  const tx2NextStepName = tx2?.nextStep?.name;
+  const tx1AuthKey = tx1 && getAuthenticatorKey(tx1);
+  const tx2AuthKey = tx2 && getAuthenticatorKey(tx2);
+  const tx1AuthId = tx1?.context.currentAuthenticator?.value?.id;
+  const tx2AuthId = tx2?.context.currentAuthenticator?.value?.id;
+
+  return tx1NextStepName === tx2NextStepName
+    && tx1AuthKey === tx2AuthKey
+    && tx1AuthId === tx2AuthId;
+};

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -13,6 +13,7 @@
 import { setup } from './util';
 
 import * as cookieUtils from '../../src/util/cookieUtils';
+import invalidUsernameMockResponse from '../../src/mocks/response/idp/idx/identify/error-invalid-username.json';
 import mockResponse from '../../src/mocks/response/idp/idx/introspect/default.json';
 import wrongPasswordMockresponse from '../../src/mocks/response/idp/idx/identify/error-wrong-password.json';
 
@@ -50,5 +51,62 @@ describe('identify-with-password-error-flow', () => {
 
     await findByText('Unable to sign in');
     expect((await findByTestId('identifier') as HTMLInputElement).value).toBe(badUsername);
+  });
+
+  it('should display warning message when invalid identifier is entered and should allow user to resubmit same information without showing client-side errors', async () => {
+    const {
+      authClient,
+      user,
+      findByTestId,
+      findByText,
+    } = await setup({
+      mockResponses: {
+        '/introspect': {
+          data: mockResponse,
+          status: 200,
+        },
+        '/idp/idx/identify': {
+          data: invalidUsernameMockResponse,
+          status: 200,
+        },
+      },
+    });
+
+    const submitButton = await findByText('Sign in', { selector: 'button' });
+    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+
+    const username = 'testeruser@okta1.com';
+    const password = 'pass@word123';
+    await user.type(usernameEl, username);
+    await user.type(passwordEl, password);
+    await user.click(submitButton);
+
+    await findByText(/There is no account with the Username/);
+
+    expect((await findByTestId('identifier') as HTMLInputElement).value).toBe(username);
+    expect((await findByTestId('credentials.passcode') as HTMLInputElement).value).toBe(password);
+
+    await user.click(await findByText('Sign in', { selector: 'button' }));
+    // TODO: OKTA-526754 - Update this assertion once merged back into 0.1
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      'POST',
+      'https://oie-8425965.oktapreview.com/idp/idx/identify',
+      {
+        data: JSON.stringify({
+          identifier: username,
+          credentials: {
+            passcode: password,
+          },
+          stateHandle: 'fake-stateHandle',
+        }),
+        headers: {
+          Accept: 'application/json; okta-version=1.0.0',
+          'Content-Type': 'application/json',
+          'X-Okta-User-Agent-Extended': 'okta-auth-js/9.9.9',
+        },
+        withCredentials: true,
+      },
+    );
   });
 });


### PR DESCRIPTION
## Description:

The purpose of this PR is to fix an issue where when a user enters an invalid username and submits, the widget displays the error (regarding the invalid username) but the fields are pre-populated with the previously submitted values but the values are not present in the formBag, so when the user resubmits (without changing one of the fields) a client side error is displayed stating the field cannot be blank.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-534547](https://oktainc.atlassian.net/browse/OKTA-534547)

### Reviewers:

### Screenshot/Video:

https://user-images.githubusercontent.com/97472729/192340584-fb75fb43-c057-4676-80a3-1795575c4fb9.mov



### Downstream Monolith Build:



