### PR TITLE
OKTA-516578 : Re-enabling and fixing select authenticator tests

### DIFF
--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorEnroll.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorEnroll.test.ts.snap
@@ -1,0 +1,173 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Enroll Authenticator Selector Transformer Tests should transform authenticator elements when step is not skippable 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.enroll.subtitle",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.setup.required",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "Email",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.id": "123abc",
+          },
+          "ctaLabel": "Select",
+          "description": "Enroll in email authenticator",
+          "key": "okta_email",
+          "step": "select-authenticator-enroll",
+          "type": "button",
+        },
+        "type": "AuthenticatorButton",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Enroll Authenticator Selector Transformer Tests should transform authenticator elements when step is skippable 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.enroll.subtitle",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.setup.optional",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "Email",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.id": "123abc",
+          },
+          "ctaLabel": "Select",
+          "description": "Enroll in email authenticator",
+          "key": "okta_email",
+          "step": "select-authenticator-enroll",
+          "type": "button",
+        },
+        "type": "AuthenticatorButton",
+      },
+      Object {
+        "label": "oie.optional.authenticator.button.title",
+        "options": Object {
+          "step": "skip",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Enroll Authenticator Selector Transformer Tests should transform authenticator elements when step is skippable and brandName is provided 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.enroll.subtitle.custom",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.setup.optional",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "Email",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.id": "123abc",
+          },
+          "ctaLabel": "Select",
+          "description": "Enroll in email authenticator",
+          "key": "okta_email",
+          "step": "select-authenticator-enroll",
+          "type": "button",
+        },
+        "type": "AuthenticatorButton",
+      },
+      Object {
+        "label": "oie.optional.authenticator.button.title",
+        "options": Object {
+          "step": "skip",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorUnlockVerify.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorUnlockVerify.test.ts.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Unlock Verification Authenticator Selector Tests should add UI elements for unlock verification authenticator selector 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "unlockaccount",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "Email",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.id": "123abc",
+          },
+          "ctaLabel": "Select",
+          "key": "okta_email",
+          "step": "select-authenticator-unlock-account",
+          "type": "button",
+        },
+        "type": "AuthenticatorButton",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorVerify.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorVerify.test.ts.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Verify Authenticator Selector Transformer Tests should add UI elements for verification authenticator selector when in password recovery flow 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.reset.title.generic",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.password.reset.verification",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "Email",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.id": "123abc",
+          },
+          "ctaLabel": "Select",
+          "key": "okta_email",
+          "step": "select-authenticator-authenticate",
+          "type": "button",
+        },
+        "type": "AuthenticatorButton",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Verify Authenticator Selector Transformer Tests should add UI elements for verification authenticator selector when in password recovery flow and brand name is provided 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.reset.title.specific",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.password.reset.verification",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "Email",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.id": "123abc",
+          },
+          "ctaLabel": "Select",
+          "key": "okta_email",
+          "step": "select-authenticator-authenticate",
+          "type": "button",
+        },
+        "type": "AuthenticatorButton",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Verify Authenticator Selector Transformer Tests should add UI elements for verification authenticator selector when not in password recovery flow 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.verify.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.verify.subtitle",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "Email",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.id": "123abc",
+          },
+          "ctaLabel": "Select",
+          "key": "okta_email",
+          "step": "select-authenticator-authenticate",
+          "type": "button",
+        },
+        "type": "AuthenticatorButton",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectOVMethodVerify.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectOVMethodVerify.test.ts.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Transform Select OV Method Verify Tests should transform elements when transaction contains push and totp method types 1`] = `
+Object {
+  "data": Object {
+    "authenticator.autoChallenge": "true",
+    "authenticator.methodType": "push",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.verify.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.select.authenticators.verify.subtitle",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "Get a push notification",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "push",
+          },
+          "ctaLabel": "Select",
+          "key": "okta_verify",
+          "step": "select-authenticator-authenticate",
+          "type": "button",
+        },
+        "type": "AuthenticatorButton",
+      },
+      Object {
+        "label": "Enter a code",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "totp",
+          },
+          "ctaLabel": "Select",
+          "key": "okta_verify",
+          "step": "select-authenticator-authenticate",
+          "type": "button",
+        },
+        "type": "AuthenticatorButton",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Transform Select OV Method Verify Tests should transform elements when transaction only contains push method type with autoChallenge option 1`] = `
+Object {
+  "data": Object {
+    "authenticator.autoChallenge": "true",
+    "authenticator.methodType": "push",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "authenticator.autoChallenge",
+            "value": "true",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oie.okta_verify.sendPushButton",
+        "options": Object {
+          "step": "select-authenticator-authenticate",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/utils.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/utils.test.ts.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Select Authenticator Utility Tests getAuthenticatorEnrollButtonElements Tests should format on_prem authenticator option when display name exists 1`] = `
+Array [
+  Object {
+    "label": "On Prem",
+    "options": Object {
+      "actionParams": Object {
+        "authenticator.enrollmentId": undefined,
+        "authenticator.id": undefined,
+        "authenticator.methodType": "onprem_mfa",
+      },
+      "authenticator": Object {
+        "displayName": "Some Company Name",
+        "id": "",
+        "key": "onprem_mfa",
+        "methods": Array [
+          Object {
+            "type": "",
+          },
+        ],
+        "type": "",
+      },
+      "ctaLabel": "oie.enroll.authenticator.button.text",
+      "dataSe": "onprem_mfa-onprem_mfa",
+      "description": "oie.on_prem.authenticator.description",
+      "iconName": "onprem_mfa_0",
+      "includeData": true,
+      "includeImmutableData": false,
+      "key": "onprem_mfa",
+      "logoUri": undefined,
+      "step": "select-authenticator-enroll",
+      "type": "button",
+      "usageDescription": undefined,
+    },
+    "type": "AuthenticatorButton",
+  },
+]
+`;
+
+exports[`Select Authenticator Utility Tests getAuthenticatorEnrollButtonElements Tests should return formatted Okta Verify method type options when raw options are provided 1`] = `
+Array [
+  Object {
+    "label": "Code",
+    "options": Object {
+      "actionParams": Object {
+        "authenticator.id": "1234abc",
+        "authenticator.methodType": "totp",
+      },
+      "ctaLabel": "oie.enroll.authenticator.button.text",
+      "dataSe": "okta_verify-totp",
+      "description": "oie.okta_verify.authenticator.description",
+      "iconDescr": "factor.totpSoft.description",
+      "iconName": "oktaVerify",
+      "includeData": true,
+      "includeImmutableData": false,
+      "key": "okta_verify",
+      "step": "select-authenticator-enroll",
+      "type": "button",
+    },
+    "type": "AuthenticatorButton",
+  },
+  Object {
+    "label": "Push",
+    "options": Object {
+      "actionParams": Object {
+        "authenticator.id": "1234abc",
+        "authenticator.methodType": "push",
+      },
+      "ctaLabel": "oie.enroll.authenticator.button.text",
+      "dataSe": "okta_verify-push",
+      "description": "oie.okta_verify.authenticator.description",
+      "iconDescr": "factor.push.description",
+      "iconName": "oktaVerifyPush",
+      "includeData": true,
+      "includeImmutableData": false,
+      "key": "okta_verify",
+      "step": "select-authenticator-enroll",
+      "type": "button",
+    },
+    "type": "AuthenticatorButton",
+  },
+]
+`;
+
+exports[`Select Authenticator Utility Tests getAuthenticatorVerifyButtonElements Tests should return formatted Okta Verify method type options when raw options are provided 1`] = `
+Array [
+  Object {
+    "label": "Code",
+    "options": Object {
+      "actionParams": Object {
+        "authenticator.id": "1234abc",
+        "authenticator.methodType": "totp",
+      },
+      "ctaLabel": "oie.verify.authenticator.button.text",
+      "dataSe": "okta_verify-totp",
+      "description": undefined,
+      "iconDescr": "factor.totpSoft.description",
+      "iconName": "oktaVerify",
+      "includeData": true,
+      "includeImmutableData": false,
+      "key": "okta_verify",
+      "step": "select-authenticator-enroll",
+      "type": "button",
+    },
+    "type": "AuthenticatorButton",
+  },
+  Object {
+    "label": "Push",
+    "options": Object {
+      "actionParams": Object {
+        "authenticator.id": "1234abc",
+        "authenticator.methodType": "push",
+      },
+      "ctaLabel": "oie.verify.authenticator.button.text",
+      "dataSe": "okta_verify-push",
+      "description": undefined,
+      "iconDescr": "factor.push.description",
+      "iconName": "oktaVerifyPush",
+      "includeData": true,
+      "includeImmutableData": false,
+      "key": "okta_verify",
+      "step": "select-authenticator-enroll",
+      "type": "button",
+    },
+    "type": "AuthenticatorButton",
+  },
+]
+`;

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.test.ts
@@ -15,10 +15,7 @@ import { AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   AuthenticatorButtonElement,
-  ButtonElement,
   ButtonType,
-  DescriptionElement,
-  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -49,7 +46,7 @@ jest.mock('./utils', () => ({
   ) => (options.length ? getMockAuthenticatorButtons() : []),
 }));
 
-describe.skip('Enroll Authenticator Selector Transformer Tests', () => {
+describe('Enroll Authenticator Selector Transformer Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const formBag = getStubFormBag();
   const isSkippable = jest.fn();
@@ -57,6 +54,7 @@ describe.skip('Enroll Authenticator Selector Transformer Tests', () => {
 
   beforeEach(() => {
     formBag.uischema.elements = [];
+    transaction.availableSteps = [];
     transaction.nextStep = {
       name: IDX_STEP.SELECT_AUTHENTICATOR_ENROLL,
       canSkip: isSkippable.mockReturnValue(false)(),
@@ -95,21 +93,7 @@ describe.skip('Enroll Authenticator Selector Transformer Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.select.authenticators.enroll.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.select.authenticators.enroll.subtitle');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
-      .toBe('oie.setup.optional');
-    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
-
-    expect(updatedFormBag.uischema.elements[4].type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
-      .toBe('oie.optional.authenticator.button.title');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should transform authenticator elements when step is not skippable', () => {
@@ -118,17 +102,7 @@ describe.skip('Enroll Authenticator Selector Transformer Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.select.authenticators.enroll.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.select.authenticators.enroll.subtitle');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
-      .toBe('oie.setup.required');
-    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should transform authenticator elements when step is skippable and brandName is provided', () => {
@@ -140,19 +114,6 @@ describe.skip('Enroll Authenticator Selector Transformer Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.select.authenticators.enroll.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.select.authenticators.enroll.subtitle.custom');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
-      .toBe('oie.setup.optional');
-    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
-    expect(updatedFormBag.uischema.elements[4].type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
-      .toBe('oie.optional.authenticator.button.title');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.test.ts
@@ -15,7 +15,10 @@ import { AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   AuthenticatorButtonElement,
+  ButtonElement,
   ButtonType,
+  DescriptionElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -92,8 +95,27 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
       transaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.select.authenticators.enroll.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.select.authenticators.enroll.subtitle');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.setup.optional');
+    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButton');
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+
+    expect(updatedFormBag.uischema.elements[4].type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+      .toBe('oie.optional.authenticator.button.title');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options.step)
+      .toBe('skip');
   });
 
   it('should transform authenticator elements when step is not skippable', () => {
@@ -101,8 +123,23 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
       transaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.select.authenticators.enroll.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.select.authenticators.enroll.subtitle');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.setup.required');
+    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButton');
+    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).options.step)
+      .toBe('select-authenticator-enroll');
+    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).options.type)
+      .toBe(ButtonType.BUTTON);
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id'])).toBe('123abc');
   });
 
   it('should transform authenticator elements when step is skippable and brandName is provided', () => {
@@ -113,7 +150,27 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
       transaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.select.authenticators.enroll.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.select.authenticators.enroll.subtitle.custom');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.setup.optional');
+    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButton');
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).options.step)
+      .toBe('select-authenticator-enroll');
+    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).options.type)
+      .toBe(ButtonType.BUTTON);
+    expect(updatedFormBag.uischema.elements[4].type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+      .toBe('oie.optional.authenticator.button.title');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.ts
@@ -41,8 +41,11 @@ export const transformSelectAuthenticatorEnroll: IdxStepTransformer = ({
   const { nextStep: { inputs, name: stepName } = {} as NextStep, availableSteps } = transaction;
 
   const authenticator = inputs?.find(({ name }) => name === 'authenticator');
+  if (!authenticator?.options?.length) {
+    return formBag;
+  }
   const authenticatorButtons = getAuthenticatorEnrollButtonElements(
-    authenticator!.options!,
+    authenticator.options,
     stepName,
   );
   const skipStep = availableSteps?.find(({ name }) => name === 'skip');

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.test.ts
@@ -17,6 +17,7 @@ import {
   AuthenticatorButtonElement,
   ButtonType,
   FieldElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -94,7 +95,19 @@ describe('Unlock Verification Authenticator Selector Tests', () => {
       widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('unlockaccount');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
+      .toBe('identifier');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.step)).toBe('select-authenticator-unlock-account');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.type)).toBe(ButtonType.BUTTON);
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.test.ts
@@ -16,7 +16,7 @@ import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/
 import {
   AuthenticatorButtonElement,
   ButtonType,
-  TitleElement,
+  FieldElement,
   WidgetProps,
 } from 'src/types';
 
@@ -46,23 +46,30 @@ jest.mock('./utils', () => ({
   ) => (options?.length ? getMockAuthenticatorButtons() : []),
 }));
 
-describe.skip('Unlock Verification Authenticator Selector Tests', () => {
+describe('Unlock Verification Authenticator Selector Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const widgetProps: WidgetProps = {};
   const formBag = getStubFormBag();
   beforeEach(() => {
-    formBag.uischema.elements = [];
+    formBag.uischema.elements = [{ type: 'Field', options: { inputMeta: { name: 'identifier' } } } as FieldElement];
     transaction.nextStep = {
       name: IDX_STEP.SELECT_AUTHENTICATOR_UNLOCK,
-      inputs: [{
-        name: 'authenticator',
-        options: [
-          {
-            label: 'Email',
-            value: 'okta_email',
-          } as IdxOption,
-        ],
-      }],
+      inputs: [
+        {
+          name: 'authenticator',
+          options: [
+            {
+              label: 'Email',
+              value: 'okta_email',
+            } as IdxOption,
+          ],
+        },
+        {
+          name: 'identifier',
+          label: 'Username',
+          required: true,
+        },
+      ],
     };
   });
 
@@ -87,12 +94,7 @@ describe.skip('Unlock Verification Authenticator Selector Tests', () => {
       widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(2);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('unlockaccount');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[1] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.ts
@@ -29,8 +29,11 @@ export const transformSelectAuthenticatorUnlockVerify: IdxStepTransformer = ({
   const { uischema } = formBag;
 
   const authenticator = inputs?.find(({ name }) => name === 'authenticator');
+  if (!authenticator?.options?.length) {
+    return formBag;
+  }
   const authenticatorButtons = getAuthenticatorVerifyButtonElements(
-    authenticator!.options!,
+    authenticator.options,
     stepName,
   );
 

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.test.ts
@@ -16,8 +16,6 @@ import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/
 import {
   AuthenticatorButtonElement,
   ButtonType,
-  DescriptionElement,
-  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -89,13 +87,7 @@ describe('Verify Authenticator Selector Transformer Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.select.authenticators.verify.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.select.authenticators.verify.subtitle');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add UI elements for verification authenticator selector'
@@ -114,13 +106,7 @@ describe('Verify Authenticator Selector Transformer Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.reset.title.generic');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.password.reset.verification');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add UI elements for verification authenticator selector'
@@ -142,12 +128,6 @@ describe('Verify Authenticator Selector Transformer Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.reset.title.specific');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.password.reset.verification');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.test.ts
@@ -16,6 +16,8 @@ import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/
 import {
   AuthenticatorButtonElement,
   ButtonType,
+  DescriptionElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -86,8 +88,19 @@ describe('Verify Authenticator Selector Transformer Tests', () => {
       transaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.select.authenticators.verify.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.select.authenticators.verify.subtitle');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.step)).toBe('select-authenticator-authenticate');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.type)).toBe(ButtonType.BUTTON);
   });
 
   it('should add UI elements for verification authenticator selector'
@@ -105,8 +118,19 @@ describe('Verify Authenticator Selector Transformer Tests', () => {
       transaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.reset.title.generic');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.password.reset.verification');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.step)).toBe('select-authenticator-authenticate');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.type)).toBe(ButtonType.BUTTON);
   });
 
   it('should add UI elements for verification authenticator selector'
@@ -127,7 +151,18 @@ describe('Verify Authenticator Selector Transformer Tests', () => {
       transaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.reset.title.specific');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.password.reset.verification');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.step)).toBe('select-authenticator-authenticate');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.type)).toBe(ButtonType.BUTTON);
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.test.ts
@@ -15,8 +15,11 @@ import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   AuthenticatorButtonElement,
+  ButtonElement,
   ButtonType,
+  DescriptionElement,
   FieldElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -105,8 +108,22 @@ describe('Transform Select OV Method Verify Tests', () => {
     isPushOnly = true;
     const updatedFormBag = transformSelectOVMethodVerify({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.okta_verify.push.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.autoChallenge');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oie.okta_verify.sendPushButton');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options?.step)
+      .toBe('select-authenticator-authenticate');
+    expect(updatedFormBag.data)
+      .toEqual({ 'authenticator.autoChallenge': 'true', 'authenticator.methodType': 'push' });
   });
 
   it('should transform elements when transaction contains push and totp method types', () => {
@@ -134,7 +151,22 @@ describe('Transform Select OV Method Verify Tests', () => {
     isPushOnly = false;
     const updatedFormBag = transformSelectOVMethodVerify({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.select.authenticators.verify.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.select.authenticators.verify.subtitle');
+    expect((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement).type).toBe('AuthenticatorButton');
+    expect((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.methodType']).toBe('push');
+    expect((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement).label)
+      .toBe('Get a push notification');
+    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).type).toBe('AuthenticatorButton');
+    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.methodType']).toBe('totp');
+    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).label).toBe('Enter a code');
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.test.ts
@@ -15,11 +15,8 @@ import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   AuthenticatorButtonElement,
-  ButtonElement,
   ButtonType,
-  DescriptionElement,
   FieldElement,
-  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -109,18 +106,7 @@ describe('Transform Select OV Method Verify Tests', () => {
     const updatedFormBag = transformSelectOVMethodVerify({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.okta_verify.push.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
-      .toBe('authenticator.autoChallenge');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
-      .toBe('oie.okta_verify.sendPushButton');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
-    expect(updatedFormBag.data)
-      .toEqual({ 'authenticator.autoChallenge': 'true', 'authenticator.methodType': 'push' });
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should transform elements when transaction contains push and totp method types', () => {
@@ -149,15 +135,6 @@ describe('Transform Select OV Method Verify Tests', () => {
     const updatedFormBag = transformSelectOVMethodVerify({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.select.authenticators.verify.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.select.authenticators.verify.subtitle');
-    expect((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement).type).toBe('AuthenticatorButton');
-    expect((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement).label)
-      .toBe('Get a push notification');
-    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).label).toBe('Enter a code');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -221,14 +221,7 @@ describe('Select Authenticator Utility Tests', () => {
       const authenticatorOptionValues = getAuthenticatorVerifyButtonElements(options, stepName);
 
       expect(authenticatorOptionValues.length).toBe(2);
-      expect(authenticatorOptionValues[0].options.key).toBe(AUTHENTICATOR_KEY.OV);
-      expect(authenticatorOptionValues[0].label).toBe('Code');
-      expect(authenticatorOptionValues[0].options.ctaLabel).toBe('oie.verify.authenticator.button.text');
-      expect(authenticatorOptionValues[0].options.actionParams!['authenticator.methodType']).toBe('totp');
-      expect(authenticatorOptionValues[1].options.key).toBe(AUTHENTICATOR_KEY.OV);
-      expect(authenticatorOptionValues[1].label).toBe('Push');
-      expect(authenticatorOptionValues[1].options.ctaLabel).toBe('oie.verify.authenticator.button.text');
-      expect(authenticatorOptionValues[1].options.actionParams!['authenticator.methodType']).toBe('push');
+      expect(authenticatorOptionValues).toMatchSnapshot();
     });
   });
 
@@ -291,12 +284,7 @@ describe('Select Authenticator Utility Tests', () => {
       const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options, stepName);
 
       expect(authenticatorOptionValues.length).toBe(1);
-      expect(authenticatorOptionValues[0].options.key).toBe(AUTHENTICATOR_KEY.ON_PREM);
-      expect(authenticatorOptionValues[0].label).toBe('On Prem');
-      expect(authenticatorOptionValues[0].options.ctaLabel)
-        .toBe('oie.enroll.authenticator.button.text');
-      expect(authenticatorOptionValues[0].options.description)
-        .toBe(AUTHENTICATOR_ENROLLMENT_DESCR_KEY_MAP[AUTHENTICATOR_KEY.ON_PREM]);
+      expect(authenticatorOptionValues).toMatchSnapshot();
     });
 
     it('should return formatted Okta Verify method type options '
@@ -325,13 +313,7 @@ describe('Select Authenticator Utility Tests', () => {
       const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options, stepName);
 
       expect(authenticatorOptionValues.length).toBe(2);
-      expect(authenticatorOptionValues[0].options.key).toBe(AUTHENTICATOR_KEY.OV);
-      expect(authenticatorOptionValues[0].label).toBe('Code');
-      expect(authenticatorOptionValues[0].options.ctaLabel).toBe('oie.enroll.authenticator.button.text');
-      expect(authenticatorOptionValues[0].options.actionParams!['authenticator.methodType']).toBe('totp');
-      expect(authenticatorOptionValues[1].label).toBe('Push');
-      expect(authenticatorOptionValues[1].options.ctaLabel).toBe('oie.enroll.authenticator.button.text');
-      expect(authenticatorOptionValues[1].options.actionParams!['authenticator.methodType']).toBe('push');
+      expect(authenticatorOptionValues).toMatchSnapshot();
     });
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -220,8 +220,16 @@ describe('Select Authenticator Utility Tests', () => {
 
       const authenticatorOptionValues = getAuthenticatorVerifyButtonElements(options, stepName);
 
-      expect(authenticatorOptionValues.length).toBe(2);
       expect(authenticatorOptionValues).toMatchSnapshot();
+      expect(authenticatorOptionValues.length).toBe(2);
+      expect(authenticatorOptionValues[0].options.key).toBe(AUTHENTICATOR_KEY.OV);
+      expect(authenticatorOptionValues[0].label).toBe('Code');
+      expect(authenticatorOptionValues[0].options.ctaLabel).toBe('oie.verify.authenticator.button.text');
+      expect(authenticatorOptionValues[0].options.actionParams!['authenticator.methodType']).toBe('totp');
+      expect(authenticatorOptionValues[1].options.key).toBe(AUTHENTICATOR_KEY.OV);
+      expect(authenticatorOptionValues[1].label).toBe('Push');
+      expect(authenticatorOptionValues[1].options.ctaLabel).toBe('oie.verify.authenticator.button.text');
+      expect(authenticatorOptionValues[1].options.actionParams!['authenticator.methodType']).toBe('push');
     });
   });
 
@@ -283,8 +291,14 @@ describe('Select Authenticator Utility Tests', () => {
       }];
       const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options, stepName);
 
-      expect(authenticatorOptionValues.length).toBe(1);
       expect(authenticatorOptionValues).toMatchSnapshot();
+      expect(authenticatorOptionValues.length).toBe(1);
+      expect(authenticatorOptionValues[0].options.key).toBe(AUTHENTICATOR_KEY.ON_PREM);
+      expect(authenticatorOptionValues[0].label).toBe('On Prem');
+      expect(authenticatorOptionValues[0].options.ctaLabel)
+        .toBe('oie.enroll.authenticator.button.text');
+      expect(authenticatorOptionValues[0].options.description)
+        .toBe(AUTHENTICATOR_ENROLLMENT_DESCR_KEY_MAP[AUTHENTICATOR_KEY.ON_PREM]);
     });
 
     it('should return formatted Okta Verify method type options '
@@ -312,8 +326,15 @@ describe('Select Authenticator Utility Tests', () => {
 
       const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options, stepName);
 
-      expect(authenticatorOptionValues.length).toBe(2);
       expect(authenticatorOptionValues).toMatchSnapshot();
+      expect(authenticatorOptionValues.length).toBe(2);
+      expect(authenticatorOptionValues[0].options.key).toBe(AUTHENTICATOR_KEY.OV);
+      expect(authenticatorOptionValues[0].label).toBe('Code');
+      expect(authenticatorOptionValues[0].options.ctaLabel).toBe('oie.enroll.authenticator.button.text');
+      expect(authenticatorOptionValues[0].options.actionParams!['authenticator.methodType']).toBe('totp');
+      expect(authenticatorOptionValues[1].label).toBe('Push');
+      expect(authenticatorOptionValues[1].options.ctaLabel).toBe('oie.enroll.authenticator.button.text');
+      expect(authenticatorOptionValues[1].options.actionParams!['authenticator.methodType']).toBe('push');
     });
   });
 });


### PR DESCRIPTION
## Description:

The purpose of this PR is to enable and fix tests in Select Authenticator folder. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-516578](https://oktainc.atlassian.net/browse/OKTA-516578)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



