### PR TITLE
OKTA-518950 : Generic error handling spec test update

### DIFF
--- a/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
@@ -35,6 +35,7 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
+          "contentType": "string",
           "message": "oie.configuration.error",
         },
         "type": "InfoBox",
@@ -57,6 +58,7 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
+          "contentType": "string",
           "message": "oie.feature.disabled",
         },
         "type": "InfoBox",
@@ -79,6 +81,7 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
+          "contentType": "string",
           "message": "oie.invalid.recovery.token",
         },
         "type": "InfoBox",

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
@@ -16,78 +16,67 @@ import { getMessage } from '../../../../v2/ion/i18nTransformer';
 import {
   FormBag,
   InfoboxElement,
-  UISchemaElement,
   WidgetProps,
 } from '../../types';
 import { loc } from '../../util';
 import { createForm } from '../utils';
 
-type ErrorTransformer = (widgetProps: WidgetProps, error?: AuthApiError) => FormBag;
+type ErrorTransformer = (widgetProps: WidgetProps, error: AuthApiError) => FormBag;
 
-const appendSpecialErrorMessages = (
-  elements: UISchemaElement[],
-  errorDescription: string,
-  error?: string,
-) => {
-  let message;
-  if (error === 'invalid_request' && errorDescription === 'The recovery token is invalid') {
-    message = 'oie.invalid.recovery.token';
-  } else if (error === 'access_denied' && !!errorDescription) {
-    message = 'oie.feature.disabled';
-  } else {
-    message = 'oie.configuration.error';
-  }
+const getErrorMessage = (error: AuthApiError, widgetProps?: WidgetProps) : string => {
+  const errorChecks = [
+    // error message comes from server response
+    {
+      tester: (err: AuthApiError) => err && err.xhr && !err.errorSummary && err.xhr.responseText?.includes('messages'),
+      message: (err: AuthApiError) => {
+        const errorResponse = JSON.parse(err.xhr!.responseText);
+        const { messages: { value: [message] } } = errorResponse;
 
-  elements.push({
-    type: 'InfoBox',
-    options: {
-      message: loc(message, 'login'),
-      class: 'ERROR',
+        // TODO: re-visit, handle side effects in hooks
+        // If the session expired, this clears session to allow new transaction bootstrap
+        if (widgetProps && message.i18n.key === 'idx.session.expired') {
+          const { authClient } = widgetProps;
+          authClient?.transactionManager.clear();
+        }
+
+        return getMessage(message);
+      },
     },
-  } as InfoboxElement);
+    // special error messages
+    {
+      tester: (err: AuthApiError) => err?.errorCode === 'invalid_request' && err?.errorSummary === 'The recovery token is invalid',
+      message: () => loc('oie.invalid.recovery.token', 'login'),
+    },
+    {
+      tester: (err: AuthApiError) => err?.errorCode === 'access_denied' && !!err?.errorSummary,
+      message: () => loc('oie.feature.disabled', 'login'),
+    },
+    {
+      tester: (err: AuthApiError) => err?.errorCode && !!err?.errorSummary,
+      message: () => loc('oie.configuration.error', 'login'),
+    },
+    // default fall back for unknown errors
+    {
+      tester: () => true,
+      message: () => loc('oform.error.unexpected', 'login'),
+    },
+  ];
+
+  // find the message that meets the tester condition
+  return errorChecks.find(({ tester }) => tester(error))?.message(error);
 };
 
 export const transformUnhandledErrors: ErrorTransformer = (widgetProps, error) => {
   const formBag: FormBag = createForm();
 
-  if (!error) {
-    formBag.uischema.elements.push({
-      type: 'InfoBox',
-      options: {
-        message: loc('oform.error.unexpected', 'login'),
-        class: 'ERROR',
-        contentType: 'string',
-      },
-    } as InfoboxElement);
-    return formBag;
-  }
-
-  if (error && error.xhr && !error.errorSummary) {
-    const { xhr } = error;
-    if (xhr && xhr.responseText?.includes('messages')) {
-      const errorResponse = JSON.parse(xhr.responseText);
-      const { messages: { value: [message] } } = errorResponse;
-      formBag.uischema.elements.push({
-        type: 'InfoBox',
-        options: {
-          message: getMessage(message),
-          class: 'ERROR',
-          contentType: 'string',
-        },
-      } as InfoboxElement);
-
-      // TODO: re-visit, handle side effects in hooks
-      // If the session expired, this clears session to allow new transaction bootstrap
-      if (message.i18n.key === 'idx.session.expired') {
-        const { authClient } = widgetProps;
-        authClient?.transactionManager.clear();
-      }
-
-      return formBag;
-    }
-  }
-
-  appendSpecialErrorMessages(formBag.uischema.elements, error.errorSummary, error.errorCode);
+  formBag.uischema.elements = [{
+    type: 'InfoBox',
+    options: {
+      message: getErrorMessage(error, widgetProps),
+      class: 'ERROR',
+      contentType: 'string',
+    },
+  } as InfoboxElement];
 
   return formBag;
 };

--- a/test/testcafe/spec/GenericErrorHandling_spec.js
+++ b/test/testcafe/spec/GenericErrorHandling_spec.js
@@ -11,7 +11,7 @@ const noMessagesErrorMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(noMessageResponse, 403);
 
-fixture('GenericErrors');
+fixture('GenericErrors').meta('v3', true);
 
 async function setup(t) {
   const terminalPage = new TerminalPageObject(t);
@@ -23,11 +23,11 @@ async function setup(t) {
 test.requestHooks(noMessagesErrorMock)('should be able generic error when request does not have messages', async t => {
   const terminalPage = await setup(t);
   await terminalPage.waitForErrorBox();
-  await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('There was an unexpected internal error. Please try again.');
+  await t.expect(terminalPage.getErrorBoxText()).eql('There was an unexpected internal error. Please try again.');
 });
 
 test.requestHooks(securityAccessDeniedMock)('should be able display error when request failed ith 403 with no stateToken', async t => {
   const terminalPage = await setup(t);
   await terminalPage.waitForErrorBox();
-  await t.expect(terminalPage.getErrorMessages().getTextContent()).contains('You do not have permission to perform the requested action');
+  await t.expect(terminalPage.getErrorBoxText()).contains('You do not have permission to perform the requested action');
 });


### PR DESCRIPTION
## Description:

Updates Generic error handling spec test for parity.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



