### PR TITLE
Add remediation type and map to view for 519111

### DIFF
--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -41,6 +41,7 @@ const FORMS = {
   SELECT_AUTHENTICATOR_ENROLL: 'select-authenticator-enroll',
   SELECT_AUTHENTICATOR_ENROLL_DATA: 'select-authenticator-enroll-data',
   AUTHENTICATOR_ENROLLMENT_DATA: 'authenticator-enrollment-data',
+  AUTHENTICATOR_PRE_ENROLLMENT_DATA: 'authenticator-pre-enrollment-data',
   ENROLL_AUTHENTICATOR: 'enroll-authenticator',
   SELECT_ENROLLMENT_CHANNEL: 'select-enrollment-channel',
   ENROLLMENT_CHANNEL_DATA: 'enrollment-channel-data',

--- a/src/v2/view-builder/ViewFactory.ts
+++ b/src/v2/view-builder/ViewFactory.ts
@@ -228,6 +228,9 @@ const VIEWS_MAPPING = {
     [AUTHENTICATOR_KEY.OV]: ChallengeOktaVerifyResendPushView,
     [AUTHENTICATOR_KEY.CUSTOM_APP]: ChallengeCustomAppResendPushView,
   },
+  [RemediationForms.AUTHENTICATOR_PRE_ENROLLMENT_DATA]: {
+    [AUTHENTICATOR_KEY.EMAIL]: ChallengeAuthenticatorDataEmailView,
+  },
   [RemediationForms.AUTHENTICATOR_VERIFICATION_DATA]: {
     [AUTHENTICATOR_KEY.PHONE]: ChallengeAuthenticatorDataPhoneView,
     [AUTHENTICATOR_KEY.OV]: ChallengeOktaVerifyCustomAppDataView,


### PR DESCRIPTION
## Description:
- This PR is the UI change for OKTA-519111, adding a new remediation type and mapping it to the email verification view to handle and enforce email enrollment first when "email verification is required before access is granted" is checked in profile enrollment settings
- Related backend changes: https://github.com/okta/okta-core/pull/71660 
- Tests are being worked on and to be added in this PR


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-542167](https://oktainc.atlassian.net/browse/OKTA-542167)

### Reviewers:
@kumarabhinav-okta 

### Screenshot/Video:
[VerificationRequired_EmailEnrollmentRequired](https://okta.box.com/s/byoqcu2ikngb8ig3yradvc03wkmmco2t)
[VerificationRequired_EmailEnrollmentOptional](https://okta.box.com/s/72q6z5zm6dhufjhgbcq38href86be7ru)

### Downstream Monolith Build:



