### PR TITLE
OKTA-537962 : Admin login back to sign in link fix

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -239,7 +239,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       return;
     }
 
-    const { messages: newMessages = [], status } = idxTransaction;
+    const { messages: newMessages = [] } = idxTransaction;
 
     events?.afterRender?.(getEventContext(idxTransaction));
 

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -140,7 +140,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     }
 
     // cancelled transactions will be bootstrapped again, so we wait if that happens
-    if (idxTransaction === undefined || idxTransaction?.status === IdxStatus.CANCELED) {
+    if (idxTransaction === undefined) {
       return createForm();
     }
 
@@ -254,11 +254,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       }
     });
 
-    // clear idxTransaction to start loading state
-    if (status === IdxStatus.CANCELED) {
-      setIdxTransaction(undefined);
-      bootstrap();
-    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [idxTransaction, bootstrap]);
 

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -111,6 +111,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       const newTransaction = await fn(payload);
       // TODO: OKTA-538791 this is a temp work around until the auth-js fix
       if (!newTransaction.nextStep && newTransaction.availableSteps?.length) {
+        // eslint-disable-next-line prefer-destructuring
         newTransaction.nextStep = newTransaction.availableSteps[0];
       }
       setIdxTransaction(newTransaction);

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -109,6 +109,10 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setMessage(undefined);
     try {
       const newTransaction = await fn(payload);
+      // TODO: OKTA-538791 this is a temp work around until the auth-js fix
+      if (!newTransaction.nextStep && newTransaction.availableSteps?.length) {
+        newTransaction.nextStep = newTransaction.availableSteps[0];
+      }
       setIdxTransaction(newTransaction);
       const transactionHasWarning = (newTransaction.messages || []).some(
         (message) => message.class === MessageType.WARNING.toString(),


### PR DESCRIPTION
## Description:

This PR fixes the issue where a session timeout error would occur after pressing the "back to sign in" link in the admin dashboard login flow.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-537962](https://oktainc.atlassian.net/browse/OKTA-537962)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



