### PR TITLE
OKTA-531082 : Removing circular dependent components

### DIFF
--- a/src/v3/src/components/Form/Accordion.tsx
+++ b/src/v3/src/components/Form/Accordion.tsx
@@ -22,8 +22,7 @@ import { styled } from '@mui/material/styles';
 import { FunctionComponent, h } from 'preact';
 
 import { AccordionLayout } from '../../types';
-// eslint-disable-next-line import/no-cycle
-import Layout from './Layout';
+import Layout from './SimpleLayout';
 
 type AccordionProps = {
   uischema: AccordionLayout;
@@ -64,7 +63,6 @@ const Accordion: FunctionComponent<AccordionProps> = ({ uischema }) => {
               <Typography>{element.options.summary}</Typography>
             </StyledAccordionSummary>
             <AccordionDetails sx={{ padding: 0 }}>
-              {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
               <Layout uischema={element.options.content} />
             </AccordionDetails>
           </MuiAccordion>

--- a/src/v3/src/components/Form/Accordion.tsx
+++ b/src/v3/src/components/Form/Accordion.tsx
@@ -22,7 +22,7 @@ import { styled } from '@mui/material/styles';
 import { FunctionComponent, h } from 'preact';
 
 import { AccordionLayout } from '../../types';
-import Layout from './SimpleLayout';
+import LayoutContainer from './LayoutContainer';
 
 type AccordionProps = {
   uischema: AccordionLayout;
@@ -63,7 +63,7 @@ const Accordion: FunctionComponent<AccordionProps> = ({ uischema }) => {
               <Typography>{element.options.summary}</Typography>
             </StyledAccordionSummary>
             <AccordionDetails sx={{ padding: 0 }}>
-              <Layout uischema={element.options.content} />
+              <LayoutContainer uischema={element.options.content} />
             </AccordionDetails>
           </MuiAccordion>
         ))

--- a/src/v3/src/components/Form/ElementContainer.tsx
+++ b/src/v3/src/components/Form/ElementContainer.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Box } from '@mui/material';
+import { FunctionComponent, h } from 'preact';
+
+import {
+  UISchemaElement,
+  UISchemaElementComponent,
+} from '../../types';
+import { isDevelopmentEnvironment, isTestEnvironment } from '../../util';
+import renderers from './renderers';
+
+const ElementContainer: FunctionComponent<{ element: UISchemaElement }> = ({ element }) => {
+  const renderer = renderers.find((r) => r.tester(element));
+  if (!renderer) {
+    // TODO: for now do not render for unmatch render object
+    // remove unnecessary uischema in future refactor and throw error
+    // throw new Error(`Failed to find render component for uischema: ${JSON.stringify(element)}`);
+    if (isDevelopmentEnvironment() || isTestEnvironment()) {
+      console.warn(`Failed to find render component for uischema: ${JSON.stringify(element)}`);
+    }
+    return null;
+  }
+
+  const Component = renderer.renderer as UISchemaElementComponent;
+  return (
+    <Box
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...(!(element).noMargin && { marginBottom: 4 })}
+    >
+      <Component uischema={element} />
+    </Box>
+  );
+};
+
+export default ElementContainer;

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -17,13 +17,12 @@ import {
   AccordionLayout,
   StepperLayout,
   UISchemaElement,
-  UISchemaElementComponent,
   UISchemaLayout,
   UISchemaLayoutType,
 } from '../../types';
-import { getElementKey, isDevelopmentEnvironment, isTestEnvironment } from '../../util';
+import { getElementKey } from '../../util';
 import Accordion from './Accordion';
-import renderers from './renderers';
+import ElementContainer from './ElementContainer';
 import Stepper from './Stepper';
 
 const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) => {
@@ -55,27 +54,11 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
             return <Layout uischema={element as UISchemaLayout} />;
           }
 
