### PR TITLE
OKTA 539140 a11y plugin grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,7 +132,7 @@ module.exports = function(grunt) {
           {
             expand: true,
             cwd: JS,
-            src: ['okta-plugins*', 'okta-sign-in*', '!*.html', '!*.txt'],
+            src: ['okta-plugin*', 'okta-sign-in*', '!*.html', '!*.txt'],
             dest: DIST + '/js'
           },
           {

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -58,9 +58,7 @@ usePolyfill(devConfig);
 // 6. plugins: a11y
 var a11yPluginConfig = config('okta-plugin-a11y.js', 'production');
 a11yPluginConfig.entry = [path.resolve(__dirname, 'src/plugins/OktaPluginA11y.ts')];
-a11yPluginConfig.output.filename = 'okta-plugin-a11y.js';
 a11yPluginConfig.output.library = 'OktaPluginA11y';
-useRuntime(a11yPluginConfig);
 
 module.exports = [
   entryConfig,


### PR DESCRIPTION
- fix: webpack config for okta-plugin-a11y.js
- fix: grunt task "copy:target-to-dist"

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-539140](https://oktainc.atlassian.net/browse/OKTA-539140)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



