### PR TITLE
OKTA-530519 :-  Enter button click submits form when hide of link and unhide of texbox 

### DIFF
--- a/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
@@ -54,7 +54,7 @@ const Body = BaseAuthenticatorEmailForm.extend(
       this.render();
 
       this.showCodeEntryField(true);
-      this.showEnterAuthCodeInsteadLink(false);
+      this.removeEnterAuthCodeInsteadLink();
     },
 
     showCodeEntryField(show = true) {
@@ -62,11 +62,8 @@ const Body = BaseAuthenticatorEmailForm.extend(
       $textField.toggle(show);
     },
 
-    showEnterAuthCodeInsteadLink(show = true) {
-      const $enterAuthCodeInsteadLink = this.$el.find(
-        '.enter-auth-code-instead-link'
-      );
-      $enterAuthCodeInsteadLink.toggle(show);
+    removeEnterAuthCodeInsteadLink() {
+      this.$el.find('.enter-auth-code-instead-link').remove();
     },
   })
 );

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -58,7 +58,7 @@ const Body = BaseAuthenticatorEmailForm.extend(
       this.render();
 
       this.showCodeEntryField(true);
-      this.showEnterAuthCodeInsteadLink(false);
+      this.removeEnterAuthCodeInsteadLink();
     },
 
     showCodeEntryField(show = true) {
@@ -66,11 +66,8 @@ const Body = BaseAuthenticatorEmailForm.extend(
       $textField.toggle(show);
     },
 
-    showEnterAuthCodeInsteadLink(show = true) {
-      const $enterAuthCodeInsteadLink = this.$el.find(
-        '.enter-auth-code-instead-link'
-      );
-      $enterAuthCodeInsteadLink.toggle(show);
+    removeEnterAuthCodeInsteadLink() {
+      this.$el.find('.enter-auth-code-instead-link').remove();
     },
   })
 );

--- a/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
@@ -30,6 +30,10 @@ export default class ChallengeFactorPageObject extends BasePageObject {
     return this.form.clickSaveButton();
   }
 
+  pressEnter() {
+    return this.t.pressKey('enter');
+  }
+
   /**
    * @deprecated {@see this.form.getTitle}
    */

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -393,14 +393,14 @@ test
 
 test
   .requestHooks(invalidOTPMock)('challenge email authenticator with invalid OTP', async t => {
-  const challengeEmailPageObject = await setup(t);
-  await challengeEmailPageObject.clickEnterCodeLink();
+    const challengeEmailPageObject = await setup(t);
+    await challengeEmailPageObject.clickEnterCodeLink();
 
-  await challengeEmailPageObject.verifyFactor('credentials.passcode', 'xyz');
-  await challengeEmailPageObject.pressEnter();
-  await challengeEmailPageObject.waitForErrorBox();
-  await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
-  await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
+    await challengeEmailPageObject.verifyFactor('credentials.passcode', 'xyz');
+    await challengeEmailPageObject.pressEnter();
+    await challengeEmailPageObject.waitForErrorBox();
+    await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
+    await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
 });
 
 test

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -280,6 +280,8 @@ test
     const emailAddress = emailVerification.currentAuthenticatorEnrollment.value.profile.email;
     await t.expect(challengeEmailPageObject.getFormSubtitle())
       .eql(`We sent an email to ${emailAddress}. Click the verification link in your email to continue or enter the code below.`);
+    const enterVerificationCodeText = challengeEmailPageObject.getEnterVerificationCodeText();
+    await t.expect(enterVerificationCodeText).eql(enterVerificationCode);
 
     // Verify links (switch authenticator link not present since there are no other authenticators available)
     await t.expect(await challengeEmailPageObject.switchAuthenticatorLinkExists()).notOk();
@@ -313,6 +315,8 @@ test
       authenticatorKey: 'okta_email',
       methodType: 'email',
     });
+    const enterVerificationCodeText = challengeEmailPageObject.getEnterVerificationCodeText();
+    await t.expect(enterVerificationCodeText).eql(enterVerificationCode);
     await challengeEmailPageObject.clickEnterCodeLink();
 
     const pageTitle = challengeEmailPageObject.getFormTitle();
