### PR TITLE
Fixing IDP flow where the routing rule could be bypassed (for classic)

### DIFF
--- a/assets/sass/modules/_footer.scss
+++ b/assets/sass/modules/_footer.scss
@@ -14,3 +14,7 @@
   }
 }
 
+.auth-footer.footer-back-link {
+  margin-top: 0.75em;
+}
+

--- a/src/v1/controllers/PrimaryAuthController.js
+++ b/src/v1/controllers/PrimaryAuthController.js
@@ -18,6 +18,7 @@ import CustomButtons from 'v1/views/primary-auth/CustomButtons';
 import PrimaryAuthForm from 'v1/views/primary-auth/PrimaryAuthForm';
 import Footer from 'v1/views/shared/Footer';
 import FooterRegistration from 'v1/views/shared/FooterRegistration';
+import FooterWithBackLink from 'v1/views/shared/FooterWithBackLink';
 export default BaseLoginController.extend({
   className: 'primary-auth',
 
@@ -68,6 +69,15 @@ export default BaseLoginController.extend({
           appState: options.appState,
         })
       );
+    }
+  },
+
+  addFooterWithBackLink: function(options) {
+    if (!this.$el.find('.footer-back-link').length) {
+      this.add(new FooterWithBackLink(this.toJSON({ 
+        appState: options.appState,
+        className: 'auth-footer footer-back-link',
+      })));
     }
   },
 
@@ -125,6 +135,10 @@ export default BaseLoginController.extend({
     });
     this.listenTo(this.model, 'error', function() {
       this.state.set('enabled', true);
+      if (this.options.appState.get('disableUsername')) {
+        this.state.set('disableUsername', true);
+        this.addFooterWithBackLink(this.options);
+      }
     });
     this.listenTo(this.state, 'togglePrimaryAuthButton', function(buttonState) {
       this.toggleButtonState(buttonState);

--- a/src/v1/controllers/PrimaryAuthController.js
+++ b/src/v1/controllers/PrimaryAuthController.js
@@ -55,6 +55,9 @@ export default BaseLoginController.extend({
     }
 
     this.addFooter(options);
+    if (this.options.appState.get('disableUsername')) {
+      this.addFooterWithBackLink(this.options);
+    }
 
     this.setUsername();
   },

--- a/src/v1/views/primary-auth/PrimaryAuthForm.js
+++ b/src/v1/views/primary-auth/PrimaryAuthForm.js
@@ -75,6 +75,7 @@ export default Form.extend({
     });
 
     this.stateEnableChange();
+    this.stateUsernameChange();
   },
 
   stateEnableChange: function() {
@@ -83,6 +84,16 @@ export default Form.extend({
         this.enable();
       } else {
         this.disable();
+      }
+    });
+  },
+
+  stateUsernameChange: function() {
+    this.listenTo(this.state, 'change:disableUsername', function(model, disable) {
+      if (disable) {
+        this.$el.find('#okta-signin-username').attr('disabled', true);
+      } else {
+        this.$el.find('#okta-signin-username').removeAttr('disabled');
       }
     });
   },

--- a/test/unit/helpers/dom/PrimaryAuthForm.js
+++ b/test/unit/helpers/dom/PrimaryAuthForm.js
@@ -136,6 +136,10 @@ export default Form.extend({
     return this.helpFooter().text();
   },
 
+  backLinkFooter: function() {
+    return this.$('.footer-back-link');
+  },
+
   helpLink: function() {
     return this.$('.js-help-link');
   },
@@ -238,6 +242,10 @@ export default Form.extend({
 
   isDisabled: function() {
     return this.inputsDisabled() && this.linksAppearDisabled();
+  },
+
+  isUsernameDisabled: function() {
+    return this.usernameField().is(':disabled');
   },
 
   additionalAuthButton: function() {

--- a/test/unit/spec/v1/IDPDiscovery_spec.js
+++ b/test/unit/spec/v1/IDPDiscovery_spec.js
@@ -1505,7 +1505,6 @@ Expect.describe('IDPDiscovery', function() {
         .then(function(test) {
           Util.mockRouterNavigate(test.router);
           test.setNextWebfingerResponse(resSuccessOktaIDP);
-          test.setNextResponse(resErrorUnauthorized);
           test.form.setUsername('testuser');
           test.form.submit();
           return Expect.waitForPrimaryAuth(test);

--- a/test/unit/spec/v1/IDPDiscovery_spec.js
+++ b/test/unit/spec/v1/IDPDiscovery_spec.js
@@ -1514,6 +1514,9 @@ Expect.describe('IDPDiscovery', function() {
           expect(test.router.appState.get('disableUsername')).toBe(true);
           expect(test.form.isUsernameDisabled()).toBe(true);
           expect(test.router.navigate).toHaveBeenCalledWith('signin', { trigger: true });
+          // ensure 'Back to sign in' footer is there
+          expect(test.form.backLinkFooter().length).toBe(1);
+
           test.setNextResponse(resErrorUnauthorized);
           test.form.setPassword('dummyPassword');
           test.form.submit();
@@ -1523,8 +1526,6 @@ Expect.describe('IDPDiscovery', function() {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.router.appState.get('disableUsername')).toBe(true);
           expect(test.form.isUsernameDisabled()).toBe(true);
-          // ensure 'Back to sign in' footer is there
-          expect(test.form.backLinkFooter().length).toBe(1);
         });           
     });     
     itp('redirects to idp for SAML idps', function() {


### PR DESCRIPTION
## Description:
- This fixes the bug where during an IDP flow, the routing rule could be bypassed if there was an authentication error in the username/password screen and the username was corrected:
https://user-images.githubusercontent.com/77295104/194087362-8eafab18-7062-460b-9e34-8eb10496c1a0.mov

- As per UX and PM, the preferred solution is to ensure the username field remains disabled even after the error and to allow the user to go back to the initial screen to restart if needed.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-529941](https://oktainc.atlassian.net/browse/OKTA-529941)

### Reviewers:

### Screenshot/Video:

https://user-images.githubusercontent.com/77295104/194086703-358550f9-eb82-4da8-a2a3-c11f14ff777a.mov

### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-585b99b-633dbfb4&page=1&pageSize=6&sha=2b7cfdfa2a5c8ef121668743620c7e8b749c39aa&tab=main



