### PR TITLE
adds nonce option to authParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "webpack-dev-server": "^4.8.1"
   },
   "dependencies": {
-    "@okta/okta-auth-js": "6.5.4",
+    "@okta/okta-auth-js": "6.9.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "@types/backbone": "^1.4.15",
     "@types/jquery": "^3.5.14",

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -127,6 +127,7 @@ const local: Record<string, ModelProperty> = {
   clientId: 'string',
   redirectUri: 'string',
   state: 'string',
+  nonce: 'string',
   scopes: 'array',
   codeChallenge: 'string',
   codeChallengeMethod: ['string', false],

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -12,7 +12,7 @@ export interface WidgetOptions extends Partial<Pick<OktaAuthOptions,
   'issuer' | 
   'clientId' | 
   'redirectUri' |
-  'state' | 
+  'state' |
   'scopes' |
   'codeChallenge' |
   'codeChallengeMethod' |
@@ -21,6 +21,7 @@ export interface WidgetOptions extends Partial<Pick<OktaAuthOptions,
   el?: string;
   
   // OIDC
+  nonce?: string;     // nonce is not a member of OktaAuthOptions
   oAuthTimeout?: number;
 
   // Auth client

--- a/src/v2/client/startLoginFlow.ts
+++ b/src/v2/client/startLoginFlow.ts
@@ -28,11 +28,13 @@ const handleProxyIdxResponse = async (settings) => {
 // eslint-disable-next-line complexity, max-statements
 export async function startLoginFlow(settings) {
   const authClient = settings.getAuthClient();
-  const { authParams } = settings.toJSON();
+  // nonce is not a top-level auth-js option, must be passed in manually
+  const { authParams } = settings.toJSON({verbose: true});
+  const nonce = settings.get('nonce') || authParams?.nonce;
   const idxOptions: ProceedOptions = {
     exchangeCodeForTokens: false, // we handle this in interactionCodeFlow.js
     shouldProceedWithEmailAuthenticator: false, // do not auto-select email authenticator
-    ...((authParams || {})?.nonce && { nonce: authParams.nonce })
+    ...(nonce && { nonce })
   };
 
   // Return a preset response

--- a/src/v2/client/startLoginFlow.ts
+++ b/src/v2/client/startLoginFlow.ts
@@ -32,7 +32,7 @@ export async function startLoginFlow(settings) {
   const idxOptions: ProceedOptions = {
     exchangeCodeForTokens: false, // we handle this in interactionCodeFlow.js
     shouldProceedWithEmailAuthenticator: false, // do not auto-select email authenticator
-    ...((authParams || {})?.nonce && { nonce: authParams!.nonce })
+    ...((authParams || {})?.nonce && { nonce: authParams.nonce })
   };
 
   // Return a preset response

--- a/src/v2/client/startLoginFlow.ts
+++ b/src/v2/client/startLoginFlow.ts
@@ -32,7 +32,7 @@ export async function startLoginFlow(settings) {
   const idxOptions: ProceedOptions = {
     exchangeCodeForTokens: false, // we handle this in interactionCodeFlow.js
     shouldProceedWithEmailAuthenticator: false, // do not auto-select email authenticator
-    ...(!!authParams?.nonce && { nonce: authParams?.nonce })
+    ...((authParams || {})?.nonce && { nonce: authParams!.nonce })
   };
 
   // Return a preset response

--- a/src/v2/client/startLoginFlow.ts
+++ b/src/v2/client/startLoginFlow.ts
@@ -28,9 +28,11 @@ const handleProxyIdxResponse = async (settings) => {
 // eslint-disable-next-line complexity, max-statements
 export async function startLoginFlow(settings) {
   const authClient = settings.getAuthClient();
+  const { authParams } = settings.toJSON();
   const idxOptions: ProceedOptions = {
     exchangeCodeForTokens: false, // we handle this in interactionCodeFlow.js
     shouldProceedWithEmailAuthenticator: false, // do not auto-select email authenticator
+    ...(!!authParams?.nonce && { nonce: authParams?.nonce })
   };
 
   // Return a preset response

--- a/test/unit/spec/v2/client/startLoginFlow_spec.js
+++ b/test/unit/spec/v2/client/startLoginFlow_spec.js
@@ -216,25 +216,44 @@ describe('v2/client/startLoginFlow', () => {
   });
 
   describe('nonce', () => {
-    beforeEach(() => {
-      const { settings, ...ctx } = testContext;
+    it('shall pass nonce to /interact when provided with authParams', async () => {
+      let { settings } = testContext;
       const authClient = settings.getAuthClient();
-      const s = new Settings({
+      const { start, proceed } = testContext;
+      settings = new Settings({
         baseUrl: 'localhost:1234',
         stateToken: 'a test state token from settings',
         authParams: {
           nonce: 'nonce upon a time'
         }
       });
-      s.authClient = authClient;
-      testContext = {
-        settings: s,
-        ...ctx
-      };
+      settings.authClient = authClient;
+      settings.set('useInteractionCodeFlow', true);
+      const result = await startLoginFlow(settings);
+      expect(result).toEqual({
+        fake: 'fake start response'
+      });
+
+      expect(start).toHaveBeenCalledTimes(1);
+
+      expect(start).toHaveBeenCalledWith({
+        exchangeCodeForTokens: false,
+        shouldProceedWithEmailAuthenticator: false,
+        nonce: 'nonce upon a time'
+      });
+      expect(proceed).not.toHaveBeenCalled();
     });
 
-    it('shall pass nonce to /interact when provided with authParams', async () => {
-      const { settings, start, proceed } = testContext;
+    it('shall pass nonce to /interact when provided on top-level config', async () => {
+      let { settings } = testContext;
+      const authClient = settings.getAuthClient();
+      const { start, proceed } = testContext;
+      settings = new Settings({
+        baseUrl: 'localhost:1234',
+        stateToken: 'a test state token from settings',
+        nonce: 'nonce upon a time'
+      });
+      settings.authClient = authClient;
       settings.set('useInteractionCodeFlow', true);
       const result = await startLoginFlow(settings);
       expect(result).toEqual({

--- a/test/unit/spec/v2/client/startLoginFlow_spec.js
+++ b/test/unit/spec/v2/client/startLoginFlow_spec.js
@@ -215,4 +215,41 @@ describe('v2/client/startLoginFlow', () => {
     }
   });
 
+  describe('nonce', () => {
+    beforeEach(() => {
+      const { settings, ...ctx } = testContext;
+      const authClient = settings.getAuthClient();
+      const s = new Settings({
+        baseUrl: 'localhost:1234',
+        stateToken: 'a test state token from settings',
+        authParams: {
+          nonce: 'nonce upon a time'
+        }
+      });
+      s.authClient = authClient;
+      testContext = {
+        settings: s,
+        ...ctx
+      };
+    })
+
+    it('shall pass nonce to /interact when provided with authParams', async () => {
+      const { settings, start, proceed } = testContext;
+      settings.set('useInteractionCodeFlow', true);
+      const result = await startLoginFlow(settings);
+      expect(result).toEqual({
+        fake: 'fake start response'
+      });
+
+      expect(start).toHaveBeenCalledTimes(1);
+
+      expect(start).toHaveBeenCalledWith({
+        exchangeCodeForTokens: false,
+        shouldProceedWithEmailAuthenticator: false,
+        nonce: 'nonce upon a time'
+      });
+      expect(proceed).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/test/unit/spec/v2/client/startLoginFlow_spec.js
+++ b/test/unit/spec/v2/client/startLoginFlow_spec.js
@@ -231,7 +231,7 @@ describe('v2/client/startLoginFlow', () => {
         settings: s,
         ...ctx
       };
-    })
+    });
 
     it('shall pass nonce to /interact when provided with authParams', async () => {
       const { settings, start, proceed } = testContext;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3232,29 +3232,6 @@
     node-properties-parser "^0.0.2"
     properties-to-json "^0.1.7"
 
-"@okta/okta-auth-js@6.5.4":
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.5.4.tgz#a61877162113e6e0cfe7e05ecaf55840aa287669"
-  integrity sha512-a96D1QUBlE464Xm0GBSIWTcRYyGgsDf/TchGJeDbUvEa2rcFJcxG1x+7gRUzMW+WiX1DN7N0v8Dd+j6Fgou+ow==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@babel/runtime-corejs3" "^7.17.0"
-    "@peculiar/webcrypto" "1.1.6"
-    Base64 "1.1.0"
-    atob "^2.1.2"
-    broadcast-channel "4.13.0"
-    btoa "^1.2.1"
-    core-js "^3.6.5"
-    cross-fetch "^3.1.5"
-    js-cookie "^3.0.1"
-    jsonpath-plus "^6.0.1"
-    node-cache "^5.1.2"
-    p-cancelable "^2.0.0"
-    text-encoding "^0.7.0"
-    tiny-emitter "1.1.0"
-    webcrypto-shim "^0.1.5"
-    xhr2 "0.1.3"
-
 "@okta/okta-auth-js@6.9.0":
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.9.0.tgz#2b568234f1c2ef203160faa4f4697bb02038ab83"
@@ -3293,15 +3270,6 @@
     rasha "^1.2.5"
     safe-flat "^2.0.2"
 
-"@peculiar/asn1-schema@^2.0.27":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.0.tgz#5368416eb336138770c692ffc2bab119ee3ae917"
-  integrity sha512-DtNLAG4vmDrdSJFPe7rypkcj597chNQL7u+2dBtYo5mh7VW2+im6ke+O0NVr8W1f4re4C3F71LhoMb0Yxqa48Q==
-  dependencies:
-    asn1js "^3.0.5"
-    pvtsutils "^1.3.2"
-    tslib "^2.4.0"
-
 "@peculiar/asn1-schema@^2.1.6":
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.1.7.tgz#17d9b79f7df748ef84158ea61a24fc11d9f3f4d9"
@@ -3317,17 +3285,6 @@
   integrity sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==
   dependencies:
     tslib "^2.0.0"
-
-"@peculiar/webcrypto@1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz#484bb58be07149e19e873861b585b0d5e4f83b7b"
-  integrity sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==
-  dependencies:
-    "@peculiar/asn1-schema" "^2.0.27"
-    "@peculiar/json-schema" "^1.1.12"
-    pvtsutils "^1.1.2"
-    tslib "^2.1.0"
-    webcrypto-core "^1.2.0"
 
 "@peculiar/webcrypto@^1.4.0":
   version "1.4.0"
@@ -5093,15 +5050,6 @@ asn1js@^3.0.1, asn1js@^3.0.3:
     pvutils "^1.1.3"
     tslib "^2.4.0"
 
-asn1js@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.5.tgz#5ea36820443dbefb51cc7f88a2ebb5b462114f38"
-  integrity sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==
-  dependencies:
-    pvtsutils "^1.3.2"
-    pvutils "^1.1.3"
-    tslib "^2.4.0"
-
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -5656,19 +5604,6 @@ braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   dependencies:
     fill-range "^7.0.1"
-
-broadcast-channel@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.13.0.tgz#21387b2602b9e9ec3b97b03bd8a8d2c198352ff6"
-  integrity sha512-fcDr8QNJ4SOb6jyjUNZatVNmcHtSWfW4PFcs4xIEFZAtorKCIFoEYtjIjaQ4c0jrbr/Bl8NIwOWiLSyspoAnEQ==
-  dependencies:
-    "@babel/runtime" "^7.16.0"
-    detect-node "^2.1.0"
-    microtime "3.0.0"
-    oblivious-set "1.1.1"
-    p-queue "6.6.2"
-    rimraf "3.0.2"
-    unload "2.3.1"
 
 broadcast-channel@~4.17.0:
   version "4.17.0"
@@ -7464,7 +7399,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@2.1.0, detect-node@^2.1.0:
+detect-node@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -12911,14 +12846,6 @@ micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-microtime@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/microtime/-/microtime-3.0.0.tgz#d140914bde88aa89b4f9fd2a18620b435af0f39b"
-  integrity sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==
-  dependencies:
-    node-addon-api "^1.2.0"
-    node-gyp-build "^3.8.0"
-
 mime-db@1.44.0, mime-db@^1.41.0:
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
@@ -13303,11 +13230,6 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-addon-api@^1.2.0:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
-  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
-
 node-cache@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
@@ -13333,11 +13255,6 @@ node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
-
-node-gyp-build@^3.8.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz#53a350187dd4d5276750da21605d1cb681d09e25"
-  integrity sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==
 
 node-http2@^4.0.1:
   version "4.0.1"
@@ -14957,7 +14874,7 @@ pure-utilities@^1.1.4:
   resolved "https://registry.yarnpkg.com/pure-utilities/-/pure-utilities-1.2.4.tgz#d98e06ce656358022dc2efaa7d1edd15b02edc92"
   integrity sha512-wKrO9wxN2inA57pgA9mZZi81CvHt7xo50y4OxW4EqOYsL38DBriiQL3hGGb78MWi1Sjxkj+gCzYMvKcltQOe3w==
 
-pvtsutils@^1.1.2, pvtsutils@^1.3.2:
+pvtsutils@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.2.tgz#9f8570d132cdd3c27ab7d51a2799239bf8d8d5de"
   integrity sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==
@@ -18443,7 +18360,7 @@ webauth@^1.1.0:
   resolved "https://registry.yarnpkg.com/webauth/-/webauth-1.1.0.tgz#64704f6b8026986605bc3ca629952e6e26fdd100"
   integrity sha1-ZHBPa4AmmGYFvDymKZUubib90QA=
 
-webcrypto-core@^1.2.0, webcrypto-core@^1.7.4:
+webcrypto-core@^1.7.4:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.7.5.tgz#c02104c953ca7107557f9c165d194c6316587ca4"
   integrity sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3255,6 +3255,29 @@
     webcrypto-shim "^0.1.5"
     xhr2 "0.1.3"
 
+"@okta/okta-auth-js@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.9.0.tgz#2b568234f1c2ef203160faa4f4697bb02038ab83"
+  integrity sha512-IAh9mh2iGT4bsGeRMSSGBYoeEJ4f3ABTO+Jf9mYr0MbKgyU+X+7RwYAo/z8JHJ9AW0ynmjERTMOgDJ7/H/N+Dw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@babel/runtime-corejs3" "^7.17.0"
+    "@peculiar/webcrypto" "^1.4.0"
+    Base64 "1.1.0"
+    atob "^2.1.2"
+    broadcast-channel "~4.17.0"
+    btoa "^1.2.1"
+    core-js "^3.6.5"
+    cross-fetch "^3.1.5"
+    js-cookie "^3.0.1"
+    jsonpath-plus "^6.0.1"
+    node-cache "^5.1.2"
+    p-cancelable "^2.0.0"
+    text-encoding "^0.7.0"
+    tiny-emitter "1.1.0"
+    webcrypto-shim "^0.1.5"
+    xhr2 "0.1.3"
+
 "@okta/okta-sdk-nodejs@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-6.2.0.tgz#081cb86b2ac9c875778aef53ed7b3f3f24772887"
@@ -3305,6 +3328,17 @@
     pvtsutils "^1.1.2"
     tslib "^2.1.0"
     webcrypto-core "^1.2.0"
+
+"@peculiar/webcrypto@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz#f941bd95285a0f8a3d2af39ccda5197b80cd32bf"
+  integrity sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.1.6"
+    "@peculiar/json-schema" "^1.1.12"
+    pvtsutils "^1.3.2"
+    tslib "^2.4.0"
+    webcrypto-core "^1.7.4"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
@@ -5631,6 +5665,17 @@ broadcast-channel@4.13.0:
     "@babel/runtime" "^7.16.0"
     detect-node "^2.1.0"
     microtime "3.0.0"
+    oblivious-set "1.1.1"
+    p-queue "6.6.2"
+    rimraf "3.0.2"
+    unload "2.3.1"
+
+broadcast-channel@~4.17.0:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.17.0.tgz#599d44674b09a4e2e07af6da5d03b45ca8bffd11"
+  integrity sha512-r2GSQMNgZv7eAsbdsu9xofSjc3J2diCQTPkSuyVhLBfx8fylLCVhi5KheuhuAQBJNd4pxqUyz9U6rvdnt7GZng==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
     oblivious-set "1.1.1"
     p-queue "6.6.2"
     rimraf "3.0.2"
@@ -18398,7 +18443,7 @@ webauth@^1.1.0:
   resolved "https://registry.yarnpkg.com/webauth/-/webauth-1.1.0.tgz#64704f6b8026986605bc3ca629952e6e26fdd100"
   integrity sha1-ZHBPa4AmmGYFvDymKZUubib90QA=
 
-webcrypto-core@^1.2.0:
+webcrypto-core@^1.2.0, webcrypto-core@^1.7.4:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.7.5.tgz#c02104c953ca7107557f9c165d194c6316587ca4"
   integrity sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==


### PR DESCRIPTION
## Description:
* bumps `okta-auth-js` to `6.9.0`
* adds `nonce` option to `authParams`, passes value to `/interact` call


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-534901](https://oktainc.atlassian.net/browse/OKTA-534901)

### Reviewers:

### Screenshot/Video:

https://user-images.githubusercontent.com/90656038/192562616-b5ee8e94-6f58-477d-9f36-68887cefa53a.mov



### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=651c57c9ab6aff1e68a6b7d450c88d0eed27bd30&tab=main


