### PR TITLE
OKTA-537283 : Re-enable OV transformer tests

### DIFF
--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyChallengePoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyChallengePoll.test.ts.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Transform Okta Verify Challenge Poll Tests should transform elements when method type is push and has enhanced security when resend is unavailable 1`] = `
+Object {
+  "data": Object {
+    "autoChallenge": undefined,
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.numberchallenge.instruction",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "code",
+          "textContent": "42",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "label": "Loading...",
+          "valueText": "Loading...",
+        },
+        "type": "Spinner",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Transform Okta Verify Challenge Poll Tests should transform elements when method type is push and has enhanced security with resend avaialable 1`] = `
+Object {
+  "data": Object {
+    "autoChallenge": undefined,
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "actionParams": Object {
+            "resend": true,
+          },
+          "buttonText": "email.button.resend",
+          "content": "oie.numberchallenge.warning",
+          "isActionStep": true,
+          "step": "resend",
+        },
+        "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.numberchallenge.instruction",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "id": "code",
+          "textContent": "42",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "options": Object {
+          "label": "Loading...",
+          "valueText": "Loading...",
+        },
+        "type": "Spinner",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Transform Okta Verify Challenge Poll Tests should transform elements when method type is standard push only 1`] = `
+Object {
+  "data": Object {
+    "autoChallenge": undefined,
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oktaverify.warning",
+        },
+        "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "label": "Loading...",
+          "valueText": "Loading...",
+        },
+        "type": "Spinner",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyChannelSelection.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyChannelSelection.test.ts.snap
@@ -1,0 +1,437 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TransformOktaVerifyChannelSelection Tests should only append (qrcode/email) channel options when NOT on mobile and sms is the selectedChannel 1`] = `
+Object {
+  "data": Object {
+    "authenticator.channel": "qrcode",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.okta_verify.select.channel.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "label": "oie.enroll.okta_verify.select.channel.description",
+        "options": Object {
+          "customOptions": Array [
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.qrcode.label",
+              "value": "qrcode",
+            },
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.email.label",
+              "value": "email",
+            },
+          ],
+          "format": "radio",
+          "inputMeta": Object {
+            "name": "authenticator.channel",
+            "options": Array [
+              Object {
+                "label": "QRCode",
+                "value": "qrcode",
+              },
+              Object {
+                "label": "SMS",
+                "value": "sms",
+              },
+              Object {
+                "label": "EMAIL",
+                "value": "email",
+              },
+            ],
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oform.next",
+        "options": Object {
+          "step": "select-enrollment-channel",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`TransformOktaVerifyChannelSelection Tests should only append (qrcode/sms) channel options when NOT on mobile and email is the selectedChannel 1`] = `
+Object {
+  "data": Object {
+    "authenticator.channel": "qrcode",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.okta_verify.select.channel.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "label": "oie.enroll.okta_verify.select.channel.description",
+        "options": Object {
+          "customOptions": Array [
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.qrcode.label",
+              "value": "qrcode",
+            },
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.sms.label",
+              "value": "sms",
+            },
+          ],
+          "format": "radio",
+          "inputMeta": Object {
+            "name": "authenticator.channel",
+            "options": Array [
+              Object {
+                "label": "QRCode",
+                "value": "qrcode",
+              },
+              Object {
+                "label": "SMS",
+                "value": "sms",
+              },
+              Object {
+                "label": "EMAIL",
+                "value": "email",
+              },
+            ],
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oform.next",
+        "options": Object {
+          "step": "select-enrollment-channel",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`TransformOktaVerifyChannelSelection Tests should only append (sms/email) channel options when NOT on mobile and qrcode is the selectedChannel 1`] = `
+Object {
+  "data": Object {
+    "authenticator.channel": "sms",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.okta_verify.select.channel.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "label": "oie.enroll.okta_verify.select.channel.description",
+        "options": Object {
+          "customOptions": Array [
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.sms.label",
+              "value": "sms",
+            },
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.email.label",
+              "value": "email",
+            },
+          ],
+          "format": "radio",
+          "inputMeta": Object {
+            "name": "authenticator.channel",
+            "options": Array [
+              Object {
+                "label": "QRCode",
+                "value": "qrcode",
+              },
+              Object {
+                "label": "SMS",
+                "value": "sms",
+              },
+              Object {
+                "label": "EMAIL",
+                "value": "email",
+              },
+            ],
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oform.next",
+        "options": Object {
+          "step": "select-enrollment-channel",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.enroll.okta_verify.switch.channel.link.text",
+          "contentClassname": "switch-channel-link",
+          "step": "select-enrollment-channel",
+        },
+        "type": "TextWithHtml",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`TransformOktaVerifyChannelSelection Tests should only append (sms/email) channel options when on mobile and email is the selectedChannel 1`] = `
+Object {
+  "data": Object {
+    "authenticator.channel": "qrcode",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.okta_verify.setup.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "label": "oie.enroll.okta_verify.select.channel.description",
+        "options": Object {
+          "customOptions": Array [
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.qrcode.label",
+              "value": "qrcode",
+            },
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.sms.label",
+              "value": "sms",
+            },
+          ],
+          "format": "radio",
+          "inputMeta": Object {
+            "name": "authenticator.channel",
+            "options": Array [
+              Object {
+                "label": "QRCode",
+                "value": "qrcode",
+              },
+              Object {
+                "label": "SMS",
+                "value": "sms",
+              },
+              Object {
+                "label": "EMAIL",
+                "value": "email",
+              },
+            ],
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oform.next",
+        "options": Object {
+          "step": "select-enrollment-channel",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`TransformOktaVerifyChannelSelection Tests should only append (sms/email) channel options when on mobile and qrcode is the selectedChannel 1`] = `
+Object {
+  "data": Object {
+    "authenticator.channel": "sms",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.okta_verify.setup.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "label": "oie.enroll.okta_verify.select.channel.description",
+        "options": Object {
+          "customOptions": Array [
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.sms.label",
+              "value": "sms",
+            },
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.email.label",
+              "value": "email",
+            },
+          ],
+          "format": "radio",
+          "inputMeta": Object {
+            "name": "authenticator.channel",
+            "options": Array [
+              Object {
+                "label": "QRCode",
+                "value": "qrcode",
+              },
+              Object {
+                "label": "SMS",
+                "value": "sms",
+              },
+              Object {
+                "label": "EMAIL",
+                "value": "email",
+              },
+            ],
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oform.next",
+        "options": Object {
+          "step": "select-enrollment-channel",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.enroll.okta_verify.switch.channel.link.text",
+          "contentClassname": "switch-channel-link",
+          "step": "select-enrollment-channel",
+        },
+        "type": "TextWithHtml",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`TransformOktaVerifyChannelSelection Tests should only append (sms/email) channel options when on mobile and sms is the selectedChannel 1`] = `
+Object {
+  "data": Object {
+    "authenticator.channel": "qrcode",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.enroll.okta_verify.setup.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "label": "oie.enroll.okta_verify.select.channel.description",
+        "options": Object {
+          "customOptions": Array [
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.qrcode.label",
+              "value": "qrcode",
+            },
+            Object {
+              "label": "oie.enroll.okta_verify.select.channel.email.label",
+              "value": "email",
+            },
+          ],
+          "format": "radio",
+          "inputMeta": Object {
+            "name": "authenticator.channel",
+            "options": Array [
+              Object {
+                "label": "QRCode",
+                "value": "qrcode",
+              },
+              Object {
+                "label": "SMS",
+                "value": "sms",
+              },
+              Object {
+                "label": "EMAIL",
+                "value": "email",
+              },
+            ],
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oform.next",
+        "options": Object {
+          "step": "select-enrollment-channel",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollChannel.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollChannel.test.ts.snap
@@ -3,7 +3,14 @@
 exports[`TransformOktaVerifyEnrollChannel Tests should append email input field to elements list when email is the selectedChannel 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -14,8 +21,12 @@ Object {
         "type": "Title",
       },
       Object {
-        "name": "email",
-        "type": "Control",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "email",
+          },
+        },
+        "type": "Field",
       },
       Object {
         "options": Object {
@@ -29,18 +40,16 @@ Object {
           "step": "",
           "type": "submit",
         },
-        "scope": "#/properties/setupLink",
         "type": "Button",
       },
       Object {
-        "label": "oie.enroll.okta_verify.switch.channel.link.text",
         "options": Object {
+          "content": "oie.enroll.okta_verify.switch.channel.link.text",
+          "contentClassname": "switch-channel-link",
           "step": "select-enrollment-channel",
           "stepToRender": "select-enrollment-channel",
-          "type": "button",
-          "variant": "secondary",
         },
-        "type": "Button",
+        "type": "TextWithHtml",
       },
     ],
     "type": "VerticalLayout",
@@ -51,7 +60,14 @@ Object {
 exports[`TransformOktaVerifyEnrollChannel Tests should append phone input field to elements list when sms is the selectedChannel 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -62,8 +78,12 @@ Object {
         "type": "Title",
       },
       Object {
-        "name": "phoneNumber",
-        "type": "Control",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "phoneNumber",
+          },
+        },
+        "type": "Field",
       },
       Object {
         "options": Object {
@@ -77,18 +97,16 @@ Object {
           "step": "",
           "type": "submit",
         },
-        "scope": "#/properties/setupLink",
         "type": "Button",
       },
       Object {
-        "label": "oie.enroll.okta_verify.switch.channel.link.text",
         "options": Object {
+          "content": "oie.enroll.okta_verify.switch.channel.link.text",
+          "contentClassname": "switch-channel-link",
           "step": "select-enrollment-channel",
           "stepToRender": "select-enrollment-channel",
-          "type": "button",
-          "variant": "secondary",
         },
-        "type": "Button",
+        "type": "TextWithHtml",
       },
     ],
     "type": "VerticalLayout",

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
@@ -3,7 +3,14 @@
 exports[`TransformOktaVerifyEnrollPoll Tests should add Stepper elements when selectedChannel is qrcode and canResend = true 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -30,14 +37,14 @@ Object {
               },
               Object {
                 "options": Object {
-                  "data": "",
-                  "label": undefined,
+                  "data": "#mockQrCode",
                 },
                 "type": "QRCode",
               },
               Object {
                 "label": "enroll.totp.cannotScan",
                 "options": Object {
+                  "ariaLabel": "enroll.totp.aria.cannotScan",
                   "step": "select-enrollment-channel",
                   "stepToRender": "select-enrollment-channel",
                   "type": "button",
@@ -63,14 +70,13 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "oie.enroll.okta_verify.switch.channel.link.text",
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
                   "step": "select-enrollment-channel",
                   "stepToRender": "select-enrollment-channel",
-                  "type": "button",
-                  "variant": "secondary",
                 },
-                "type": "Button",
+                "type": "TextWithHtml",
               },
             ],
             "type": "VerticalLayout",
@@ -90,14 +96,13 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "oie.enroll.okta_verify.switch.channel.link.text",
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
                   "step": "select-enrollment-channel",
                   "stepToRender": "select-enrollment-channel",
-                  "type": "button",
-                  "variant": "secondary",
                 },
-                "type": "Button",
+                "type": "TextWithHtml",
               },
             ],
             "type": "VerticalLayout",
@@ -117,7 +122,14 @@ Object {
 exports[`TransformOktaVerifyEnrollPoll Tests should return a channel selection formBag when email is selected channel and canResend = true 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -127,9 +139,14 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "oie.enroll.okta_verify.email.notReceived",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.email.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -152,14 +169,14 @@ Object {
               },
               Object {
                 "options": Object {
-                  "data": undefined,
-                  "label": undefined,
+                  "data": "#mockQrCode",
                 },
                 "type": "QRCode",
               },
               Object {
                 "label": "enroll.totp.cannotScan",
                 "options": Object {
+                  "ariaLabel": "enroll.totp.aria.cannotScan",
                   "step": "select-enrollment-channel",
                   "stepToRender": "select-enrollment-channel",
                   "type": "button",
@@ -174,9 +191,14 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "oie.enroll.okta_verify.email.notReceived",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.email.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -193,14 +215,13 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "oie.enroll.okta_verify.switch.channel.link.text",
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
                   "step": "select-enrollment-channel",
                   "stepToRender": "select-enrollment-channel",
-                  "type": "button",
-                  "variant": "secondary",
                 },
-                "type": "Button",
+                "type": "TextWithHtml",
               },
             ],
             "type": "VerticalLayout",
@@ -209,9 +230,14 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "oie.enroll.okta_verify.email.notReceived",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.email.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -228,14 +254,13 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "oie.enroll.okta_verify.switch.channel.link.text",
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
                   "step": "select-enrollment-channel",
                   "stepToRender": "select-enrollment-channel",
-                  "type": "button",
-                  "variant": "secondary",
                 },
-                "type": "Button",
+                "type": "TextWithHtml",
               },
             ],
             "type": "VerticalLayout",
@@ -255,7 +280,14 @@ Object {
 exports[`TransformOktaVerifyEnrollPoll Tests should return a channel selection formBag when sms is selected channel with canResend = true 1`] = `
 Object {
   "data": Object {},
-  "dataSchema": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
   "schema": Object {},
   "uischema": Object {
     "elements": Array [
@@ -265,9 +297,14 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "oie.enroll.okta_verify.sms.notReceived",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.sms.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -290,14 +327,14 @@ Object {
               },
               Object {
                 "options": Object {
-                  "data": undefined,
-                  "label": undefined,
+                  "data": "#mockQrCode",
                 },
                 "type": "QRCode",
               },
               Object {
                 "label": "enroll.totp.cannotScan",
                 "options": Object {
+                  "ariaLabel": "enroll.totp.aria.cannotScan",
                   "step": "select-enrollment-channel",
                   "stepToRender": "select-enrollment-channel",
                   "type": "button",
@@ -312,9 +349,14 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "oie.enroll.okta_verify.sms.notReceived",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.sms.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -331,14 +373,13 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "oie.enroll.okta_verify.switch.channel.link.text",
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
                   "step": "select-enrollment-channel",
                   "stepToRender": "select-enrollment-channel",
-                  "type": "button",
-                  "variant": "secondary",
                 },
-                "type": "Button",
+                "type": "TextWithHtml",
               },
             ],
             "type": "VerticalLayout",
@@ -347,9 +388,14 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
-                  "action": [Function],
-                  "ctaText": "oie.enroll.okta_verify.sms.notReceived",
-                  "linkLabel": "email.button.resend",
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.sms.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
                 },
                 "type": "Reminder",
               },
@@ -366,14 +412,13 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "oie.enroll.okta_verify.switch.channel.link.text",
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
                   "step": "select-enrollment-channel",
                   "stepToRender": "select-enrollment-channel",
-                  "type": "button",
-                  "variant": "secondary",
                 },
-                "type": "Button",
+                "type": "TextWithHtml",
               },
             ],
             "type": "VerticalLayout",

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformTOTPChallenge.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformTOTPChallenge.test.ts.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Transform Okta Verify Totp Challenge Tests should build UI elements for OV TOTP remediation 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.totp.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "label": "Enter Code",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.totp",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
@@ -12,10 +12,7 @@
 
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
-import {
-  DescriptionElement, ImageWithTextElement,
-  ReminderElement, TitleElement, WidgetProps,
-} from 'src/types';
+import { WidgetProps } from 'src/types';
 
 import { transformOktaVerifyChallengePoll } from './transformOktaVerifyChallengePoll';
 
@@ -66,18 +63,7 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     const updatedFormBag = transformOktaVerifyChallengePoll({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.okta_verify.push.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Reminder');
-    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.content)
-      .toBe('oktaverify.warning');
-    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.buttonText)
-      .toBeUndefined();
-    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.okta_verify.push.sent');
-    expect(updatedFormBag.uischema.elements[3].type).toBe('Spinner');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should transform elements when method type is push and '
@@ -100,24 +86,7 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     const updatedFormBag = transformOktaVerifyChallengePoll({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Reminder');
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
-      .toBe('oie.numberchallenge.warning');
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.buttonText)
-      .toBe('email.button.resend');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[1] as TitleElement).options?.content)
-      .toBe('oie.okta_verify.push.sent');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.numberchallenge.instruction');
-    expect((updatedFormBag.uischema.elements[3] as ImageWithTextElement).type)
-      .toBe('ImageWithText');
-    expect((updatedFormBag.uischema.elements[3] as ImageWithTextElement).options?.textContent)
-      .toBe(correctAnswer);
-    expect((updatedFormBag.uischema.elements[3] as ImageWithTextElement).options?.SVGIcon)
-      .not.toBeUndefined();
-    expect(updatedFormBag.uischema.elements[4].type).toBe('Spinner');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should transform elements when method type is push and '
@@ -139,18 +108,6 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     const updatedFormBag = transformOktaVerifyChallengePoll({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.okta_verify.push.sent');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.numberchallenge.instruction');
-    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).type)
-      .toBe('ImageWithText');
-    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).options?.textContent)
-      .toBe(correctAnswer);
-    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).options?.SVGIcon)
-      .not.toBeUndefined();
-    expect(updatedFormBag.uischema.elements[3].type).toBe('Spinner');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
@@ -12,7 +12,13 @@
 
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
-import { WidgetProps } from 'src/types';
+import {
+  DescriptionElement,
+  ImageWithTextElement,
+  ReminderElement,
+  TitleElement,
+  WidgetProps,
+} from 'src/types';
 
 import { transformOktaVerifyChallengePoll } from './transformOktaVerifyChallengePoll';
 
