### PR TITLE
OKTA-537284 : Re-enabling password transformer jest tests

### DIFF
--- a/src/v3/src/transformer/password/__snapshots__/transformEnrollPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformEnrollPasswordAuthenticator.test.ts.snap
@@ -1,0 +1,255 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Enroll Password Authenticator Transformer Tests should add title, and password enrollment elements to UI Schema for enroll PW step with missing password policy settings 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.password.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Enroll Password Authenticator Transformer Tests should add title, password requirements and password enrollment elements to UI Schema for enroll PW step 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.password.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [
+            Object {
+              "label": "password.complexity.length.description",
+              "ruleKey": "minLength",
+            },
+          ],
+          "settings": Object {
+            "complexity": Object {
+              "minLength": 1,
+            },
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Enroll Password Authenticator Transformer Tests should add title, password requirements and password enrollment elements to UI Schema for enroll PW step when passcode field name is newPassword 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.newPassword": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.password.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [
+            Object {
+              "label": "password.complexity.length.description",
+              "ruleKey": "minLength",
+            },
+          ],
+          "settings": Object {
+            "complexity": Object {
+              "minLength": 1,
+            },
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.newPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/password/__snapshots__/transformEnrollPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformEnrollPasswordAuthenticator.test.ts.snap
@@ -14,7 +14,7 @@ Object {
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
     "submit": Object {
-      "step": "challenge-authenticator",
+      "step": "enroll-authenticator",
     },
   },
   "schema": Object {},
@@ -84,7 +84,7 @@ Object {
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
     "submit": Object {
-      "step": "challenge-authenticator",
+      "step": "enroll-authenticator",
     },
   },
   "schema": Object {},
@@ -176,7 +176,7 @@ Object {
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
     "submit": Object {
-      "step": "challenge-authenticator",
+      "step": "enroll-authenticator",
     },
   },
   "schema": Object {},

--- a/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordAuthenticator.test.ts.snap
@@ -1,0 +1,279 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expired Password Authenticator Transformer Tests should add updated title element and submit button to UI Schema for expired PW step 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.expired.title.generic",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [
+            Object {
+              "label": "password.complexity.length.description",
+              "ruleKey": "minLength",
+            },
+          ],
+          "settings": Object {
+            "complexity": Object {
+              "minLength": 1,
+            },
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.expired.submit",
+        "options": Object {
+          "step": "reenroll-authenticator",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Expired Password Authenticator Transformer Tests should add updated title element and submit button to UI Schema for expired PW step with brandName provided 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.expired.title.specific",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [
+            Object {
+              "label": "password.complexity.length.description",
+              "ruleKey": "minLength",
+            },
+          ],
+          "settings": Object {
+            "complexity": Object {
+              "minLength": 1,
+            },
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.expired.submit",
+        "options": Object {
+          "step": "reenroll-authenticator",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Expired Password Authenticator Transformer Tests should add updated title element and submit button to UI Schema for expired PW step without password policy settings 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.expired.title.generic",
+        },
+        "type": "Title",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.expired.submit",
+        "options": Object {
+          "step": "reenroll-authenticator",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordWarningAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordWarningAuthenticator.test.ts.snap
@@ -1,0 +1,583 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expired Password Warning Authenticator Transformer Tests should add updated title element and submit button elements w/ 0 days to expire to UI Schema 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.expiring.today",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [],
+          "settings": Object {
+            "complexity": Object {},
+            "daysToExpiry": 0,
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.expired.submit",
+        "options": Object {
+          "step": "reenroll-authenticator-warning",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Expired Password Warning Authenticator Transformer Tests should add updated title element and submit button elements w/ 5 days to expire to UI Schema 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.expiring.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [],
+          "settings": Object {
+            "complexity": Object {},
+            "daysToExpiry": 5,
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.expired.submit",
+        "options": Object {
+          "step": "reenroll-authenticator-warning",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Expired Password Warning Authenticator Transformer Tests should add updated title element and submit button elements when daysToExpire is not present to UI Schema 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.expiring.soon",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [],
+          "settings": Object {
+            "complexity": Object {},
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.expired.submit",
+        "options": Object {
+          "step": "reenroll-authenticator-warning",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Expired Password Warning Authenticator Transformer Tests should add updated title element, submit button and skip button elements to UI Schema for expired PW step with skip remediation in the transaction 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.expiring.soon",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [],
+          "settings": Object {
+            "complexity": Object {},
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.expired.submit",
+        "options": Object {
+          "step": "reenroll-authenticator-warning",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "label": "password.expiring.later",
+        "options": Object {
+          "step": "skip",
+          "type": "button",
+          "variant": "floating",
+          "wide": false,
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Expired Password Warning Authenticator Transformer Tests should add updated title element, submit button, and additional subtitle elements to UI Schema for expired PW step with brandName provided 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.expiring.soon",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "password.expiring.subtitle.specific",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [],
+          "settings": Object {
+            "complexity": Object {},
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.expired.submit",
+        "options": Object {
+          "step": "reenroll-authenticator-warning",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Expired Password Warning Authenticator Transformer Tests should add updated title element, submit button, and additional subtitle elements to UI Schema for expired PW step with messages in the transaction 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.expiring.soon",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "When your password is locked, you cannot access the account",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [],
+          "settings": Object {
+            "complexity": Object {},
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.expired.submit",
+        "options": Object {
+          "step": "reenroll-authenticator-warning",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/password/__snapshots__/transformPasswordChallenge.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformPasswordChallenge.test.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Password Challenge Transformer Tests should add title & submt button elements to ui schema when transforming password challenge step 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.password.challenge.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": undefined,
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/password/__snapshots__/transformPasswordChallenge.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformPasswordChallenge.test.ts.snap
@@ -24,7 +24,7 @@ Object {
         "noMargin": true,
         "options": Object {
           "name": "username",
-          "value": undefined,
+          "value": "someuser@noemail.com",
         },
         "type": "HiddenInput",
       },

--- a/src/v3/src/transformer/password/__snapshots__/transformResetPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformResetPasswordAuthenticator.test.ts.snap
@@ -1,0 +1,279 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reset Password Authenticator Transformer Tests should add updated title element and submit button to UI Schema for reset PW step 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.reset.title.generic",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [
+            Object {
+              "label": "password.complexity.length.description",
+              "ruleKey": "minLength",
+            },
+          ],
+          "settings": Object {
+            "complexity": Object {
+              "minLength": 1,
+            },
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.reset",
+        "options": Object {
+          "step": "reset-authenticator",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Reset Password Authenticator Transformer Tests should add updated title element and submit button to UI Schema for reset PW step with brandName provided 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.reset.title.specific",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [
+            Object {
+              "label": "password.complexity.length.description",
+              "ruleKey": "minLength",
+            },
+          ],
+          "settings": Object {
+            "complexity": Object {
+              "minLength": 1,
+            },
+          },
+          "userInfo": Object {
+            "identifier": "someuser@noemail.com",
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.reset",
+        "options": Object {
+          "step": "reset-authenticator",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Reset Password Authenticator Transformer Tests should add updated title element and submit button to UI Schema for reset PW step without password policy settings 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "confirmPassword": Object {
+      "validate": [Function],
+    },
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "password.reset.title.generic",
+        },
+        "type": "Title",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "name": "username",
+          "value": "someuser@noemail.com",
+        },
+        "type": "HiddenInput",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "confirmPassword",
+        "label": "oie.password.confirmPasswordLabel",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "messages": Object {
+              "value": undefined,
+            },
+            "name": "confirmPassword",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "password.reset",
+        "options": Object {
+          "step": "reset-authenticator",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.test.ts
+++ b/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.test.ts
@@ -16,17 +16,17 @@ import { IDX_STEP } from '../../constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from '../../mocks/utils/utils';
 import {
   FieldElement,
-  PasswordRequirementsElement,
-  TitleElement,
+  FormBag,
   WidgetProps,
 } from '../../types';
 import { transformEnrollPasswordAuthenticator } from '.';
 
-describe.skip('Enroll Password Authenticator Transformer Tests', () => {
+describe('Enroll Password Authenticator Transformer Tests', () => {
   const transaction = getStubTransactionWithNextStep();
-  const formBag = getStubFormBag();
+  let formBag: FormBag;
   let widgetProps: WidgetProps;
   beforeEach(() => {
+    formBag = getStubFormBag();
     formBag.uischema.elements = [
       {
         type: 'Field',
@@ -65,29 +65,38 @@ describe.skip('Enroll Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect(updatedFormBag.uischema.elements[0]?.type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.password.enroll.title');
-    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
-      .toBe('password.complexity.requirements.header');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: { minLength: 1 } });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options?.inputMeta?.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag).toMatchSnapshot();
+  });
+
+  it('should add title, password requirements and password enrollment elements to UI Schema for enroll PW step when passcode field name is newPassword', () => {
+    formBag.uischema.elements = [
+      {
+        type: 'Field',
+        label: 'Password',
+        options: {
+          inputMeta: { name: 'credentials.newPassword', secret: true },
+          attributes: { autocomplete: 'current-password' },
+        },
+      } as FieldElement,
+    ];
+    transaction.nextStep = {
+      name: IDX_STEP.ENROLL_AUTHENTICATOR,
+      relatesTo: {
+        value: {
+          settings: {
+            complexity: { minLength: 1 },
+          },
+        } as unknown as IdxAuthenticator,
+      },
+    };
+    const updatedFormBag = transformEnrollPasswordAuthenticator({
+      transaction, formBag, widgetProps,
+    });
+
+    // Verify added elements
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add title, and password enrollment elements to UI Schema for enroll PW step with missing password policy settings', () => {
@@ -102,17 +111,7 @@ describe.skip('Enroll Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(2);
-    expect(updatedFormBag.uischema.elements[0]?.type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.password.enroll.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.test.ts
+++ b/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.test.ts
@@ -17,6 +17,9 @@ import { getStubFormBag, getStubTransactionWithNextStep } from '../../mocks/util
 import {
   FieldElement,
   FormBag,
+  HiddenInputElement,
+  PasswordRequirementsElement,
+  TitleElement,
   WidgetProps,
 } from '../../types';
 import { transformEnrollPasswordAuthenticator } from '.';
@@ -26,7 +29,7 @@ describe('Enroll Password Authenticator Transformer Tests', () => {
   let formBag: FormBag;
   let widgetProps: WidgetProps;
   beforeEach(() => {
-    formBag = getStubFormBag();
+    formBag = getStubFormBag(IDX_STEP.ENROLL_AUTHENTICATOR);
     formBag.uischema.elements = [
       {
         type: 'Field',
@@ -65,8 +68,32 @@ describe('Enroll Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.password.enroll.title');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: { minLength: 1 } });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
   });
 
   it('should add title, password requirements and password enrollment elements to UI Schema for enroll PW step when passcode field name is newPassword', () => {
@@ -95,8 +122,32 @@ describe('Enroll Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.password.enroll.title');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: { minLength: 1 } });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.newPassword');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
   });
 
   it('should add title, and password enrollment elements to UI Schema for enroll PW step with missing password policy settings', () => {
@@ -111,7 +162,20 @@ describe('Enroll Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.password.enroll.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[1] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
   });
 });

--- a/src/v3/src/transformer/password/transformExpiredPasswordAuthenticator.test.ts
+++ b/src/v3/src/transformer/password/transformExpiredPasswordAuthenticator.test.ts
@@ -15,19 +15,18 @@ import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { IDX_STEP } from '../../constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from '../../mocks/utils/utils';
 import {
-  ButtonElement,
   FieldElement,
-  PasswordRequirementsElement,
-  TitleElement,
+  FormBag,
   WidgetProps,
 } from '../../types';
 import { transformExpiredPasswordAuthenticator } from '.';
 
-describe.skip('Expired Password Authenticator Transformer Tests', () => {
+describe('Expired Password Authenticator Transformer Tests', () => {
   const transaction = getStubTransactionWithNextStep();
-  const formBag = getStubFormBag();
+  let formBag: FormBag;
   let widgetProps: WidgetProps;
   beforeEach(() => {
+    formBag = getStubFormBag();
     formBag.uischema.elements = [
       {
         type: 'Field',
@@ -66,57 +65,8 @@ describe.skip('Expired Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0]?.type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.expired.title.generic');
-    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toEqual('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: { minLength: 1 } });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .label).toBe('password.expired.submit');
-  });
-
-  it('should add updated title element and submit button to UI Schema for expired PW step without password policy settings', () => {
-    transaction.nextStep = {
-      name: IDX_STEP.REENROLL_AUTHENTICATOR,
-      relatesTo: {
-        value: {} as unknown as IdxAuthenticator,
-      },
-    };
-    const updatedFormBag = transformExpiredPasswordAuthenticator({
-      transaction, formBag, widgetProps,
-    });
-
-    // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect(updatedFormBag.uischema.elements[0]?.type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.expired.title.generic');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement)
-      .label).toBe('password.expired.submit');
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add updated title element and submit button to UI Schema for expired PW step with brandName provided', () => {
@@ -136,29 +86,23 @@ describe.skip('Expired Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0]?.type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.expired.title.specific');
-    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: { minLength: 1 } });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag).toMatchSnapshot();
+  });
 
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .label).toBe('password.expired.submit');
+  it('should add updated title element and submit button to UI Schema for expired PW step without password policy settings', () => {
+    transaction.nextStep = {
+      name: IDX_STEP.REENROLL_AUTHENTICATOR,
+      relatesTo: {
+        value: {} as unknown as IdxAuthenticator,
+      },
+    };
+    const updatedFormBag = transformExpiredPasswordAuthenticator({
+      transaction, formBag, widgetProps,
+    });
+
+    // Verify added elements
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/password/transformExpiredPasswordAuthenticator.test.ts
+++ b/src/v3/src/transformer/password/transformExpiredPasswordAuthenticator.test.ts
@@ -15,8 +15,13 @@ import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { IDX_STEP } from '../../constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from '../../mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
   FieldElement,
   FormBag,
+  HiddenInputElement,
+  PasswordRequirementsElement,
+  TitleElement,
   WidgetProps,
 } from '../../types';
 import { transformExpiredPasswordAuthenticator } from '.';
@@ -65,8 +70,37 @@ describe('Expired Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.expired.title.generic');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: { minLength: 1 } });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label).toBe('password.expired.submit');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.step)
+      .toBe('reenroll-authenticator');
   });
 
   it('should add updated title element and submit button to UI Schema for expired PW step with brandName provided', () => {
@@ -86,8 +120,37 @@ describe('Expired Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.expired.title.specific');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: { minLength: 1 } });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label).toBe('password.expired.submit');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.step)
+      .toBe('reenroll-authenticator');
   });
 
   it('should add updated title element and submit button to UI Schema for expired PW step without password policy settings', () => {
@@ -102,7 +165,25 @@ describe('Expired Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.expired.title.generic');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[1] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label).toBe('password.expired.submit');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options.step)
+      .toBe('reenroll-authenticator');
   });
 });

--- a/src/v3/src/transformer/password/transformExpiredPasswordWarningAuthenticator.test.ts
+++ b/src/v3/src/transformer/password/transformExpiredPasswordWarningAuthenticator.test.ts
@@ -15,8 +15,14 @@ import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 
 import {
+  ButtonElement,
+  ButtonType,
+  DescriptionElement,
   FieldElement,
   FormBag,
+  HiddenInputElement,
+  PasswordRequirementsElement,
+  TitleElement,
   WidgetProps,
 } from '../../types';
 import { transformExpiredPasswordWarningAuthenticator } from './transformExpiredPasswordWarningAuthenticator';
@@ -70,8 +76,37 @@ describe('Expired Password Warning Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.expiring.title');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: {}, daysToExpiry: 5 });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label).toBe('password.expired.submit');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.step)
+      .toBe('reenroll-authenticator-warning');
   });
 
   it('should add updated title element and submit button elements w/ 0 days to expire to UI Schema', () => {
@@ -94,8 +129,37 @@ describe('Expired Password Warning Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.expiring.today');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: {}, daysToExpiry: 0 });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label).toBe('password.expired.submit');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.step)
+      .toBe('reenroll-authenticator-warning');
   });
 
   it('should add updated title element and submit button elements when daysToExpire is not present to UI Schema', () => {
@@ -116,8 +180,37 @@ describe('Expired Password Warning Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.expiring.soon');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: {} });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label).toBe('password.expired.submit');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.step)
+      .toBe('reenroll-authenticator-warning');
   });
 
   it('should add updated title element, submit button, and additional subtitle elements to UI Schema for expired PW step with brandName provided', () => {
@@ -140,8 +233,39 @@ describe('Expired Password Warning Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.expiring.soon');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('password.expiring.subtitle.specific');
+    expect(updatedFormBag.uischema.elements[2]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: {} });
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[3].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[3] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).label).toBe('password.expired.submit');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.step)
+      .toBe('reenroll-authenticator-warning');
   });
 
   it('should add updated title element, submit button, and additional subtitle elements to UI Schema for expired PW step with messages in the transaction', () => {
@@ -155,8 +279,9 @@ describe('Expired Password Warning Authenticator Transformer Tests', () => {
         } as unknown as IdxAuthenticator,
       },
     };
+    const mockMessage = 'When your password is locked, you cannot access the account';
     transaction.messages = [{
-      message: 'When your password is locked, you cannot access the account',
+      message: mockMessage,
       class: 'INFO',
       i18n: { key: 'some.mock.key' },
     }];
@@ -167,8 +292,39 @@ describe('Expired Password Warning Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.expiring.soon');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe(mockMessage);
+    expect(updatedFormBag.uischema.elements[2]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: {} });
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[3].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[3] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).label).toBe('password.expired.submit');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.step)
+      .toBe('reenroll-authenticator-warning');
   });
 
   it('should add updated title element, submit button and skip button elements to UI Schema for expired PW step with skip remediation in the transaction', () => {
@@ -193,7 +349,44 @@ describe('Expired Password Warning Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.expiring.soon');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: {} });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label).toBe('password.expired.submit');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.step)
+      .toBe('reenroll-authenticator-warning');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).label)
+      .toBe('password.expiring.later');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.step)
+      .toBe('skip');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.type)
+      .toBe(ButtonType.BUTTON);
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.variant)
+      .toBe('floating');
   });
 });

