### PR TITLE
OKTA-516578 : Re-enable security question transformer tests

### DIFF
--- a/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionEnroll.test.ts.snap
+++ b/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionEnroll.test.ts.snap
@@ -2,10 +2,20 @@
 
 exports[`SecurityQuestionEnroll Tests should create security question enrollment UI elements 1`] = `
 Object {
-  "data": Object {
-    "credentials.questionKey": "eternal",
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [
+      "credentials.answer",
+      "credentials.questionKey",
+    ],
+    "submit": Object {
+      "includeImmutableData": false,
+      "step": "",
+      "type": "submit",
+    },
   },
-  "dataSchema": Object {},
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -23,57 +33,70 @@ Object {
                 "options": Object {
                   "customOptions": Array [
                     Object {
+                      "callback": [Function],
                       "label": "oie.security.question.questionKey.label",
                       "value": "predefined",
                     },
                     Object {
+                      "callback": [Function],
                       "key": "credentials.questionKey",
                       "label": "oie.security.question.createQuestion.label",
                       "value": "custom",
                     },
                   ],
-                  "defaultOption": "predefined",
+                  "defaultValue": [Function],
                   "name": "questionType",
                 },
                 "type": "StepperRadio",
               },
               Object {
+                "key": "credentials.questionKey",
                 "label": "oie.security.question.questionKey.label",
-                "name": "credentials.questionKey",
                 "options": Object {
                   "customOptions": Array [
                     Object {
                       "label": "What is love?",
                       "value": "eternal",
                     },
+                    Object {
+                      "label": "Who is your favorite actor?",
+                      "value": "fav_actor",
+                    },
                   ],
                   "format": "dropdown",
                   "inputMeta": Object {
                     "name": "credentials.questionKey",
+                    "options": Array [
+                      Object {
+                        "label": "What is love?",
+                        "value": "eternal",
+                      },
+                      Object {
+                        "label": "Who is your favorite actor?",
+                        "value": "fav_actor",
+                      },
+                    ],
                   },
                 },
-                "type": "Control",
+                "type": "Field",
               },
               Object {
-                "label": "Answer",
-                "name": "credentials.answer",
+                "key": "credentials.answer_predefined",
                 "options": Object {
                   "inputMeta": Object {
-                    "label": "Answer",
                     "name": "credentials.answer",
                     "secret": true,
                   },
                 },
-                "type": "Control",
+                "type": "Field",
               },
               Object {
                 "label": "mfa.challenge.verify",
                 "options": Object {
-                  "dataType": "save",
+                  "includeImmutableData": false,
                   "step": "",
                   "type": "submit",
                 },
-                "scope": "#/properties/submit",
                 "type": "Button",
               },
             ],
@@ -91,34 +114,34 @@ Object {
                 "options": Object {
                   "customOptions": Array [
                     Object {
+                      "callback": [Function],
                       "label": "oie.security.question.questionKey.label",
                       "value": "predefined",
                     },
                     Object {
+                      "callback": [Function],
                       "key": "credentials.questionKey",
                       "label": "oie.security.question.createQuestion.label",
                       "value": "custom",
                     },
                   ],
-                  "defaultOption": "predefined",
+                  "defaultValue": [Function],
                   "name": "questionType",
                 },
                 "type": "StepperRadio",
               },
               Object {
                 "label": "oie.security.question.createQuestion.label",
-                "name": "credentials.question",
                 "options": Object {
                   "inputMeta": Object {
                     "name": "credentials.question",
                   },
-                  "type": "string",
                 },
-                "type": "Control",
+                "type": "Field",
               },
               Object {
+                "key": "credentials.answer_custom",
                 "label": "Answer",
-                "name": "credentials.answer",
                 "options": Object {
                   "inputMeta": Object {
                     "label": "Answer",
@@ -126,7 +149,7 @@ Object {
                     "secret": true,
                   },
                 },
-                "type": "Control",
+                "type": "Field",
               },
               Object {
                 "label": "mfa.challenge.verify",
@@ -134,11 +157,9 @@ Object {
                   "actionParams": Object {
                     "credentials.questionKey": "custom",
                   },
-                  "dataType": "save",
                   "step": "",
                   "type": "submit",
                 },
-                "scope": "#/properties/submit",
                 "type": "Button",
               },
             ],

--- a/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionVerify.test.ts.snap
+++ b/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionVerify.test.ts.snap
@@ -3,7 +3,14 @@
 exports[`SecurityQuestionVerify Tests should create security question verify UI elements 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -14,15 +21,20 @@ Object {
         "type": "Title",
       },
       Object {
-        "label": "What is love?",
-        "name": "credentials.answer",
         "options": Object {
           "inputMeta": Object {
             "name": "credentials.answer",
             "secret": true,
           },
         },
-        "type": "Control",
+        "translations": Array [
+          Object {
+            "i18nKey": "",
+            "name": "label",
+            "value": "What is love?",
+          },
+        ],
+        "type": "Field",
       },
       Object {
         "label": "oform.verify",
@@ -30,7 +42,6 @@ Object {
           "step": "mock-step",
           "type": "submit",
         },
-        "scope": "#/properties/submit",
         "type": "Button",
       },
     ],
