### PR TITLE
OKTA-518971 : ReEnrollAuthenticatorWarningPasswordView parity spec

### DIFF
--- a/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordWarningAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordWarningAuthenticator.test.ts.snap
@@ -369,14 +369,12 @@ Object {
         "type": "Button",
       },
       Object {
-        "label": "password.expiring.later",
         "options": Object {
+          "isActionStep": false,
+          "label": "password.expiring.later",
           "step": "skip",
-          "type": "button",
-          "variant": "floating",
-          "wide": false,
         },
-        "type": "Button",
+        "type": "Link",
       },
     ],
     "type": "VerticalLayout",

--- a/src/v3/src/transformer/password/transformExpiredPasswordWarningAuthenticator.test.ts
+++ b/src/v3/src/transformer/password/transformExpiredPasswordWarningAuthenticator.test.ts
@@ -21,6 +21,7 @@ import {
   FieldElement,
   FormBag,
   HiddenInputElement,
+  LinkElement,
   PasswordRequirementsElement,
   TitleElement,
   WidgetProps,
@@ -380,13 +381,9 @@ describe('Expired Password Warning Authenticator Transformer Tests', () => {
       .toBe(ButtonType.SUBMIT);
     expect((updatedFormBag.uischema.elements[5] as ButtonElement).options.step)
       .toBe('reenroll-authenticator-warning');
-    expect((updatedFormBag.uischema.elements[6] as ButtonElement).label)
+    expect((updatedFormBag.uischema.elements[6] as LinkElement).options.label)
       .toBe('password.expiring.later');
-    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.step)
+    expect((updatedFormBag.uischema.elements[6] as LinkElement).options.step)
       .toBe('skip');
-    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.type)
-      .toBe(ButtonType.BUTTON);
-    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options.variant)
-      .toBe('floating');
   });
 });

--- a/src/v3/src/transformer/password/transformExpiredPasswordWarningAuthenticator.ts
+++ b/src/v3/src/transformer/password/transformExpiredPasswordWarningAuthenticator.ts
@@ -16,6 +16,7 @@ import {
   ButtonType,
   DescriptionElement,
   IdxStepTransformer,
+  LinkElement,
   PasswordSettings,
   TitleElement,
 } from '../../types';