@@ -62,8 +68,15 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
   it('should transform elements when method type is standard push only', () => {
     const updatedFormBag = transformOktaVerifyChallengePoll({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.okta_verify.push.title');
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
+      .toBe('oktaverify.warning');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent');
+    expect(updatedFormBag.uischema.elements[3].type).toBe('Spinner');
   });
 
   it('should transform elements when method type is push and '
@@ -85,8 +98,24 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     };
     const updatedFormBag = transformOktaVerifyChallengePoll({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.content)
+      .toBe('oie.numberchallenge.warning');
+    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.step)
+      .toBe('resend');
+    expect((updatedFormBag.uischema.elements[1] as TitleElement).options.content)
+      .toBe('oie.okta_verify.push.sent');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.numberchallenge.instruction');
+    expect((updatedFormBag.uischema.elements[3] as ImageWithTextElement).type)
+      .toBe('ImageWithText');
+    expect((updatedFormBag.uischema.elements[3] as ImageWithTextElement).options.textContent)
+      .toBe('42');
+    expect((updatedFormBag.uischema.elements[3] as ImageWithTextElement).options.id).toBe('code');
+    expect(updatedFormBag.uischema.elements[4].type).toBe('Spinner');
   });
 
   it('should transform elements when method type is push and '
@@ -107,7 +136,17 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     };
     const updatedFormBag = transformOktaVerifyChallengePoll({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.okta_verify.push.sent');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.numberchallenge.instruction');
+    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).type)
+      .toBe('ImageWithText');
+    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).options.textContent)
+      .toBe('42');
+    expect((updatedFormBag.uischema.elements[2] as ImageWithTextElement).options.id).toBe('code');
+    expect(updatedFormBag.uischema.elements[3].type).toBe('Spinner');
   });
 });

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChannelSelection.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChannelSelection.test.ts
@@ -13,7 +13,11 @@
 import { IdxContext } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
   FieldElement,
