### PR TITLE
OKTA-516578 : Re-enabling profile transformer tests

### DIFF
--- a/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
+++ b/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
@@ -1,0 +1,311 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Enroll Profile Transformer Tests should add link to log in when select-identify step exists in remediation 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.registration.form.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.firstName",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.lastName",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.email",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oie.registration.form.submit",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "type": "Divider",
+      },
+      Object {
+        "elements": Array [
+          Object {
+            "options": Object {
+              "content": "haveaccount",
+            },
+            "type": "Description",
+          },
+          Object {
+            "options": Object {
+              "label": "signin",
+              "step": "select-identify",
+            },
+            "type": "Link",
+          },
+        ],
+        "type": "HorizontalLayout",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Enroll Profile Transformer Tests should add password requirements along with title, and submit button when passcode and password settings exists 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.registration.form.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [
+            Object {
+              "label": "password.complexity.number.description",
+              "ruleKey": "minNumber",
+            },
+            Object {
+              "label": "password.complexity.symbol.description",
+              "ruleKey": "minSymbol",
+            },
+          ],
+          "settings": Object {
+            "complexity": Object {
+              "minNumber": 1,
+              "minSymbol": 1,
+            },
+          },
+          "userInfo": Object {
+            "identifier": "testuser@okta.com",
+            "profile": Object {
+              "firstName": "test",
+              "lastName": "user",
+            },
+          },
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.firstName",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.lastName",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.email",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oie.registration.form.submit",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Enroll Profile Transformer Tests should add password requirements along with title, and submit button when passcode exists but password settings are empty 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.registration.form.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.firstName",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.lastName",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.email",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "Password",
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oie.registration.form.submit",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Enroll Profile Transformer Tests should only add title and submit button when select-identify doesnt exist in available steps and passcode element doesnt exist in schema 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.registration.form.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.firstName",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.lastName",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "userProfile.email",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oie.registration.form.submit",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/profile/transformEnrollProfile.test.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfile.test.ts
@@ -11,10 +11,17 @@
  */
 
 import { IdxAuthenticator } from '@okta/okta-auth-js';
-import { IDX_STEP } from 'src/constants';
+import { IDX_STEP, PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
+  DescriptionElement,
   FieldElement,
+  LinkElement,
+  PasswordRequirementsElement,
+  TitleElement,
+  UISchemaLayout,
   WidgetProps,
 } from 'src/types';
 
@@ -40,8 +47,22 @@ describe('Enroll Profile Transformer Tests', () => {
     + 'and passcode element doesnt exist in schema', () => {
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.registration.form.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.lastName');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.email');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+      .toBe('oie.registration.form.submit');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should add password requirements along with title, and submit button when passcode exists but password settings are empty', () => {
@@ -71,8 +92,26 @@ describe('Enroll Profile Transformer Tests', () => {
 
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.registration.form.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.lastName');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.email');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label)
+      .toBe('oie.registration.form.submit');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should add password requirements along with title, and submit button when passcode and password settings exists', () => {
@@ -102,8 +141,37 @@ describe('Enroll Profile Transformer Tests', () => {
 
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.registration.form.title');
+    expect(updatedFormBag.uischema.elements[1].type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.userInfo)
+      .toEqual(mockUserInfo);
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: { minNumber: 1, minSymbol: 1 } });
+    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS);
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.lastName');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.email');
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options?.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options?.attributes?.autocomplete)
+      .toBe('new-password');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).label)
+      .toBe('oie.registration.form.submit');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should add link to log in when select-identify step exists in remediation', () => {
@@ -114,7 +182,26 @@ describe('Enroll Profile Transformer Tests', () => {
 
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.registration.form.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.lastName');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.email');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+      .toBe('oie.registration.form.submit');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
+    expect(updatedFormBag.uischema.elements[5].type).toBe('Divider');
+    expect(updatedFormBag.uischema.elements[6].type).toBe('HorizontalLayout');
+    expect(((updatedFormBag.uischema.elements[6] as UISchemaLayout)
+      .elements[0] as DescriptionElement).options.content).toBe('haveaccount');
+    expect(((updatedFormBag.uischema.elements[6] as UISchemaLayout)
+      .elements[1] as LinkElement).options.label).toBe('signin');
   });
 });

--- a/src/v3/src/transformer/profile/transformEnrollProfile.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfile.ts
@@ -57,7 +57,9 @@ export const transformEnrollProfile: IdxStepTransformer = ({ transaction, formBa
         validationDelayMs: PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS,
       },
     };
-    uischema.elements.unshift(passwordRequirementsElement);
+    if (Object.keys(passwordSettings)?.length) {
+      uischema.elements.unshift(passwordRequirementsElement);
+    }
   }
 
   const titleElement: TitleElement = {
@@ -79,9 +81,7 @@ export const transformEnrollProfile: IdxStepTransformer = ({ transaction, formBa
 
   const selectIdentifyStep = availableSteps?.find(({ name }) => name === IDX_STEP.SELECT_IDENTIFY);
   if (selectIdentifyStep) {
-    uischema.elements.push({
-      type: 'Divider',
-    });
+    uischema.elements.push({ type: 'Divider' });
     const { name: step } = selectIdentifyStep;
     const signinLink: LinkElement = {
       type: 'Link',


### PR DESCRIPTION
## Description:

The purpose of this PR is to re-enable the profile enrollment transformer tests.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-516578](https://oktainc.atlassian.net/browse/OKTA-516578)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



