### PR TITLE
OKTA-537285 : Re-enable phone transformer tests

### DIFF
--- a/src/v3/src/transformer/phone/__snapshots__/phoneEnrollmentCodeTransformer.test.ts.snap
+++ b/src/v3/src/transformer/phone/__snapshots__/phoneEnrollmentCodeTransformer.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements when phone number not available 1`] = `
+exports[`PhoneEnrollmentCodeTransformer Tests should create phone code enrollment UI elements with sms as the first method type 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -16,7 +16,99 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "oie.phone.verify.title",
+          "content": "oie.phone.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.verify.sms.codeSentText oie.phone.alternate.title. oie.phone.verify.enterCodeText",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.carrier.charges",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`PhoneEnrollmentCodeTransformer Tests should create phone code enrollment UI elements with sms as the first method type and phoneNumber in profile 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.phone.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.verify.sms.codeSentText 1215XXXXXX8. oie.phone.verify.enterCodeText",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.carrier.charges",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`PhoneEnrollmentCodeTransformer Tests should create phone code enrollment UI elements with voice as the first method type 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.phone.enroll.title",
         },
         "type": "Title",
       },
@@ -46,7 +138,7 @@ Object {
 }
 `;
 
-exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements when resend code is NOT available 1`] = `
+exports[`PhoneEnrollmentCodeTransformer Tests should create phone code enrollment UI elements with voice as the first method type and phoneNumber in profile 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -62,13 +154,13 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "oie.phone.verify.title",
+          "content": "oie.phone.enroll.title",
         },
         "type": "Title",
       },
       Object {
         "options": Object {
-          "content": "oie.phone.verify.sms.codeSentText +1 XXX-XXX-4601. oie.phone.verify.enterCodeText",
+          "content": "mfa.calling 1215XXXXXX8. oie.phone.verify.enterCodeText",
         },
         "type": "Description",
       },
@@ -81,157 +173,7 @@ Object {
       Object {
         "label": "mfa.challenge.verify",
         "options": Object {
-          "step": "mock-step",
-          "type": "submit",
-        },
-        "type": "Button",
-      },
-    ],
-    "type": "VerticalLayout",
-  },
-}
-`;
-
-exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements when resend code is available 1`] = `
-Object {
-  "data": Object {},
-  "dataSchema": Object {
-    "fieldsToExclude": [Function],
-    "fieldsToTrim": Array [],
-    "fieldsToValidate": Array [],
-    "submit": Object {
-      "step": "challenge-authenticator",
-    },
-  },
-  "schema": Object {},
-  "uischema": Object {
-    "elements": Array [
-      Object {
-        "options": Object {
-          "actionParams": Object {
-            "resend": true,
-          },
-          "buttonText": "oie.phone.verify.sms.resendLinkText",
-          "content": "oie.phone.verify.sms.resendText",
-          "isActionStep": true,
-          "step": "resend",
-        },
-        "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.phone.verify.title",
-        },
-        "type": "Title",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.phone.verify.sms.codeSentText +1 XXX-XXX-4601. oie.phone.verify.enterCodeText",
-        },
-        "type": "Description",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.phone.carrier.charges",
-        },
-        "type": "Description",
-      },
-      Object {
-        "label": "mfa.challenge.verify",
-        "options": Object {
-          "step": "mock-step",
-          "type": "submit",
-        },
-        "type": "Button",
-      },
-    ],
-    "type": "VerticalLayout",
-  },
-}
-`;
-
-exports[`PhoneChallengeTransformer Tests should create voice challenge UI elements when phoneNumber is available 1`] = `
-Object {
-  "data": Object {},
-  "dataSchema": Object {
-    "fieldsToExclude": [Function],
-    "fieldsToTrim": Array [],
-    "fieldsToValidate": Array [],
-    "submit": Object {
-      "step": "challenge-authenticator",
-    },
-  },
-  "schema": Object {},
-  "uischema": Object {
-    "elements": Array [
-      Object {
-        "options": Object {
-          "content": "oie.phone.verify.title",
-        },
-        "type": "Title",
-      },
-      Object {
-        "options": Object {
-          "content": "mfa.calling +1 XXX-XXX-4601. oie.phone.verify.enterCodeText",
-        },
-        "type": "Description",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.phone.carrier.charges",
-        },
-        "type": "Description",
-      },
-      Object {
-        "label": "mfa.challenge.verify",
-        "options": Object {
-          "step": "mock-step",
-          "type": "submit",
-        },
-        "type": "Button",
-      },
-    ],
-    "type": "VerticalLayout",
-  },
-}
-`;
-
-exports[`PhoneChallengeTransformer Tests should create voice challenge UI elements when phoneNumber not available 1`] = `
-Object {
-  "data": Object {},
-  "dataSchema": Object {
-    "fieldsToExclude": [Function],
-    "fieldsToTrim": Array [],
-    "fieldsToValidate": Array [],
-    "submit": Object {
-      "step": "challenge-authenticator",
-    },
-  },
-  "schema": Object {},
-  "uischema": Object {
-    "elements": Array [
-      Object {
-        "options": Object {
-          "content": "oie.phone.verify.title",
-        },
-        "type": "Title",
-      },
-      Object {
-        "options": Object {
-          "content": "mfa.calling oie.phone.alternate.title. oie.phone.verify.enterCodeText",
-        },
-        "type": "Description",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.phone.carrier.charges",
-        },
-        "type": "Description",
-      },
-      Object {
-        "label": "mfa.challenge.verify",
-        "options": Object {
-          "step": "mock-step",
+          "step": "",
           "type": "submit",
         },
         "type": "Button",

--- a/src/v3/src/transformer/phone/__snapshots__/phoneEnrollmentTransformer.test.ts.snap
+++ b/src/v3/src/transformer/phone/__snapshots__/phoneEnrollmentTransformer.test.ts.snap
@@ -2,10 +2,16 @@
 
 exports[`PhoneEnrollmentTransformer Tests should create phone enrollment UI elements when multiple method types exist in transaction 1`] = `
 Object {
-  "data": Object {
-    "authenticator.methodType": "sms",
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "",
+      "type": "submit",
+    },
   },
-  "dataSchema": Object {},
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -26,33 +32,32 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "methodType",
-                "name": "authenticator.methodType",
                 "options": Object {
-                  "format": "radio",
-                  "inputMeta": Object {
-                    "name": "authenticator.methodType",
-                    "options": Array [
-                      Object {
-                        "label": "SMS",
-                        "value": "sms",
-                      },
-                      Object {
-                        "label": "Phone Call",
-                        "value": "voice",
-                      },
-                    ],
-                  },
+                  "customOptions": Array [
+                    Object {
+                      "callback": [Function],
+                      "label": "SMS",
+                      "value": "sms",
+                    },
+                    Object {
+                      "callback": [Function],
+                      "label": "Phone Call",
+                      "value": "voice",
+                    },
+                  ],
+                  "defaultValue": [Function],
+                  "name": "authenticator.methodType",
                 },
-                "type": "Control",
+                "type": "StepperRadio",
               },
               Object {
                 "label": "mfa.phoneNumber.placeholder",
-                "name": "authenticator.phoneNumber",
                 "options": Object {
-                  "targetKey": "authenticator.methodType",
+                  "inputMeta": Object {
+                    "name": "authenticator.phoneNumber",
+                  },
                 },
-                "type": "Control",
+                "type": "Field",
               },
               Object {
                 "label": "oie.phone.sms.primaryButton",
@@ -60,7 +65,6 @@ Object {
                   "step": "",
                   "type": "submit",
                 },
-                "scope": "#/properties/submit",
                 "type": "Button",
               },
             ],
@@ -75,33 +79,32 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "methodType",
-                "name": "authenticator.methodType",
                 "options": Object {
-                  "format": "radio",
-                  "inputMeta": Object {
-                    "name": "authenticator.methodType",
-                    "options": Array [
-                      Object {
-                        "label": "SMS",
-                        "value": "sms",
-                      },
-                      Object {
-                        "label": "Phone Call",
-                        "value": "voice",
-                      },
-                    ],
-                  },
+                  "customOptions": Array [
+                    Object {
+                      "callback": [Function],
+                      "label": "SMS",
+                      "value": "sms",
+                    },
+                    Object {
+                      "callback": [Function],
+                      "label": "Phone Call",
+                      "value": "voice",
+                    },
+                  ],
+                  "defaultValue": [Function],
+                  "name": "authenticator.methodType",
                 },
-                "type": "Control",
+                "type": "StepperRadio",
               },
               Object {
                 "label": "mfa.phoneNumber.placeholder",
-                "name": "authenticator.phoneNumber",
                 "options": Object {
-                  "targetKey": "authenticator.methodType",
+                  "inputMeta": Object {
+                    "name": "authenticator.phoneNumber",
+                  },
                 },
-                "type": "Control",
+                "type": "Field",
               },
               Object {
                 "label": "oie.phone.call.primaryButton",
@@ -109,7 +112,6 @@ Object {
                   "step": "",
                   "type": "submit",
                 },
-                "scope": "#/properties/submit",
                 "type": "Button",
               },
             ],
@@ -117,6 +119,110 @@ Object {
           },
         ],
         "type": "Stepper",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`PhoneEnrollmentTransformer Tests should create phone enrollment UI elements when only sms method types exist in transaction 1`] = `
+Object {
+  "data": Object {
+    "authenticator.methodType": "sms",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "",
+      "type": "submit",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.phone.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.enroll.sms.subtitle",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "mfa.phoneNumber.placeholder",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "authenticator.phoneNumber",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oie.phone.sms.primaryButton",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`PhoneEnrollmentTransformer Tests should create phone enrollment UI elements when only voice method types exist in transaction 1`] = `
+Object {
+  "data": Object {
+    "authenticator.methodType": "voice",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "",
+      "type": "submit",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.phone.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.enroll.call.subtitle",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "mfa.phoneNumber.placeholder",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "authenticator.phoneNumber",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oie.phone.call.primaryButton",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
       },
     ],
     "type": "VerticalLayout",

--- a/src/v3/src/transformer/phone/__snapshots__/phoneVerificationTransformer.test.ts.snap
+++ b/src/v3/src/transformer/phone/__snapshots__/phoneVerificationTransformer.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements when phone number not available 1`] = `
+exports[`Phone verification Transformer Tests should add correct UI elements to schema when multiple methodType choices exists and sms is the first methodType choice 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -22,7 +22,7 @@ Object {
       },
       Object {
         "options": Object {
-          "content": "mfa.calling oie.phone.alternate.title. oie.phone.verify.enterCodeText",
+          "content": "oie.phone.verify.sms.sendText oie.phone.alternate.title",
         },
         "type": "Description",
       },
@@ -33,8 +33,133 @@ Object {
         "type": "Description",
       },
       Object {
-        "label": "mfa.challenge.verify",
+        "label": "oie.phone.sms.primaryButton",
         "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "sms",
+          },
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "label": "oie.phone.call.secondaryButton",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "voice",
+          },
+          "step": "",
+          "type": "button",
+          "variant": "secondary",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Phone verification Transformer Tests should add correct UI elements to schema when multiple methodType choices exists and voice is the first methodType choice 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.phone.verify.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.verify.call.sendText oie.phone.alternate.title",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.carrier.charges",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "oie.phone.call.primaryButton",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "voice",
+          },
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "label": "oie.phone.sms.secondaryButton",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "sms",
+          },
+          "step": "",
+          "type": "button",
+          "variant": "secondary",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Phone verification Transformer Tests should add correct UI elements to schema when only sms methodType choice exists 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.phone.verify.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.verify.sms.sendText oie.phone.alternate.title",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.phone.carrier.charges",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "oie.phone.sms.primaryButton",
+        "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "sms",
+          },
           "step": "",
           "type": "submit",
         },