+  TextWithHtmlElement,
+  TitleElement,
   WidgetProps,
 } from 'src/types';
 
@@ -62,8 +66,32 @@ describe('TransformOktaVerifyChannelSelection Tests', () => {
       transaction, prevTransaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
+      .toBe('oie.enroll.okta_verify.select.channel.description');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.format)
+      .toBe('radio');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.customOptions?.length)
+      .toBe(2);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.channel');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.options?.length)
+      .toBe(3);
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oform.next');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[3] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((updatedFormBag.uischema.elements[3] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((updatedFormBag.uischema.elements[3] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
   });
 
   it('should only append (sms/email) channel options when on mobile and sms is the selectedChannel', () => {
@@ -81,8 +109,26 @@ describe('TransformOktaVerifyChannelSelection Tests', () => {
       transaction, prevTransaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
+      .toBe('oie.enroll.okta_verify.select.channel.description');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.format)
+      .toBe('radio');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.customOptions?.length)
+      .toBe(2);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.channel');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.options?.length)
+      .toBe(3);
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oform.next');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should only append (sms/email) channel options when on mobile and email is the selectedChannel', () => {
@@ -100,8 +146,26 @@ describe('TransformOktaVerifyChannelSelection Tests', () => {
       transaction, prevTransaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
+      .toBe('oie.enroll.okta_verify.select.channel.description');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.format)
+      .toBe('radio');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.customOptions?.length)
+      .toBe(2);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.channel');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.options?.length)
+      .toBe(3);
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oform.next');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should only append (qrcode/email) channel options when NOT on mobile and sms is the selectedChannel', () => {
@@ -119,8 +183,26 @@ describe('TransformOktaVerifyChannelSelection Tests', () => {
       transaction, prevTransaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.select.channel.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
+      .toBe('oie.enroll.okta_verify.select.channel.description');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.format)
+      .toBe('radio');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.customOptions?.length)
+      .toBe(2);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.channel');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.options?.length)
+      .toBe(3);
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oform.next');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should only append (qrcode/sms) channel options when NOT on mobile and email is the selectedChannel', () => {
@@ -138,8 +220,26 @@ describe('TransformOktaVerifyChannelSelection Tests', () => {
       transaction, prevTransaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.select.channel.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
+      .toBe('oie.enroll.okta_verify.select.channel.description');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.format)
+      .toBe('radio');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.customOptions?.length)
+      .toBe(2);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.channel');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.options?.length)
+      .toBe(3);
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oform.next');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
   });
 
   it('should only append (sms/email) channel options when NOT on mobile and qrcode is the selectedChannel', () => {
@@ -157,7 +257,31 @@ describe('TransformOktaVerifyChannelSelection Tests', () => {
       transaction, prevTransaction, formBag, widgetProps,
     });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.select.channel.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
+      .toBe('oie.enroll.okta_verify.select.channel.description');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.format)
+      .toBe('radio');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.customOptions?.length)
+      .toBe(2);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('authenticator.channel');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.options?.length)
+      .toBe(3);
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oform.next');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[3] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((updatedFormBag.uischema.elements[3] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((updatedFormBag.uischema.elements[3] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
   });
 });

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChannelSelection.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChannelSelection.test.ts
@@ -13,23 +13,19 @@
 import { IdxContext } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  ButtonElement,
   FieldElement,
