### PR TITLE
fix: webpack config for okta-plugin-a11y.js

### DIFF
--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -58,7 +58,9 @@ usePolyfill(devConfig);
 // 6. plugins: a11y
 var a11yPluginConfig = config('okta-plugin-a11y.js', 'production');
 a11yPluginConfig.entry = [path.resolve(__dirname, 'src/plugins/OktaPluginA11y.ts')];
+a11yPluginConfig.output.filename = 'okta-plugin-a11y.js';
 a11yPluginConfig.output.library = 'OktaPluginA11y';
+useRuntime(a11yPluginConfig);
 
 module.exports = [
   entryConfig,


### PR DESCRIPTION
## Description:

update webpack config to output `okta-plugin-a11y.js` to `/dist/dist/js`

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-538630](https://oktainc.atlassian.net/browse/OKTA-538630)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