-          const renderer = renderers.find((r) => r.tester(element));
-          if (!renderer) {
-            // TODO: for now do not render for unmatch render object
-            // remove unnecessary uischema in future refactor and throw error
-            // throw new Error(`Failed to find render component for uischema: ${JSON.stringify(element)}`);
-            if (isDevelopmentEnvironment() || isTestEnvironment()) {
-              console.warn(`Failed to find render component for uischema: ${JSON.stringify(element)}`);
-            }
-            return null;
-          }
-
-          const uischemaElement = (element as UISchemaElement);
-          const Component = renderer.renderer as UISchemaElementComponent;
           return (
-            <Box
+            <ElementContainer
               key={elementKey}
-              // eslint-disable-next-line react/jsx-props-no-spreading
-              {...(!(uischemaElement).noMargin && { marginBottom: 4 })}
-            >
-              <Component uischema={uischemaElement} />
-            </Box>
+              element={element as UISchemaElement}
+            />
           );
         })
       }

--- a/src/v3/src/components/Form/LayoutContainer.tsx
+++ b/src/v3/src/components/Form/LayoutContainer.tsx
@@ -15,12 +15,11 @@ import { FunctionComponent, h } from 'preact';
 
 import {
   UISchemaElement,
-  UISchemaElementComponent,
   UISchemaLayout,
   UISchemaLayoutType,
 } from '../../types';