@@ -333,7 +337,10 @@ test
 test
   .requestHooks(validOTPmockNoProfile)('challenge email authenticator screen has right labels when profile is null', async t => {
     const challengeEmailPageObject = await setup(t);
+    const enterVerificationCodeText = challengeEmailPageObject.getEnterVerificationCodeText();
+    await t.expect(enterVerificationCodeText).eql(enterVerificationCode);
     await challengeEmailPageObject.clickEnterCodeLink();
+    await t.expect(challengeEmailPageObject.form.getElement('.enter-auth-code-instead-link').exists).eql(false);
 
     const pageTitle = challengeEmailPageObject.getPageTitle();
     const saveBtnText = challengeEmailPageObject.getSaveButtonLabel();
@@ -360,6 +367,8 @@ test
 test
   .requestHooks(validOTPmockEmptyProfile)('challenge email authenticator screen has right labels when profile is empty', async t => {
     const challengeEmailPageObject = await setup(t);
+    const enterVerificationCodeText = challengeEmailPageObject.getEnterVerificationCodeText();
+    await t.expect(enterVerificationCodeText).eql(enterVerificationCode);
     await challengeEmailPageObject.clickEnterCodeLink();
 
     const pageTitle = challengeEmailPageObject.getPageTitle();

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -321,10 +321,8 @@ test
     await t.expect(saveBtnText).eql('Verify');
 
     const emailAddress = emailVerification.currentAuthenticatorEnrollment.value.profile.email;
-    const enterVerificationCodeText = challengeEmailPageObject.getEnterVerificationCodeText();
     await t.expect(challengeEmailPageObject.getFormSubtitle())
       .eql(`We sent an email to ${emailAddress}. Click the verification link in your email to continue or enter the code below.`);
-    await t.expect(enterVerificationCodeText).eql(enterVerificationCode);
 
     // Verify links (switch authenticator link not present since there are no other authenticators available)
     await t.expect(await challengeEmailPageObject.switchAuthenticatorLinkExists()).notOk();
@@ -339,13 +337,11 @@ test
 
     const pageTitle = challengeEmailPageObject.getPageTitle();
     const saveBtnText = challengeEmailPageObject.getSaveButtonLabel();
-    const enterVerificationCodeText = challengeEmailPageObject.getEnterVerificationCodeText();
     await t.expect(saveBtnText).contains('Verify');
     await t.expect(pageTitle).contains('Verify with your email');
 
     await t.expect(challengeEmailPageObject.getFormSubtitle())
       .contains('We sent you a verification email. Click the verification link in your email to continue or enter the code below.');
-    await t.expect(enterVerificationCodeText).eql(enterVerificationCode);
   });
 
 test
@@ -368,12 +364,10 @@ test
 
     const pageTitle = challengeEmailPageObject.getPageTitle();
     const saveBtnText = challengeEmailPageObject.getSaveButtonLabel();
-    const enterVerificationCodeText = challengeEmailPageObject.getEnterVerificationCodeText();
     await t.expect(saveBtnText).contains('Verify');
     await t.expect(pageTitle).contains('Verify with your email');
     await t.expect(challengeEmailPageObject.getFormSubtitle())
       .contains('We sent you a verification email. Click the verification link in your email to continue or enter the code below.');
-    await t.expect(enterVerificationCodeText).eql(enterVerificationCode);
   });
 
 test

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -401,7 +401,7 @@ test
     await challengeEmailPageObject.waitForErrorBox();
     await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
     await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
-});
+  });
 
 test
   .requestHooks(invalidOTPMockWithPoll)('challenge email authenticator - ensure poll does not clear invalid OTP error', async t => {

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -392,7 +392,7 @@ test
   });
 
 test
-.requestHooks(invalidOTPMock)('challenge email authenticator with invalid OTP', async t => {
+  .requestHooks(invalidOTPMock)('challenge email authenticator with invalid OTP', async t => {
   const challengeEmailPageObject = await setup(t);
   await challengeEmailPageObject.clickEnterCodeLink();
 

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -392,6 +392,18 @@ test
   });
 
 test
+.requestHooks(invalidOTPMock)('challenge email authenticator with invalid OTP', async t => {
+  const challengeEmailPageObject = await setup(t);
+  await challengeEmailPageObject.clickEnterCodeLink();
+
+  await challengeEmailPageObject.verifyFactor('credentials.passcode', 'xyz');
+  await challengeEmailPageObject.pressEnter();
+  await challengeEmailPageObject.waitForErrorBox();
+  await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
+  await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
+});
+
+test
   .requestHooks(invalidOTPMockWithPoll)('challenge email authenticator - ensure poll does not clear invalid OTP error', async t => {
     const challengeEmailPageObject = await setup(t);
     await challengeEmailPageObject.clickEnterCodeLink();


### PR DESCRIPTION
## OKTA-530519

- When link and textbox both present on SIW, on unhide of textbox the Enter button was not submitting form
- Removed the `'Enter the verification code instead'` link on click of it which removed the click event along with it and Enter button goes back to submit form behavior
- Monolith Downstream Build: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=lh-okta-530519&page=1&pageSize=6&sha=d9b771f4c23ff13e7b2635c24708f83b444d4535&tab=main
- Github commit: https://github.com/okta/okta-core/commit/d9b771f4c23ff13e7b2635c24708f83b444d4535 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-530519](https://oktainc.atlassian.net/browse/OKTA-530519)

### Reviewers:
@okta/ciamx @aarongranick-okta @shuowu 

### Screenshot/Video:
https://okta.box.com/s/idwcr626vbzkbrhwfhurvo4r3jbaqe8s 

### Downstream Monolith Build:
