### PR TITLE
OKTA-518959 : Identify unknown user spec test update

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -235,7 +235,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       return;
     }
     events?.afterRender?.(getEventContext(idxTransaction));
-
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [idxTransaction, bootstrap]);
 

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -235,6 +235,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       return;
     }
     events?.afterRender?.(getEventContext(idxTransaction));
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [idxTransaction, bootstrap]);
 

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, userVariables } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 const CALLOUT_SELECTOR = '[data-se="callout"]';
@@ -145,11 +145,14 @@ export default class IdentityPageObject extends BasePageObject {
   }
 
   hasUnknownUserErrorCallout() {
+    if(userVariables.v3) {
+      return this.form.hasErrorBox();
+    }
     return this.form.getCallout(CALLOUT_SELECTOR).hasClass('infobox-error');
   }
 
   getUnknownUserCalloutContent() {
-    return this.form.getCallout(CALLOUT_SELECTOR).textContent;
+    return this.form.getErrorBoxText();
   }
 
   getIdpButton(selector) {

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -194,6 +194,10 @@ export default class BaseFormObject {
     return this.el.find(FORM_INFOBOX_ERROR).innerText;
   }
 
+  hasErrorBox() {
+    return within(this.el).getByRole('alert').exists;
+  }
+
   getAllErrorBoxTexts() {
     return this.getInnerTexts(FORM_INFOBOX_ERROR);
   }

--- a/test/testcafe/spec/IdentifyUnknownUser_spec.js
+++ b/test/testcafe/spec/IdentifyUnknownUser_spec.js
@@ -20,7 +20,7 @@ const unassignedApplinkMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(notAssignedApp);
 
-fixture('Identify Unknown User');
+fixture('Identify Unknown User').meta('v3', true);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);


### PR DESCRIPTION
## Description:

Updates Identify unknown user spec test for parity with v3.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-518959](https://oktainc.atlassian.net/browse/OKTA-518959)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