@@ -85,17 +86,15 @@ export const transformExpiredPasswordWarningAuthenticator: IdxStepTransformer = 
   const skipStep = availableSteps?.find(({ name }) => name === 'skip' );
   if (skipStep) {
     const { name: step } = skipStep;
-    const skipBtnElement: ButtonElement = {
-      type: 'Button',
-      label: loc('password.expiring.later', 'login'),
+    const skipLinkEle: LinkElement = {
+      type: 'Link',
       options: {
-        type: ButtonType.BUTTON,
-        variant: 'floating',
-        wide: false,
+        label: loc('password.expiring.later', 'login'),
         step,
+        isActionStep: false,
       },
     };
-    uischema.elements.push(skipBtnElement);
+    uischema.elements.push(skipLinkEle);
   }
 
   return baseFormBag;

--- a/src/v3/src/transformer/testAttribute/transform.ts
+++ b/src/v3/src/transformer/testAttribute/transform.ts
@@ -66,6 +66,7 @@ const updateRegularButtons: TransformStepFn = (formbag) => {
     'currentAuthenticatorEnrollment-recover': 'forgot-password',
     'unlock-account': 'unlock',
     cancel: 'cancel',
+    skip: 'skip',
     'select-identify': 'back',
     'select-authenticator-authenticate': 'switchAuthenticator',
     'select-authenticator-enroll': 'switchAuthenticator',

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -611,19 +611,19 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-70"
-                    tabindex="0"
-                    type="button"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-70"
+                    data-se="skip"
+                    href="javascript:void(0)"
                   >
                     Remind me later
-                  </button>
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-72"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-70"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
+++ b/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
@@ -84,7 +84,7 @@ export default class EnrollPasswordPageObject extends BasePageObject {
   }
 
   async clickRemindMeLaterLink() {
-    await this.t.click(this.getLink('Remind me later'));
+    await this.t.click(this.form.getLink('Remind me later'));
   }
 
   doesTextExist(content) {

--- a/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
+++ b/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
@@ -70,4 +70,24 @@ export default class EnrollPasswordPageObject extends BasePageObject {
   getErrorBoxText() {
     return this.form.getErrorBoxText();
   }
+
+  clickChangePasswordButton() {
+    return this.form.clickSaveButton('Change Password');
+  }
+
+  changePasswordButtonExists() {
+    return this.form.getButton('Change Password').exists;
+  }
+
+  remindMeLaterLinkExists() {
+    return this.form.getLink('Remind me later').exists;
+  }
+
+  async clickRemindMeLaterLink() {
+    await this.t.click(this.getLink('Remind me later'));
+  }
+
+  doesTextExist(content) {
+    return this.form.getTextElement(content).exists;
+  }
 }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -170,6 +170,10 @@ export default class BaseFormObject {
     return within(this.el).getByRole('button').value;
   }
 
+  getTextElement(content) {
+    return within(this.el).getByText(content);
+  }
+
   // =====================================
   // Error
   // =====================================

--- a/test/testcafe/framework/shared/index.js
+++ b/test/testcafe/framework/shared/index.js
@@ -84,6 +84,13 @@ export async function assertRequestMatches(loggedRequest, url, method, body) {
   }
 }
 
+// eslint-disable-next-line @okta/okta/no-unlocalized-text-in-templates
+export const oktaDashboardContent = `
+  <h1 id="mock-user-dashboard-title">Mock User Dashboard</h1>
+  <h2>Query parameters</h2>
+  <a href="/">Back to Login</a>
+`;
+
 /**
  * Provides mock responses for common endpoints. Use this export instead of
  * importing from "testcafe" directly to avoid falling back to dyson mock server

--- a/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
@@ -45,7 +45,8 @@ const mockChangePasswordNotAllowed = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/skip')
   .respond(xhrSuccess);
 
-fixture('Password Authenticator Expiry Warning');
+fixture('Password Authenticator Expiry Warning')
+  .meta('v3', true);
 
 async function setup(t) {
   const passwordExpiryWarningPage = new FactorEnrollPasswordPageObject(t);
@@ -65,11 +66,11 @@ async function setup(t) {
   [ 'Your password will expire later today', mockExpireToday ],
   [ 'Your password is expiring soon', mockExpireSoon ],
 ].forEach(([ formTitle, mock ]) => {
-  test
+  test.meta('v3', false)
     .requestHooks(logger, mock)('Should have the correct labels - expire in days', async t => {
       const passwordExpiryWarningPage = await setup(t);
       await t.expect(passwordExpiryWarningPage.getFormTitle()).eql(formTitle);
-      await t.expect(passwordExpiryWarningPage.getSaveButtonLabel()).eql('Change Password');
+      await t.expect(passwordExpiryWarningPage.changePasswordButtonExists()).eql(true);
       await t.expect(passwordExpiryWarningPage.getRequirements()).contains('Password requirements:');
       await t.expect(passwordExpiryWarningPage.getRequirements()).contains('At least 8 characters');
       await t.expect(passwordExpiryWarningPage.getRequirements()).contains('An uppercase letter');
@@ -77,9 +78,9 @@ async function setup(t) {
       await t.expect(passwordExpiryWarningPage.getRequirements()).contains('A number');
       await t.expect(passwordExpiryWarningPage.getRequirements()).contains('No parts of your username');
       await t.expect(passwordExpiryWarningPage.getRequirements()).contains('Your password cannot be any of your last 4 passwords');
-      await t.expect(passwordExpiryWarningPage.getSkipLinkText()).eql('Remind me later');
+      await t.expect(passwordExpiryWarningPage.remindMeLaterLinkExists()).eql(true);
       await t.expect(passwordExpiryWarningPage.getSignoutLinkText()).eql('Back to sign in');
-      await t.expect(passwordExpiryWarningPage.getIonMessages()).eql('When your password expires you will be locked out of your Okta account.');
+      await t.expect(passwordExpiryWarningPage.doesTextExist('When your password expires you will be locked out of your Okta account.')).eql(true);
     });
 });
 
@@ -90,7 +91,7 @@ test
     await t.expect(passwordExpiryWarningPage.confirmPasswordFieldExists()).eql(true);
 
     // fields are required
-    await passwordExpiryWarningPage.clickNextButton();
+    await passwordExpiryWarningPage.clickChangePasswordButton();
     await passwordExpiryWarningPage.waitForErrorBox();
     await t.expect(passwordExpiryWarningPage.getPasswordError()).eql('This field cannot be left blank');
     await t.expect(passwordExpiryWarningPage.getConfirmPasswordError()).eql('This field cannot be left blank');
@@ -98,13 +99,13 @@ test
     // password must match
     await passwordExpiryWarningPage.fillPassword('abcd');
     await passwordExpiryWarningPage.fillConfirmPassword('1234');
-    await passwordExpiryWarningPage.clickNextButton();
+    await passwordExpiryWarningPage.clickChangePasswordButton();
     await passwordExpiryWarningPage.waitForErrorBox();
     await t.expect(passwordExpiryWarningPage.hasPasswordError()).eql(false);
     await t.expect(passwordExpiryWarningPage.getConfirmPasswordError()).eql('New passwords must match');
 
     await t.expect(await passwordExpiryWarningPage.signoutLinkExists()).ok();
-    await t.expect(await passwordExpiryWarningPage.skipLinkExists()).ok();
+    await t.expect(passwordExpiryWarningPage.remindMeLaterLinkExists()).eql(true);
   });
 
 test
@@ -114,7 +115,7 @@ test
 
     await passwordExpiryWarningPage.fillPassword('abcdabcd');
     await passwordExpiryWarningPage.fillConfirmPassword('abcdabcd');
-    await passwordExpiryWarningPage.clickNextButton();
+    await passwordExpiryWarningPage.clickChangePasswordButton();
 
     const pageUrl = await successPage.getPageUrl();
     await t.expect(pageUrl)
@@ -130,14 +131,14 @@ test
     });
   });
 
-test
+test.meta('v3', false)
   .requestHooks(logger, mockChangePasswordNotAllowed)('can choose "skip" if password change is not allowed', async t => {
     const passwordExpiryWarningPage = await setup(t);
     const successPage = new SuccessPageObject(t);
 
     await passwordExpiryWarningPage.fillPassword('abcdabcd');
     await passwordExpiryWarningPage.fillConfirmPassword('abcdabcd');
-    await passwordExpiryWarningPage.clickNextButton();
+    await passwordExpiryWarningPage.clickChangePasswordButton();
 
     await passwordExpiryWarningPage.waitForErrorBox();
 
@@ -146,9 +147,8 @@ test
     const errorText = passwordExpiryWarningPage.form.getErrorBoxText();
     await t.expect(errorText).eql('Change password not allowed on specified user.');
     await passwordExpiryWarningPage.confirmPasswordFieldExists();
-    const skipText = await passwordExpiryWarningPage.getSkipLinkText();
-    await t.expect(skipText).eql('Remind me later');
-    await passwordExpiryWarningPage.clickSkipLink();
+    await t.expect(passwordExpiryWarningPage.remindMeLaterLinkExists()).eql(true);
+    await passwordExpiryWarningPage.clickRemindMeLaterLink();
 
     const pageUrl = await successPage.getPageUrl();
     await t.expect(pageUrl)

--- a/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
@@ -1,4 +1,5 @@
 import { RequestMock, RequestLogger, userVariables } from 'testcafe';
+import { oktaDashboardContent } from '../framework/shared';
 import FactorEnrollPasswordPageObject from '../framework/page-objects/FactorEnrollPasswordPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import { checkConsoleMessages } from '../framework/shared';
@@ -17,7 +18,9 @@ const mockExpireInDays = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorExpiryWarningPassword)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
-  .respond(xhrSuccess);
+  .respond(xhrSuccess)
+  .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
+  .respond(oktaDashboardContent);
 
 const xhrAuthenticatorExpiryWarningPasswordExpireToday = JSON.parse(JSON.stringify(xhrAuthenticatorExpiryWarningPassword));
 xhrAuthenticatorExpiryWarningPasswordExpireToday.currentAuthenticator.value.settings.daysToExpiry = 0;


### PR DESCRIPTION
## Description:

The purpose of this PR is to implement necessary changes for Re-Enroll authenticator password warning spec for parity testing.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-518971](https://oktainc.atlassian.net/browse/OKTA-518971)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