-import { getElementKey, isDevelopmentEnvironment, isTestEnvironment } from '../../util';
-import renderers from './renderers';
+import { getElementKey } from '../../util';
+import ElementContainer from './ElementContainer';
 
 /**
  *
@@ -50,27 +49,11 @@ const LayoutContainer: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uisc
             return <LayoutContainer uischema={element as UISchemaLayout} />;
           }
 
-          const renderer = renderers.find((r) => r.tester(element));
-          if (!renderer) {
-            // TODO: for now do not render for unmatch render object
-            // remove unnecessary uischema in future refactor and throw error
-            // throw new Error(`Failed to find render component for uischema: ${JSON.stringify(element)}`);
-            if (isDevelopmentEnvironment() || isTestEnvironment()) {
-              console.warn(`Failed to find render component for uischema: ${JSON.stringify(element)}`);
-            }
-            return null;
-          }
-
-          const uischemaElement = (element as UISchemaElement);
-          const Component = renderer.renderer as UISchemaElementComponent;
           return (
-            <Box
+            <ElementContainer
               key={elementKey}
-              // eslint-disable-next-line react/jsx-props-no-spreading
-              {...(!(uischemaElement).noMargin && { marginBottom: 4 })}
-            >
-              <Component uischema={uischemaElement} />
-            </Box>
+              element={element as UISchemaElement}
+            />
           );
         })
       }

--- a/src/v3/src/components/Form/SimpleLayout.tsx
+++ b/src/v3/src/components/Form/SimpleLayout.tsx
@@ -14,19 +14,22 @@ import { Box } from '@mui/material';
 import { FunctionComponent, h } from 'preact';
 
 import {
-  AccordionLayout,
-  StepperLayout,
   UISchemaElement,
   UISchemaElementComponent,
   UISchemaLayout,
   UISchemaLayoutType,
 } from '../../types';
 import { getElementKey, isDevelopmentEnvironment, isTestEnvironment } from '../../util';
-import Accordion from './Accordion';
 import renderers from './renderers';
-import Stepper from './Stepper';
 
-const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) => {
+/**
+ *
+ * The purpose of this component is to act as an abstracted layer
+ * for use by non standard UISchemaLayout interfaces to prevent a circular dependency
+ * i.e. {@link AccordionLayout} and {@link StepperLayout}
+ *
+ */
+const LayoutContainer: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) => {
   const { type, elements } = uischema;
 
   const isHorizontalLayout = type === UISchemaLayoutType.HORIZONTAL;
@@ -42,17 +45,9 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
         elements.map((element, index) => {
           const elementKey = getElementKey(element, index);
 
-          if (element.type === UISchemaLayoutType.STEPPER) {
-            return <Stepper uischema={element as StepperLayout} />;
-          }
-
-          if (element.type === UISchemaLayoutType.ACCORDION) {
-            return <Accordion uischema={element as AccordionLayout} />;
-          }
-
           if ([UISchemaLayoutType.HORIZONTAL, UISchemaLayoutType.VERTICAL]
             .includes((element as UISchemaLayout).type)) {
-            return <Layout uischema={element as UISchemaLayout} />;
+            return <LayoutContainer uischema={element as UISchemaLayout} />;
           }
 
           const renderer = renderers.find((r) => r.tester(element));
@@ -83,4 +78,4 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
   );
 };
 
-export default Layout;
+export default LayoutContainer;

--- a/src/v3/src/components/Form/Stepper.tsx
+++ b/src/v3/src/components/Form/Stepper.tsx
@@ -15,8 +15,7 @@ import { useState } from 'preact/hooks';
 
 import { StepperContext } from '../../contexts';
 import { StepperLayout } from '../../types';
-// eslint-disable-next-line import/no-cycle
-import Layout from './Layout';
+import Layout from './SimpleLayout';
 
 type StepperProps = {
   uischema: StepperLayout;

--- a/src/v3/src/components/Form/Stepper.tsx
+++ b/src/v3/src/components/Form/Stepper.tsx
@@ -15,7 +15,7 @@ import { useState } from 'preact/hooks';
 
 import { StepperContext } from '../../contexts';
 import { StepperLayout } from '../../types';
-import Layout from './SimpleLayout';
+import LayoutContainer from './LayoutContainer';
 
 type StepperProps = {
   uischema: StepperLayout;
@@ -38,7 +38,7 @@ const Stepper: FunctionComponent<StepperProps> = ({ uischema }) => {
     // Scope setStepIndex by only providing it to its own children components
     // Nested stepper can be supported with this pattern
     <StepperContext.Provider value={{ setStepIndex, stepIndex }}>
-      <Layout uischema={elements[stepIndex]} />
+      <LayoutContainer uischema={elements[stepIndex]} />
     </StepperContext.Provider>
   );
 };

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -302,7 +302,7 @@ export interface AccordionPanelElement extends UISchemaElement {
   options: {
     id: string;
     summary: string;
-    content: UISchemaLayout;
+    content: Omit<UISchemaLayout, 'AccordionLayout'>;
   };
 }
 
@@ -356,7 +356,7 @@ export type StepperNavButtonConfigAttrs = {
 
 export interface StepperLayout {
   type: UISchemaLayoutType.STEPPER;
-  elements: UISchemaLayout[];
+  elements: Omit<UISchemaLayout, 'StepperLayout'>[];
   options?: {
     defaultStepIndex: () => number;
   }

--- a/src/v3/src/util/getElementKey.ts
+++ b/src/v3/src/util/getElementKey.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { FieldElement, UISchemaElement } from '../types';
+
+export const getElementKey = (element: UISchemaElement, index: number): string => {
+  const defaultKey = [element.type, element.key, index].join('_');
+  return element.type === 'Field' && (element as FieldElement).key
+    ? [(element as FieldElement).key].join('_')
+    : defaultKey;
+};

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -19,6 +19,7 @@ export * from './formatError';
 export * from './formUtils';
 export * from './generateRandomString';
 export * from './getAuthenticatorKey';
+export * from './getElementKey';
 export * from './getImmutableData';
 export * from './getTranslation';
 export * from './getValidationMessages';

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -30,7 +30,7 @@ export default class TerminalPageObject extends BasePageObject {
   }
 
   doesTextExist(content) {
-    return this.form.getTextElement(content).exists;
+    return this.form.getByText(content).exists;
   }
 
   // Check for go back link unique to V2


### PR DESCRIPTION
## Description:

The purpose of this PR is to remove the circular dependency between 

`Layout.tsx` ->
     `Stepper.tsx` -> `Layout.tsx`
     `Accordion.tsx` -> `Layout.tsx`

One assumption that was made with this approach was that we will _not_ nest Stepper or Accordion components within themselves. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-531082](https://oktainc.atlassian.net/browse/OKTA-531082)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



