### PR TITLE
OKTA-518966 : Introspect parity spec test

### DIFF
--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -48,7 +48,8 @@ const InfoBox: UISchemaElementComponent<{
         variant="infobox"
         title={title}
         // eslint-disable-next-line react/jsx-props-no-spreading
-        {...(dataSe && { 'data-se': dataSe })}
+        {...({ 'data-se': dataSe })}
+        className={`infobox-${messageClass.toLowerCase()}`}
       >
         {message}
       </Alert>

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -37,7 +37,6 @@ import { transformTerminalTransaction, transformUnhandledErrors } from '../../tr
 import { createForm } from '../../transformer/utils';
 import {
   FormBag,
-  MessageType,
   UISchemaLayout,
   UISchemaLayoutType,
   WidgetProps,
@@ -235,21 +234,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     if (!idxTransaction) {
       return;
     }
-
-    const { messages: newMessages = [] } = idxTransaction;
-
     events?.afterRender?.(getEventContext(idxTransaction));
-
-    // for multiple error messages
-    newMessages?.forEach((newMessage) => {
-      const { class: type, message: msg } = newMessage;
-      if (type === MessageType.ERROR) {
-        // error event
-        events?.afterError?.({
-          stepName: idxTransaction?.nextStep?.name,
-        }, { message: msg });
-      }
-    });
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [idxTransaction, bootstrap]);

--- a/src/v3/src/transformer/messages/transform.ts
+++ b/src/v3/src/transformer/messages/transform.ts
@@ -67,6 +67,7 @@ const transformCustomMessages = (formBag: FormBag, messages: IdxMessage[]): Form
       class: message.class ?? 'INFO',
       message: message.message,
       title: message.title && loc(message.title, 'login'),
+      dataSe: 'callout',
     },
   } as InfoboxElement));
 
@@ -98,7 +99,7 @@ export const transformMessages: TransformStepFnWithOptions = ({ transaction }) =
         contentType: 'string',
         class: messageClass,
         message: message.message,
-        dataSe: `infobox-${messageClass.toLowerCase()}`,
+        dataSe: 'callout',
       },
     } as InfoboxElement);
   });

