### PR TITLE
OKTA-518962 : IdentifyWithRememberUsername parity spec test

### DIFF
--- a/src/v3/src/transformer/identify/__snapshots__/transformIdentify.test.ts.snap
+++ b/src/v3/src/transformer/identify/__snapshots__/transformIdentify.test.ts.snap
@@ -111,6 +111,68 @@ Object {
 }
 `;
 
+exports[`Identify Transformer Tests should add UI elements for identifier, passcode & rememberMe with username default option when username is provided in remediation (inputMeta) 1`] = `
+Object {
+  "data": Object {
+    "identifier": "mockUser",
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "primaryauth.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+            "value": "mockUser",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+            "secret": true,
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "rememberMe",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "oie.primaryauth.submit",
+        "options": Object {
+          "step": "identify",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
 exports[`Identify Transformer Tests should add UI elements for identifier, passcode & rememberMe with username pulled from cookie as the default option when username is not provided in options but features rememberMe & rememberMyUsernameOnOIE are provided 1`] = `
 Object {
   "data": Object {

--- a/src/v3/src/transformer/identify/transformIdentify.test.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.test.ts
@@ -150,6 +150,43 @@ describe('Identify Transformer Tests', () => {
       .toBe(IDX_STEP.IDENTIFY);
   });
 
+  it('should add UI elements for identifier, passcode & rememberMe with username default option '
+    + 'when username is provided in remediation (inputMeta)', () => {
+    widgetProps = { features: { rememberMe: true, rememberMyUsernameOnOIE: true } };
+    formBag.uischema.elements = [
+      {
+        type: 'Field',
+        options: { inputMeta: { name: 'identifier', value: 'mockUser' } },
+      } as FieldElement,
+      {
+        type: 'Field',
+        options: { inputMeta: { name: 'credentials.passcode', secret: true } },
+      } as FieldElement,
+      {
+        type: 'Field',
+        options: { inputMeta: { name: 'rememberMe' } },
+      } as FieldElement,
+    ];
+    const updatedFormBag = transformIdentify({ transaction, formBag, widgetProps });
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.data.identifier).toBe('mockUser');
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('primaryauth.title');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('identifier');
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+      .toBe('rememberMe');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).label)
+      .toBe('oie.primaryauth.submit');
+    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options.step)
+      .toBe(IDX_STEP.IDENTIFY);
+  });
+
   it('should add UI elements for identifier, passcode & rememberMe with username pulled from '
     + 'cookie as the default option when username is not provided in options but features '
     + 'rememberMe & rememberMyUsernameOnOIE are provided', () => {

--- a/src/v3/src/transformer/identify/transformIdentify.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.ts
@@ -37,6 +37,8 @@ export const transformIdentify: IdxStepTransformer = ({
     // add username/identifier from config if provided
     if (username) {
       data.identifier = username;
+    } else if (typeof identifierElement.options.inputMeta.value === 'string') {
+      data.identifier = identifierElement.options.inputMeta.value;
     // TODO: OKTA-508744 - to use rememberMe in features once Default values are added widgetProps.
     // (i.e. rememberMe is default = true in v2)
     } else if (features?.rememberMe !== false && features?.rememberMyUsernameOnOIE) {

--- a/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
@@ -1,3 +1,4 @@
+import { userVariables } from 'testcafe';
 import ChallengeFactorPageObject from './ChallengeFactorPageObject';
 
 const RESEND_EMAIL_VIEW_SELECTOR = '.resend-email-view';
@@ -20,6 +21,10 @@ export default class ChallengeEmailPageObject extends ChallengeFactorPageObject 
   }
 
   async clickEnterCodeLink() {
-    await this.form.clickElement('.enter-auth-code-instead-link');
+    if (userVariables.v3) {
+      await this.t.click(this.form.getButton('Enter a code from the email instead'));
+    } else {
+      await this.form.clickElement('.enter-auth-code-instead-link');
+    }
   }
 }

--- a/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
@@ -30,6 +30,10 @@ export default class ChallengeFactorPageObject extends BasePageObject {
     return this.form.clickSaveButton();
   }
 
+  clickVerifyButton() {
+    return this.form.clickSaveButton('Verify');
+  }
+
   /**
    * @deprecated
    * @see getTitle

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -100,6 +100,14 @@ export default class IdentityPageObject extends BasePageObject {
     return this.form.clickSaveButton('Next');
   }
 
+  clickVerifyButton() {
+    return this.form.clickSaveButton('Verify');
+  }
+
+  clickSignInButton() {
+    return this.form.clickSaveButton('Sign in');
+  }
+
   waitForErrorBox() {
     return this.form.waitForErrorBox();
   }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -134,7 +134,7 @@ export default class BaseFormObject {
    */
   getButton(name) {
     return within(this.el).getByRole('button', {
-      value: name,
+      name,
     });
   }
 

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -133,9 +133,8 @@ export default class BaseFormObject {
    * @param {string} name the text of the button to return
    */
   getButton(name) {
-    return within(this.el).getByRole('button', {
-      name,
-    });
+    const options = userVariables.v3 ? { name } : { value: name };
+    return within(this.el).getByRole('button', options);
   }
 
   /**

--- a/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
+++ b/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
@@ -74,7 +74,8 @@ const baseConfig = {
   }
 };
 
-fixture('Identify With Remember Username');
+fixture('Identify With Remember Username')
+  .meta('v3', true);
 
 async function setup(t, options) {
   const identityPage = new IdentityPageObject(t);
@@ -90,7 +91,7 @@ test.requestHooks(identifyRequestLogger, identifyWithError)('identifer first flo
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();
+  await identityPage.clickVerifyButton();
 
   await identityPage.waitForErrorBox();
 
@@ -107,7 +108,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordError)('identifer w
 
   await identityPage.fillIdentifierField('test@okta.com');
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();
+  await identityPage.clickSignInButton();
 
   await identityPage.waitForErrorBox();
 
@@ -126,7 +127,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('identifer first flow - s
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();  
+  await identityPage.clickVerifyButton();  
 
   await t.expect(identifyRequestLogger.count(() => true)).eql(2);
   const req = identifyRequestLogger.requests[0].request;
@@ -148,7 +149,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('identifer wi
 
   await identityPage.fillIdentifierField('testUser@okta.com');
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();  
+  await identityPage.clickSignInButton();  
 
   await t.expect(identifyRequestLogger.count(() => true)).eql(1);
   const req = identifyRequestLogger.requests[0].request;
@@ -179,7 +180,7 @@ test.requestHooks(identifyRequestLogger, identifyWithEmailAuthenticatorError)('i
   await challengeEmailPageObject.clickEnterCodeLink();
 
   await challengeEmailPageObject.verifyFactor('credentials.passcode', '1234');
-  await challengeEmailPageObject.clickNextButton();
+  await challengeEmailPageObject.clickVerifyButton();
   await challengeEmailPageObject.waitForErrorBox();
 
   // Ensure identifier field is not pre-filled
@@ -209,7 +210,7 @@ test.requestHooks(identifyRequestLogger, identifyWithEmailAuthenticator)('identi
   await challengeEmailPageObject.clickEnterCodeLink();
 
   await challengeEmailPageObject.verifyFactor('credentials.passcode', '1234');
-  await challengeEmailPageObject.clickNextButton();
+  await challengeEmailPageObject.clickVerifyButton();
 
   const req = identifyRequestLogger.requests[0].request;
   const reqBody = JSON.parse(req.body);
@@ -233,7 +234,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should pre-fill identifi
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();  
+  await identityPage.clickVerifyButton();
 
   await t.expect(identifyRequestLogger.count(() => true)).eql(2);
   const req = identifyRequestLogger.requests[0].request;
@@ -265,7 +266,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should pre-fill identifi
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();  
+  await identityPage.clickVerifyButton();  
 
   await t.expect(identifyRequestLogger.count(() => true)).eql(2);
   const req = identifyRequestLogger.requests[0].request;


### PR DESCRIPTION
## Description:

Purpose of this PR is to enable IdentifyWithRememberUsername spec test to run on v3 SIW.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-518962](https://oktainc.atlassian.net/browse/OKTA-518962)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



