### PR TITLE
OKTA-537289 : Re-enable Terminal Transformer jest tests

### DIFF
--- a/src/v3/src/transformer/terminal/__snapshots__/transformEmailMagicLinkOTPOnlyElements.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformEmailMagicLinkOTPOnlyElements.test.ts.snap
@@ -1,0 +1,457 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Email Magic Link OTP Only Transformer Tests should add default instructions, otp and warning text when client, app, and intent data are missing from context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "idx.enter.otp.in.original.tab",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "123456",
+          "level": 3,
+          "visualLevel": 3,
+        },
+        "type": "Heading",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.warning.text",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Email Magic Link OTP Only Transformer Tests should add password reset instructions (with recovery intent), otp and warning text when client & app dataare missing from context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.enter.code.on.page",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "123456",
+          "level": 3,
+          "visualLevel": 3,
+        },
+        "type": "Heading",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.warning.text",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Email Magic Link OTP Only Transformer Tests should add sign up instructions (with enroll intent), otp and warning text when client & app data are missing from context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.enter.code.on.page",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "123456",
+          "level": 3,
+          "visualLevel": 3,
+        },
+        "type": "Heading",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.warning.text",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Email Magic Link OTP Only Transformer Tests should add sign-in instructions (with auth intent), otp and warning text when client & app data are missing from context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.enter.code.on.page",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "123456",
+          "level": 3,
+          "visualLevel": 3,
+        },
+        "type": "Heading",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.warning.text",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Email Magic Link OTP Only Transformer Tests should add sign-in instructions, otp, warning and app info only when client data is missing from context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.enter.code.on.page",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "123456",
+          "level": 3,
+          "visualLevel": 3,
+        },
+        "type": "Heading",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.request",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "app",
+          "textContent": "idx.return.link.otponly.app",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.warning.text",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Email Magic Link OTP Only Transformer Tests should add sign-in instructions, otp, warning, app info, and browser info and partial location when all data exists except for state in context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.enter.code.on.page",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "123456",
+          "level": 3,
+          "visualLevel": 3,
+        },
+        "type": "Heading",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.request",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "browser",
+          "textContent": "idx.return.link.otponly.browser.on.os",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "app",
+          "textContent": "idx.return.link.otponly.app",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "location",
+          "textContent": "geolocation.formatting.partial",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.warning.text",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Email Magic Link OTP Only Transformer Tests should add sign-in instructions, otp, warning, app info, and browser info when all data exists except for location in context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.enter.code.on.page",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "123456",
+          "level": 3,
+          "visualLevel": 3,
+        },
+        "type": "Heading",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.request",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "browser",
+          "textContent": "idx.return.link.otponly.browser.on.os",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "app",
+          "textContent": "idx.return.link.otponly.app",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.warning.text",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Email Magic Link OTP Only Transformer Tests should add sign-in instructions, otp, warning, app info, browser info, and location when all expected data exists in context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.enter.code.on.page",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "123456",
+          "level": 3,
+          "visualLevel": 3,
+        },
+        "type": "Heading",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.request",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "browser",
+          "textContent": "idx.return.link.otponly.browser.on.os",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "app",
+          "textContent": "idx.return.link.otponly.app",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "location",
+          "textContent": "geolocation.formatting.all",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.warning.text",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Email Magic Link OTP Only Transformer Tests should add unlock acct instructions (with unlock intent), otp and warning text when client & app dataare missing from context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.enter.code.on.page",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "123456",
+          "level": 3,
+          "visualLevel": 3,
+        },
+        "type": "Heading",
+      },
+      Object {
+        "options": Object {
+          "content": "idx.return.link.otponly.warning.text",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/terminal/__snapshots__/transformTerminalMessages.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformTerminalMessages.test.ts.snap
@@ -1,0 +1,238 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Terminal Message Transformer Tests should add Description element with message for oie.selfservice.unlock_user.success.message message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.selfservice.unlock_user.success.message",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Message Transformer Tests should add Info box element with message for tooManyRequests message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "contentType": "string",
+          "dataSe": "infobox-error",
+          "message": "oie.tooManyRequests",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Message Transformer Tests should add an Info box and Description elements for idx.operation.cancelled.on.other.device message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "contentType": "string",
+          "dataSe": "infobox-error",
+          "message": "idx.operation.cancelled.on.other.device",
+        },
+        "type": "InfoBox",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.consent.enduser.deny.description",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Message Transformer Tests should add error Info box element for idx.session.expired message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "contentType": "string",
+          "dataSe": "infobox-error",
+          "message": "idx.session.expired",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Message Transformer Tests should add info Box element for link expired message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "contentType": "string",
+          "dataSe": "infobox-error",
+          "message": "idx.return.link.expired",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Message Transformer Tests should add info box & cancel elements when transaction contains API error 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "contentType": "string",
+          "message": "oform.error.unexpected",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Message Transformer Tests should add info box element for generic terminal message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "contentType": "string",
+          "dataSe": "infobox-error",
+          "message": "Test error message",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Message Transformer Tests should transform elements when terminal key indicates to return to orig tab 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.consent.enduser.email.allow.description",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.return.to.original.tab",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/terminal/__snapshots__/transformTerminalTransaction.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformTerminalTransaction.test.ts.snap
@@ -1,0 +1,302 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Terminal Transaction Transformer Tests Interaction code flow & Redirection Tests should add successCallback renderer for interaction code flow 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "label": "Loading...",
+          "valueText": "Loading...",
+        },
+        "type": "Spinner",
+      },
+      Object {
+        "options": Object {
+          "data": Object {
+            "status": "SUCCESS",
+            "tokens": Object {
+              "accessToken": Object {
+                "accessToken": "abc123456",
+                "authorizeUrl": "acme.okta1.com",
+                "claims": Object {
+                  "sub": "",
+                  "user": true,
+                },
+                "expiresAt": 1234567,
+                "scopes": Array [
+                  "admin",
+                ],
+                "tokenType": "id",
+                "userinfoUrl": "acme.okta1.com/userinfo",
+              },
+              "idToken": Object {
+                "authorizeUrl": "acme.okta1.com",
+                "claims": Object {
+                  "sub": "",
+                  "user": true,
+                },
+                "clientId": "abcdefth",
+                "expiresAt": 1234567,
+                "idToken": "1234567asdfghj",
+                "issuer": "okta",
+                "scopes": Array [
+                  "admin",
+                ],
+              },
+            },
+          },
+        },
+        "type": "SuccessCallback",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Transaction Transformer Tests Interaction code flow & Redirection Tests should add successCallback renderer for interaction code flow in remediation mode 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "label": "Loading...",
+          "valueText": "Loading...",
+        },
+        "type": "Spinner",
+      },
+      Object {
+        "options": Object {
+          "data": Object {
+            "interaction_code": "123456789aabbcc",
+            "state": "abc123",
+            "status": "SUCCESS",
+          },
+        },
+        "type": "SuccessCallback",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Transaction Transformer Tests should add back to sign in link with href when backToSigninUri is set in widget options 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "focus": true,
+        "options": Object {
+          "href": "/",
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Transaction Transformer Tests should add back to signin element when transaction contains API error 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "focus": true,
+        "options": Object {
+          "href": undefined,
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Transaction Transformer Tests should add back to signin link for tooManyRequests message key when baseUrl not provided 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "focus": true,
+        "options": Object {
+          "href": "http://localhost:3000/",
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Transaction Transformer Tests should add title and back to signin elements for link expired message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.email.return.link.expired.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "focus": true,
+        "options": Object {
+          "href": undefined,
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Transaction Transformer Tests should add title and skip setup link for idx.error.server.safe.mode.enrollment.unavailable message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.safe.mode.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "focus": true,
+        "options": Object {
+          "isActionStep": false,
+          "label": "oie.enroll.skip.setup",
+          "step": "skip",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Transaction Transformer Tests should add title and try again link for idx.device.not.activated.consent.denied message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "device.code.activated.error.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "focus": true,
+        "options": Object {
+          "href": "http://localhost:8080/",
+          "isActionStep": true,
+          "label": "oie.try.again",
+          "step": "cancel",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Transaction Transformer Tests should add title element with message for oie.selfservice.unlock_user.success.message message key 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "account.unlock.unlocked.title",
+        },
+        "type": "Title",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal Transaction Transformer Tests should add title when terminal key indicates to return to orig tab 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.consent.enduser.email.allow.title",
+        },
+        "type": "Title",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/terminal/__snapshots__/transformTerminalTransaction.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformTerminalTransaction.test.ts.snap
@@ -246,7 +246,7 @@ Object {
       Object {
         "focus": true,
         "options": Object {
-          "href": "http://localhost:8080/",
+          "href": "http://localhost:3000/",
           "isActionStep": true,
           "label": "oie.try.again",
           "step": "cancel",

--- a/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Unhandled Error Transformer Tests should add Infobox with unexpected error message when error is not provided 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "contentType": "string",
+          "message": "oform.error.unexpected",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Unhandled Error Transformer Tests should add info box when oie configuration error 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "message": "oie.configuration.error",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Unhandled Error Transformer Tests should add info box when oie is not enabled error 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "message": "oie.feature.disabled",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Unhandled Error Transformer Tests should add info box when response is invalid recovery token error 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "message": "oie.invalid.recovery.token",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/terminal/transformEmailMagicLinkOTPOnlyElements.test.ts
+++ b/src/v3/src/transformer/terminal/transformEmailMagicLinkOTPOnlyElements.test.ts
@@ -13,9 +13,6 @@
 import { IdxStatus, IdxTransaction } from '@okta/okta-auth-js';
 
 import { getStubFormBag, getStubTransaction } from '../../mocks/utils/utils';
-import {
-  DescriptionElement, HeadingElement, ImageWithTextElement,
-} from '../../types';
 import { transformEmailMagicLinkOTPOnly } from './transformEmailMagicLinkOTPOnlyElements';
 
 describe('Email Magic Link OTP Only Transformer Tests', () => {
@@ -69,16 +66,7 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
-      .toBe('idx.enter.otp.in.original.tab');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Heading');
-    expect((updatedFormBag.uischema.elements[1] as HeadingElement).options?.level).toBe(3);
-    expect((updatedFormBag.uischema.elements[1] as HeadingElement).options?.visualLevel).toBe(3);
-    expect((updatedFormBag.uischema.elements[1] as HeadingElement).options?.content).toBe(mockOTP);
-    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('idx.return.link.otponly.warning.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add sign-in instructions (with auth intent), otp and warning text'
@@ -93,21 +81,7 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    const [
-      el1, el2, el3,
-    ] = updatedFormBag.uischema.elements as [
-      DescriptionElement, HeadingElement, DescriptionElement,
-    ];
-    expect(el1.type).toBe('Description');
-    expect(el1.options?.content)
-      .toBe('idx.return.link.otponly.enter.code.on.page');
-    expect(el2.type).toBe('Heading');
-    expect(el2.options?.level).toBe(3);
-    expect(el2.options?.visualLevel).toBe(3);
-    expect(el2.options?.content).toBe(mockOTP);
-    expect(el3.type).toBe('Description');
-    expect(el3.options?.content)
-      .toBe('idx.return.link.otponly.warning.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add sign up instructions (with enroll intent), otp and warning text'
@@ -122,21 +96,7 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    const [
-      el1, el2, el3,
-    ] = updatedFormBag.uischema.elements as [
-      DescriptionElement, HeadingElement, DescriptionElement,
-    ];
-    expect(el1.type).toBe('Description');
-    expect(el1.options?.content)
-      .toBe('idx.return.link.otponly.enter.code.on.page');
-    expect(el2.type).toBe('Heading');
-    expect(el2.options?.level).toBe(3);
-    expect(el2.options?.visualLevel).toBe(3);
-    expect(el2.options?.content).toBe(mockOTP);
-    expect(el3.type).toBe('Description');
-    expect(el3.options?.content)
-      .toBe('idx.return.link.otponly.warning.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add password reset instructions (with recovery intent), otp and warning text'
@@ -151,21 +111,7 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    const [
-      el1, el2, el3,
-    ] = updatedFormBag.uischema.elements as [
-      DescriptionElement, HeadingElement, DescriptionElement,
-    ];
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Description');
-    expect(el1.options?.content)
-      .toBe('idx.return.link.otponly.enter.code.on.page');
-    expect(el2.type).toBe('Heading');
-    expect(el2.options?.level).toBe(3);
-    expect(el2.options?.visualLevel).toBe(3);
-    expect(el2.options?.content).toBe(mockOTP);
-    expect(el3.type).toBe('Description');
-    expect(el3.options?.content)
-      .toBe('idx.return.link.otponly.warning.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add unlock acct instructions (with unlock intent), otp and warning text'
@@ -180,21 +126,7 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    const [
-      el1, el2, el3,
-    ] = updatedFormBag.uischema.elements as [
-      DescriptionElement, HeadingElement, DescriptionElement,
-    ];
-    expect(el1.type).toBe('Description');
-    expect(el1.options?.content)
-      .toBe('idx.return.link.otponly.enter.code.on.page');
-    expect(el2.type).toBe('Heading');
-    expect(el2.options?.level).toBe(3);
-    expect(el2.options?.visualLevel).toBe(3);
-    expect(el2.options?.content).toBe(mockOTP);
-    expect(el3.type).toBe('Description');
-    expect(el3.options?.content)
-      .toBe('idx.return.link.otponly.warning.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add sign-in instructions, otp, warning and app info only'
@@ -213,32 +145,7 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-    const [
-      el1, el2, el3, el4, el5,
-    ] = updatedFormBag.uischema.elements as [
-      DescriptionElement,
-      HeadingElement,
-      DescriptionElement,
-      ImageWithTextElement,
-      DescriptionElement,
-    ];
-    expect(el1.type).toBe('Description');
-    expect(el1.options?.content)
-      .toBe('idx.return.link.otponly.enter.code.on.page');
-    expect(el2.type).toBe('Heading');
-    expect(el2.options?.level).toBe(3);
-    expect(el2.options?.visualLevel).toBe(3);
-    expect(el2.options?.content).toBe(mockOTP);
-    expect(el3.type).toBe('Description');
-    expect(el3.options?.content)
-      .toBe('idx.return.link.otponly.request');
-    expect(el4.type).toBe('ImageWithText');
-    expect(el4.options?.textContent)
-      .toBe('idx.return.link.otponly.app');
-    expect(el4.options?.SVGIcon).not.toBeUndefined();
-    expect(el5.type).toBe('Description');
-    expect(el5.options?.content)
-      .toBe('idx.return.link.otponly.warning.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add sign-in instructions, otp, warning, app info, and browser info'
@@ -264,37 +171,7 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(6);
-    const [
-      el1, el2, el3, el4, el5, el6,
-    ] = updatedFormBag.uischema.elements as [
-      DescriptionElement,
-      HeadingElement,
-      DescriptionElement,
-      ImageWithTextElement,
-      ImageWithTextElement,
-      DescriptionElement,
-    ];
-    expect(el1.type).toBe('Description');
-    expect(el1.options?.content)
-      .toBe('idx.return.link.otponly.enter.code.on.page');
-    expect(el2.type).toBe('Heading');
-    expect(el2.options?.level).toBe(3);
-    expect(el2.options?.visualLevel).toBe(3);
-    expect(el2.options?.content).toBe(mockOTP);
-    expect(el3.type).toBe('Description');
-    expect(el3.options?.content)
-      .toBe('idx.return.link.otponly.request');
-    expect(el4.type).toBe('ImageWithText');
-    expect(el4.options?.textContent)
-      .toBe('idx.return.link.otponly.browser.on.os');
-    expect(el4.options?.SVGIcon).not.toBeUndefined();
-    expect(el5.type).toBe('ImageWithText');
-    expect(el5.options?.textContent)
-      .toBe('idx.return.link.otponly.app');
-    expect(el5.options?.SVGIcon).not.toBeUndefined();
-    expect(el6.type).toBe('Description');
-    expect(el6.options?.content)
-      .toBe('idx.return.link.otponly.warning.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add sign-in instructions, otp, warning, app info, and browser info'
@@ -329,42 +206,7 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(7);
-    const [
-      el1, el2, el3, el4, el5, el6, el7,
-    ] = updatedFormBag.uischema.elements as [
-      DescriptionElement,
-      HeadingElement,
-      DescriptionElement,
-      ImageWithTextElement,
-      ImageWithTextElement,
-      ImageWithTextElement,
-      DescriptionElement,
-    ];
-    expect(el1.type).toBe('Description');
-    expect(el1.options?.content)
-      .toBe('idx.return.link.otponly.enter.code.on.page');
-    expect(el2.type).toBe('Heading');
-    expect(el2.options?.level).toBe(3);
-    expect(el2.options?.visualLevel).toBe(3);
-    expect(el2.options?.content).toBe(mockOTP);
-    expect(el3.type).toBe('Description');
-    expect(el3.options?.content)
-      .toBe('idx.return.link.otponly.request');
-    expect(el4.type).toBe('ImageWithText');
-    expect(el4.options?.textContent)
-      .toBe('idx.return.link.otponly.browser.on.os');
-    expect(el4.options?.SVGIcon).not.toBeUndefined();
-    expect(el5.type).toBe('ImageWithText');
-    expect(el5.options?.textContent)
-      .toBe('idx.return.link.otponly.app');
-    expect(el5.options?.SVGIcon).not.toBeUndefined();
-    expect(el6.type).toBe('ImageWithText');
-    expect(el6.options?.textContent)
-      .toBe('geolocation.formatting.partial');
-    expect(el6.options?.SVGIcon).not.toBeUndefined();
-    expect(el7.type).toBe('Description');
-    expect(el7.options?.content)
-      .toBe('idx.return.link.otponly.warning.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add sign-in instructions, otp, warning, app info, browser info, and location'
@@ -372,41 +214,6 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(7);
-    const [
-      el1, el2, el3, el4, el5, el6, el7,
-    ] = updatedFormBag.uischema.elements as [
-      DescriptionElement,
-      HeadingElement,
-      DescriptionElement,
-      ImageWithTextElement,
-      ImageWithTextElement,
-      ImageWithTextElement,
-      DescriptionElement,
-    ];
-    expect(el1.type).toBe('Description');
-    expect(el1.options?.content)
-      .toBe('idx.return.link.otponly.enter.code.on.page');
-    expect(el2.type).toBe('Heading');
-    expect(el2.options?.level).toBe(3);
-    expect(el2.options?.visualLevel).toBe(3);
-    expect(el2.options?.content).toBe(mockOTP);
-    expect(el3.type).toBe('Description');
-    expect(el3.options?.content)
-      .toBe('idx.return.link.otponly.request');
-    expect(el4.type).toBe('ImageWithText');
-    expect(el4.options?.textContent)
-      .toBe('idx.return.link.otponly.browser.on.os');
-    expect(el4.options?.SVGIcon).not.toBeUndefined();
-    expect(el5.type).toBe('ImageWithText');
-    expect(el5.options?.textContent)
-      .toBe('idx.return.link.otponly.app');
-    expect(el5.options?.SVGIcon).not.toBeUndefined();
-    expect(el6.type).toBe('ImageWithText');
-    expect(el6.options?.textContent)
-      .toBe('geolocation.formatting.all');
-    expect(el6.options?.SVGIcon).not.toBeUndefined();
-    expect(el7.type).toBe('Description');
-    expect(el7.options?.content)
-      .toBe('idx.return.link.otponly.warning.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/terminal/transformEmailMagicLinkOTPOnlyElements.test.ts
+++ b/src/v3/src/transformer/terminal/transformEmailMagicLinkOTPOnlyElements.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { IdxStatus, IdxTransaction } from '@okta/okta-auth-js';
+import { DescriptionElement, HeadingElement, ImageWithTextElement } from 'src/types';
 
 import { getStubFormBag, getStubTransaction } from '../../mocks/utils/utils';
 import { transformEmailMagicLinkOTPOnly } from './transformEmailMagicLinkOTPOnlyElements';
@@ -65,8 +66,18 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     };
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
+      .toBe('idx.enter.otp.in.original.tab');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Heading');
+    expect((updatedFormBag.uischema.elements[1] as HeadingElement).options?.level).toBe(3);
+    expect((updatedFormBag.uischema.elements[1] as HeadingElement).options?.visualLevel).toBe(3);
+    expect((updatedFormBag.uischema.elements[1] as HeadingElement).options?.content).toBe(mockOTP);
+    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('idx.return.link.otponly.warning.text');
   });
 
   it('should add sign-in instructions (with auth intent), otp and warning text'
@@ -80,8 +91,23 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     };
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    const [
+      el1, el2, el3,
+    ] = updatedFormBag.uischema.elements as [
+      DescriptionElement, HeadingElement, DescriptionElement,
+    ];
+    expect(el1.type).toBe('Description');
+    expect(el1.options?.content)
+      .toBe('idx.return.link.otponly.enter.code.on.page');
+    expect(el2.type).toBe('Heading');
+    expect(el2.options?.level).toBe(3);
+    expect(el2.options?.visualLevel).toBe(3);
+    expect(el2.options?.content).toBe(mockOTP);
+    expect(el3.type).toBe('Description');
+    expect(el3.options?.content)
+      .toBe('idx.return.link.otponly.warning.text');
   });
 
   it('should add sign up instructions (with enroll intent), otp and warning text'
@@ -95,8 +121,23 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     };
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    const [
+      el1, el2, el3,
+    ] = updatedFormBag.uischema.elements as [
+      DescriptionElement, HeadingElement, DescriptionElement,
+    ];
+    expect(el1.type).toBe('Description');
+    expect(el1.options?.content)
+      .toBe('idx.return.link.otponly.enter.code.on.page');
+    expect(el2.type).toBe('Heading');
+    expect(el2.options?.level).toBe(3);
+    expect(el2.options?.visualLevel).toBe(3);
+    expect(el2.options?.content).toBe(mockOTP);
+    expect(el3.type).toBe('Description');
+    expect(el3.options?.content)
+      .toBe('idx.return.link.otponly.warning.text');
   });
 
   it('should add password reset instructions (with recovery intent), otp and warning text'
@@ -110,8 +151,23 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     };
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    const [
+      el1, el2, el3,
+    ] = updatedFormBag.uischema.elements as [
+      DescriptionElement, HeadingElement, DescriptionElement,
+    ];
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Description');
+    expect(el1.options?.content)
+      .toBe('idx.return.link.otponly.enter.code.on.page');
+    expect(el2.type).toBe('Heading');
+    expect(el2.options?.level).toBe(3);
+    expect(el2.options?.visualLevel).toBe(3);
+    expect(el2.options?.content).toBe(mockOTP);
+    expect(el3.type).toBe('Description');
+    expect(el3.options?.content)
+      .toBe('idx.return.link.otponly.warning.text');
   });
 
   it('should add unlock acct instructions (with unlock intent), otp and warning text'
@@ -125,8 +181,23 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     };
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    const [
+      el1, el2, el3,
+    ] = updatedFormBag.uischema.elements as [
+      DescriptionElement, HeadingElement, DescriptionElement,
+    ];
+    expect(el1.type).toBe('Description');
+    expect(el1.options?.content)
+      .toBe('idx.return.link.otponly.enter.code.on.page');
+    expect(el2.type).toBe('Heading');
+    expect(el2.options?.level).toBe(3);
+    expect(el2.options?.visualLevel).toBe(3);
+    expect(el2.options?.content).toBe(mockOTP);
+    expect(el3.type).toBe('Description');
+    expect(el3.options?.content)
+      .toBe('idx.return.link.otponly.warning.text');
   });
 
   it('should add sign-in instructions, otp, warning and app info only'
@@ -144,8 +215,34 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     };
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    const [
+      el1, el2, el3, el4, el5,
+    ] = updatedFormBag.uischema.elements as [
+      DescriptionElement,
+      HeadingElement,
+      DescriptionElement,
+      ImageWithTextElement,
+      DescriptionElement,
+    ];
+    expect(el1.type).toBe('Description');
+    expect(el1.options?.content)
+      .toBe('idx.return.link.otponly.enter.code.on.page');
+    expect(el2.type).toBe('Heading');
+    expect(el2.options?.level).toBe(3);
+    expect(el2.options?.visualLevel).toBe(3);
+    expect(el2.options?.content).toBe(mockOTP);
+    expect(el3.type).toBe('Description');
+    expect(el3.options?.content)
+      .toBe('idx.return.link.otponly.request');
+    expect(el4.type).toBe('ImageWithText');
+    expect(el4.options?.textContent)
+      .toBe('idx.return.link.otponly.app');
+    expect(el4.options?.SVGIcon).not.toBeUndefined();
+    expect(el5.type).toBe('Description');
+    expect(el5.options?.content)
+      .toBe('idx.return.link.otponly.warning.text');
   });
 
   it('should add sign-in instructions, otp, warning, app info, and browser info'
@@ -170,8 +267,39 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     };
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    const [
+      el1, el2, el3, el4, el5, el6,
+    ] = updatedFormBag.uischema.elements as [
+      DescriptionElement,
+      HeadingElement,
+      DescriptionElement,
+      ImageWithTextElement,
+      ImageWithTextElement,
+      DescriptionElement,
+    ];
+    expect(el1.type).toBe('Description');
+    expect(el1.options?.content)
+      .toBe('idx.return.link.otponly.enter.code.on.page');
+    expect(el2.type).toBe('Heading');
+    expect(el2.options?.level).toBe(3);
+    expect(el2.options?.visualLevel).toBe(3);
+    expect(el2.options?.content).toBe(mockOTP);
+    expect(el3.type).toBe('Description');
+    expect(el3.options?.content)
+      .toBe('idx.return.link.otponly.request');
+    expect(el4.type).toBe('ImageWithText');
+    expect(el4.options?.textContent)
+      .toBe('idx.return.link.otponly.browser.on.os');
+    expect(el4.options?.SVGIcon).not.toBeUndefined();
+    expect(el5.type).toBe('ImageWithText');
+    expect(el5.options?.textContent)
+      .toBe('idx.return.link.otponly.app');
+    expect(el5.options?.SVGIcon).not.toBeUndefined();
+    expect(el6.type).toBe('Description');
+    expect(el6.options?.content)
+      .toBe('idx.return.link.otponly.warning.text');
   });
 
   it('should add sign-in instructions, otp, warning, app info, and browser info'
@@ -205,15 +333,87 @@ describe('Email Magic Link OTP Only Transformer Tests', () => {
     };
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    const [
+      el1, el2, el3, el4, el5, el6, el7,
+    ] = updatedFormBag.uischema.elements as [
+      DescriptionElement,
+      HeadingElement,
+      DescriptionElement,
+      ImageWithTextElement,
+      ImageWithTextElement,
+      ImageWithTextElement,
+      DescriptionElement,
+    ];
+    expect(el1.type).toBe('Description');
+    expect(el1.options?.content)
+      .toBe('idx.return.link.otponly.enter.code.on.page');
+    expect(el2.type).toBe('Heading');
+    expect(el2.options?.level).toBe(3);
+    expect(el2.options?.visualLevel).toBe(3);
+    expect(el2.options?.content).toBe(mockOTP);
+    expect(el3.type).toBe('Description');
+    expect(el3.options?.content)
+      .toBe('idx.return.link.otponly.request');
+    expect(el4.type).toBe('ImageWithText');
+    expect(el4.options?.textContent)
+      .toBe('idx.return.link.otponly.browser.on.os');
+    expect(el4.options?.SVGIcon).not.toBeUndefined();
+    expect(el5.type).toBe('ImageWithText');
+    expect(el5.options?.textContent)
+      .toBe('idx.return.link.otponly.app');
+    expect(el5.options?.SVGIcon).not.toBeUndefined();
+    expect(el6.type).toBe('ImageWithText');
+    expect(el6.options?.textContent)
+      .toBe('geolocation.formatting.partial');
+    expect(el6.options?.SVGIcon).not.toBeUndefined();
+    expect(el7.type).toBe('Description');
+    expect(el7.options?.content)
+      .toBe('idx.return.link.otponly.warning.text');
   });
 
   it('should add sign-in instructions, otp, warning, app info, browser info, and location'
     + ' when all expected data exists in context', () => {
     const updatedFormBag = transformEmailMagicLinkOTPOnly(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    const [
+      el1, el2, el3, el4, el5, el6, el7,
+    ] = updatedFormBag.uischema.elements as [
+      DescriptionElement,
+      HeadingElement,
+      DescriptionElement,
+      ImageWithTextElement,
+      ImageWithTextElement,
+      ImageWithTextElement,
+      DescriptionElement,
+    ];
+    expect(el1.type).toBe('Description');
+    expect(el1.options?.content)
+      .toBe('idx.return.link.otponly.enter.code.on.page');
+    expect(el2.type).toBe('Heading');
+    expect(el2.options?.level).toBe(3);
+    expect(el2.options?.visualLevel).toBe(3);
+    expect(el2.options?.content).toBe(mockOTP);
+    expect(el3.type).toBe('Description');
+    expect(el3.options?.content)
+      .toBe('idx.return.link.otponly.request');
+    expect(el4.type).toBe('ImageWithText');
+    expect(el4.options?.textContent)
+      .toBe('idx.return.link.otponly.browser.on.os');
+    expect(el4.options?.SVGIcon).not.toBeUndefined();
+    expect(el5.type).toBe('ImageWithText');
+    expect(el5.options?.textContent)
+      .toBe('idx.return.link.otponly.app');
+    expect(el5.options?.SVGIcon).not.toBeUndefined();
+    expect(el6.type).toBe('ImageWithText');
+    expect(el6.options?.textContent)
+      .toBe('geolocation.formatting.all');
+    expect(el6.options?.SVGIcon).not.toBeUndefined();
+    expect(el7.type).toBe('Description');
+    expect(el7.options?.content)
+      .toBe('idx.return.link.otponly.warning.text');
   });
 });

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.test.ts
@@ -14,9 +14,6 @@ import { IdxStatus, IdxTransaction } from '@okta/okta-auth-js';
 
 import { TERMINAL_KEY } from '../../constants';
 import { getStubFormBag, getStubTransaction } from '../../mocks/utils/utils';
-import {
-  DescriptionElement, InfoboxElement,
-} from '../../types';
 import { transformTerminalMessages } from './transformTerminalMessages';
 
 const getMockMessage = (message: string, className: string, key: string) => ({
@@ -60,11 +57,7 @@ describe('Terminal Message Transformer Tests', () => {
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
-    expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.message).toBe('oform.error.unexpected');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.class).toBe('ERROR');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should transform elements when terminal key indicates to return to orig tab', () => {
@@ -77,10 +70,7 @@ describe('Terminal Message Transformer Tests', () => {
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(2);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
-      .toBe('oie.consent.enduser.email.allow.description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content).toBe('oie.return.to.original.tab');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add info box element for generic terminal message key', () => {
@@ -93,13 +83,7 @@ describe('Terminal Message Transformer Tests', () => {
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe(mockErrorMessage);
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.class).toBe('ERROR');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add info Box element for link expired message key', () => {
@@ -112,13 +96,7 @@ describe('Terminal Message Transformer Tests', () => {
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe('idx.return.link.expired');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.class).toBe('ERROR');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add Description element with message for'
@@ -132,9 +110,7 @@ describe('Terminal Message Transformer Tests', () => {
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
-      .toBe(TERMINAL_KEY.UNLOCK_ACCOUNT_KEY);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add an Info box and Description elements for'
@@ -148,15 +124,7 @@ describe('Terminal Message Transformer Tests', () => {
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(2);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe('idx.operation.cancelled.on.other.device');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.class).toBe('ERROR');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content).toBe('oie.consent.enduser.deny.description');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add Info box element with message for tooManyRequests message key', () => {
@@ -169,13 +137,7 @@ describe('Terminal Message Transformer Tests', () => {
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe('oie.tooManyRequests');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.class).toBe('ERROR');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add error Info box element for idx.session.expired message key', () => {
@@ -188,13 +150,7 @@ describe('Terminal Message Transformer Tests', () => {
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe(TERMINAL_KEY.SESSION_EXPIRED);
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.class).toBe('ERROR');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should return custom formBag when message key contains idx.enter.otp.in.original.tab', () => {

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { IdxStatus, IdxTransaction } from '@okta/okta-auth-js';
+import { DescriptionElement, InfoboxElement } from 'src/types';
 
 import { TERMINAL_KEY } from '../../constants';
 import { getStubFormBag, getStubTransaction } from '../../mocks/utils/utils';
@@ -56,8 +57,13 @@ describe('Terminal Message Transformer Tests', () => {
     };
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(1);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
+    expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.message).toBe('oform.error.unexpected');
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.class).toBe('ERROR');
   });
 
   it('should transform elements when terminal key indicates to return to orig tab', () => {
@@ -69,8 +75,12 @@ describe('Terminal Message Transformer Tests', () => {
     ));
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(2);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(2);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
+      .toBe('oie.consent.enduser.email.allow.description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content).toBe('oie.return.to.original.tab');
   });
 
   it('should add info box element for generic terminal message key', () => {
@@ -82,8 +92,15 @@ describe('Terminal Message Transformer Tests', () => {
     ));
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(1);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.message).toBe(mockErrorMessage);
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.class).toBe('ERROR');
   });
 
   it('should add info Box element for link expired message key', () => {
@@ -95,8 +112,15 @@ describe('Terminal Message Transformer Tests', () => {
     ));
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(1);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.message).toBe('idx.return.link.expired');
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.class).toBe('ERROR');
   });
 
   it('should add Description element with message for'
@@ -109,8 +133,11 @@ describe('Terminal Message Transformer Tests', () => {
     ));
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(1);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
+      .toBe(TERMINAL_KEY.UNLOCK_ACCOUNT_KEY);
   });
 
   it('should add an Info box and Description elements for'
@@ -123,8 +150,17 @@ describe('Terminal Message Transformer Tests', () => {
     ));
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(2);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(2);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.message).toBe('idx.operation.cancelled.on.other.device');
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.class).toBe('ERROR');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content).toBe('oie.consent.enduser.deny.description');
   });
 
   it('should add Info box element with message for tooManyRequests message key', () => {
@@ -136,8 +172,15 @@ describe('Terminal Message Transformer Tests', () => {
     ));
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(1);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.message).toBe('oie.tooManyRequests');
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.class).toBe('ERROR');
   });
 
   it('should add error Info box element for idx.session.expired message key', () => {
@@ -149,8 +192,15 @@ describe('Terminal Message Transformer Tests', () => {
     ));
     const updatedFormBag = transformTerminalMessages(transaction, formBag);
 
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(1);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.message).toBe(TERMINAL_KEY.SESSION_EXPIRED);
+    expect((
+      updatedFormBag.uischema.elements[0] as InfoboxElement
+    ).options?.class).toBe('ERROR');
   });
 
   it('should return custom formBag when message key contains idx.enter.otp.in.original.tab', () => {

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
@@ -11,17 +11,9 @@
  */
 
 import { IdxContext, IdxStatus, IdxTransaction } from '@okta/okta-auth-js';
-import {
-  ButtonElement,
-  FormBag,
-  LinkElement,
-  SpinnerElement,
-  SuccessCallback,
-  TitleElement,
-  WidgetProps,
-} from 'src/types';
+import { FormBag, WidgetProps } from 'src/types';
 
-import { TERMINAL_KEY, TERMINAL_TITLE_KEY } from '../../constants';
+import { TERMINAL_KEY } from '../../constants';
 import { getStubTransaction } from '../../mocks/utils/utils';
 import { removeUsernameCookie, setUsernameCookie } from '../../util';
 import { transformTerminalTransaction } from '.';
@@ -51,7 +43,7 @@ jest.mock('../../util', () => {
   };
 });
 
-describe.skip('Terminal Transaction Transformer Tests', () => {
+describe('Terminal Transaction Transformer Tests', () => {
   let transaction: IdxTransaction;
   let mockAuthClient: any;
   let widgetProps: WidgetProps;
@@ -107,12 +99,8 @@ describe.skip('Terminal Transaction Transformer Tests', () => {
       widgetProps = { authClient: mockAuthClient, useInteractionCodeFlow: true };
       const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
-      expect(formBag.uischema.elements[0].type).toBe('Spinner');
-      expect((formBag.uischema.elements[0] as SpinnerElement).options?.label).toBe('Loading...');
-      expect((formBag.uischema.elements[0] as SpinnerElement).options?.valueText).toBe('Loading...');
-      expect(formBag.uischema.elements[1].type).toBe('SuccessCallback');
-      expect((formBag.uischema.elements[1] as SuccessCallback).options?.data)
-        .toEqual({ status: IdxStatus.SUCCESS, tokens: mockTokens });
+      expect(formBag.uischema.elements.length).toBe(2);
+      expect(formBag).toMatchSnapshot();
     });
 
     it('should add successCallback renderer for interaction code flow in remediation mode', () => {
@@ -121,16 +109,8 @@ describe.skip('Terminal Transaction Transformer Tests', () => {
       widgetProps = { authClient: mockAuthClient, useInteractionCodeFlow: true, codeChallenge: 'bbccdde' };
       const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
-      expect(formBag.uischema.elements[0].type).toBe('Spinner');
-      expect((formBag.uischema.elements[0] as SpinnerElement).options?.label).toBe('Loading...');
-      expect((formBag.uischema.elements[0] as SpinnerElement).options?.valueText).toBe('Loading...');
-      expect(formBag.uischema.elements[1].type).toBe('SuccessCallback');
-      expect((formBag.uischema.elements[1] as SuccessCallback).options?.data)
-        .toEqual({
-          status: IdxStatus.SUCCESS,
-          interaction_code: transaction.interactionCode,
-          state: mockAuthClient.options.state,
-        });
+      expect(formBag.uischema.elements.length).toBe(2);
+      expect(formBag).toMatchSnapshot();
       expect(mockClearMetaFn).toHaveBeenCalled();
     });
 
@@ -203,8 +183,7 @@ describe.skip('Terminal Transaction Transformer Tests', () => {
     const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
     expect(formBag.uischema.elements.length).toBe(1);
-    expect(formBag.uischema.elements[0].type).toBe('Link');
-    expect((formBag.uischema.elements[0] as LinkElement).options?.label).toBe('goback');
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should add title when terminal key indicates to return to orig tab', () => {
@@ -217,9 +196,7 @@ describe.skip('Terminal Transaction Transformer Tests', () => {
     const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
     expect(formBag.uischema.elements.length).toBe(1);
-    expect(formBag.uischema.elements[0].type).toBe('Title');
-    expect((formBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe(TERMINAL_TITLE_KEY[TERMINAL_KEY.RETURN_TO_ORIGINAL_TAB_KEY]);
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should add title and back to signin elements for link expired message key', () => {
@@ -232,11 +209,7 @@ describe.skip('Terminal Transaction Transformer Tests', () => {
     const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
     expect(formBag.uischema.elements.length).toBe(2);
-    expect(formBag.uischema.elements[0].type).toBe('Title');
-    expect((formBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe(TERMINAL_TITLE_KEY[TERMINAL_KEY.RETURN_LINK_EXPIRED_KEY]);
-    expect(formBag.uischema.elements[1].type).toBe('Link');
-    expect((formBag.uischema.elements[1] as LinkElement).options?.label).toBe('goback');
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should add title and skip setup link for'
@@ -251,18 +224,11 @@ describe.skip('Terminal Transaction Transformer Tests', () => {
     const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
     expect(formBag.uischema.elements.length).toBe(2);
-    expect(formBag.uischema.elements[0].type).toBe('Title');
-    expect((formBag.uischema.elements[0] as TitleElement).options?.content).toBe('oie.safe.mode.title');
-    expect(formBag.uischema.elements[1].type).toBe('Button');
-    expect((formBag.uischema.elements[1] as ButtonElement).label).toBe('oie.enroll.skip.setup');
-    expect((
-      formBag.uischema.elements[1] as ButtonElement
-    ).options?.step).toBe('skip');
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should add title and try again link for'
-    + ' idx.device.not.activated.consent.denied message key when baseUrl is provided', () => {
-    widgetProps = { baseUrl: 'https://acme.okta1.com' };
+    + ' idx.device.not.activated.consent.denied message key', () => {
     const mockErrorMessage = 'Set up is temporarily unavailable due to server maintenance. Try again later.';
     transaction.messages?.push(getMockMessage(
       mockErrorMessage,
@@ -272,12 +238,7 @@ describe.skip('Terminal Transaction Transformer Tests', () => {
     const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
     expect(formBag.uischema.elements.length).toBe(2);
-    expect(formBag.uischema.elements[0].type).toBe('Title');
-    expect((formBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe(TERMINAL_TITLE_KEY[TERMINAL_KEY.DEVICE_NOT_ACTIVATED_CONSENT_DENIED]);
-    expect(formBag.uischema.elements[1].type).toBe('Link');
-    expect((formBag.uischema.elements[1] as LinkElement).options?.label).toBe('oie.try.again');
-    expect((formBag.uischema.elements[1] as LinkElement).options?.href).toBe('https://acme.okta1.com');
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should add title element with message for'
@@ -291,12 +252,12 @@ describe.skip('Terminal Transaction Transformer Tests', () => {
     const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
     expect(formBag.uischema.elements.length).toBe(1);
-    expect(formBag.uischema.elements[0].type).toBe('Title');
-    expect((formBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe(TERMINAL_TITLE_KEY[TERMINAL_KEY.UNLOCK_ACCOUNT_KEY]);
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should add back to signin link for tooManyRequests message key when baseUrl not provided', () => {
+    mockAuthClient = { getIssuerOrigin: () => 'http://localhost:3000/' };
+    widgetProps = { authClient: mockAuthClient };
     const mockErrorMessage = 'Too many requests';
     transaction.messages?.push(getMockMessage(
       mockErrorMessage,
@@ -306,9 +267,34 @@ describe.skip('Terminal Transaction Transformer Tests', () => {
     const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
     expect(formBag.uischema.elements.length).toBe(1);
-    expect(formBag.uischema.elements[0].type).toBe('Link');
-    expect((formBag.uischema.elements[0] as LinkElement).options?.label).toBe('goback');
-    expect((formBag.uischema.elements[0] as LinkElement).options?.href).toBe('/');
+    expect(formBag).toMatchSnapshot();
+  });
+
+  it('should not add back to sign in link when cancel is not available', () => {
+    widgetProps = { features: { hideSignOutLinkInMFA: true } };
+    const mockErrorMessage = 'Session expired';
+    transaction.messages?.push(getMockMessage(
+      mockErrorMessage,
+      'ERROR',
+      TERMINAL_KEY.SESSION_EXPIRED,
+    ));
+    const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
+
+    expect(formBag.uischema.elements.length).toBe(0);
+  });
+
+  it('should add back to sign in link with href when backToSigninUri is set in widget options', () => {
+    widgetProps = { backToSignInLink: '/' };
+    const mockErrorMessage = 'Session expired';
+    transaction.messages?.push(getMockMessage(
+      mockErrorMessage,
+      'ERROR',
+      TERMINAL_KEY.SESSION_EXPIRED,
+    ));
+    const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
+
+    expect(formBag.uischema.elements.length).toBe(1);
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should set username cookie when successful authentication and rememberMyUsernameOnOIE feature is set', () => {

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { AuthApiError } from '@okta/okta-auth-js';
-import { InfoboxElement, WidgetProps } from 'src/types';
+import { WidgetProps } from 'src/types';
 
 import { transformUnhandledErrors } from './transformUnhandledErrors';
 
@@ -33,10 +33,7 @@ describe('Unhandled Error Transformer Tests', () => {
     const formBag = transformUnhandledErrors(widgetProps);
 
     expect(formBag.uischema.elements.length).toBe(1);
-    const el = formBag.uischema.elements[0] as InfoboxElement;
-    expect(el.type).toBe('InfoBox');
-    expect(el.options?.message).toBe('oform.error.unexpected');
-    expect(el.options?.class).toBe('ERROR');
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should add info box when response is invalid recovery token error', () => {
@@ -49,11 +46,7 @@ describe('Unhandled Error Transformer Tests', () => {
     const formBag = transformUnhandledErrors(widgetProps, apiError);
 
     expect(formBag.uischema.elements.length).toBe(1);
-    expect(formBag.uischema.elements[0].type).toBe('InfoBox');
-    expect((formBag.uischema.elements[0] as InfoboxElement).options?.message).toBe('oie.invalid.recovery.token');
-    expect((
-      formBag.uischema.elements[0] as InfoboxElement
-    ).options?.class).toBe('ERROR');
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should add info box when oie is not enabled error', () => {
@@ -66,10 +59,7 @@ describe('Unhandled Error Transformer Tests', () => {
     const formBag = transformUnhandledErrors(widgetProps, apiError);
 
     expect(formBag.uischema.elements.length).toBe(1);
-    const el = formBag.uischema.elements[0] as InfoboxElement;
-    expect(el.type).toBe('InfoBox');
-    expect(el.options?.message).toBe('oie.feature.disabled');
-    expect(el.options?.class).toBe('ERROR');
+    expect(formBag).toMatchSnapshot();
   });
 
   it('should add info box when oie configuration error', () => {
@@ -82,9 +72,6 @@ describe('Unhandled Error Transformer Tests', () => {
     const formBag = transformUnhandledErrors(widgetProps, apiError);
 
     expect(formBag.uischema.elements.length).toBe(1);
-    const el = formBag.uischema.elements[0] as InfoboxElement;
-    expect(el.type).toBe('InfoBox');
-    expect(el.options?.message).toBe('oie.configuration.error');
-    expect(el.options?.class).toBe('ERROR');
+    expect(formBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { AuthApiError } from '@okta/okta-auth-js';
-import { WidgetProps } from 'src/types';
+import { InfoboxElement, WidgetProps } from 'src/types';
 
 import { transformUnhandledErrors } from './transformUnhandledErrors';
 
@@ -32,8 +32,12 @@ describe('Unhandled Error Transformer Tests', () => {
   it('should add Infobox with unexpected error message when error is not provided', () => {
     const formBag = transformUnhandledErrors(widgetProps);
 
-    expect(formBag.uischema.elements.length).toBe(1);
     expect(formBag).toMatchSnapshot();
+    expect(formBag.uischema.elements.length).toBe(1);
+    const el = formBag.uischema.elements[0] as InfoboxElement;
+    expect(el.type).toBe('InfoBox');
+    expect(el.options?.message).toBe('oform.error.unexpected');
+    expect(el.options?.class).toBe('ERROR');
   });
 
   it('should add info box when response is invalid recovery token error', () => {
@@ -45,8 +49,13 @@ describe('Unhandled Error Transformer Tests', () => {
     };
     const formBag = transformUnhandledErrors(widgetProps, apiError);
 
-    expect(formBag.uischema.elements.length).toBe(1);
     expect(formBag).toMatchSnapshot();
+    expect(formBag.uischema.elements.length).toBe(1);
+    expect(formBag.uischema.elements[0].type).toBe('InfoBox');
+    expect((formBag.uischema.elements[0] as InfoboxElement).options?.message).toBe('oie.invalid.recovery.token');
+    expect((
+      formBag.uischema.elements[0] as InfoboxElement
+    ).options?.class).toBe('ERROR');
   });
 
   it('should add info box when oie is not enabled error', () => {
@@ -58,8 +67,12 @@ describe('Unhandled Error Transformer Tests', () => {
     };
     const formBag = transformUnhandledErrors(widgetProps, apiError);
 
-    expect(formBag.uischema.elements.length).toBe(1);
     expect(formBag).toMatchSnapshot();
+    expect(formBag.uischema.elements.length).toBe(1);
+    const el = formBag.uischema.elements[0] as InfoboxElement;
+    expect(el.type).toBe('InfoBox');
+    expect(el.options?.message).toBe('oie.feature.disabled');
+    expect(el.options?.class).toBe('ERROR');
   });
 
   it('should add info box when oie configuration error', () => {
@@ -71,7 +84,11 @@ describe('Unhandled Error Transformer Tests', () => {
     };
     const formBag = transformUnhandledErrors(widgetProps, apiError);
 
-    expect(formBag.uischema.elements.length).toBe(1);
     expect(formBag).toMatchSnapshot();
+    expect(formBag.uischema.elements.length).toBe(1);
+    const el = formBag.uischema.elements[0] as InfoboxElement;
+    expect(el.type).toBe('InfoBox');
+    expect(el.options?.message).toBe('oie.configuration.error');
+    expect(el.options?.class).toBe('ERROR');
   });
 });


### PR DESCRIPTION
## Description:

The purpose of this PR is to re-enable terminal transformer jest tests.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-537289](https://oktainc.atlassian.net/browse/OKTA-537289)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