@@ -46,7 +171,7 @@ Object {
 }
 `;
 
-exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements when resend code is NOT available 1`] = `
+exports[`Phone verification Transformer Tests should add correct UI elements to schema when only sms methodType choice exists and redacted phoneNumber exists in Idx response  1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -68,7 +193,7 @@ Object {
       },
       Object {
         "options": Object {
-          "content": "oie.phone.verify.sms.codeSentText +1 XXX-XXX-4601. oie.phone.verify.enterCodeText",
+          "content": "oie.phone.verify.sms.sendText +121xxxxx34",
         },
         "type": "Description",
       },
@@ -79,66 +204,11 @@ Object {
         "type": "Description",
       },
       Object {
-        "label": "mfa.challenge.verify",
-        "options": Object {
-          "step": "mock-step",
-          "type": "submit",
-        },
-        "type": "Button",
-      },
-    ],
-    "type": "VerticalLayout",
-  },
-}
-`;
-
-exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements when resend code is available 1`] = `
-Object {
-  "data": Object {},
-  "dataSchema": Object {
-    "fieldsToExclude": [Function],
-    "fieldsToTrim": Array [],
-    "fieldsToValidate": Array [],
-    "submit": Object {
-      "step": "challenge-authenticator",
-    },
-  },
-  "schema": Object {},
-  "uischema": Object {
-    "elements": Array [
-      Object {
+        "label": "oie.phone.sms.primaryButton",
         "options": Object {
           "actionParams": Object {
-            "resend": true,
+            "authenticator.methodType": "sms",
           },
-          "buttonText": "oie.phone.verify.sms.resendLinkText",
-          "content": "oie.phone.verify.sms.resendText",
-          "isActionStep": true,
-          "step": "resend",
-        },
-        "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.phone.verify.title",
-        },
-        "type": "Title",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.phone.verify.sms.codeSentText +1 XXX-XXX-4601. oie.phone.verify.enterCodeText",
-        },
-        "type": "Description",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.phone.carrier.charges",
-        },
-        "type": "Description",
-      },
-      Object {
-        "label": "mfa.challenge.verify",
-        "options": Object {
           "step": "mock-step",
           "type": "submit",
         },
@@ -150,7 +220,7 @@ Object {
 }
 `;
 