--- a/src/v3/src/transformer/password/transformExpiredPasswordWarningAuthenticator.test.ts
+++ b/src/v3/src/transformer/password/transformExpiredPasswordWarningAuthenticator.test.ts
@@ -15,20 +15,18 @@ import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 
 import {
-  ButtonElement,
-  DescriptionElement,
   FieldElement,
-  PasswordRequirementsElement,
-  TitleElement,
+  FormBag,
   WidgetProps,
 } from '../../types';
 import { transformExpiredPasswordWarningAuthenticator } from './transformExpiredPasswordWarningAuthenticator';
 
-describe.skip('Expired Password Warning Authenticator Transformer Tests', () => {
+describe('Expired Password Warning Authenticator Transformer Tests', () => {
   let transaction: IdxTransaction;
-  const formBag = getStubFormBag();
+  let formBag: FormBag;
   let widgetProps: WidgetProps;
   beforeEach(() => {
+    formBag = getStubFormBag();
     transaction = getStubTransactionWithNextStep();
     formBag.uischema.elements = [
       {
@@ -54,7 +52,7 @@ describe.skip('Expired Password Warning Authenticator Transformer Tests', () => 
 
   it('should add updated title element and submit button elements w/ 5 days to expire to UI Schema', () => {
     transaction.nextStep = {
-      name: IDX_STEP.REENROLL_AUTHENTICATOR,
+      name: IDX_STEP.REENROLL_AUTHENTICATOR_WARNING,
       relatesTo: {
         value: {
           settings: {
@@ -72,35 +70,13 @@ describe.skip('Expired Password Warning Authenticator Transformer Tests', () => 
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.expiring.title');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).type)
-      .toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: {}, daysToExpiry: 5 });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .label).toBe('password.expired.submit');
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add updated title element and submit button elements w/ 0 days to expire to UI Schema', () => {
     transaction.nextStep = {
-      name: IDX_STEP.REENROLL_AUTHENTICATOR,
+      name: IDX_STEP.REENROLL_AUTHENTICATOR_WARNING,
       relatesTo: {
         value: {
           settings: {
@@ -118,34 +94,13 @@ describe.skip('Expired Password Warning Authenticator Transformer Tests', () => 
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.expiring.today');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: {}, daysToExpiry: 0 });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .label).toBe('password.expired.submit');
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add updated title element and submit button elements when daysToExpire is not present to UI Schema', () => {
     transaction.nextStep = {
-      name: IDX_STEP.REENROLL_AUTHENTICATOR,
+      name: IDX_STEP.REENROLL_AUTHENTICATOR_WARNING,
       relatesTo: {
         value: {
           settings: {
@@ -161,38 +116,15 @@ describe.skip('Expired Password Warning Authenticator Transformer Tests', () => 
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.expiring.soon');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).type)
-      .toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier)
-      .toEqual('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: {} });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .label).toBe('password.expired.submit');
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add updated title element, submit button, and additional subtitle elements to UI Schema for expired PW step with brandName provided', () => {
     const mockBrandName = 'Acme Corp.';
     widgetProps = { brandName: mockBrandName };
     transaction.nextStep = {
-      name: IDX_STEP.REENROLL_AUTHENTICATOR,
+      name: IDX_STEP.REENROLL_AUTHENTICATOR_WARNING,
       relatesTo: {
         value: {
           settings: {
@@ -208,38 +140,13 @@ describe.skip('Expired Password Warning Authenticator Transformer Tests', () => 
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.expiring.soon');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).type)
-      .toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('password.expiring.subtitle.specific');
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).type).toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)?.options?.settings)
-      .toEqual({ complexity: {} });
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)?.options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[3] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[3] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[3] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[3] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement)
-      .label).toBe('password.expired.submit');
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add updated title element, submit button, and additional subtitle elements to UI Schema for expired PW step with messages in the transaction', () => {
     transaction.nextStep = {
-      name: IDX_STEP.REENROLL_AUTHENTICATOR,
+      name: IDX_STEP.REENROLL_AUTHENTICATOR_WARNING,
       relatesTo: {
         value: {
           settings: {
@@ -260,39 +167,13 @@ describe.skip('Expired Password Warning Authenticator Transformer Tests', () => 
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.expiring.soon');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).type)
-      .toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('When your password is locked, you cannot access the account');
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).type)
-      .toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: {} });
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[3] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[3] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[3] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[3] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement)
-      .label).toBe('password.expired.submit');
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add updated title element, submit button and skip button elements to UI Schema for expired PW step with skip remediation in the transaction', () => {
     transaction.nextStep = {
-      name: IDX_STEP.REENROLL_AUTHENTICATOR,
+      name: IDX_STEP.REENROLL_AUTHENTICATOR_WARNING,
       relatesTo: {
         value: {
           settings: {
@@ -312,33 +193,7 @@ describe.skip('Expired Password Warning Authenticator Transformer Tests', () => 
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.expiring.soon');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).type)
-      .toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: {} });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .label).toBe('password.expired.submit');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label).toBe('password.expiring.later');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.variant).toBe('floating');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.wide).toBe(false);
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/password/transformPasswordChallenge.test.ts
+++ b/src/v3/src/transformer/password/transformPasswordChallenge.test.ts
@@ -12,7 +12,11 @@
 
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
   FieldElement,
+  HiddenInputElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -26,13 +30,35 @@ describe('Password Challenge Transformer Tests', () => {
     formBag.uischema.elements = [
       { type: 'Field', options: { inputMeta: { name: 'credentials.passcode' } } } as FieldElement,
     ];
+    transaction.context = {
+      ...transaction.context,
+      user: {
+        type: 'string',
+        value: {
+          identifier: 'someuser@noemail.com',
+        },
+      },
+    };
     widgetProps = {};
   });
 
   it('should add title & submt button elements to ui schema when transforming password challenge step', () => {
     const updatedFormBag = transformPasswordChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.password.challenge.title');
+    expect((updatedFormBag.uischema.elements[1] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type)
+      .toBe('Button');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/password/transformPasswordChallenge.test.ts
+++ b/src/v3/src/transformer/password/transformPasswordChallenge.test.ts
@@ -12,16 +12,13 @@
 
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  ButtonElement,
-  ButtonType,
   FieldElement,
-  TitleElement,
   WidgetProps,
 } from 'src/types';
 
 import { transformPasswordChallenge } from './transformPasswordChallenge';
 
-describe.skip('Password Challenge Transformer Tests', () => {
+describe('Password Challenge Transformer Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const formBag = getStubFormBag();
   let widgetProps: WidgetProps;
@@ -35,15 +32,7 @@ describe.skip('Password Challenge Transformer Tests', () => {
   it('should add title & submt button elements to ui schema when transforming password challenge step', () => {
     const updatedFormBag = transformPasswordChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(2);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.password.challenge.title');
-    expect((updatedFormBag.uischema.elements[1] as ButtonElement).label)
-      .toBe('mfa.challenge.verify');
-    expect((updatedFormBag.uischema.elements[1] as ButtonElement).type)
-      .toBe('Button');
-    expect((updatedFormBag.uischema.elements[1] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/password/transformResetPasswordAuthenticator.test.ts
+++ b/src/v3/src/transformer/password/transformResetPasswordAuthenticator.test.ts
@@ -15,7 +15,12 @@ import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { IDX_STEP } from '../../constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from '../../mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
   FieldElement,
+  HiddenInputElement,
+  PasswordRequirementsElement,
+  TitleElement,
   WidgetProps,
 } from '../../types';
 import { transformResetPasswordAuthenticator } from './transformResetPasswordAuthenticator';
@@ -63,8 +68,37 @@ describe('Reset Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.reset.title.generic');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: { minLength: 1 } });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label).toBe('password.reset');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.step)
+      .toBe('reset-authenticator');
   });
 
   it('should add updated title element and submit button to UI Schema for reset PW step without password policy settings', () => {
@@ -79,8 +113,26 @@ describe('Reset Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.reset.title.generic');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[1] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label).toBe('password.reset');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options.step)
+      .toBe('reset-authenticator');
   });
 
   it('should add updated title element and submit button to UI Schema for reset PW step with brandName provided', () => {
@@ -100,7 +152,36 @@ describe('Reset Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('password.reset.title.specific');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: { minLength: 1 } });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(50);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('HiddenInput');
+    expect((updatedFormBag.uischema.elements[2] as HiddenInputElement).options.value)
+      .toBe('someuser@noemail.com');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.inputMeta.name)
+      .toBe('confirmPassword');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label).toBe('password.reset');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.step)
+      .toBe('reset-authenticator');
   });
 });

--- a/src/v3/src/transformer/password/transformResetPasswordAuthenticator.test.ts
+++ b/src/v3/src/transformer/password/transformResetPasswordAuthenticator.test.ts
@@ -15,15 +15,12 @@ import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { IDX_STEP } from '../../constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from '../../mocks/utils/utils';
 import {
-  ButtonElement,
   FieldElement,
-  PasswordRequirementsElement,
-  TitleElement,
   WidgetProps,
 } from '../../types';
 import { transformResetPasswordAuthenticator } from './transformResetPasswordAuthenticator';
 
-describe.skip('Reset Password Authenticator Transformer Tests', () => {
+describe('Reset Password Authenticator Transformer Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const formBag = getStubFormBag();
   let widgetProps: WidgetProps;
@@ -66,30 +63,8 @@ describe.skip('Reset Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.reset.title.generic');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).type)
-      .toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: { minLength: 1 } });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .label).toBe('password.reset');
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add updated title element and submit button to UI Schema for reset PW step without password policy settings', () => {
@@ -104,20 +79,8 @@ describe.skip('Reset Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.reset.title.generic');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement)
-      .label).toBe('password.reset');
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add updated title element and submit button to UI Schema for reset PW step with brandName provided', () => {
@@ -137,29 +100,7 @@ describe.skip('Reset Password Authenticator Transformer Tests', () => {
     });
 
     // Verify added elements
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('password.reset.title.specific');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).type)
-      .toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.userInfo?.identifier).toBe('someuser@noemail.com');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: { minLength: 1 } });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(50);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).type)
-      .toBe('PasswordWithConfirmation');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.name).toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.inputMeta.secret).toBe(true);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement)
-      .options.attributes?.autocomplete).toBe('new-password');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .label).toBe('password.reset');
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Description:
The purpose of this PR is to re-enable the password transformer jest tests.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-537284](https://oktainc.atlassian.net/browse/OKTA-537284)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



