### PR TITLE
OKTA-537278 : Re-enabling google auth transformer tests

### DIFF
--- a/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorEnroll.test.ts.snap
+++ b/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorEnroll.test.ts.snap
@@ -3,7 +3,14 @@
 exports[`Google Authenticator Enroll Transformer Tests should add Stepper layout to UI Schema elements when GA Enroll params exists in Idx response 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -26,7 +33,6 @@ Object {
               Object {
                 "options": Object {
                   "data": "#mockhref",
-                  "label": "google auth",
                 },
                 "type": "QRCode",
               },
@@ -86,8 +92,12 @@ Object {
                 "type": "Description",
               },
               Object {
-                "name": "credentials.passcode",
-                "type": "Control",
+                "options": Object {
+                  "inputMeta": Object {
+                    "name": "credentials.passcode",
+                  },
+                },
+                "type": "Field",
               },
               Object {
                 "label": "oform.verify",
@@ -95,7 +105,6 @@ Object {
                   "step": "enroll-authenticator",
                   "type": "submit",
                 },
-                "scope": "#/properties/submit",
                 "type": "Button",
               },
             ],

--- a/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorVerify.test.ts.snap
+++ b/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorVerify.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Google Authenticator Verify Transformer Tests should add UI elements 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.verify.google_authenticator.otp.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.verify.google_authenticator.otp.description",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
@@ -13,7 +13,14 @@
 import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
+  DescriptionElement,
   FieldElement,
+  QRCodeElement,
+  StepperButtonElement,
+  StepperLayout,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -66,5 +73,45 @@ describe('Google Authenticator Enroll Transformer Tests', () => {
       transaction, formBag, widgetProps,
     });
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(2);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.google_authenticator.setup.title');
+
+    const stepperLayout = updatedFormBag.uischema.elements[1] as StepperLayout;
+    const [layoutOne, layoutTwo, layoutThree] = stepperLayout.elements;
+
+    expect(layoutOne.elements.length).toBe(4);
+    expect((layoutOne.elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.google_authenticator.scanBarcode.description');
+    expect((layoutOne.elements[1] as QRCodeElement).options.data)
+      .toBe('#mockhref');
+    expect((layoutOne.elements[2] as StepperButtonElement).label)
+      .toBe('oie.enroll.google_authenticator.cannotScanBarcode.title');
+    expect((layoutOne.elements[2] as StepperButtonElement).options.nextStepIndex)
+      .toBe(1);
+    expect((layoutOne.elements[3] as StepperButtonElement).label)
+      .toBe('oform.next');
+    expect((layoutOne.elements[3] as StepperButtonElement).options.nextStepIndex)
+      .toBe(2);
+
+    expect(layoutTwo.elements.length).toBe(3);
+    expect((layoutTwo.elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.google_authenticator.manualSetupInstructions');
+    expect((layoutTwo.elements[1] as DescriptionElement).options.content)
+      .toBe('A B C 1 2 3 D E F 4 5 6');
+    expect((layoutTwo.elements[2] as StepperButtonElement).label)
+      .toBe('oform.next');
+    expect((layoutTwo.elements[2] as StepperButtonElement).options.nextStepIndex)
+      .toBe(2);
+
+    expect(layoutThree.elements.length).toBe(3);
+    expect((layoutThree.elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.google_authenticator.enterCode.title');
+    expect((layoutThree.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((layoutThree.elements[2] as ButtonElement).label)
+      .toBe('oform.verify');
+    expect((layoutThree.elements[2] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
@@ -19,7 +19,7 @@ import {
 
 import { transformGoogleAuthenticatorEnroll } from '.';
 
-describe.skip('Google Authenticator Enroll Transformer Tests', () => {
+describe('Google Authenticator Enroll Transformer Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const widgetProps: WidgetProps = {};
   const formBag = getStubFormBag();

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorVerify.test.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorVerify.test.ts
@@ -12,11 +12,7 @@
 
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  ButtonElement,
-  ButtonType,
-  DescriptionElement,
   FieldElement,
-  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -39,15 +35,6 @@ describe('Google Authenticator Verify Transformer Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0]?.type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.verify.google_authenticator.otp.title');
-    expect(updatedFormBag.uischema.elements[1]?.type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe('oie.verify.google_authenticator.otp.description');
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
-      .toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorVerify.test.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorVerify.test.ts
@@ -12,7 +12,11 @@
 
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
+  DescriptionElement,
   FieldElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -34,7 +38,17 @@ describe('Google Authenticator Verify Transformer Tests', () => {
       transaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag.uischema.elements[0]?.type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.verify.google_authenticator.otp.title');
+    expect(updatedFormBag.uischema.elements[1]?.type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.verify.google_authenticator.otp.description');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 });


### PR DESCRIPTION
## Description:

The purpose of this PR is to re-enable the Google Authenticator transformer tests.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-537278](https://oktainc.atlassian.net/browse/OKTA-537278)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