-exports[`PhoneChallengeTransformer Tests should create voice challenge UI elements when phoneNumber is available 1`] = `
+exports[`Phone verification Transformer Tests should add correct UI elements to schema when only voice methodType choice exists 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -172,7 +242,7 @@ Object {
       },
       Object {
         "options": Object {
-          "content": "mfa.calling +1 XXX-XXX-4601. oie.phone.verify.enterCodeText",
+          "content": "oie.phone.verify.call.sendText oie.phone.alternate.title",
         },
         "type": "Description",
       },
@@ -183,9 +253,12 @@ Object {
         "type": "Description",
       },
       Object {
-        "label": "mfa.challenge.verify",
+        "label": "oie.phone.call.primaryButton",
         "options": Object {
-          "step": "mock-step",
+          "actionParams": Object {
+            "authenticator.methodType": "voice",
+          },
+          "step": "",
           "type": "submit",
         },
         "type": "Button",
@@ -196,7 +269,7 @@ Object {
 }
 `;
 
-exports[`PhoneChallengeTransformer Tests should create voice challenge UI elements when phoneNumber not available 1`] = `
+exports[`Phone verification Transformer Tests should add correct UI elements to schema when only voice methodType choice exists and redacted phoneNumber exists in Idx response  1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -218,7 +291,7 @@ Object {
       },
       Object {
         "options": Object {
-          "content": "mfa.calling oie.phone.alternate.title. oie.phone.verify.enterCodeText",
+          "content": "oie.phone.verify.call.sendText +121xxxxx34",
         },
         "type": "Description",
       },
@@ -229,8 +302,11 @@ Object {
         "type": "Description",
       },
       Object {
-        "label": "mfa.challenge.verify",
+        "label": "oie.phone.call.primaryButton",
         "options": Object {
+          "actionParams": Object {
+            "authenticator.methodType": "voice",
+          },
           "step": "mock-step",
           "type": "submit",
         },

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
@@ -12,16 +12,11 @@
 
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
-import {
-  ButtonElement,
-  ButtonType,
-  DescriptionElement,
-  WidgetProps,
-} from 'src/types';
+import { WidgetProps } from 'src/types';
 
 import { transformPhoneChallenge } from '.';
 
-describe.skip('PhoneChallengeTransformer Tests', () => {
+describe('PhoneChallengeTransformer Tests', () => {
   const redactedPhone = '+1 XXX-XXX-4601';
   const transaction = getStubTransactionWithNextStep();
   const widgetProps: WidgetProps = {};
@@ -47,21 +42,8 @@ describe.skip('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag).toMatchSnapshot();
-
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-
-    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
-      .toBe(`oie.phone.verify.sms.codeSentText ${redactedPhone}. oie.phone.verify.enterCodeText`);
-
-    expect(updatedFormBag.uischema.elements[3].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[3] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should create SMS challenge UI elements when resend code is NOT available', () => {
@@ -79,21 +61,8 @@ describe.skip('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag).toMatchSnapshot();
-
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe(`oie.phone.verify.sms.codeSentText ${redactedPhone}. oie.phone.verify.enterCodeText`);
-
-    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should create SMS challenge UI elements when phone number not available', () => {
@@ -103,21 +72,8 @@ describe.skip('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag).toMatchSnapshot();
-
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe('oie.phone.verify.sms.codeSentText oie.phone.alternate.title. oie.phone.verify.enterCodeText');
-
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should create voice challenge UI elements when phoneNumber not available', () => {
@@ -132,21 +88,8 @@ describe.skip('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag).toMatchSnapshot();
-
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe('mfa.calling oie.phone.alternate.title. oie.phone.verify.enterCodeText');
-
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should create voice challenge UI elements when phoneNumber is available', () => {
@@ -164,20 +107,7 @@ describe.skip('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag).toMatchSnapshot();
-
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe(`mfa.calling ${redactedPhone}. oie.phone.verify.enterCodeText`);
-
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
@@ -12,7 +12,14 @@
 
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
-import { WidgetProps } from 'src/types';
+import {
+  ButtonElement,
+  ButtonType,
+  DescriptionElement,
+  ReminderElement,
+  TitleElement,
+  WidgetProps,
+} from 'src/types';
 
 import { transformPhoneChallenge } from '.';
 
@@ -42,8 +49,25 @@ describe('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.content)
+      .toBe('oie.phone.verify.sms.resendText');
+    expect((updatedFormBag.uischema.elements[1] as TitleElement).options.content)
+      .toBe('oie.phone.verify.title');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe(`oie.phone.verify.sms.codeSentText ${redactedPhone}. oie.phone.verify.enterCodeText`);
+
+    expect(updatedFormBag.uischema.elements[3].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[3] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should create SMS challenge UI elements when resend code is NOT available', () => {
@@ -61,8 +85,23 @@ describe('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.verify.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe(`oie.phone.verify.sms.codeSentText ${redactedPhone}. oie.phone.verify.enterCodeText`);
+
+    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should create SMS challenge UI elements when phone number not available', () => {
@@ -72,8 +111,23 @@ describe('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.verify.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('mfa.calling oie.phone.alternate.title. oie.phone.verify.enterCodeText');
+
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should create voice challenge UI elements when phoneNumber not available', () => {
@@ -88,8 +142,23 @@ describe('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.verify.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('mfa.calling oie.phone.alternate.title. oie.phone.verify.enterCodeText');
+
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should create voice challenge UI elements when phoneNumber is available', () => {
@@ -107,7 +176,22 @@ describe('PhoneChallengeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneChallenge({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.verify.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe(`mfa.calling ${redactedPhone}. oie.phone.verify.enterCodeText`);
+
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.test.ts
@@ -12,7 +12,13 @@
 
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
-import { WidgetProps } from 'src/types';
+import {
+  ButtonElement,
+  ButtonType,
+  DescriptionElement,
+  TitleElement,
+  WidgetProps,
+} from 'src/types';
 
 import { transformPhoneCodeEnrollment } from '.';
 
@@ -35,8 +41,21 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneCodeEnrollment({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.enroll.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement)
+      .options?.content).toBe('mfa.calling oie.phone.alternate.title. oie.phone.verify.enterCodeText');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
   });
 
   it('should create phone code enrollment UI elements with sms as the first method type', () => {
@@ -50,8 +69,21 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneCodeEnrollment({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.enroll.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.phone.verify.sms.codeSentText oie.phone.alternate.title. oie.phone.verify.enterCodeText');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.phone.carrier.charges');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
   });
 
   it('should create phone code enrollment UI elements with sms as the first method type and phoneNumber in profile', () => {
@@ -67,8 +99,21 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneCodeEnrollment({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.enroll.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe(`oie.phone.verify.sms.codeSentText ${mockPhoneNumber}. oie.phone.verify.enterCodeText`);
+    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.phone.carrier.charges');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
   });
 
   it('should create phone code enrollment UI elements with voice as the first method type and phoneNumber in profile', () => {
@@ -84,7 +129,20 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
     };
     const updatedFormBag = transformPhoneCodeEnrollment({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.enroll.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement)
+      .options?.content).toBe(`mfa.calling ${mockPhoneNumber}. oie.phone.verify.enterCodeText`);
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
   });
 });

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.test.ts
@@ -12,10 +12,7 @@
 
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
-import {
-  ButtonElement, ButtonType, DescriptionElement,
-  TitleElement, WidgetProps,
-} from 'src/types';
+import { WidgetProps } from 'src/types';
 
 import { transformPhoneCodeEnrollment } from '.';
 
@@ -39,19 +36,7 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
     const updatedFormBag = transformPhoneCodeEnrollment({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.phone.enroll.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement)
-      .options?.content).toBe('mfa.calling oie.phone.alternate.title. oie.phone.verify.enterCodeText');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('mfa.challenge.verify');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should create phone code enrollment UI elements with sms as the first method type', () => {
@@ -66,19 +51,7 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
     const updatedFormBag = transformPhoneCodeEnrollment({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.phone.enroll.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.phone.verify.sms.codeSentText oie.phone.alternate.title. oie.phone.verify.enterCodeText');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
-      .toBe('oie.phone.carrier.charges');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('mfa.challenge.verify');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should create phone code enrollment UI elements with sms as the first method type and phoneNumber in profile', () => {
@@ -95,19 +68,7 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
     const updatedFormBag = transformPhoneCodeEnrollment({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.phone.enroll.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe(`oie.phone.verify.sms.codeSentText ${mockPhoneNumber}. oie.phone.verify.enterCodeText`);
-    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
-      .toBe('oie.phone.carrier.charges');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('mfa.challenge.verify');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should create phone code enrollment UI elements with voice as the first method type and phoneNumber in profile', () => {
@@ -124,18 +85,6 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
     const updatedFormBag = transformPhoneCodeEnrollment({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.phone.enroll.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement)
-      .options?.content).toBe(`mfa.calling ${mockPhoneNumber}. oie.phone.verify.enterCodeText`);
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('mfa.challenge.verify');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/phone/phoneEnrollmentTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentTransformer.test.ts
@@ -18,7 +18,7 @@ import {
 
 import { transformPhoneEnrollment } from '.';
 
-describe.skip('PhoneEnrollmentTransformer Tests', () => {
+describe('PhoneEnrollmentTransformer Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const widgetProps: WidgetProps = {};
   const formBag = getStubFormBag();
@@ -49,6 +49,56 @@ describe.skip('PhoneEnrollmentTransformer Tests', () => {
   });
 
   it('should create phone enrollment UI elements when multiple method types exist in transaction', () => {
+    const updatedFormBag = transformPhoneEnrollment({ transaction, formBag, widgetProps });
+    expect(updatedFormBag).toMatchSnapshot();
+  });
+
+  it('should create phone enrollment UI elements when only sms method types exist in transaction', () => {
+    formBag.uischema.elements = [
+      {
+        type: 'Field',
+        label: 'methodType',
+        options: {
+          inputMeta: {
+            name: 'authenticator.methodType',
+            options: [{
+              value: 'sms',
+              label: 'SMS',
+            }],
+          },
+        },
+      } as FieldElement,
+      {
+        type: 'Field',
+        label: 'Phone number',
+        options: { inputMeta: { name: 'authenticator.phoneNumber' } },
+      } as FieldElement,
+    ];
+    const updatedFormBag = transformPhoneEnrollment({ transaction, formBag, widgetProps });
+    expect(updatedFormBag).toMatchSnapshot();
+  });
+
+  it('should create phone enrollment UI elements when only voice method types exist in transaction', () => {
+    formBag.uischema.elements = [
+      {
+        type: 'Field',
+        label: 'methodType',
+        options: {
+          inputMeta: {
+            name: 'authenticator.methodType',
+            options: [{
+              value: 'voice',
+              label: 'Phone Call',
+            }],
+          },
+        },
+      } as FieldElement,
+      {
+        type: 'Field',
+        label: 'Phone number',
+        options: { inputMeta: { name: 'authenticator.phoneNumber' } },
+      } as FieldElement,
+    ];
     const updatedFormBag = transformPhoneEnrollment({ transaction, formBag, widgetProps });
     expect(updatedFormBag).toMatchSnapshot();
   });

--- a/src/v3/src/transformer/phone/phoneEnrollmentTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentTransformer.test.ts
@@ -12,7 +12,13 @@
 
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
+  DescriptionElement,
   FieldElement,
+  StepperLayout,
+  StepperRadioElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -51,6 +57,44 @@ describe('PhoneEnrollmentTransformer Tests', () => {
   it('should create phone enrollment UI elements when multiple method types exist in transaction', () => {
     const updatedFormBag = transformPhoneEnrollment({ transaction, formBag, widgetProps });
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(2);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.enroll.title');
+
+    const [,stepperLayout] = updatedFormBag.uischema.elements;
+    const [layoutOne, layoutTwo] = (stepperLayout as StepperLayout).elements;
+
+    expect(layoutOne.elements.length).toBe(4);
+    expect((layoutOne.elements[0] as DescriptionElement).options.content)
+      .toBe('oie.phone.enroll.sms.subtitle');
+    expect((layoutOne.elements[1] as StepperRadioElement).options.name)
+      .toBe('authenticator.methodType');
+    expect((layoutOne.elements[1] as StepperRadioElement).options.customOptions.length)
+      .toBe(2);
+    expect((layoutOne.elements[2] as FieldElement).label)
+      .toBe('mfa.phoneNumber.placeholder');
+    expect((layoutOne.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.phoneNumber');
+    expect((layoutOne.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.sms.primaryButton');
+    expect((layoutOne.elements[3] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+
+    expect(layoutTwo.elements.length).toBe(4);
+    expect((layoutTwo.elements[0] as DescriptionElement).options.content)
+      .toBe('oie.phone.enroll.call.subtitle');
+    expect((layoutTwo.elements[1] as StepperRadioElement).options.name)
+      .toBe('authenticator.methodType');
+    expect((layoutTwo.elements[1] as StepperRadioElement).options.customOptions.length)
+      .toBe(2);
+    expect((layoutTwo.elements[2] as FieldElement).label)
+      .toBe('mfa.phoneNumber.placeholder');
+    expect((layoutTwo.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.phoneNumber');
+    expect((layoutTwo.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.call.primaryButton');
+    expect((layoutTwo.elements[3] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should create phone enrollment UI elements when only sms method types exist in transaction', () => {
@@ -76,6 +120,19 @@ describe('PhoneEnrollmentTransformer Tests', () => {
     ];
     const updatedFormBag = transformPhoneEnrollment({ transaction, formBag, widgetProps });
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.enroll.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.phone.enroll.sms.subtitle');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).label)
+      .toBe('mfa.phoneNumber.placeholder');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.phoneNumber');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.sms.primaryButton');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should create phone enrollment UI elements when only voice method types exist in transaction', () => {
@@ -101,5 +158,18 @@ describe('PhoneEnrollmentTransformer Tests', () => {
     ];
     const updatedFormBag = transformPhoneEnrollment({ transaction, formBag, widgetProps });
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.phone.enroll.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.phone.enroll.call.subtitle');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).label)
+      .toBe('mfa.phoneNumber.placeholder');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.phoneNumber');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.call.primaryButton');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
@@ -13,7 +13,10 @@
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  DescriptionElement,
   FieldElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -41,8 +44,24 @@ describe('Phone verification Transformer Tests', () => {
     + ' and sms is the first methodType choice', () => {
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.phone.verify.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.phone.verify.sms.sendText oie.phone.alternate.title');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+    // primary button
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.sms.primaryButton');
+    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
+      .options.actionParams?.['authenticator.methodType'])).toBe('sms');
+    // secondary button
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+      .toBe('oie.phone.call.secondaryButton');
+    expect(((updatedFormBag.uischema.elements[4] as ButtonElement).options
+      ?.actionParams?.['authenticator.methodType'])).toBe('voice');
   });
 
   it('should add correct UI elements to schema when multiple methodType choices exists'
@@ -58,8 +77,25 @@ describe('Phone verification Transformer Tests', () => {
     } as FieldElement];
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.phone.verify.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.phone.verify.call.sendText oie.phone.alternate.title');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+    // primary button
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.call.primaryButton');
+    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
+      .options.actionParams?.['authenticator.methodType']))
+      .toBe('voice');
+    // secondary button
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+      .toBe('oie.phone.sms.secondaryButton');
+    expect(((updatedFormBag.uischema.elements[4] as ButtonElement).options
+      ?.actionParams?.['authenticator.methodType'])).toBe('sms');
   });
 
   it('should add correct UI elements to schema when only voice methodType choice exists', () => {
@@ -74,8 +110,20 @@ describe('Phone verification Transformer Tests', () => {
     } as FieldElement];
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.phone.verify.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.phone.verify.call.sendText oie.phone.alternate.title');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+    // primary button
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.call.primaryButton');
+    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
+      .options.actionParams?.['authenticator.methodType']))
+      .toBe('voice');
   });
 
   it('should add correct UI elements to schema when only sms methodType choice exists', () => {
@@ -90,8 +138,20 @@ describe('Phone verification Transformer Tests', () => {
     } as FieldElement];
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.phone.verify.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.phone.verify.sms.sendText oie.phone.alternate.title');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+    // primary button
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.sms.primaryButton');
+    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
+      .options.actionParams?.['authenticator.methodType']))
+      .toBe('sms');
   });
 
   it('should add correct UI elements to schema when only sms methodType choice exists'
@@ -119,8 +179,20 @@ describe('Phone verification Transformer Tests', () => {
     };
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.phone.verify.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe(`oie.phone.verify.sms.sendText ${mockPhoneNumber}`);
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+    // primary button
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.sms.primaryButton');
+    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
+      .options.actionParams?.['authenticator.methodType']))
+      .toBe('sms');
   });
 
   it('should add correct UI elements to schema when only voice methodType choice exists'
@@ -148,7 +220,19 @@ describe('Phone verification Transformer Tests', () => {
     };
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.phone.verify.title');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe(`oie.phone.verify.call.sendText ${mockPhoneNumber}`);
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+      .toBe('oie.phone.carrier.charges');
+    // primary button
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.phone.call.primaryButton');
+    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
+      .options.actionParams?.['authenticator.methodType']))
+      .toBe('voice');
   });
 });

--- a/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
@@ -13,10 +13,7 @@
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  ButtonElement,
-  DescriptionElement,
   FieldElement,
-  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -45,22 +42,7 @@ describe('Phone verification Transformer Tests', () => {
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.phone.verify.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.phone.verify.sms.sendText oie.phone.alternate.title');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-    // primary button
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('oie.phone.sms.primaryButton');
-    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .options.actionParams?.['authenticator.methodType'])).toBe('sms');
-    // secondary button
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
-      .toBe('oie.phone.call.secondaryButton');
-    expect(((updatedFormBag.uischema.elements[4] as ButtonElement).options
-      ?.actionParams?.['authenticator.methodType'])).toBe('voice');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add correct UI elements to schema when multiple methodType choices exists'
@@ -77,23 +59,7 @@ describe('Phone verification Transformer Tests', () => {
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.phone.verify.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.phone.verify.call.sendText oie.phone.alternate.title');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-    // primary button
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('oie.phone.call.primaryButton');
-    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .options.actionParams?.['authenticator.methodType']))
-      .toBe('voice');
-    // secondary button
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
-      .toBe('oie.phone.sms.secondaryButton');
-    expect(((updatedFormBag.uischema.elements[4] as ButtonElement).options
-      ?.actionParams?.['authenticator.methodType'])).toBe('sms');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add correct UI elements to schema when only voice methodType choice exists', () => {
@@ -109,18 +75,7 @@ describe('Phone verification Transformer Tests', () => {
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.phone.verify.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.phone.verify.call.sendText oie.phone.alternate.title');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-    // primary button
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('oie.phone.call.primaryButton');
-    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .options.actionParams?.['authenticator.methodType']))
-      .toBe('voice');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add correct UI elements to schema when only sms methodType choice exists', () => {
@@ -136,18 +91,7 @@ describe('Phone verification Transformer Tests', () => {
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.phone.verify.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.phone.verify.sms.sendText oie.phone.alternate.title');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-    // primary button
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('oie.phone.sms.primaryButton');
-    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .options.actionParams?.['authenticator.methodType']))
-      .toBe('sms');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add correct UI elements to schema when only sms methodType choice exists'
@@ -176,18 +120,7 @@ describe('Phone verification Transformer Tests', () => {
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.phone.verify.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe(`oie.phone.verify.sms.sendText ${mockPhoneNumber}`);
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-    // primary button
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('oie.phone.sms.primaryButton');
-    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .options.actionParams?.['authenticator.methodType']))
-      .toBe('sms');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should add correct UI elements to schema when only voice methodType choice exists'
@@ -216,17 +149,6 @@ describe('Phone verification Transformer Tests', () => {
     const updatedFormBag = transformPhoneVerification({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.phone.verify.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe(`oie.phone.verify.call.sendText ${mockPhoneNumber}`);
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.phone.carrier.charges');
-    // primary button
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('oie.phone.call.primaryButton');
-    expect(((updatedFormBag.uischema.elements[3] as ButtonElement)
-      .options.actionParams?.['authenticator.methodType']))
-      .toBe('voice');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Description:

The purpose of this PR is to re-enable the transformer jest tests in the phone layout folder.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-537285](https://oktainc.atlassian.net/browse/OKTA-537285)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



