### PR TITLE
OKTA-516578 : Re-enabling email transformer jest tests

### DIFF
--- a/src/v3/src/transformer/layout/email/__snapshots__/emailChallengeConsentTransformer.test.ts.snap
+++ b/src/v3/src/transformer/layout/email/__snapshots__/emailChallengeConsentTransformer.test.ts.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmailChallengeConsentTransformer Tests should create email consent ui elements with valid response 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "email-challenge-consent",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.consent.enduser.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "browser",
+          "textContent": "CHROME",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "appName",
+          "textContent": "Okta Dashboard",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "label": "oie.consent.enduser.deny.label",
+        "options": Object {
+          "actionParams": Object {
+            "consent": false,
+          },
+          "dataType": "cancel",
+          "step": "email-challenge-consent",
+          "type": "button",
+          "variant": "secondary",
+        },
+        "type": "Button",
+      },
+      Object {
+        "label": "oie.consent.enduser.accept.label",
+        "options": Object {
+          "actionParams": Object {
+            "consent": true,
+          },
+          "dataType": "save",
+          "step": "email-challenge-consent",
+          "type": "button",
+          "variant": "secondary",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/layout/email/__snapshots__/emailChallengeTransformer.test.ts.snap
+++ b/src/v3/src/transformer/layout/email/__snapshots__/emailChallengeTransformer.test.ts.snap
@@ -3,7 +3,14 @@
 exports[`EmailChallengeTransformer Tests should create email challenge UI elements when profile email is NOT available 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -13,9 +20,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "email.code.not.received",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "buttonText": "email.button.resend",
+                  "content": "email.code.not.received",
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -47,9 +58,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "email.code.not.received",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "buttonText": "email.button.resend",
+                  "content": "email.code.not.received",
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -66,8 +81,13 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "email.enroll.enterCode",
-                "name": "credentials.passcode",
+                "focus": true,
+                "options": Object {
+                  "inputMeta": Object {
+                    "name": "credentials.passcode",
+                  },
+                },
+                "type": "Field",
               },
               Object {
                 "label": "mfa.challenge.verify",
@@ -75,7 +95,6 @@ Object {
                   "step": "mock-step",
                   "type": "submit",
                 },
-                "scope": "#/properties/submit",
                 "type": "Button",
               },
             ],
@@ -93,7 +112,14 @@ Object {
 exports[`EmailChallengeTransformer Tests should create email challenge UI elements when resend code is NOT available 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -140,8 +166,13 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "email.enroll.enterCode",
-                "name": "credentials.passcode",
+                "focus": true,
+                "options": Object {
+                  "inputMeta": Object {
+                    "name": "credentials.passcode",
+                  },
+                },
+                "type": "Field",
               },
               Object {
                 "label": "mfa.challenge.verify",
@@ -149,7 +180,6 @@ Object {
                   "step": "mock-step",
                   "type": "submit",
                 },
-                "scope": "#/properties/submit",
                 "type": "Button",
               },
             ],
@@ -167,7 +197,14 @@ Object {
 exports[`EmailChallengeTransformer Tests should create email challenge UI elements when resend code is available 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -177,9 +214,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "email.code.not.received",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "buttonText": "email.button.resend",
+                  "content": "email.code.not.received",
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -211,9 +252,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "email.code.not.received",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "buttonText": "email.button.resend",
+                  "content": "email.code.not.received",
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -230,8 +275,13 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "email.enroll.enterCode",
-                "name": "credentials.passcode",
+                "focus": true,
+                "options": Object {
+                  "inputMeta": Object {
+                    "name": "credentials.passcode",
+                  },
+                },
+                "type": "Field",
               },
               Object {
                 "label": "mfa.challenge.verify",
@@ -239,7 +289,6 @@ Object {
                   "step": "",
                   "type": "submit",
                 },
-                "scope": "#/properties/submit",
                 "type": "Button",
               },
             ],

--- a/src/v3/src/transformer/layout/email/__snapshots__/emailVerificationTransformer.test.ts.snap
+++ b/src/v3/src/transformer/layout/email/__snapshots__/emailVerificationTransformer.test.ts.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Email Verification Transformer Tests should update methodType element and add appropriate UI elements to schema when redacted email does not exist in Idx response 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.email.verify.subtitleWithoutEmailAddress",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "oie.email.verify.primaryButton",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "email",
+          },
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Email Verification Transformer Tests should update methodType element and add appropriate UI elements to schema when redacted email exists in Idx response 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.email.verify.subtitleWithEmailAddress",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "oie.email.verify.primaryButton",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "email",
+          },
+          "step": "mock-step",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/layout/email/emailChallengeConsentTransformer.test.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeConsentTransformer.test.ts
@@ -12,10 +12,7 @@
 
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  ButtonElement,
   FieldElement,
-  ImageWithTextElement,
-  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -48,24 +45,6 @@ describe('EmailChallengeConsentTransformer Tests', () => {
     const updatedFormBag = transformEmailChallengeConsent({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content).toBe('oie.consent.enduser.title');
-    expect((updatedFormBag.uischema.elements[1] as ImageWithTextElement).type).toBe('ImageWithText');
-    expect((updatedFormBag.uischema.elements[1] as ImageWithTextElement).options.id).toBe('browser');
-    expect((updatedFormBag.uischema.elements[1] as ImageWithTextElement).options?.textContent).toBe('CHROME');
-
-    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).type).toBe('ImageWithText');
-    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).options.id).toBe('appName');
-    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).options?.textContent).toBe('Okta Dashboard');
-
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.actionParams?.consent)
-      .toBe(false);
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.dataType).toBe('cancel');
-
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.actionParams?.consent)
-      .toBe(true);
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.dataType).toBe('save');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/layout/email/emailChallengeConsentTransformer.test.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeConsentTransformer.test.ts
@@ -12,7 +12,10 @@
 
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
   FieldElement,
+  ImageWithTextElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -44,7 +47,30 @@ describe('EmailChallengeConsentTransformer Tests', () => {
   it('should create email consent ui elements with valid response', () => {
     const updatedFormBag = transformEmailChallengeConsent({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content).toBe('oie.consent.enduser.title');
+    expect((updatedFormBag.uischema.elements[1] as ImageWithTextElement).type).toBe('ImageWithText');
+    expect((updatedFormBag.uischema.elements[1] as ImageWithTextElement).options.id).toBe('browser');
+    expect((updatedFormBag.uischema.elements[1] as ImageWithTextElement).options?.textContent).toBe('CHROME');
+
+    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).type).toBe('ImageWithText');
+    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).options.id).toBe('appName');
+    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).options?.textContent).toBe('Okta Dashboard');
+
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.actionParams?.consent)
+      .toBe(false);
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.consent.enduser.deny.label');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.dataType).toBe('cancel');
+
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.actionParams?.consent)
+      .toBe(true);
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.dataType).toBe('save');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+      .toBe('oie.consent.enduser.accept.label');
   });
 });

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.test.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.test.ts
@@ -10,31 +10,24 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxAuthenticator, OktaAuth } from '@okta/okta-auth-js';
+import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  ButtonElement,
-  ButtonType,
-  DescriptionElement,
   FieldElement,
-  StepperLayout,
-  UISchemaLayoutType,
+  FormBag,
   WidgetProps,
 } from 'src/types';
 
 import { transformEmailChallenge } from '.';
 
-describe.skip('EmailChallengeTransformer Tests', () => {
+describe('EmailChallengeTransformer Tests', () => {
   const redactedEmail = 'fxxxe@xxx.com';
   const transaction = getStubTransactionWithNextStep();
-  const widgetProps: WidgetProps = {
-    authClient: {
-      idx: { proceed: jest.fn() },
-    } as unknown as OktaAuth,
-  };
-  const formBag = getStubFormBag();
+  const widgetProps: WidgetProps = {};
+  let formBag: FormBag;
 
   beforeEach(() => {
+    formBag = getStubFormBag();
     formBag.uischema.elements = [
       { type: 'Field', options: { inputMeta: { name: 'credentials.passcode' } } } as FieldElement,
     ];
@@ -58,33 +51,6 @@ describe.skip('EmailChallengeTransformer Tests', () => {
     });
 
     expect(updatedFormBag).toMatchSnapshot();
-
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Stepper');
-
-    const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
-
-    const layoutOne = stepperElements[0];
-
-    expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutOne.elements.length).toBe(4);
-
-    expect(layoutOne.elements[2].type).toBe('Description');
-    expect((layoutOne.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
-
-    const layoutTwo = stepperElements[1];
-
-    expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutTwo.elements.length).toBe(5);
-    expect(layoutTwo.elements[2].type).toBe('Description');
-    expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
-
-    expect((layoutTwo.elements[3] as FieldElement).label).toBe('email.enroll.enterCode');
-
-    expect((layoutTwo.elements[4] as ButtonElement).type).toBe('Button');
-    expect((layoutTwo.elements[4] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
   });
 
   it('should create email challenge UI elements when profile email is NOT available', () => {
@@ -101,21 +67,6 @@ describe.skip('EmailChallengeTransformer Tests', () => {
     });
 
     expect(updatedFormBag).toMatchSnapshot();
-
-    const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
-
-    const layoutOne = stepperElements[0];
-
-    expect(layoutOne.elements.length).toBe(4);
-
-    expect((layoutOne.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
-
-    const layoutTwo = stepperElements[1];
-
-    expect(layoutTwo.elements.length).toBe(5);
-    expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
   });
 
   it('should create email challenge UI elements when resend code is NOT available', () => {
@@ -135,32 +86,5 @@ describe.skip('EmailChallengeTransformer Tests', () => {
     });
 
     expect(updatedFormBag).toMatchSnapshot();
-
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Stepper');
-
-    const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
-
-    const layoutOne = stepperElements[0];
-
-    expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutOne.elements.length).toBe(3);
-
-    expect(layoutOne.elements[1].type).toBe('Description');
-    expect((layoutOne.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
-
-    const layoutTwo = stepperElements[1];
-
-    expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutTwo.elements.length).toBe(4);
-    expect(layoutTwo.elements[1].type).toBe('Description');
-    expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
-
-    expect((layoutTwo.elements[2] as FieldElement).label).toBe('email.enroll.enterCode');
-
-    expect((layoutTwo.elements[3] as ButtonElement).type).toBe('Button');
-    expect((layoutTwo.elements[3] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.test.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.test.ts
@@ -13,8 +13,15 @@
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
+  DescriptionElement,
   FieldElement,
   FormBag,
+  ReminderElement,
+  StepperButtonElement,
+  StepperLayout,
+  UISchemaLayoutType,
   WidgetProps,
 } from 'src/types';
 
@@ -51,6 +58,57 @@ describe('EmailChallengeTransformer Tests', () => {
     });
 
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(1);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Stepper');
+
+    const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
+
+    const layoutOne = stepperElements[0];
+
+    expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
+    expect(layoutOne.elements.length).toBe(4);
+
+    expect((layoutOne.elements[0] as ReminderElement).options?.content)
+      .toBe('email.code.not.received');
+    expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
+      .toBe(true);
+    expect((layoutOne.elements[0] as ReminderElement).options?.step)
+      .toBe('resend');
+    expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
+      .toBe(true);
+    expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.email.mfa.title');
+    expect(layoutOne.elements[2].type).toBe('Description');
+    expect((layoutOne.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+    expect(layoutOne.elements[3].type).toBe('StepperButton');
+    expect((layoutOne.elements[3] as StepperButtonElement).label)
+      .toBe('oie.email.verify.alternate.showCodeTextField');
+
+    const layoutTwo = stepperElements[1];
+
+    expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
+    expect(layoutTwo.elements.length).toBe(5);
+    expect((layoutTwo.elements[0] as ReminderElement).options?.content)
+      .toBe('email.code.not.received');
+    expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
+      .toBe(true);
+    expect((layoutTwo.elements[0] as ReminderElement).options?.step)
+      .toBe('resend');
+    expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
+      .toBe(true);
+    expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.email.mfa.title');
+    expect(layoutTwo.elements[2].type).toBe('Description');
+    expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+
+    expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+
+    expect((layoutTwo.elements[4] as ButtonElement).type).toBe('Button');
+    expect((layoutTwo.elements[4] as ButtonElement).label).toBe('mfa.challenge.verify');
+    expect((layoutTwo.elements[4] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
   });
 
   it('should create email challenge UI elements when profile email is NOT available', () => {
@@ -67,6 +125,54 @@ describe('EmailChallengeTransformer Tests', () => {
     });
 
     expect(updatedFormBag).toMatchSnapshot();
+    const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
+
+    const layoutOne = stepperElements[0];
+
+    expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
+    expect(layoutOne.elements.length).toBe(4);
+
+    expect((layoutOne.elements[0] as ReminderElement).options?.content)
+      .toBe('email.code.not.received');
+    expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
+      .toBe(true);
+    expect((layoutOne.elements[0] as ReminderElement).options?.step)
+      .toBe('resend');
+    expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
+      .toBe(true);
+    expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.email.mfa.title');
+    expect(layoutOne.elements[2].type).toBe('Description');
+    expect((layoutOne.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
+    expect(layoutOne.elements[3].type).toBe('StepperButton');
+    expect((layoutOne.elements[3] as StepperButtonElement).label)
+      .toBe('oie.email.verify.alternate.showCodeTextField');
+
+    const layoutTwo = stepperElements[1];
+
+    expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
+    expect(layoutTwo.elements.length).toBe(5);
+    expect((layoutTwo.elements[0] as ReminderElement).options?.content)
+      .toBe('email.code.not.received');
+    expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
+      .toBe(true);
+    expect((layoutTwo.elements[0] as ReminderElement).options?.step)
+      .toBe('resend');
+    expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
+      .toBe(true);
+    expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.email.mfa.title');
+    expect(layoutTwo.elements[2].type).toBe('Description');
+    expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
+
+    expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+
+    expect((layoutTwo.elements[4] as ButtonElement).type).toBe('Button');
+    expect((layoutTwo.elements[4] as ButtonElement).label).toBe('mfa.challenge.verify');
+    expect((layoutTwo.elements[4] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
   });
 
   it('should create email challenge UI elements when resend code is NOT available', () => {
@@ -86,5 +192,40 @@ describe('EmailChallengeTransformer Tests', () => {
     });
 
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(1);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Stepper');
+
+    const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
+
+    const layoutOne = stepperElements[0];
+
+    expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
+    expect(layoutOne.elements.length).toBe(3);
+
+    expect((layoutOne.elements[0] as DescriptionElement).options?.content)
+      .toBe('oie.email.mfa.title');
+    expect(layoutOne.elements[1].type).toBe('Description');
+    expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+    expect(layoutOne.elements[2].type).toBe('StepperButton');
+    expect((layoutOne.elements[2] as StepperButtonElement).label)
+      .toBe('oie.email.verify.alternate.showCodeTextField');
+
+    const layoutTwo = stepperElements[1];
+
+    expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
+    expect(layoutTwo.elements.length).toBe(4);
+    expect((layoutTwo.elements[0] as DescriptionElement).options?.content)
+      .toBe('oie.email.mfa.title');
+    expect(layoutTwo.elements[1].type).toBe('Description');
+    expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+
+    expect((layoutTwo.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+
+    expect((layoutTwo.elements[3] as ButtonElement).type).toBe('Button');
+    expect((layoutTwo.elements[3] as ButtonElement).label).toBe('mfa.challenge.verify');
+    expect((layoutTwo.elements[3] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/layout/email/emailVerificationTransformer.test.ts
+++ b/src/v3/src/transformer/layout/email/emailVerificationTransformer.test.ts
@@ -13,8 +13,8 @@
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  ButtonElement, DescriptionElement, FieldElement,
-  TitleElement, WidgetProps,
+  FieldElement,
+  WidgetProps,
 } from 'src/types';
 
 import { transformEmailVerification } from '.';
@@ -43,16 +43,7 @@ describe('Email Verification Transformer Tests', () => {
     const updatedFormBag = transformEmailVerification({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.email.mfa.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.subtitleWithoutEmailAddress');
-    expect(((updatedFormBag.uischema.elements[2] as ButtonElement)
-      .options?.actionParams?.['authenticator.methodType'])).toBe('email');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
-      .toBe('oie.email.verify.primaryButton');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should update methodType element and add appropriate UI elements to schema'
@@ -72,16 +63,6 @@ describe('Email Verification Transformer Tests', () => {
     const updatedFormBag = transformEmailVerification({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.email.mfa.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.subtitleWithEmailAddress');
-    expect(((updatedFormBag.uischema.elements[2] as ButtonElement)
-      .options?.actionParams?.['authenticator.methodType']))
-      .toBe('email');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
-      .toBe('oie.email.verify.primaryButton');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/layout/email/emailVerificationTransformer.test.ts
+++ b/src/v3/src/transformer/layout/email/emailVerificationTransformer.test.ts
@@ -13,7 +13,10 @@
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  DescriptionElement,
   FieldElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -42,8 +45,18 @@ describe('Email Verification Transformer Tests', () => {
     + ' when redacted email does not exist in Idx response', () => {
     const updatedFormBag = transformEmailVerification({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.email.mfa.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.email.verify.subtitleWithoutEmailAddress');
+    expect(((updatedFormBag.uischema.elements[2] as ButtonElement)
+      .options?.actionParams?.['authenticator.methodType'])).toBe('email');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oie.email.verify.primaryButton');
   });
 
   it('should update methodType element and add appropriate UI elements to schema'
@@ -62,7 +75,18 @@ describe('Email Verification Transformer Tests', () => {
 
     const updatedFormBag = transformEmailVerification({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.email.mfa.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.email.verify.subtitleWithEmailAddress');
+    expect(((updatedFormBag.uischema.elements[2] as ButtonElement)
+      .options?.actionParams?.['authenticator.methodType']))
+      .toBe('email');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oie.email.verify.primaryButton');
   });
 });


### PR DESCRIPTION
## Description:
The purpose of this PR is to re-enable email transformer jest tests.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-516578](https://oktainc.atlassian.net/browse/OKTA-516578)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



