### PR TITLE
Add backToSignInLink to WidgetOptions

### DIFF
--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -63,6 +63,7 @@ export interface WidgetOptions extends Partial<Pick<OktaAuthOptions,
     custom?: Array<Link>;
   };
   signOutLink?: string;
+  backToSignInLink?: string;
   // Buttons
   customButtons?: Array<CustomButton>;
   // Registration


### PR DESCRIPTION
## Description:
fix: Add backToSignInLink to WidgetOptions.ts
According to the [documentation](https://github.com/okta/okta-signin-widget#back-to-sign-in-link), the SIW should allow a `backToSignInLink` to be specified in its config.
However, this option is missing from the `WidgetOptions.ts`, which prevents the TypeScript from compiling.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



