### PR TITLE
OKTA-518949 : Failure Redirect parity spec test update

### DIFF
--- a/test/testcafe/spec/FailureRedirect_spec.js
+++ b/test/testcafe/spec/FailureRedirect_spec.js
@@ -8,7 +8,8 @@ const userNotAssignedMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrErrorWithFailureRedirect);
 
-fixture('Failure with redirect');
+fixture('Failure with redirect')
+  .meta('v3', true);
 
 test.requestHooks(userNotAssignedMock)('generic case: redirects', async t => {
   const terminalPage = new TerminalPageObject(t);
@@ -25,7 +26,7 @@ test.requestHooks(userNotAssignedMock)('oauth: shows the error message', async t
     redirectUri: 'http://totally-fake'
   });
   await terminalPage.waitForErrorBox();
-  await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('You are not allowed to access this app. To request access, contact an admin.');
+  await t.expect(terminalPage.getErrorBoxText()).eql('You are not allowed to access this app. To request access, contact an admin.');
 });
 
 test.requestHooks(userNotAssignedMock)('oauth: will redirect if `redirect === "always"`', async t => {


### PR DESCRIPTION
## Description:

The purpose of this PR is to add the flag to enable v3 parity testing to the Failure redirect spec test.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-518949](https://oktainc.atlassian.net/browse/OKTA-518949)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



