### PR TITLE
fixes jQuery error "invalid argument" on SMS enroll activate flow

### DIFF
--- a/packages/@okta/courage-dist/esm/src/CourageForSigninWidget.js
+++ b/packages/@okta/courage-dist/esm/src/CourageForSigninWidget.js
@@ -31,6 +31,7 @@ import Toolbar from './courage/views/forms/components/Toolbar.js';
 import FormUtil from './courage/views/forms/helpers/FormUtil.js';
 import InputRegistry from './courage/views/forms/helpers/InputRegistry.js';
 import SchemaFormFactory from './courage/views/forms/helpers/SchemaFormFactory.js';
+import BaseInput from './courage/views/forms/BaseInput.js';
 import CheckBox from './courage/views/forms/inputs/CheckBox.js';
 import PasswordBox from './courage/views/forms/inputs/PasswordBox.js';
 import Radio from './courage/views/forms/inputs/Radio.js';
@@ -47,14 +48,22 @@ import './courage/util/SettingsModel.js';
 
 const Controller = BaseController.extend({
   // The courage BaseController renders asynchronously in current versions of jQuery
-  // https://github.com/okta/okta-ui/blob/master/packages/courage/src/util/BaseController.js#L108
+  // https://github.com/okta/okta-ui/blob/master/packages/courage/src/util/BaseController.ts#L117-L119
   // https://api.jquery.com/jquery/#jQuery-callback
   // Override so that render is synchronous
   render: function (...args) {
     BaseView.prototype.render.apply(this, args);
     return this;
   }
-}); // The string will be returned unchanged. All templates should be precompiled.
+});
+
+Select.prototype.remove = function () {
+  // Patched to remove unneeded call to
+  // this.$select.trigger('remove');
+  // which causes error on IE11
+  return BaseInput.prototype.remove.apply(this, arguments);
+}; // The string will be returned unchanged. All templates should be precompiled.
+
 
 FrameworkView.prototype.compileTemplate = function (str) {
   const compiledTmpl = function fakeTemplate() {

--- a/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.ts
+++ b/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.ts
@@ -25,6 +25,7 @@ import Toolbar from './courage/views/forms/components/Toolbar';
 import FormUtil from './courage/views/forms/helpers/FormUtil';
 import InputRegistry from './courage/views/forms/helpers/InputRegistry';
 import SchemaFormFactory from './courage/views/forms/helpers/SchemaFormFactory';
+import BaseInput from './courage/views/forms/BaseInput';
 import CheckBox from './courage/views/forms/inputs/CheckBox';
 import PasswordBox from './courage/views/forms/inputs/PasswordBox';
 import Radio from './courage/views/forms/inputs/Radio';
@@ -47,6 +48,13 @@ const Controller = BaseController.extend({
     return this;
   }
 });
+
+Select.prototype.remove = function () {
+  // Patched to remove unneeded call to
+  // this.$select.trigger('remove');
+  // which causes error on IE11
+  return BaseInput.prototype.remove.apply(this, arguments);
+};
 
 // The string will be returned unchanged. All templates should be precompiled.
 FrameworkView.prototype.compileTemplate = function(str) {

--- a/playground/README.md
+++ b/playground/README.md
@@ -62,7 +62,15 @@ In summary, testcafe tests are using playground application but not mock sever. 
 
 ## Testing minified CDN bundle
 
-Run `yarn build:webpack-release` to generate CDN bundle. Open `http://localhost:3000/cdn.html` to test the minified bundle loads and renders correctly. Saucelabs tunnel can be used to test in IE11. Although you can use mocks via responseConfig, the `.widgetrc.js` file will not be loaded. Configuration can be edited directly in `cdn.html`. 
+Run `yarn build:webpack-release` to generate CDN bundle (this can be run with the `--watch` flag). Open `http://localhost:3000/cdn.html` to test the minified bundle loads and renders correctly. Saucelabs tunnel can be used to test in IE11. Although you can use mocks via responseConfig, the `.widgetrc.js` file will not be loaded. Configuration can be edited directly in `cdn.html`. Before starting the playground set `DISABLE_CSP` environment variable.
+
+```
+DISABLE_CSP=1 yarn start
+```
+
+## Testing on IE11
+
+Follow instructions for [Testing minified CDN bundle](#testing-minified-cdn-bundle).
 
 ## Some thoughts on enhancement
 

--- a/playground/cdn.html
+++ b/playground/cdn.html
@@ -14,7 +14,16 @@
       var config = {
         el: '#okta-login-container',
         baseUrl: 'http://localhost:3000',
-        stateToken: 'abc'
+
+        // OIE config
+        stateToken: 'abc',
+
+        // Classic config
+        // stateToken: '00abc',
+        // useClassicEngine: true,
+        // features: {
+        //   router: false
+        // }
       };
       var signIn = new OktaSignIn(config);
       signIn.renderEl();

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -234,8 +234,15 @@ const authn = {
   '/api/v1/authn/introspect': [
     // 'mfa-required-email',
     // 'unauthenticated',
-    'admin-consent-required',
-    // 'device-code-activate'
+    // 'admin-consent-required',
+    // 'device-code-activate',
+    'mfa-enroll-sms'
+  ],
+  '/api/v1/authn/factors': [
+    'mfa-enroll-activate-sms'
+  ],
+  '/api/v1/authn/factors/:factorid/lifecycle/activate': [
+    'mfa-enroll-sms'
   ],
   '/api/v1/authn': [
     'error-authentication-failed',

--- a/playground/mocks/data/api/v1/authn/mfa-enroll-activate-sms.json
+++ b/playground/mocks/data/api/v1/authn/mfa-enroll-activate-sms.json
@@ -1,0 +1,55 @@
+{
+  "stateToken": "00vr2lZLK8ciKcTVYS91pPFJ3RFS2BsgxtoNP5jWPS",
+  "expiresAt": "2022-10-03T17:31:51.000Z",
+  "status": "MFA_ENROLL_ACTIVATE",
+  "_embedded": {
+    "user": {
+      "id": "00u3sxoelNuhUf5sO9c5",
+      "passwordChanged": "2022-10-02T05:17:40.000Z",
+      "profile": {
+        "login": "test.user@test.com",
+        "firstName": "Test",
+        "lastName": "User",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    },
+    "factor": {
+      "id": "mbl3sxoxUXKoACWNZ9c5",
+      "factorType": "sms",
+      "provider": "OKTA",
+      "vendorName": "OKTA",
+      "profile": {
+        "phoneNumber": "+1 XXX-XXX-4586"
+      }
+    }
+  },
+  "_links": {
+    "next": {
+      "name": "activate",
+      "href": "http://localhost:3000/api/v1/authn/factors/mbl3sxoxUXKoACWNZ9c5/lifecycle/activate",
+      "hints": {
+        "allow": ["POST"]
+      }
+    },
+    "prev": {
+      "href": "http://localhost:3000/api/v1/authn/previous",
+      "hints": {
+        "allow": ["POST"]
+      }
+    },
+    "resend": [{
+      "name": "sms",
+      "href": "http://localhost:3000/api/v1/authn/factors/mbl3sxoxUXKoACWNZ9c5/lifecycle/resend",
+      "hints": {
+        "allow": ["POST"]
+      }
+    }],
+    "cancel": {
+      "href": "http://localhost:3000/api/v1/authn/cancel",
+      "hints": {
+        "allow": ["POST"]
+      }
+    }
+  }
+}

--- a/playground/mocks/data/api/v1/authn/mfa-enroll-sms.json
+++ b/playground/mocks/data/api/v1/authn/mfa-enroll-sms.json
@@ -1,0 +1,75 @@
+{
+  "stateToken": "00vr2lZLK8ciKcTVYS91pPFJ3RFS2BsgxtoNP5jWPS",
+  "expiresAt": "2022-10-03T17:31:38.000Z",
+  "status": "MFA_ENROLL",
+  "_embedded": {
+    "user": {
+      "id": "00u3sxoelNuhUf5sO9c5",
+      "passwordChanged": "2022-10-02T05:17:40.000Z",
+      "profile": {
+        "login": "test.user@test.com",
+        "firstName": "Test",
+        "lastName": "User",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    },
+    "factors": [{
+      "factorType": "question",
+      "provider": "OKTA",
+      "vendorName": "OKTA",
+      "_links": {
+        "questions": {
+          "href": "http://localhost:3000/api/v1/users/00u3sxoelNuhUf5sO9c5/factors/questions",
+          "hints": {
+            "allow": ["GET"]
+          }
+        },
+        "enroll": {
+          "href": "http://localhost:3000/api/v1/authn/factors",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      },
+      "status": "NOT_SETUP",
+      "enrollment": "REQUIRED"
+    }, {
+      "factorType": "call",
+      "provider": "OKTA",
+      "vendorName": "OKTA",
+      "_links": {
+        "enroll": {
+          "href": "http://localhost:3000/api/v1/authn/factors",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      },
+      "status": "NOT_SETUP",
+      "enrollment": "REQUIRED"
+    }, {
+      "factorType": "sms",
+      "provider": "OKTA",
+      "vendorName": "OKTA",
+      "_links": {
+        "enroll": {
+          "href": "http://localhost:3000/api/v1/authn/factors",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      },
+      "status": "NOT_SETUP",
+      "enrollment": "REQUIRED"
+    }]
+  },
+  "_links": {
+    "cancel": {
+      "href": "http://localhost:3000/api/v1/authn/cancel",
+      "hints": {
+        "allow": ["POST"]
+      }
+    }
+  }
+}

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -28,6 +28,15 @@ if (!fs.existsSync(WIDGET_RC_JS)) {
   fs.copyFileSync('.widgetrc.sample.js', WIDGET_RC_JS);
 }
 
+const headers = {};
+
+if (!process.env.DISABLE_CSP) {
+  headers['Content-Security-Policy'] =
+    // Allow google domains for testing recaptcha
+    // eslint-disable-next-line max-len
+    `script-src http://${HOST}:${DEV_SERVER_PORT} https://www.google.com https://www.gstatic.com`;
+}
+
 module.exports = {
   mode: 'development',
   target: 'web',
@@ -81,11 +90,7 @@ module.exports = {
       }
     ],
     historyApiFallback: true,
-    headers: {
-      // Allow google domains for testing recaptcha
-      // eslint-disable-next-line max-len
-      'Content-Security-Policy': `script-src http://${HOST}:${DEV_SERVER_PORT} https://www.google.com https://www.gstatic.com`
-    },
+    headers,
     compress: true,
     port: DEV_SERVER_PORT,
     proxy: [{


### PR DESCRIPTION
## Description:
- After upgrade to jQuery there is an error on SMS enroll activate flow
- Error was caused by `trigger('remove')` in Select component
- Since event is not needed, adding patch to prevent triggering this event on remove


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-538344](https://oktainc.atlassian.net/browse/OKTA-538344)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