-  TitleElement,
   WidgetProps,
 } from 'src/types';
 
 import * as utils from '../../util/browserUtils';
-import * as transformerUtils from '../field/transform';
 import { transformOktaVerifyChannelSelection } from './transformOktaVerifyChannelSelection';
 
-describe.skip('TransformOktaVerifyChannelSelection Tests', () => {
+describe('TransformOktaVerifyChannelSelection Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const prevTransaction = getStubTransactionWithNextStep();
   const formBag = getStubFormBag();
   const widgetProps: WidgetProps = {};
   let mobileDeviceStub: jest.SpyInstance<boolean>;
-  let stepTransformerStub: jest.SpyInstance;
 
   beforeEach(() => {
     formBag.uischema.elements = [
@@ -49,15 +45,6 @@ describe.skip('TransformOktaVerifyChannelSelection Tests', () => {
     ];
 
     mobileDeviceStub = jest.spyOn(utils, 'isAndroidOrIOS');
-    stepTransformerStub = jest.spyOn(
-      transformerUtils,
-      'transformStepInputs',
-    ).mockReturnValue(formBag);
-  });
-
-  afterAll(() => {
-    stepTransformerStub.mockReset();
-    jest.restoreAllMocks();
   });
 
   it('should only append (sms/email) channel options when on mobile and qrcode is the selectedChannel', () => {
@@ -76,26 +63,10 @@ describe.skip('TransformOktaVerifyChannelSelection Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.enroll.okta_verify.setup.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
-      .toBe('oie.enroll.okta_verify.select.channel.description');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
-      .toBe('authenticator.channel');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions?.length)
-      .toBe(2);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions)
-      .toEqual([
-        { value: 'sms', label: 'oie.enroll.okta_verify.select.channel.sms.label' },
-        { value: 'email', label: 'oie.enroll.okta_verify.select.channel.email.label' },
-      ]);
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.next');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
-  // TODO: revist and test mobile view for OV enrollment and fix test if needed
-  it.skip('should only append (sms/email) channel options when on mobile and sms is the selectedChannel', () => {
+  it('should only append (sms/email) channel options when on mobile and sms is the selectedChannel', () => {
     prevTransaction.context = {
       // TODO: OKTA-503490 temporary sln access missing relatesTo obj
       currentAuthenticator: {
@@ -111,23 +82,10 @@ describe.skip('TransformOktaVerifyChannelSelection Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.enroll.okta_verify.setup.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
-      .toBe('oie.enroll.okta_verify.select.channel.description');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
-      .toBe('authenticator.channel');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions?.length)
-      .toBe(2);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions)
-      .toEqual([
-        { value: 'sms', label: 'oie.enroll.okta_verify.select.channel.sms.label' },
-        { value: 'email', label: 'oie.enroll.okta_verify.select.channel.email.label' },
-      ]);
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.next');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
-  it.skip('should only append (sms/email) channel options when on mobile and email is the selectedChannel', () => {
+  it('should only append (sms/email) channel options when on mobile and email is the selectedChannel', () => {
     prevTransaction.context = {
       // TODO: OKTA-503490 temporary sln access missing relatesTo obj
       currentAuthenticator: {
@@ -143,20 +101,7 @@ describe.skip('TransformOktaVerifyChannelSelection Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.enroll.okta_verify.setup.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
-      .toBe('oie.enroll.okta_verify.select.channel.description');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
-      .toBe('authenticator.channel');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions?.length)
-      .toBe(2);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions)
-      .toEqual([
-        { value: 'sms', label: 'oie.enroll.okta_verify.select.channel.sms.label' },
-        { value: 'email', label: 'oie.enroll.okta_verify.select.channel.email.label' },
-      ]);
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.next');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should only append (qrcode/email) channel options when NOT on mobile and sms is the selectedChannel', () => {
@@ -175,20 +120,7 @@ describe.skip('TransformOktaVerifyChannelSelection Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.enroll.okta_verify.select.channel.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
-      .toBe('oie.enroll.okta_verify.select.channel.description');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
-      .toBe('authenticator.channel');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions?.length)
-      .toBe(2);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions)
-      .toEqual([
-        { value: 'qrcode', label: 'oie.enroll.okta_verify.select.channel.qrcode.label' },
-        { value: 'email', label: 'oie.enroll.okta_verify.select.channel.email.label' },
-      ]);
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.next');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should only append (qrcode/sms) channel options when NOT on mobile and email is the selectedChannel', () => {
@@ -207,20 +139,7 @@ describe.skip('TransformOktaVerifyChannelSelection Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(3);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.enroll.okta_verify.select.channel.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).label)
-      .toBe('oie.enroll.okta_verify.select.channel.description');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
-      .toBe('authenticator.channel');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions?.length)
-      .toBe(2);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions)
-      .toEqual([
-        { value: 'qrcode', label: 'oie.enroll.okta_verify.select.channel.qrcode.label' },
-        { value: 'sms', label: 'oie.enroll.okta_verify.select.channel.sms.label' },
-      ]);
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.next');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 
   it('should only append (sms/email) channel options when NOT on mobile and qrcode is the selectedChannel', () => {
@@ -239,19 +158,6 @@ describe.skip('TransformOktaVerifyChannelSelection Tests', () => {
     });
 
     expect(updatedFormBag.uischema.elements.length).toBe(4);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
-      .toBe('oie.enroll.okta_verify.select.channel.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
-      .toBe('authenticator.channel');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions?.length)
-      .toBe(2);
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.customOptions)
-      .toEqual([
-        { value: 'sms', label: 'oie.enroll.okta_verify.select.channel.sms.label' },
-        { value: 'email', label: 'oie.enroll.okta_verify.select.channel.email.label' },
-      ]);
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.next');
-    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
-      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect(updatedFormBag).toMatchSnapshot();
   });
 });

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollChannel.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollChannel.test.ts
@@ -13,7 +13,10 @@
 import { IdxContext } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ButtonElement,
+  ButtonType,
   FieldElement,
+  TextWithHtmlElement,
   TitleElement,
   WidgetProps,
 } from 'src/types';
@@ -21,7 +24,7 @@ import {
 import * as channelTransformer from './transformOktaVerifyChannelSelection';
 import { transformOktaVerifyEnrollChannel } from './transformOktaVerifyEnrollChannel';
 
-describe.skip('TransformOktaVerifyEnrollChannel Tests', () => {
+describe('TransformOktaVerifyEnrollChannel Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const widgetProps: WidgetProps = {};
   const formBag = getStubFormBag();
@@ -63,6 +66,25 @@ describe.skip('TransformOktaVerifyEnrollChannel Tests', () => {
     const updatedFormBag = transformOktaVerifyEnrollChannel({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.enroll.channel.email.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('email');
+    expect((updatedFormBag.uischema.elements[2] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.channel.email.description');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.enroll.okta_verify.setupLink');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[4] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((updatedFormBag.uischema.elements[4] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((updatedFormBag.uischema.elements[4] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((updatedFormBag.uischema.elements[4] as TextWithHtmlElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
   });
 
   it('should append phone input field to elements list when sms is the selectedChannel', () => {
@@ -79,5 +101,24 @@ describe.skip('TransformOktaVerifyEnrollChannel Tests', () => {
     const updatedFormBag = transformOktaVerifyEnrollChannel({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.enroll.channel.sms.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('phoneNumber');
+    expect((updatedFormBag.uischema.elements[2] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.channel.sms.description');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).label)
+      .toBe('oie.enroll.okta_verify.setupLink');
+    expect((updatedFormBag.uischema.elements[3] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+    expect((updatedFormBag.uischema.elements[4] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((updatedFormBag.uischema.elements[4] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((updatedFormBag.uischema.elements[4] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((updatedFormBag.uischema.elements[4] as TextWithHtmlElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
   });
 });

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollChannel.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollChannel.ts
@@ -42,7 +42,7 @@ export const transformOktaVerifyEnrollChannel: IdxStepTransformer = ({
   transaction,
   formBag,
 }) => {
-  const { context } = transaction;
+  const { context, nextStep: { name } = {} } = transaction;
   const authenticator = context.currentAuthenticator.value;
   const { uischema } = formBag;
   const selectedChannel = authenticator.contextualData?.selectedChannel;
@@ -81,7 +81,7 @@ export const transformOktaVerifyEnrollChannel: IdxStepTransformer = ({
     label: loc('oie.enroll.okta_verify.setupLink', 'login'),
     options: {
       type: ButtonType.SUBMIT,
-      step: transaction.nextStep!.name,
+      step: name,
     },
   } as ButtonElement);
 

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
@@ -12,11 +12,21 @@
 
 import { IdxContext } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
-import { WidgetProps } from 'src/types';
+import {
+  ButtonElement,
+  DescriptionElement,
+  ListElement,
+  QRCodeElement,
+  ReminderElement,
+  StepperLayout,
+  TextWithHtmlElement,
+  TitleElement,
+  WidgetProps,
+} from 'src/types';
 
 import { transformOktaVerifyEnrollPoll } from './transformOktaVerifyEnrollPoll';
 
-describe.skip('TransformOktaVerifyEnrollPoll Tests', () => {
+describe('TransformOktaVerifyEnrollPoll Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const formBag = getStubFormBag();
   let widgetProps: WidgetProps;
@@ -44,6 +54,7 @@ describe.skip('TransformOktaVerifyEnrollPoll Tests', () => {
           contextualData: {
             selectedChannel: 'sms',
             phoneNumber: '+14215551262',
+            qrcode: { href: '#mockQrCode' },
           },
         },
       },
@@ -52,6 +63,93 @@ describe.skip('TransformOktaVerifyEnrollPoll Tests', () => {
     const updatedFormBag = transformOktaVerifyEnrollPoll({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
+    const [stepperLayout] = updatedFormBag.uischema.elements;
+    const [layoutOne, layoutTwo, layoutThree] = (stepperLayout as StepperLayout).elements;
+
+    expect(layoutOne.elements.length).toBe(5);
+    expect((layoutOne.elements[0] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.sms.notReceived');
+    expect((layoutOne.elements[0] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutOne.elements[0] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutOne.elements[0] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutOne.elements[0] as ReminderElement).options.step)
+      .toBe('resend');
+    expect((layoutOne.elements[1] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.sms.title');
+    expect(layoutOne.elements[2].type)
+      .toBe('List');
+    expect((layoutOne.elements[2] as ListElement).options.type)
+      .toBe('ordered');
+    expect((layoutOne.elements[2] as ListElement).options.items)
+      .toEqual([
+        'oie.enroll.okta_verify.qrcode.step1',
+        'oie.enroll.okta_verify.qrcode.step2',
+        'oie.enroll.okta_verify.qrcode.step3',
+      ]);
+    expect(layoutOne.elements[3].type).toBe('QRCode');
+    expect((layoutOne.elements[3] as QRCodeElement).options.data)
+      .toBe('#mockQrCode');
+    expect((layoutOne.elements[4] as ButtonElement).label)
+      .toBe('enroll.totp.cannotScan');
+    expect((layoutOne.elements[4] as ButtonElement).options.ariaLabel)
+      .toBe('enroll.totp.aria.cannotScan');
+    expect((layoutOne.elements[4] as ButtonElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((layoutOne.elements[4] as ButtonElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
+
+    expect(layoutTwo.elements.length).toBe(4);
+    expect((layoutTwo.elements[0] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.sms.notReceived');
+    expect((layoutTwo.elements[0] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutTwo.elements[0] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutTwo.elements[0] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutTwo.elements[0] as ReminderElement).options.step)
+      .toBe('resend');
+    expect((layoutTwo.elements[1] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.sms.title');
+    expect((layoutTwo.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.email.info');
+    expect(layoutTwo.elements[3].type).toBe('TextWithHtml');
+    expect((layoutTwo.elements[3] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((layoutTwo.elements[3] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((layoutTwo.elements[3] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((layoutTwo.elements[3] as TextWithHtmlElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
+
+    expect(layoutThree.elements.length).toBe(4);
+    expect((layoutThree.elements[0] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.sms.notReceived');
+    expect((layoutThree.elements[0] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutThree.elements[0] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutThree.elements[0] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutThree.elements[0] as ReminderElement).options.step)
+      .toBe('resend');
+    expect((layoutThree.elements[1] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.sms.title');
+    expect((layoutThree.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.sms.info');
+    expect(layoutThree.elements[3].type).toBe('TextWithHtml');
+    expect((layoutThree.elements[3] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((layoutThree.elements[3] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((layoutThree.elements[3] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((layoutThree.elements[3] as TextWithHtmlElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
   });
 
   it('should return a channel selection formBag when email is selected channel and canResend = true', () => {
@@ -67,6 +165,7 @@ describe.skip('TransformOktaVerifyEnrollPoll Tests', () => {
           contextualData: {
             selectedChannel: 'email',
             email: 'noreply@noemail.com',
+            qrcode: { href: '#mockQrCode' },
           },
         },
       },
@@ -75,6 +174,93 @@ describe.skip('TransformOktaVerifyEnrollPoll Tests', () => {
     const updatedFormBag = transformOktaVerifyEnrollPoll({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
+    const [stepperLayout] = updatedFormBag.uischema.elements;
+    const [layoutOne, layoutTwo, layoutThree] = (stepperLayout as StepperLayout).elements;
+
+    expect(layoutOne.elements.length).toBe(5);
+    expect((layoutOne.elements[0] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.email.notReceived');
+    expect((layoutOne.elements[0] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutOne.elements[0] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutOne.elements[0] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutOne.elements[0] as ReminderElement).options.step)
+      .toBe('resend');
+    expect((layoutOne.elements[1] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.email.title');
+    expect(layoutOne.elements[2].type)
+      .toBe('List');
+    expect((layoutOne.elements[2] as ListElement).options.type)
+      .toBe('ordered');
+    expect((layoutOne.elements[2] as ListElement).options.items)
+      .toEqual([
+        'oie.enroll.okta_verify.qrcode.step1',
+        'oie.enroll.okta_verify.qrcode.step2',
+        'oie.enroll.okta_verify.qrcode.step3',
+      ]);
+    expect(layoutOne.elements[3].type).toBe('QRCode');
+    expect((layoutOne.elements[3] as QRCodeElement).options.data)
+      .toBe('#mockQrCode');
+    expect((layoutOne.elements[4] as ButtonElement).label)
+      .toBe('enroll.totp.cannotScan');
+    expect((layoutOne.elements[4] as ButtonElement).options.ariaLabel)
+      .toBe('enroll.totp.aria.cannotScan');
+    expect((layoutOne.elements[4] as ButtonElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((layoutOne.elements[4] as ButtonElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
+
+    expect(layoutTwo.elements.length).toBe(4);
+    expect((layoutTwo.elements[0] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.email.notReceived');
+    expect((layoutTwo.elements[0] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutTwo.elements[0] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutTwo.elements[0] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutTwo.elements[0] as ReminderElement).options.step)
+      .toBe('resend');
+    expect((layoutTwo.elements[1] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.email.title');
+    expect((layoutTwo.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.email.info');
+    expect(layoutTwo.elements[3].type).toBe('TextWithHtml');
+    expect((layoutTwo.elements[3] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((layoutTwo.elements[3] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((layoutTwo.elements[3] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((layoutTwo.elements[3] as TextWithHtmlElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
+
+    expect(layoutThree.elements.length).toBe(4);
+    expect((layoutThree.elements[0] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.email.notReceived');
+    expect((layoutThree.elements[0] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutThree.elements[0] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutThree.elements[0] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutThree.elements[0] as ReminderElement).options.step)
+      .toBe('resend');
+    expect((layoutThree.elements[1] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.email.title');
+    expect((layoutThree.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.sms.info');
+    expect(layoutThree.elements[3].type).toBe('TextWithHtml');
+    expect((layoutThree.elements[3] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((layoutThree.elements[3] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((layoutThree.elements[3] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((layoutThree.elements[3] as TextWithHtmlElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
   });
 
   it('should add Stepper elements when selectedChannel is qrcode and canResend = true', () => {
@@ -89,7 +275,7 @@ describe.skip('TransformOktaVerifyEnrollPoll Tests', () => {
         value: {
           contextualData: {
             selectedChannel: 'qrcode',
-            qrcode: { href: '', method: '', type: '' },
+            qrcode: { href: '#mockQrCode', method: '', type: '' },
           },
         },
       },
@@ -98,5 +284,62 @@ describe.skip('TransformOktaVerifyEnrollPoll Tests', () => {
     const updatedFormBag = transformOktaVerifyEnrollPoll({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
+    const [stepperLayout] = updatedFormBag.uischema.elements;
+    const [layoutOne, layoutTwo, layoutThree] = (stepperLayout as StepperLayout).elements;
+
+    expect(layoutOne.elements.length).toBe(4);
+    expect((layoutOne.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.title');
+    expect(layoutOne.elements[1].type)
+      .toBe('List');
+    expect((layoutOne.elements[1] as ListElement).options.type)
+      .toBe('ordered');
+    expect((layoutOne.elements[1] as ListElement).options.items)
+      .toEqual([
+        'oie.enroll.okta_verify.qrcode.step1',
+        'oie.enroll.okta_verify.qrcode.step2',
+        'oie.enroll.okta_verify.qrcode.step3',
+      ]);
+    expect(layoutOne.elements[2].type).toBe('QRCode');
+    expect((layoutOne.elements[2] as QRCodeElement).options.data)
+      .toBe('#mockQrCode');
+    expect((layoutOne.elements[3] as ButtonElement).label)
+      .toBe('enroll.totp.cannotScan');
+    expect((layoutOne.elements[3] as ButtonElement).options.ariaLabel)
+      .toBe('enroll.totp.aria.cannotScan');
+    expect((layoutOne.elements[3] as ButtonElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((layoutOne.elements[3] as ButtonElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
+
+    expect(layoutTwo.elements.length).toBe(3);
+    expect((layoutTwo.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.title');
+    expect((layoutTwo.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.email.info');
+    expect(layoutTwo.elements[2].type).toBe('TextWithHtml');
+    expect((layoutTwo.elements[2] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((layoutTwo.elements[2] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((layoutTwo.elements[2] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((layoutTwo.elements[2] as TextWithHtmlElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
+
+    expect(layoutThree.elements.length).toBe(3);
+    expect((layoutThree.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.title');
+    expect((layoutThree.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.sms.info');
+    expect(layoutThree.elements[2].type).toBe('TextWithHtml');
+    expect((layoutThree.elements[2] as TextWithHtmlElement).options.content)
+      .toBe('oie.enroll.okta_verify.switch.channel.link.text');
+    expect((layoutThree.elements[2] as TextWithHtmlElement).options.contentClassname)
+      .toBe('switch-channel-link');
+    expect((layoutThree.elements[2] as TextWithHtmlElement).options.step)
+      .toBe('select-enrollment-channel');
+    expect((layoutThree.elements[2] as TextWithHtmlElement).options.stepToRender)
+      .toBe('select-enrollment-channel');
   });
 });

--- a/src/v3/src/transformer/oktaVerify/transformTOTPChallenge.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformTOTPChallenge.test.ts
@@ -21,7 +21,7 @@ import {
 
 import { transformTOTPChallenge } from './transformTOTPChallenge';
 
-describe.skip('Transform Okta Verify Totp Challenge Tests', () => {
+describe('Transform Okta Verify Totp Challenge Tests', () => {
   const transaction = getStubTransactionWithNextStep();
   const formBag = getStubFormBag();
   const widgetProps: WidgetProps = {};
@@ -39,6 +39,7 @@ describe.skip('Transform Okta Verify Totp Challenge Tests', () => {
   it('should build UI elements for OV TOTP remediation', () => {
     const updatedFormBag = transformTOTPChallenge({ transaction, formBag, widgetProps });
 
+    expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)


### PR DESCRIPTION
## Description:

The purpose of this PR is to re-enable OV transformer tests

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-537283](https://oktainc.atlassian.net/browse/OKTA-537283)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



