### PR TITLE
Auto-select first radio button in OV enrollment options

### DIFF
--- a/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
@@ -16,6 +16,8 @@ const Body = BaseForm.extend({
     channelField.options = _.filter(channelField?.options, (option) =>
       option.value !== this.options.appState.get('currentAuthenticator')?.contextualData?.selectedChannel);
     channelField.value = channelField.options[0]?.value;
+    channelField.sublabel = null;
+    this.model.set('authenticator.channel', channelField.value);
     const description = {
       View: loc('oie.enroll.okta_verify.select.channel.description', 'login'),
       selector: '.o-form-fieldset-container',

--- a/test/testcafe/framework/page-objects/SwitchOVEnrollChannelPageObject.js
+++ b/test/testcafe/framework/page-objects/SwitchOVEnrollChannelPageObject.js
@@ -21,7 +21,8 @@ export default class SwitchOVEnrollPageObject extends BasePageObject {
   }
 
   async isFirstRadioButtonAutoSelected(ovFlowIsQrcode = true) {
-    return await this.form.isRadioButtonSelected(channelOptionFieldName, ovFlowIsQrcode ? 'sms' : 'qrcode');
+    const value = ovFlowIsQrcode ? 'sms' : 'qrcode';
+    return await this.form.elementExist(`input[value="${value}"] + .checked`);
   }
 
   clickNextButton() {

--- a/test/testcafe/framework/page-objects/SwitchOVEnrollChannelPageObject.js
+++ b/test/testcafe/framework/page-objects/SwitchOVEnrollChannelPageObject.js
@@ -20,9 +20,8 @@ export default class SwitchOVEnrollPageObject extends BasePageObject {
     await this.form.selectRadioButtonOption(channelOptionFieldName, index);
   }
 
-  async isFirstRadioButtonAutoSelected(ovFlowIsQrcode = true) {
-    const value = ovFlowIsQrcode ? 'sms' : 'qrcode';
-    return await this.form.elementExist(`input[value="${value}"] + .checked`);
+  isRadioButtonChecked(value) {
+    return this.form.elementExist(`input[value="${value}"] + .checked`);
   }
 
   clickNextButton() {

--- a/test/testcafe/framework/page-objects/SwitchOVEnrollChannelPageObject.js
+++ b/test/testcafe/framework/page-objects/SwitchOVEnrollChannelPageObject.js
@@ -20,6 +20,10 @@ export default class SwitchOVEnrollPageObject extends BasePageObject {
     await this.form.selectRadioButtonOption(channelOptionFieldName, index);
   }
 
+  async isFirstRadioButtonAutoSelected(ovFlowIsQrcode = true) {
+    return await this.form.isRadioButtonSelected(channelOptionFieldName, ovFlowIsQrcode ? 'sms' : 'qrcode');
+  }
+
   clickNextButton() {
     return this.form.clickSaveButton();
   }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -203,11 +203,6 @@ export default class BaseFormObject {
     return radioOptionLabel;
   }
 
-  async isRadioButtonSelected(fieldName, value) {
-    return await this.findFormFieldInput(fieldName)
-      .find(`input[value="${value}"] + .checked`).exists;
-  }
-
   // =====================================
   // helper methods
   // =====================================

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -203,6 +203,11 @@ export default class BaseFormObject {
     return radioOptionLabel;
   }
 
+  async isRadioButtonSelected(fieldName, value) {
+    return await this.findFormFieldInput(fieldName)
+      .find(`input[value="${value}"] + .checked`).exists;
+  }
+
   // =====================================
   // helper methods
   // =====================================

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -226,6 +226,7 @@ test.requestHooks(mock)('should render switch channel view when Can\'t scan is c
     .eql('Text me a setup link');
   await t.expect(switchChannelPageObject.getOptionLabel(1))
     .eql('Email me a setup link');
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
 
   // Verify links
   await t.expect(await switchChannelPageObject.switchAuthenticatorLinkExists()).ok();
@@ -244,6 +245,7 @@ test.requestHooks(resendEmailMocks)('should render switch channel view when "try
     .eql('Scan a QR code');
   await t.expect(switchChannelPageObject.getOptionLabel(1))
     .eql('Text me a setup link');
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected(false)).eql(true);
 
   // Verify links
   await t.expect(await switchChannelPageObject.switchAuthenticatorLinkExists()).ok();
@@ -261,6 +263,7 @@ test.requestHooks(resendSmsMocks)('should render switch channel view when "try d
     .eql('Scan a QR code');
   await t.expect(switchChannelPageObject.getOptionLabel(1))
     .eql('Email me a setup link');
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected(false)).eql(true);
 });
 
 test.requestHooks(enrollViaEmailMocks)('should be able enroll via email', async t => {
@@ -268,6 +271,8 @@ test.requestHooks(enrollViaEmailMocks)('should be able enroll via email', async 
   await enrollOktaVerifyPage.clickSwitchChannel();
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
+  await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
   await switchChannelPageObject.selectChannelOption(1);
   await switchChannelPageObject.clickNextButton();
   const enrollViaEmailPageObject = new EnrollOVViaEmailPageObject(t);
@@ -305,7 +310,8 @@ test.requestHooks(logger, enrollViaSmsMocks)('should be able enroll via sms', as
   await enrollOktaVerifyPage.clickSwitchChannel();
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
-  await switchChannelPageObject.selectChannelOption(1);
+  await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
   await switchChannelPageObject.clickNextButton();
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
   await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');
@@ -348,7 +354,8 @@ const testSmsMsg = async (t, isIos) => {
   await enrollOktaVerifyPage.clickSwitchChannel();
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
-  await switchChannelPageObject.selectChannelOption(1);
+  await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
   await switchChannelPageObject.clickNextButton();
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
   await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');
@@ -389,6 +396,8 @@ const testEmailMsg = async (t, isIos) => {
   await enrollOktaVerifyPage.clickSwitchChannel();
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
+  await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
   await switchChannelPageObject.selectChannelOption(1);
   await switchChannelPageObject.clickNextButton();
   const enrollViaEmailPageObject = new EnrollOVViaEmailPageObject(t);
@@ -457,7 +466,8 @@ test.requestHooks(logger, enrollViaSmsVersionUpgradeMocksGoBack)('should not sho
   await enrollOktaVerifyPage.clickSwitchChannel();
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
-  await switchChannelPageObject.selectChannelOption(1);
+  await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
   await switchChannelPageObject.clickNextButton();
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
   await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');
@@ -511,6 +521,8 @@ test.requestHooks(enrollViaEmailEnableBiometricsMocks)('should see ov enable bio
   await enrollOktaVerifyPage.clickSwitchChannel();
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
+  await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
   await switchChannelPageObject.selectChannelOption(1);
   await switchChannelPageObject.clickNextButton();
   const enrollViaEmailPageObject = new EnrollOVViaEmailPageObject(t);
@@ -539,7 +551,8 @@ test.requestHooks(logger, enrollViaSMSEnableBiometricsMocks)('should see ov enab
   await enrollOktaVerifyPage.clickSwitchChannel();
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
-  await switchChannelPageObject.selectChannelOption(1);
+  await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
+  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
   await switchChannelPageObject.clickNextButton();
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
   await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -226,7 +226,7 @@ test.requestHooks(mock)('should render switch channel view when Can\'t scan is c
     .eql('Text me a setup link');
   await t.expect(switchChannelPageObject.getOptionLabel(1))
     .eql('Email me a setup link');
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('sms')).eql(true);
 
   // Verify links
   await t.expect(await switchChannelPageObject.switchAuthenticatorLinkExists()).ok();
@@ -245,7 +245,7 @@ test.requestHooks(resendEmailMocks)('should render switch channel view when "try
     .eql('Scan a QR code');
   await t.expect(switchChannelPageObject.getOptionLabel(1))
     .eql('Text me a setup link');
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected(false)).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('qrcode')).eql(true);
 
   // Verify links
   await t.expect(await switchChannelPageObject.switchAuthenticatorLinkExists()).ok();
@@ -263,7 +263,7 @@ test.requestHooks(resendSmsMocks)('should render switch channel view when "try d
     .eql('Scan a QR code');
   await t.expect(switchChannelPageObject.getOptionLabel(1))
     .eql('Email me a setup link');
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected(false)).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('qrcode')).eql(true);
 });
 
 test.requestHooks(enrollViaEmailMocks)('should be able enroll via email', async t => {
@@ -272,7 +272,7 @@ test.requestHooks(enrollViaEmailMocks)('should be able enroll via email', async 
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
   await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('sms')).eql(true);
   await switchChannelPageObject.selectChannelOption(1);
   await switchChannelPageObject.clickNextButton();
   const enrollViaEmailPageObject = new EnrollOVViaEmailPageObject(t);
@@ -311,7 +311,7 @@ test.requestHooks(logger, enrollViaSmsMocks)('should be able enroll via sms', as
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
   await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('sms')).eql(true);
   await switchChannelPageObject.clickNextButton();
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
   await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');
@@ -355,7 +355,7 @@ const testSmsMsg = async (t, isIos) => {
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
   await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('sms')).eql(true);
   await switchChannelPageObject.clickNextButton();
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
   await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');
@@ -397,7 +397,7 @@ const testEmailMsg = async (t, isIos) => {
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
   await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('sms')).eql(true);
   await switchChannelPageObject.selectChannelOption(1);
   await switchChannelPageObject.clickNextButton();
   const enrollViaEmailPageObject = new EnrollOVViaEmailPageObject(t);
@@ -467,7 +467,7 @@ test.requestHooks(logger, enrollViaSmsVersionUpgradeMocksGoBack)('should not sho
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
   await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('sms')).eql(true);
   await switchChannelPageObject.clickNextButton();
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
   await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');
@@ -522,7 +522,7 @@ test.requestHooks(enrollViaEmailEnableBiometricsMocks)('should see ov enable bio
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
   await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('sms')).eql(true);
   await switchChannelPageObject.selectChannelOption(1);
   await switchChannelPageObject.clickNextButton();
   const enrollViaEmailPageObject = new EnrollOVViaEmailPageObject(t);
@@ -552,7 +552,7 @@ test.requestHooks(logger, enrollViaSMSEnableBiometricsMocks)('should see ov enab
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await t.expect(switchChannelPageObject.getFormTitle()).eql('More options');
   await t.expect(switchChannelPageObject.getOptionCount()).eql(2);
-  await t.expect(await switchChannelPageObject.isFirstRadioButtonAutoSelected()).eql(true);
+  await t.expect(switchChannelPageObject.isRadioButtonChecked('sms')).eql(true);
   await switchChannelPageObject.clickNextButton();
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
   await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');

--- a/test/unit/spec/v2/view-builder/views/SelectEnrollmentChannelOktaVerifyView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/SelectEnrollmentChannelOktaVerifyView_spec.js
@@ -1,0 +1,78 @@
+import SelectEnrollmentChannelOktaVerifyView from 'v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView';
+import { Model } from 'okta';
+import { BaseForm } from 'v2/view-builder/internals';
+import AppState from 'v2/models/AppState';
+import Settings from 'models/Settings';
+
+describe('v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView', function() {
+  const QRCODE = 'qrcode';
+  const EMAIL = 'email';
+  const TEXT = 'sms';
+  let testContext;
+  let schema;
+
+  beforeEach(function() {
+    testContext = {};
+    testContext.init = (channel) => {
+      const appState = new AppState({
+        currentAuthenticator: {
+          contextualData: {
+            selectedChannel: channel
+          }
+        },
+        idx: {
+          neededToProceed: []
+        }
+      }, {});
+      const settings = new Settings({
+        baseUrl: 'http://localhost:3000',
+      });
+      testContext.view = new SelectEnrollmentChannelOktaVerifyView({
+        appState,
+        settings,
+        currentViewState: {},
+        model: new Model({
+          'authenticator.channel': channel
+        }),
+      });
+      testContext.view.render();
+    };
+    schema = [
+      {
+        name: 'authenticator.channel',
+        options: [
+          { label: 'Scan a QR code', value: QRCODE },
+          { label: 'Email me a setup link', value: EMAIL },
+          { label: 'Text me a setup link', value: TEXT }
+        ],
+        value: QRCODE,
+        type: 'radio'
+      }
+    ];
+  });
+  afterEach(function() {
+    jest.resetAllMocks();
+  });
+
+  it('If previous channel is qrcode, then selected channel should be email', function() {
+    jest.spyOn(BaseForm.prototype.getUISchema, 'apply').mockReturnValue(schema);
+    testContext.init(QRCODE);
+
+    expect(testContext.view.model.get('authenticator.channel')).toEqual(EMAIL);
+  });
+
+  it('If previous channel is email, then selected channel should be qrcode', function() {
+    jest.spyOn(BaseForm.prototype.getUISchema, 'apply').mockReturnValue(schema);
+    testContext.init(EMAIL);
+
+    expect(testContext.view.model.get('authenticator.channel')).toEqual(QRCODE);
+  });
+
+  it('If previous channel is sms, then selected channel should be qrcode', function() {
+    jest.spyOn(BaseForm.prototype.getUISchema, 'apply').mockReturnValue(schema);
+    testContext.init(TEXT);
+
+    expect(testContext.view.model.get('authenticator.channel')).toEqual(QRCODE);
+  });
+
+});


### PR DESCRIPTION
## Description:
- Auto-select first radio button in OV enrollment options
- Remove 'Optional' text
- Refer to the [original PR ](https://github.com/okta/okta-signin-widget/pull/2791) for more details
## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-491322](https://oktainc.atlassian.net/browse/OKTA-491322)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-4f4925d-633517e4&page=1&pageSize=6&tab=main