@@ -42,7 +53,14 @@ Object {
 exports[`SecurityQuestionVerify Tests should create security question verify UI elements for custom question 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -53,15 +71,20 @@ Object {
         "type": "Title",
       },
       Object {
-        "label": "What is love?",
-        "name": "credentials.answer",
         "options": Object {
           "inputMeta": Object {
             "name": "credentials.answer",
             "secret": true,
           },
         },
-        "type": "Control",
+        "translations": Array [
+          Object {
+            "i18nKey": "",
+            "name": "label",
+            "value": "What is love?",
+          },
+        ],
+        "type": "Field",
       },
       Object {
         "label": "oform.verify",
@@ -69,7 +92,6 @@ Object {
           "step": "mock-step",
           "type": "submit",
         },
-        "scope": "#/properties/submit",
         "type": "Button",
       },
     ],

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.test.ts
@@ -14,21 +14,31 @@ import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   FieldElement,
+  FormBag,
   WidgetProps,
 } from 'src/types';
 
 import { transformSecurityQuestionEnroll } from '.';
 
-describe.skip('SecurityQuestionEnroll Tests', () => {
+describe('SecurityQuestionEnroll Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const widgetProps: WidgetProps = {};
-  const formBag = getStubFormBag();
+  let formBag: FormBag;
 
   beforeEach(() => {
+    formBag = getStubFormBag();
     formBag.uischema.elements = [
       {
         type: 'Field',
-        options: { inputMeta: { name: 'credentials' } },
+        options: { inputMeta: { name: 'credentials.questionKey' } },
+      } as FieldElement,
+      {
+        type: 'Field',
+        options: { inputMeta: { name: 'credentials.question' } },
+      } as FieldElement,
+      {
+        type: 'Field',
+        options: { inputMeta: { name: 'credentials.answer', secret: true } },
       } as FieldElement,
     ];
   });
@@ -42,7 +52,22 @@ describe.skip('SecurityQuestionEnroll Tests', () => {
           options: [
             {
               label: 'Select question',
-              value: [{ name: 'questionKey' }, { name: 'answer', label: 'Answer', secret: true }],
+              value: [
+                {
+                  name: 'questionKey',
+                  options: [
+                    {
+                      value: 'eternal',
+                      label: 'What is love?',
+                    },
+                    {
+                      value: 'fav_actor',
+                      label: 'Who is your favorite actor?',
+                    },
+                  ],
+                },
+                { name: 'answer', label: 'Answer', secret: true },
+              ],
             },
             {
               label: 'Enter question',
@@ -58,10 +83,16 @@ describe.skip('SecurityQuestionEnroll Tests', () => {
       relatesTo: {
         value: {
           contextualData: {
-            questions: [{
-              question: 'What is love?',
-              questionKey: 'eternal',
-            }],
+            questions: [
+              {
+                question: 'What is love?',
+                questionKey: 'eternal',
+              },
+              {
+                question: 'Who is your favorite actor?',
+                questionKey: 'fav_actor',
+              },
+            ],
           },
         } as unknown as IdxAuthenticator,
       },

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.test.ts
@@ -13,8 +13,13 @@
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
   FieldElement,
   FormBag,
+  StepperLayout,
+  StepperRadioElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -100,5 +105,63 @@ describe('SecurityQuestionEnroll Tests', () => {
     const updatedFormBag = transformSecurityQuestionEnroll({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
+
+    const [stepperLayout] = updatedFormBag.uischema.elements;
+
+    const [layoutOne, layoutTwo] = (stepperLayout as StepperLayout).elements;
+
+    expect(layoutOne.elements.length).toBe(5);
+    expect((layoutOne.elements[0] as TitleElement).options.content)
+      .toBe('oie.security.question.enroll.title');
+    expect(layoutOne.elements[1].type).toBe('StepperRadio');
+    expect((layoutOne.elements[1] as StepperRadioElement).options.customOptions.length)
+      .toBe(2);
+    expect((layoutOne.elements[1] as StepperRadioElement).options.name)
+      .toBe('questionType');
+
+    expect((layoutOne.elements[2] as FieldElement).label)
+      .toBe('oie.security.question.questionKey.label');
+    expect((layoutOne.elements[2] as FieldElement).options.customOptions?.length)
+      .toBe(2);
+    expect((layoutOne.elements[2] as FieldElement).options.format)
+      .toBe('dropdown');
+    expect((layoutOne.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.questionKey');
+
+    expect((layoutOne.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.answer');
+    expect((layoutOne.elements[3] as FieldElement).options.inputMeta.secret)
+      .toBe(true);
+    expect((layoutOne.elements[4] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
+    expect((layoutOne.elements[4] as ButtonElement).options.includeImmutableData)
+      .toBe(false);
+    expect((layoutOne.elements[4] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+
+    expect(layoutTwo.elements.length).toBe(5);
+    expect((layoutTwo.elements[0] as TitleElement).options.content)
+      .toBe('oie.security.question.enroll.title');
+    expect(layoutTwo.elements[1].type).toBe('StepperRadio');
+    expect((layoutTwo.elements[1] as StepperRadioElement).options.customOptions.length)
+      .toBe(2);
+    expect((layoutTwo.elements[1] as StepperRadioElement).options.name)
+      .toBe('questionType');
+
+    expect((layoutTwo.elements[2] as FieldElement).label)
+      .toBe('oie.security.question.createQuestion.label');
+    expect((layoutTwo.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.question');
+
+    expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.answer');
+    expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.secret)
+      .toBe(true);
+    expect((layoutTwo.elements[4] as ButtonElement).label)
+      .toBe('mfa.challenge.verify');
+    expect((layoutTwo.elements[4] as ButtonElement).options.actionParams)
+      .toEqual({ 'credentials.questionKey': 'custom' });
+    expect((layoutTwo.elements[4] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
@@ -13,7 +13,10 @@
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
   FieldElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -45,8 +48,28 @@ describe('SecurityQuestionVerify Tests', () => {
     };
     const updatedFormBag = transformSecurityQuestionVerify({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.security.question.challenge.title');
+
+    // answer element
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
+      .toBe('credentials.answer');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.secret)
+      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).translations?.[0])
+      .toEqual({
+        i18nKey: '',
+        name: 'label',
+        value: 'What is love?',
+      });
+
+    // submit button
+    expect(updatedFormBag.uischema.elements[2].type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.verify');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should create security question verify UI elements for custom question', () => {
@@ -63,7 +86,27 @@ describe('SecurityQuestionVerify Tests', () => {
     };
     const updatedFormBag = transformSecurityQuestionVerify({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.security.question.challenge.title');
+
+    // answer element
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
+      .toBe('credentials.answer');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.secret)
+      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).translations?.[0])
+      .toEqual({
+        i18nKey: '',
+        name: 'label',
+        value: 'What is love?',
+      });
+
+    // submit button
+    expect(updatedFormBag.uischema.elements[2].type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.verify');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
@@ -13,26 +13,22 @@
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  ButtonElement,
-  ButtonType,
   FieldElement,
   WidgetProps,
 } from 'src/types';
 
 import { transformSecurityQuestionVerify } from '.';
 
-describe.skip('SecurityQuestionVerify Tests', () => {
+describe('SecurityQuestionVerify Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const widgetProps: WidgetProps = {};
   const formBag = getStubFormBag();
 
   beforeEach(() => {
-    formBag.uischema.elements = [
-      {
-        type: 'Field',
-        options: { inputMeta: { name: 'credentials.answer', secret: true } },
-      } as FieldElement,
-    ];
+    formBag.uischema.elements = [{
+      type: 'Field',
+      options: { inputMeta: { name: 'credentials.answer', secret: true } },
+    } as FieldElement];
   });
 
   it('should create security question verify UI elements', () => {
@@ -44,31 +40,13 @@ describe.skip('SecurityQuestionVerify Tests', () => {
             question: 'What is love?',
             questionKey: 'eternal',
           },
-          id: '',
-          displayName: '',
-          key: '',
-          type: '',
-          methods: [],
         } as unknown as IdxAuthenticator,
       },
     };
     const updatedFormBag = transformSecurityQuestionVerify({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag).toMatchSnapshot();
-
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-
-    // answer element
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Control');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.secret)
-      .toBe(true);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).label).toBe('What is love?');
-
-    // submit button
-    expect(updatedFormBag.uischema.elements[2].type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should create security question verify UI elements for custom question', () => {
@@ -80,30 +58,12 @@ describe.skip('SecurityQuestionVerify Tests', () => {
             question: 'What is love?',
             questionKey: 'custom',
           },
-          id: '',
-          displayName: '',
-          key: '',
-          type: '',
-          methods: [],
         } as unknown as IdxAuthenticator,
       },
     };
     const updatedFormBag = transformSecurityQuestionVerify({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag).toMatchSnapshot();
-
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-
-    // answer element
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Control');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.secret)
-      .toBe(true);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).label).toBe('What is love?');
-
-    // submit button
-    expect(updatedFormBag.uischema.elements[2].type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options?.type)
-      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Description:

The purpose of this PR is to re-enable security question transformer jest tests.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-516578](https://oktainc.atlassian.net/browse/OKTA-516578)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



