### PR TITLE
OKTA-535144: Remove onBlur field validation

### DIFF
--- a/src/v3/src/components/Button/Button.tsx
+++ b/src/v3/src/components/Button/Button.tsx
@@ -59,7 +59,6 @@ const Button: UISchemaElementComponent<{
       stepToRender,
     });
   };
-  const onMouseDown: ClickHandler = (e) => { e.preventDefault(); };
 
   return (
     <ButtonMui
@@ -67,7 +66,6 @@ const Button: UISchemaElementComponent<{
       variant={variant ?? 'primary'}
       fullWidth={wide ?? true}
       ref={focusRef}
-      onMouseDown={onMouseDown}
       disabled={loading}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...(dataType && { 'data-type': dataType } )}

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -58,10 +58,6 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
         name={name}
         id={name}
         error={error !== undefined}
-        onBlur={() => {
-          setTouched?.(true);
-          onValidateHandler?.(setError);
-        }}
         onChange={handleChange}
         fullWidth
         inputProps={{

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -61,10 +61,6 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
         id={name}
         name={name}
         error={error !== undefined}
-        onBlur={() => {
-          setTouched?.(true);
-          onValidateHandler?.(setError);
-        }}
         onChange={handleChange}
         fullWidth
         inputProps={{

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -51,7 +51,6 @@ const Link: UISchemaElementComponent<{
       step,
     });
   };
-  const onMouseDown: ClickHandler = (e) => { e.preventDefault(); };
 
   return (
     typeof href === 'undefined' ? (
@@ -59,7 +58,6 @@ const Link: UISchemaElementComponent<{
         // eslint-disable-next-line no-script-url
         href="javascript:void(0)"
         onClick={onClickHandler || onClick}
-        onMouseDown={onMouseDown}
         ref={focusRef}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...(dataSe && { 'data-se': dataSe } )}
@@ -70,7 +68,6 @@ const Link: UISchemaElementComponent<{
       : (
         <LinkMui
           href={href}
-          onMouseDown={onMouseDown}
           ref={focusRef}
         >
           {label}

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -177,10 +177,6 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
             name={fieldName}
             id={fieldName}
             error={error !== undefined}
-            onBlur={() => {
-              setTouched?.(true);
-              onValidateHandler?.(setError);
-            }}
             onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
               // Set new phone value without phone code
               setPhone(e.currentTarget.value);

--- a/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
+++ b/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
@@ -16,7 +16,6 @@ import { h } from 'preact';
 import { useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';
 import {
-  ClickHandler,
   TextWithHtmlElement,
   UISchemaElementComponent,
 } from '../../types';
@@ -37,7 +36,6 @@ const TextWithHtml: UISchemaElementComponent<{
   } = uischema.options;
   const onSubmitHandler = useOnSubmit();
 
-  const onMouseDown: ClickHandler = (e) => { e.preventDefault(); };
   const handleClick = async (e: Event) => {
     e.preventDefault();
 
@@ -61,7 +59,6 @@ const TextWithHtml: UISchemaElementComponent<{
       <Box
         onClick={handleClick}
         dangerouslySetInnerHTML={{ __html: content }}
-        onMouseDown={onMouseDown}
       />
     </Box>
   );

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -115,33 +115,6 @@ describe('identify-with-password', () => {
       expect((await findByTestId('credentials.passcode-error')).textContent).toBe('This field cannot be left blank');
     });
 
-    it('should blur required fields to view field level errors', async () => {
-      const {
-        user,
-        findByTestId,
-        queryByTestId,
-        findByText,
-      } = await setup({ mockResponse });
-
-      const identifierEle = await findByTestId('identifier') as HTMLInputElement;
-      const passcodeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
-      await findByText('Sign in', { selector: 'button' });
-
-      expect(queryByTestId('identifier-error')).toBeNull();
-      expect(queryByTestId('credentials.passcode-error')).toBeNull();
-
-      await user.tab();
-      expect(identifierEle).toHaveFocus();
-      await user.tab();
-      expect(passcodeEle).toHaveFocus();
-      await user.tab();
-
-      const identifierError = await findByTestId('identifier-error');
-      const passwordError = await findByTestId('credentials.passcode-error');
-      expect(identifierError.textContent).toEqual('This field cannot be left blank');
-      expect(passwordError.textContent).toEqual('This field cannot be left blank');
-    });
-
     it('should type in field, then clear field to view field level error', async () => {
       const {
         user,


### PR DESCRIPTION
## Description:

This PR removes the onBlur validation trigger from all components that use them.  It also removes the onMouseDown logic we added as a fix to compensate for button/link clicking (when blur validation caused the elements to move resulting in a misclick).

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-535144](https://oktainc.atlassian.net/browse/OKTA-535144)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