--- a/src/v3/src/transformer/terminal/__snapshots__/transformTerminalMessages.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformTerminalMessages.test.ts.snap
@@ -44,7 +44,7 @@ Object {
         "options": Object {
           "class": "ERROR",
           "contentType": "string",
-          "dataSe": "infobox-error",
+          "dataSe": "callout",
           "message": "oie.tooManyRequests",
         },
         "type": "InfoBox",
@@ -73,7 +73,7 @@ Object {
         "options": Object {
           "class": "ERROR",
           "contentType": "string",
-          "dataSe": "infobox-error",
+          "dataSe": "callout",
           "message": "idx.operation.cancelled.on.other.device",
         },
         "type": "InfoBox",
@@ -108,7 +108,7 @@ Object {
         "options": Object {
           "class": "ERROR",
           "contentType": "string",
-          "dataSe": "infobox-error",
+          "dataSe": "callout",
           "message": "idx.session.expired",
         },
         "type": "InfoBox",
@@ -137,7 +137,7 @@ Object {
         "options": Object {
           "class": "ERROR",
           "contentType": "string",
-          "dataSe": "infobox-error",
+          "dataSe": "callout",
           "message": "idx.return.link.expired",
         },
         "type": "InfoBox",
@@ -194,7 +194,7 @@ Object {
         "options": Object {
           "class": "ERROR",
           "contentType": "string",
-          "dataSe": "infobox-error",
+          "dataSe": "callout",
           "message": "Test error message",
         },
         "type": "InfoBox",

--- a/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
@@ -13,6 +13,7 @@ Object {
         "options": Object {
           "class": "ERROR",
           "contentType": "string",
+          "dataSe": "callout",
           "message": "oform.error.unexpected",
         },
         "type": "InfoBox",
@@ -36,6 +37,7 @@ Object {
         "options": Object {
           "class": "ERROR",
           "contentType": "string",
+          "dataSe": "callout",
           "message": "oie.configuration.error",
         },
         "type": "InfoBox",
@@ -59,6 +61,7 @@ Object {
         "options": Object {
           "class": "ERROR",
           "contentType": "string",
+          "dataSe": "callout",
           "message": "oie.feature.disabled",
         },
         "type": "InfoBox",
@@ -82,6 +85,7 @@ Object {
         "options": Object {
           "class": "ERROR",
           "contentType": "string",
+          "dataSe": "callout",
           "message": "oie.invalid.recovery.token",
         },
         "type": "InfoBox",

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.ts
@@ -48,7 +48,7 @@ const appendMessageElements = (uischema: UISchemaLayout, messages: IdxMessage[])
           message: message.message,
           class: messageClass,
           contentType: 'string',
-          dataSe: `infobox-${messageClass.toLowerCase()}`,
+          dataSe: 'callout',
         },
       };
       uischema.elements.push(infoBoxElement);

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
@@ -75,6 +75,7 @@ export const transformUnhandledErrors: ErrorTransformer = (widgetProps, error) =
       message: getErrorMessage(error, widgetProps),
       class: 'ERROR',
       contentType: 'string',
+      dataSe: 'callout',
     },
   } as InfoboxElement];
 

--- a/src/v3/src/util/getEventContext.ts
+++ b/src/v3/src/util/getEventContext.ts
@@ -37,7 +37,7 @@ export const getFormNameForTransaction = (transaction: IdxTransaction): string |
     }
     // no remediation or only skip remediation with messages for device enrollment state
     // and the state is meant to be terminal state with different UI than the regular terminal view
-    // @ts-ignore deviceEnrollment missing from type
+    // @ts-ignore OKTA-542514 - deviceEnrollment missing from type
     if (rawIdxState.deviceEnrollment) {
       return IDX_STEP.DEVICE_ENROLLMENT_TERMINAL;
     }

--- a/src/v3/src/util/getEventContext.ts
+++ b/src/v3/src/util/getEventContext.ts
@@ -14,15 +14,44 @@ import { IdxTransaction } from '@okta/okta-auth-js';
 
 import { EventContext } from '../../../types';
 import { getV1ClassName } from '../../../v2/ion/ViewClassNamesFactory';
+import { IDX_STEP } from '../constants';
 import { getAuthenticatorKey } from './getAuthenticatorKey';
 import { isPasswordRecovery } from './isPasswordRecovery';
 
+export const getFormNameForTransaction = (transaction: IdxTransaction): string | undefined => {
+  const {
+    nextStep: { name: formName } = {},
+    neededToProceed,
+    context,
+    rawIdxState,
+  } = transaction;
+  const hasSkipRemediationOnly = neededToProceed?.length === 1 && neededToProceed[0].name === 'skip';
+  if (!neededToProceed?.length || hasSkipRemediationOnly) {
+    // no remediation or only skip remediation with success
+    if (context.success) {
+      return context.success.name;
+    }
+    // no remediation or only skip remediation with messages
+    if (context.messages) {
+      return 'terminal';
+    }
+    // no remediation or only skip remediation with messages for device enrollment state
+    // and the state is meant to be terminal state with different UI than the regular terminal view
+    // @ts-ignore deviceEnrollment missing from type
+    if (rawIdxState.deviceEnrollment) {
+      return IDX_STEP.DEVICE_ENROLLMENT_TERMINAL;
+    }
+  }
+  return formName;
+};
+
 export const getEventContext = (transaction: IdxTransaction): EventContext => {
-  const { nextStep: { name: formName } = {}, context } = transaction;
+  const { context } = transaction;
   const authenticatorKey = context.currentAuthenticator?.value?.key
     || getAuthenticatorKey(transaction);
   const methodType = transaction.context.currentAuthenticator?.value?.type;
   const isPasswordRecoveryFlow = isPasswordRecovery(transaction);
+  const formName = getFormNameForTransaction(transaction);
 
   const controller = getV1ClassName(
     formName,

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -1215,8 +1215,8 @@ exports[`authenticator-verification-email renders correct form should render ses
                     data-se="message"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
-                      data-se="infobox-error"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-8"
+                      data-se="callout"
                       role="alert"
                     >
                       <div

--- a/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
@@ -42,7 +42,8 @@ exports[`error-400-unauthorized-client should render form 1`] = `
                     data-se="message"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-8"
+                      data-se="callout"
                       role="alert"
                     >
                       <div

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -42,8 +42,8 @@ exports[`error-account-creation should render form 1`] = `
                     data-se="message"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
-                      data-se="infobox-error"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-8"
+                      data-se="callout"
                       role="alert"
                     >
                       <div

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -74,8 +74,8 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
                     data-se="message"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-12"
-                      data-se="infobox-error"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-12"
+                      data-se="callout"
                       role="alert"
                     >
                       <div

--- a/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
@@ -42,7 +42,8 @@ exports[`error-feature-not-enabled should render form 1`] = `
                     data-se="message"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-8"
+                      data-se="callout"
                       role="alert"
                     >
                       <div

--- a/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
@@ -42,7 +42,8 @@ exports[`error-recovery-token-invalid should render form 1`] = `
                     data-se="message"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-8"
+                      data-se="callout"
                       role="alert"
                     >
                       <div

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -42,8 +42,8 @@ exports[`error-session-expired should render form 1`] = `
                     data-se="message"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
-                      data-se="infobox-error"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-8"
+                      data-se="callout"
                       role="alert"
                     >
                       <div

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -108,7 +108,8 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                     data-se="message"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-13"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-13"
+                      data-se="callout"
                       role="alert"
                       title="Update Okta Verify"
                     >

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -79,8 +79,8 @@ exports[`terminal-return-email-error should render form 1`] = `
                     data-se="message"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-9"
-                      data-se="infobox-error"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-9"
+                      data-se="callout"
                       role="alert"
                     >
                       <div

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -198,7 +198,7 @@ describe('authenticator-verification-email', () => {
       // allow polling request to be triggered
       jest.advanceTimersByTime(5000 /* refresh: 4000 */);
 
-      const errorAlert = await findByTestId('infobox-error');
+      const errorAlert = await findByTestId('callout');
       await within(errorAlert).findByText(/You have been logged out due to inactivity/);
 
       expect(container).toMatchSnapshot();

--- a/test/testcafe/framework/page-objects/components/BaseFormObjectV3.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObjectV3.js
@@ -2,7 +2,7 @@ import BaseFormObject from './BaseFormObject';
 import { Selector } from 'testcafe';
 
 const FORM_SELECTOR = '[data-se="o-form"]';
-const FORM_INFOBOX_ERROR_SELECTOR = '[data-se="message"] [data-se="infobox-error"]';
+const FORM_INFOBOX_ERROR_SELECTOR = '[data-se="message"] .infobox-error';
 
 export default class BaseFormObjectV3 extends BaseFormObject {
   constructor(t, index = 0) {

--- a/test/testcafe/framework/page-objects/components/CalloutObject.js
+++ b/test/testcafe/framework/page-objects/components/CalloutObject.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, userVariables } from 'testcafe';
 
 const DATA_SE_CALLOUT = '[data-se="callout"]';
 
@@ -18,11 +18,18 @@ export default class CalloutObject {
   }
 
   isError() {
-    return this.el.hasClass('infobox-error') &&
+    const hasInfoBoxErrorClass = this.el.hasClass('infobox-error');
+    if (userVariables.v3) {
+      return hasInfoBoxErrorClass;
+    }
+    return  hasInfoBoxErrorClass &&
       this.el.child('[data-se="icon"]').hasClass('error-16');
   }
 
   getTextContent() {
+    if (userVariables.v3) {
+      return this.el.innerText;
+    }
     return this.el.child('div').textContent;
   }
 

--- a/test/testcafe/spec/Introspect_spec.js
+++ b/test/testcafe/spec/Introspect_spec.js
@@ -16,7 +16,8 @@ const introspectRequestLogger = RequestLogger(
   }
 );
 
-fixture('Introspect');
+fixture('Introspect')
+  .meta('v3', true);
 
 async function setup(t) {
   const terminalPageObject = new TerminalPageObject(t);


### PR DESCRIPTION
## Description:

The purpose of this PR is to enable parity v2/v3 spec testing and implement necessary changes to ensure the v3 widget is in parity with v2.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-518966](https://oktainc.atlassian.net/browse/OKTA-518966)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



