### PR TITLE
OKTA-537291 : Re-enabling WebAuthN transformer jest tests

### DIFF
--- a/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
@@ -295,15 +295,37 @@ Object {
                 "elements": Array [
                   Object {
                     "options": Object {
-                      "items": Array [
-                        "oie.verify.webauthn.cant.verify.enrollment.step1",
-                        "oie.verify.webauthn.cant.verify.enrollment.step2",
-                        "oie.verify.webauthn.cant.verify.enrollment.step3",
-                        "oie.verify.webauthn.cant.verify.enrollment.step4",
-                      ],
-                      "type": "ordered",
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.title",
+                      "level": 6,
+                      "visualLevel": 3,
                     },
-                    "type": "List",
+                    "type": "Heading",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description1",
+                    },
+                    "type": "Description",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description2",
+                    },
+                    "type": "Description",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.security.key.title",
+                      "level": 6,
+                      "visualLevel": 3,
+                    },
+                    "type": "Heading",
+                  },
+                  Object {
+                    "options": Object {
+                      "content": "oie.verify.webauthn.cant.verify.security.key.description",
+                    },
+                    "type": "Description",
                   },
                 ],
                 "type": "VerticalLayout",

--- a/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
@@ -3,7 +3,14 @@
 exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should only render title and description elements when WebAuthN API is not available 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -80,7 +87,14 @@ Object {
 exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should render title, description and button elements when WebAuthN API is available 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -100,7 +114,7 @@ Object {
         "options": Object {
           "onClick": [Function],
           "step": "challenge-authenticator",
-          "submitOnLoad": false,
+          "submitOnLoad": true,
         },
         "type": "WebAuthNSubmitButton",
       },
@@ -162,10 +176,87 @@ Object {
 }
 `;
 
-exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should render title, description, button, and callout elements when WebAuthN API is available in Safari Browser 1`] = `
+exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should render title, description, button and can't verify link elements for appName = Okta_Authenticaotr when WebAuthN API is available 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.verify.webauth.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.verify.webauthn.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "onClick": [Function],
+          "step": "challenge-authenticator",
+          "submitOnLoad": true,
+        },
+        "type": "WebAuthNSubmitButton",
+      },
+      Object {
+        "elements": Array [
+          Object {
+            "key": "cant-verify",
+            "options": Object {
+              "content": Object {
+                "elements": Array [
+                  Object {
+                    "options": Object {
+                      "items": Array [
+                        "oie.verify.webauthn.cant.verify.enrollment.step1",
+                        "oie.verify.webauthn.cant.verify.enrollment.step2",
+                        "oie.verify.webauthn.cant.verify.enrollment.step3",
+                        "oie.verify.webauthn.cant.verify.enrollment.step4",
+                      ],
+                      "type": "ordered",
+                    },
+                    "type": "List",
+                  },
+                ],
+                "type": "VerticalLayout",
+              },
+              "id": "cant-verify",
+              "summary": "oie.verify.webauthn.cant.verify",
+            },
+            "type": "AccordionPanel",
+          },
+        ],
+        "type": "Accordion",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`WebAuthN Transformer Tests WebAuthN Challenge Tests should render title, description, button, and user verification elements when WebAuthN API is available in Safari Browser 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -204,37 +295,15 @@ Object {
                 "elements": Array [
                   Object {
                     "options": Object {
-                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.title",
-                      "level": 6,
-                      "visualLevel": 3,
+                      "items": Array [
+                        "oie.verify.webauthn.cant.verify.enrollment.step1",
+                        "oie.verify.webauthn.cant.verify.enrollment.step2",
+                        "oie.verify.webauthn.cant.verify.enrollment.step3",
+                        "oie.verify.webauthn.cant.verify.enrollment.step4",
+                      ],
+                      "type": "ordered",
                     },
-                    "type": "Heading",
-                  },
-                  Object {
-                    "options": Object {
-                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description1",
-                    },
-                    "type": "Description",
-                  },
-                  Object {
-                    "options": Object {
-                      "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description2",
-                    },
-                    "type": "Description",
-                  },
-                  Object {
-                    "options": Object {
-                      "content": "oie.verify.webauthn.cant.verify.security.key.title",
-                      "level": 6,
-                      "visualLevel": 3,
-                    },
-                    "type": "Heading",
-                  },
-                  Object {
-                    "options": Object {
-                      "content": "oie.verify.webauthn.cant.verify.security.key.description",
-                    },
-                    "type": "Description",
+                    "type": "List",
                   },
                 ],
                 "type": "VerticalLayout",
@@ -256,7 +325,14 @@ Object {
 exports[`WebAuthN Transformer Tests WebAuthN Enroll Tests should only render title and description elements when WebAuthN API is not available 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "enroll-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -281,7 +357,14 @@ Object {
 exports[`WebAuthN Transformer Tests WebAuthN Enroll Tests should render title, description and button elements when WebAuthN API is available 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "enroll-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -299,7 +382,47 @@ Object {
       },
       Object {
         "options": Object {
-          "content": "oie.enroll.webauthn.instructions.edge",
+          "onClick": [Function],
+          "step": "enroll-authenticator",
+          "submitOnLoad": false,
+        },
+        "type": "WebAuthNSubmitButton",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`WebAuthN Transformer Tests WebAuthN Enroll Tests should render title, description, button and userVerification required elements when WebAuthN API is available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "enroll-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.enroll.webauthn.uv.required.instructions",
         },
         "type": "Description",
       },
@@ -320,7 +443,14 @@ Object {
 exports[`WebAuthN Transformer Tests WebAuthN Enroll Tests should render title, description, button, and callout elements when WebAuthN API is available on MS Edge browser 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "enroll-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -339,12 +469,6 @@ Object {
       Object {
         "options": Object {
           "content": "oie.enroll.webauthn.instructions.edge",
-        },
-        "type": "Description",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.enroll.webauthn.uv.required.instructions",
         },
         "type": "Description",
       },

--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
@@ -15,10 +15,18 @@ import {
   ChallengeData,
   IdxAuthenticator,
   IdxContext,
+  IdxTransaction,
 } from '@okta/okta-auth-js';
 import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
-import { FormBag, WidgetProps } from 'src/types';
+import {
+  AccordionLayout,
+  DescriptionElement,
+  FormBag,
+  TitleElement,
+  WebAuthNButtonElement,
+  WidgetProps,
+} from 'src/types';
 
 import { transformWebAuthNAuthenticator } from '.';
 
@@ -30,8 +38,8 @@ jest.mock('../../../../util/BrowserFeatures', () => ({
 }));
 
 describe('WebAuthN Transformer Tests', () => {
-  const transaction = getStubTransactionWithNextStep();
   const widgetProps: WidgetProps = {};
+  let transaction: IdxTransaction;
   let formBag: FormBag;
   let mockCredentialsContainer: CredentialsContainer;
 
@@ -46,6 +54,7 @@ describe('WebAuthN Transformer Tests', () => {
 
   describe('WebAuthN Enroll Tests', () => {
     beforeEach(() => {
+      transaction = getStubTransactionWithNextStep();
       formBag = getStubFormBag(IDX_STEP.ENROLL_AUTHENTICATOR);
       transaction.nextStep = {
         name: IDX_STEP.ENROLL_AUTHENTICATOR,
@@ -62,8 +71,12 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(2);
       expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(2);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('oie.enroll.webauthn.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('oie.webauthn.error.not.supported');
     });
 
     it('should render title, description and button elements when WebAuthN API is available', () => {
@@ -81,8 +94,17 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(3);
       expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(3);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('oie.enroll.webauthn.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('oie.enroll.webauthn.instructions');
+      expect(updatedFormBag.uischema.elements[2].type).toBe('WebAuthNSubmitButton');
+      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options.step)
+        .toBe('enroll-authenticator');
+      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options.submitOnLoad)
+        .toBe(false);
     });
 
     it('should render title, description, button and userVerification required elements when WebAuthN API is available', () => {
@@ -115,8 +137,19 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(4);
       expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('oie.enroll.webauthn.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('oie.enroll.webauthn.instructions');
+      expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+        .toBe('oie.enroll.webauthn.uv.required.instructions');
+      expect(updatedFormBag.uischema.elements[3].type).toBe('WebAuthNSubmitButton');
+      expect((updatedFormBag.uischema.elements[3] as WebAuthNButtonElement).options.step)
+        .toBe('enroll-authenticator');
+      expect((updatedFormBag.uischema.elements[3] as WebAuthNButtonElement).options.submitOnLoad)
+        .toBe(false);
     });
 
     it('should render title, description, button, and callout elements when WebAuthN API is available on MS Edge browser', () => {
@@ -135,13 +168,25 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(4);
       expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('oie.enroll.webauthn.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('oie.enroll.webauthn.instructions');
+      expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+        .toBe('oie.enroll.webauthn.instructions.edge');
+      expect(updatedFormBag.uischema.elements[3].type).toBe('WebAuthNSubmitButton');
+      expect((updatedFormBag.uischema.elements[3] as WebAuthNButtonElement).options.step)
+        .toBe('enroll-authenticator');
+      expect((updatedFormBag.uischema.elements[3] as WebAuthNButtonElement).options.submitOnLoad)
+        .toBe(false);
     });
   });
 
   describe('WebAuthN Challenge Tests', () => {
     beforeEach(() => {
+      transaction = getStubTransactionWithNextStep();
       formBag = getStubFormBag(IDX_STEP.CHALLENGE_AUTHENTICATOR);
       transaction.nextStep = {
         name: IDX_STEP.CHALLENGE_AUTHENTICATOR,
@@ -156,8 +201,16 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(3);
       expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(3);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('oie.verify.webauth.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('oie.webauthn.error.not.supported');
+      expect(updatedFormBag.uischema.elements[2].type).toBe('Accordion');
+      expect((updatedFormBag.uischema.elements[2] as AccordionLayout).elements.length).toBe(1);
+      expect((updatedFormBag.uischema.elements[2] as AccordionLayout).elements[0].options.summary)
+        .toBe('oie.verify.webauthn.cant.verify');
     });
 
     it('should render title, description and button elements when WebAuthN API is available', () => {
@@ -174,8 +227,23 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(4);
       expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('oie.verify.webauth.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('oie.verify.webauthn.instructions');
+      expect(updatedFormBag.uischema.elements[2].type).toBe('WebAuthNSubmitButton');
+      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options.step)
+        .toBe('challenge-authenticator');
+      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options.submitOnLoad)
+        .toBe(true);
+      expect(updatedFormBag.uischema.elements[3].type).toBe('Accordion');
+      expect((updatedFormBag.uischema.elements[3] as AccordionLayout).elements.length).toBe(1);
+      expect((updatedFormBag.uischema.elements[3] as AccordionLayout).elements[0].options.summary)
+        .toBe('oie.verify.webauthn.cant.verify');
+      expect((updatedFormBag.uischema.elements[3] as AccordionLayout)
+        .elements[0].options.content.elements.length).toBe(5);
     });
 
     it('should render title, description, button and can\'t verify link elements for appName = Okta_Authenticaotr when WebAuthN API is available', () => {
@@ -193,8 +261,23 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(4);
       expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('oie.verify.webauth.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('oie.verify.webauthn.instructions');
+      expect(updatedFormBag.uischema.elements[2].type).toBe('WebAuthNSubmitButton');
+      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options.step)
+        .toBe('challenge-authenticator');
+      expect((updatedFormBag.uischema.elements[2] as WebAuthNButtonElement).options.submitOnLoad)
+        .toBe(true);
+      expect(updatedFormBag.uischema.elements[3].type).toBe('Accordion');
+      expect((updatedFormBag.uischema.elements[3] as AccordionLayout).elements.length).toBe(1);
+      expect((updatedFormBag.uischema.elements[3] as AccordionLayout).elements[0].options.summary)
+        .toBe('oie.verify.webauthn.cant.verify');
+      expect((updatedFormBag.uischema.elements[3] as AccordionLayout)
+        .elements[0].options.content.elements.length).toBe(1);
     });
 
     it('should render title, description, button, and user verification elements when WebAuthN API is available in Safari Browser', () => {
@@ -222,8 +305,25 @@ describe('WebAuthN Transformer Tests', () => {
       const updatedFormBag = transformWebAuthNAuthenticator({ transaction, formBag, widgetProps });
 
       // Verify added elements
-      expect(updatedFormBag.uischema.elements.length).toBe(5);
       expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('oie.verify.webauth.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('oie.verify.webauthn.instructions');
+      expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+        .toBe('oie.verify.webauthn.uv.required.instructions');
+      expect(updatedFormBag.uischema.elements[3].type).toBe('WebAuthNSubmitButton');
+      expect((updatedFormBag.uischema.elements[3] as WebAuthNButtonElement).options.step)
+        .toBe('challenge-authenticator');
+      expect((updatedFormBag.uischema.elements[3] as WebAuthNButtonElement).options.submitOnLoad)
+        .toBe(false);
+      expect(updatedFormBag.uischema.elements[4].type).toBe('Accordion');
+      expect((updatedFormBag.uischema.elements[4] as AccordionLayout).elements.length).toBe(1);
+      expect((updatedFormBag.uischema.elements[4] as AccordionLayout).elements[0].options.summary)
+        .toBe('oie.verify.webauthn.cant.verify');
+      expect((updatedFormBag.uischema.elements[4] as AccordionLayout)
+        .elements[0].options.content.elements.length).toBe(5);
     });
   });
 });


### PR DESCRIPTION
## Description:

The purpose of this PR is to re-enable the WebAuthN transformer jest tests.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-537291](https://oktainc.atlassian.net/browse/OKTA-537291)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



