### PR TITLE
Creates downstream build for dockolith

### DIFF
--- a/scripts/downstream/create-downstream-for-dockolith.sh
+++ b/scripts/downstream/create-downstream-for-dockolith.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/bash -xe
 : "${upstream_artifact_branch?:"missing upstream_artifact_branch"}"
 
 local dockolith_branch="${upstream_artifact_branch}"
 local widget_home="$(readlink -f "$(dirname "$BASH_SOURCE")/../..")"
 
 # Update setup script
-pushd ${widget_home}/scripts > /dev/null
+pushd ${widget_home}/scripts/monolith > /dev/null
 echo "Update DOCKOLITH_BRANCH version in scripts/install-dockolith.sh to ${dockolith_branch}"
 sed -i "s/\(DOCKOLITH_BRANCH\=\).*/\1\"${dockolith_branch}\"/g" install-dockolith.sh
 popd > /dev/null

--- a/scripts/downstream/create-downstream-for-dockolith.sh
+++ b/scripts/downstream/create-downstream-for-dockolith.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "${upstream_artifact_branch}"
+
+DOCKOLITH_BRANCH="${upstream_artifact_branch}"
+
+# Update setup script
+echo "Update DOCKOLITH_BRANCH version in scripts/install-dockolith.sh to ${DOCKOLITH_BRANCH}"
+sed -i "s/\(DOCKOLITH_BRANCH\=\).*/\1\"${DOCKOLITH_BRANCH}\"/g" install-dockolith.sh
+

--- a/scripts/downstream/create-downstream-for-dockolith.sh
+++ b/scripts/downstream/create-downstream-for-dockolith.sh
@@ -4,8 +4,7 @@
 local dockolith_branch="${upstream_artifact_branch}"
 local widget_home="$(readlink -f "$(dirname "$BASH_SOURCE")/../..")"
 
-# Update setup script
+# Update script
 pushd ${widget_home}/scripts/monolith > /dev/null
-echo "Update DOCKOLITH_BRANCH version in scripts/install-dockolith.sh to ${dockolith_branch}"
 sed -i "s/\(DOCKOLITH_BRANCH\=\).*/\1\"${dockolith_branch}\"/g" install-dockolith.sh
 popd > /dev/null

--- a/scripts/downstream/create-downstream-for-dockolith.sh
+++ b/scripts/downstream/create-downstream-for-dockolith.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
+: "${upstream_artifact_branch?:"missing upstream_artifact_branch"}"
 
-echo "${upstream_artifact_branch}"
-
-DOCKOLITH_BRANCH="${upstream_artifact_branch}"
+local dockolith_branch="${upstream_artifact_branch}"
+local widget_home="$(readlink -f "$(dirname "$BASH_SOURCE")/../..")"
 
 # Update setup script
-echo "Update DOCKOLITH_BRANCH version in scripts/install-dockolith.sh to ${DOCKOLITH_BRANCH}"
-sed -i "s/\(DOCKOLITH_BRANCH\=\).*/\1\"${DOCKOLITH_BRANCH}\"/g" install-dockolith.sh
-
+pushd ${widget_home}/scripts > /dev/null
+echo "Update DOCKOLITH_BRANCH version in scripts/install-dockolith.sh to ${dockolith_branch}"
+sed -i "s/\(DOCKOLITH_BRANCH\=\).*/\1\"${dockolith_branch}\"/g" install-dockolith.sh
+popd > /dev/null

--- a/scripts/monolith/install-dockolith.sh
+++ b/scripts/monolith/install-dockolith.sh
@@ -1,9 +1,14 @@
 #!/bin/bash -xe
 
-DOCKOLITH_BRANCH=ag-OKTA-535068-email
+# Set this to a development branch to try new features
+export DOCKOLITH_BRANCH=
+if [[ -n ${DOCKOLITH_BRANCH} ]]; then
+  DOCKOLITH_BRANCH=master
+fi
 
 pushd ./scripts
 rm -rf dockolith
+echo "Cloning dockolith from branch ${DOCKOLITH_BRANCH}"
 git clone --depth 1 -b $DOCKOLITH_BRANCH https://github.com/okta/dockolith.git
 popd
 

--- a/scripts/monolith/install-dockolith.sh
+++ b/scripts/monolith/install-dockolith.sh
@@ -1,14 +1,12 @@
 #!/bin/bash -xe
 
-# Set this to a development branch to try new features
-export DOCKOLITH_BRANCH=
 if [[ -n ${DOCKOLITH_BRANCH} ]]; then
-  DOCKOLITH_BRANCH=master
+  export DOCKOLITH_BRANCH=master
 fi
 
 pushd ./scripts
 rm -rf dockolith
-echo "Cloning dockolith from branch ${DOCKOLITH_BRANCH}"
+echo "Cloning dockolith from branch: ${DOCKOLITH_BRANCH}"
 git clone --depth 1 -b $DOCKOLITH_BRANCH https://github.com/okta/dockolith.git
 popd
 


### PR DESCRIPTION
## Description:
Creates a downstream build from dockolith to okta-signin-widget.

This is to verify any changes to the upstream dockolith package will not break widget tests before it is merged

sample run: https://bacon-go.aue1e.saasure.net/tasks/DOWNSTREAM_ARTIFACT_CREATE_COMMIT?taskId=aa8ae5c7e65741e586da531948f1dfed

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-541910](https://oktainc.atlassian.net/browse/OKTA-541910)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



