### PR TITLE
handles case of okta-hosted classic with no statetoken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-- '12'
+- '14'
 
 install:
 - TMPDIR=/tmp yarn install

--- a/src/router/classic.ts
+++ b/src/router/classic.ts
@@ -5,8 +5,8 @@ import { ConfigError } from 'util/Errors';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function routerClassFactory(options: WidgetOptions): RouterConstructor {
-  if (options.stateToken && !Util.isV1StateToken(options.stateToken)) {
-    throw new ConfigError('This version of the Sign-in Widget does not support Identity Engine');
+  if ((options.stateToken && !Util.isV1StateToken(options.stateToken)) || options.proxyIdxResponse) {
+    throw new ConfigError('This version of the Sign-in Widget only supports Classic Engine');
   }
 
   return V1Router;

--- a/src/router/classic.ts
+++ b/src/router/classic.ts
@@ -1,7 +1,13 @@
 import V1Router from 'v1/LoginRouter';
 import { RouterConstructor, WidgetOptions } from 'types';
+import Util from 'util/Util';
+import { ConfigError } from 'util/Errors';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function routerClassFactory(options: WidgetOptions): RouterConstructor {
+  if (options.stateToken && !Util.isV1StateToken(options.stateToken)) {
+    throw new ConfigError('This version of the Sign-in Widget does not support Identity Engine');
+  }
+
   return V1Router;
 }

--- a/src/router/default.ts
+++ b/src/router/default.ts
@@ -9,10 +9,13 @@ import { RouterConstructor, WidgetOptions } from 'types';
 
 export function routerClassFactory(options: WidgetOptions) {
   let Router: RouterConstructor;
-  if ((options.stateToken && Util.isV1StateToken(options.stateToken))
-    // Self hosted widget can set the `useClassicEngine` option to use V1Router
-    || options.useClassicEngine === true)
-  {
+
+  // V1 ("classic") flow will load under these conditions:
+  const v1DefaultFlow = (!options.stateToken && !options.clientId); // Default entry flow on okta-hosted login page
+  const v1StateTokenFlow = options.stateToken && Util.isV1StateToken(options.stateToken); // Resuming a flow on okta-hosted login page
+  const v1OAuthFlow = (options.clientId && options.useClassicEngine === true); // Self hosted widget can set the `useClassicEngine` option to use V1Router
+
+  if (v1DefaultFlow || v1StateTokenFlow || v1OAuthFlow) {
     Router = V1Router;
   } else {
     Router = V2Router;

--- a/src/router/default.ts
+++ b/src/router/default.ts
@@ -13,9 +13,9 @@ export function routerClassFactory(options: WidgetOptions) {
   // V1 ("classic") flow will load under these conditions:
   const v1DefaultFlow = (!options.stateToken && !options.clientId && !options.proxyIdxResponse); // Default entry flow on okta-hosted login page
   const v1StateTokenFlow = options.stateToken && Util.isV1StateToken(options.stateToken); // Resuming a flow on okta-hosted login page
-  const v1OAuthFlow = (options.clientId && options.useClassicEngine === true); // Self hosted widget can set the `useClassicEngine` option to use V1Router
+  const v1AuthFlow = (options.clientId && options.useClassicEngine === true); // Self hosted widget can set the `useClassicEngine` option to use V1Router
 
-  if (v1DefaultFlow || v1StateTokenFlow || v1OAuthFlow) {
+  if (v1DefaultFlow || v1StateTokenFlow || v1AuthFlow) {
     Router = V1Router;
   } else {
     Router = V2Router;

--- a/src/router/default.ts
+++ b/src/router/default.ts
@@ -11,7 +11,7 @@ export function routerClassFactory(options: WidgetOptions) {
   let Router: RouterConstructor;
 
   // V1 ("classic") flow will load under these conditions:
-  const v1DefaultFlow = (!options.stateToken && !options.clientId); // Default entry flow on okta-hosted login page
+  const v1DefaultFlow = (!options.stateToken && !options.clientId && !options.proxyIdxResponse); // Default entry flow on okta-hosted login page
   const v1StateTokenFlow = options.stateToken && Util.isV1StateToken(options.stateToken); // Resuming a flow on okta-hosted login page
   const v1OAuthFlow = (options.clientId && options.useClassicEngine === true); // Self hosted widget can set the `useClassicEngine` option to use V1Router
 

--- a/src/router/oie.ts
+++ b/src/router/oie.ts
@@ -1,7 +1,12 @@
 import V2Router from 'v2/WidgetRouter';
 import { RouterConstructor, WidgetOptions } from 'types';
+import Util from 'util/Util';
+import { ConfigError } from 'util/Errors';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function routerClassFactory(options: WidgetOptions): RouterConstructor<V2Router> {
+  if (options.stateToken && Util.isV1StateToken(options.stateToken)) {
+    throw new ConfigError('This version of the Sign-in Widget does not support Classic Engine');
+  }
   return V2Router;
 }

--- a/test/unit/spec/router/classic_spec.ts
+++ b/test/unit/spec/router/classic_spec.ts
@@ -20,10 +20,21 @@ describe('classic router class factory', () => {
 
 
     it('V2 stateToken: throws an error', () => {
-      const expectedError = new ConfigError('This version of the Sign-in Widget does not support Identity Engine');
+      const expectedError = new ConfigError('This version of the Sign-in Widget only supports Classic Engine');
       const fn = () => {
         return routerClassFactory({
           stateToken: 'abc' // V2 tokens can be any string, not starting with "00"
+        });
+      };
+
+      expect(fn).toThrow(expectedError);
+    });
+
+    it('proxyIdxResponse: throws an error', () => {
+      const expectedError = new ConfigError('This version of the Sign-in Widget only supports Classic Engine');
+      const fn = () => {
+        return routerClassFactory({
+          proxyIdxResponse: {}
         });
       };
 

--- a/test/unit/spec/router/classic_spec.ts
+++ b/test/unit/spec/router/classic_spec.ts
@@ -1,0 +1,50 @@
+import { routerClassFactory } from '../../../../src/router/classic';
+import V1Router from '../../../../src/v1/LoginRouter';
+import { ConfigError } from '../../../../src/util/Errors';
+
+describe('classic router class factory', () => {
+
+  describe('okta-hosted or non-OAuth config', () => {
+
+    it('default: creates a V1 router', () => {
+      const Router = routerClassFactory({});
+      expect(Router).toBe(V1Router);
+    });
+  
+    it('V1 stateToken: creates a V1 router', () => {
+      const Router = routerClassFactory({
+        stateToken: '00abc' // V1 tokens start with "00"
+      });
+      expect(Router).toBe(V1Router);
+    });
+
+
+    it('V2 stateToken: throws an error', () => {
+      const expectedError = new ConfigError('This version of the Sign-in Widget does not support Identity Engine');
+      const fn = () => {
+        return routerClassFactory({
+          stateToken: 'abc' // V2 tokens can be any string, not starting with "00"
+        });
+      };
+
+      expect(fn).toThrow(expectedError);
+    });
+  });
+
+  describe('OAuth config', () => {
+    it('default: creates a V1 router', () => {
+      const Router = routerClassFactory({
+        clientId: 'abc'
+      });
+      expect(Router).toBe(V1Router);
+    });
+    it('"useClassicEngine" option: ignored', () => {
+      const Router = routerClassFactory({
+        clientId: 'abc',
+        useClassicEngine: false
+      });
+      expect(Router).toBe(V1Router);
+    });
+  });
+
+});

--- a/test/unit/spec/router/default_spec.ts
+++ b/test/unit/spec/router/default_spec.ts
@@ -25,6 +25,13 @@ describe('default router class factory', () => {
       });
       expect(Router).toBe(V2Router);
     });
+
+    it('proxyIdxResponse: creates a V2 router', () => {
+      const Router = routerClassFactory({
+        proxyIdxResponse: {}
+      });
+      expect(Router).toBe(V2Router);
+    });
   });
 
   describe('OAuth config', () => {

--- a/test/unit/spec/router/default_spec.ts
+++ b/test/unit/spec/router/default_spec.ts
@@ -1,0 +1,46 @@
+import { routerClassFactory } from '../../../../src/router/default';
+import V1Router from '../../../../src/v1/LoginRouter';
+import V2Router from '../../../../src/v2/WidgetRouter';
+
+describe('default router class factory', () => {
+
+  describe('okta-hosted or non-OAuth config', () => {
+
+    it('default: creates a V1 router', () => {
+      const Router = routerClassFactory({});
+      expect(Router).toBe(V1Router);
+    });
+  
+    it('V1 stateToken: creates a V1 router', () => {
+      const Router = routerClassFactory({
+        stateToken: '00abc' // V1 tokens start with "00"
+      });
+      expect(Router).toBe(V1Router);
+    });
+
+
+    it('V2 stateToken: creates a V2 router', () => {
+      const Router = routerClassFactory({
+        stateToken: 'abc' // V2 tokens can be any string, not starting with "00"
+      });
+      expect(Router).toBe(V2Router);
+    });
+  });
+
+  describe('OAuth config', () => {
+    it('default: creates a V2 router', () => {
+      const Router = routerClassFactory({
+        clientId: 'abc'
+      });
+      expect(Router).toBe(V2Router);
+    });
+    it('with "useClassicEngine" option: creates a V1 router', () => {
+      const Router = routerClassFactory({
+        clientId: 'abc',
+        useClassicEngine: true
+      });
+      expect(Router).toBe(V1Router);
+    });
+  });
+
+});

--- a/test/unit/spec/router/oie_spec.ts
+++ b/test/unit/spec/router/oie_spec.ts
@@ -1,0 +1,48 @@
+import { routerClassFactory } from '../../../../src/router/oie';
+import V2Router from '../../../../src/v2/WidgetRouter';
+import { ConfigError } from '../../../../src/util/Errors';
+
+describe('oie router class factory', () => {
+
+  describe('okta-hosted or non-OAuth config', () => {
+
+    it('default: creates a V2 router', () => {
+      const Router = routerClassFactory({});
+      expect(Router).toBe(V2Router);
+    });
+  
+    it('V2 stateToken: creates a V2 router', () => {
+      const Router = routerClassFactory({
+        stateToken: 'abc' // V2 tokens can be any string, not starting with "00"
+      });
+      expect(Router).toBe(V2Router);
+    });
+
+    it('V1 stateToken: throws an error', () => {
+      const expectedError = new ConfigError('This version of the Sign-in Widget does not support Classic Engine');
+      const fn = () => {
+        return routerClassFactory({
+          stateToken: '00abc' // V1 tokens start with "00"
+        });
+      };
+      expect(fn).toThrow(expectedError);
+    });
+  });
+
+  describe('OAuth config', () => {
+    it('default: creates a V2 router', () => {
+      const Router = routerClassFactory({
+        clientId: 'abc'
+      });
+      expect(Router).toBe(V2Router);
+    });
+    it('"useClassicEngine" option: ignored', () => {
+      const Router = routerClassFactory({
+        clientId: 'abc',
+        useClassicEngine: true
+      });
+      expect(Router).toBe(V2Router);
+    });
+  });
+
+});


### PR DESCRIPTION
## Description:
- okta-hosted classic login page may bootstrap widget with no stateToken. In this case, it should default to using V1 router.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [N] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-537584](https://oktainc.atlassian.net/browse/OKTA-537584)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&sha=175cd8d998c0767a475b842a517ffd9bb8c8d9c0

