### PR TITLE
OKTA-518980 : Unlock account challenge spec test update

### DIFF
--- a/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
@@ -22,7 +22,7 @@ export default class ChallengeEmailPageObject extends ChallengeFactorPageObject 
 
   async clickEnterCodeLink() {
     if (userVariables.v3) {
-      await this.t.click(this.form.getButton('Enter a code from the email instead'));
+      await this.form.clickButton('Enter a code from the email instead');
     } else {
       await this.form.clickElement('.enter-auth-code-instead-link');
     }

--- a/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
@@ -31,7 +31,7 @@ export default class ChallengeFactorPageObject extends BasePageObject {
   }
 
   clickVerifyButton() {
-    return this.form.clickSaveButton('Verify');
+    return this.form.clickButton('Verify');
   }
 
   /**

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -8,7 +8,6 @@ const FORGOT_PASSWORD_SELECTOR = 'a[data-se="forgot-password"]';
 const CUSTOM_HELP_LINK_SELECTOR = '.auth-footer .js-help';
 const CUSTOM_HELP_LINKS_SELECTOR = '.auth-footer .js-custom';
 const CUSTOM_BUTTON = '.custom-buttons .okta-custom-buttons-container .default-custom-button';
-const UNLOCK_ACCOUNT = '.auth-footer .js-unlock';
 const SUB_LABEL_SELECTOR = '.o-form-explain';
 const IDPS_CONTAINER = '.okta-idps-container';
 const FOOTER_INFO_SELECTOR = '.footer-info';
@@ -203,11 +202,12 @@ export default class IdentityPageObject extends BasePageObject {
     await this.t.click(Selector(ENROLL_SELECTOR));
   }
 
-  getUnlockAccountLink() {
-    if(userVariables.v3) {
-      return this.form.getLink('Unlock account?');
-    }
-    return Selector(UNLOCK_ACCOUNT);
+  getUnlockAccountLink(name = 'Unlock account?') {
+    return this.form.getLink(name);
+  }
+
+  unlockAccountLinkExists(name = 'Unlock account?') {
+    return this.getUnlockAccountLink(name).exists;
   }
 
   getUnlockAccountLinkText() {
@@ -218,8 +218,8 @@ export default class IdentityPageObject extends BasePageObject {
     await this.t.click(this.getUnlockAccountLink());
   }
 
-  getCustomUnlockAccountLinkUrl() {
-    return this.getUnlockAccountLink().getAttribute('href');
+  getCustomUnlockAccountLinkUrl(name) {
+    return this.getUnlockAccountLink(name).getAttribute('href');
   }
 
   getIdentifierSubLabelValue() {

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -218,7 +218,7 @@ export default class IdentityPageObject extends BasePageObject {
     await this.t.click(this.getUnlockAccountLink());
   }
 
-  getCustomUnlockAccountLink() {
+  getCustomUnlockAccountLinkUrl() {
     return this.getUnlockAccountLink().getAttribute('href');
   }
 

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -55,10 +55,6 @@ export default class IdentityPageObject extends BasePageObject {
     return Selector(FORGOT_PASSWORD_SELECTOR).textContent;
   }
 
-  getUnlockAccountLinkText() {
-    return Selector(UNLOCK_ACCOUNT).textContent;
-  }
-
   async hasForgotPasswordLinkText() {
     const elCount = await Selector(FORGOT_PASSWORD_SELECTOR).count;
     return elCount === 1;
@@ -207,12 +203,23 @@ export default class IdentityPageObject extends BasePageObject {
     await this.t.click(Selector(ENROLL_SELECTOR));
   }
 
+  getUnlockAccountLink() {
+    if(userVariables.v3) {
+      return this.form.getLink('Unlock account?');
+    }
+    return Selector(UNLOCK_ACCOUNT);
+  }
+
+  getUnlockAccountLinkText() {
+    return this.getUnlockAccountLink().textContent;
+  }
+
   async clickUnlockAccountLink() {
-    await this.t.click(Selector(UNLOCK_ACCOUNT));
+    await this.t.click(this.getUnlockAccountLink());
   }
 
   getCustomUnlockAccountLink() {
-    return Selector(UNLOCK_ACCOUNT).getAttribute('href');
+    return this.getUnlockAccountLink().getAttribute('href');
   }
 
   getIdentifierSubLabelValue() {

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -27,4 +27,8 @@ export default class TerminalPageObject extends BasePageObject {
   waitForErrorBox() {
     return this.form.waitForErrorBox();
   }
+
+  doesTextExist(content) {
+    return this.form.getTextElement(content).exists;
+  }
 }

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -1,5 +1,6 @@
 import BasePageObject from './BasePageObject';
 import CalloutObject from './components/CalloutObject';
+import { userVariables } from 'testcafe';
 
 const TERMINAL_VIEW = '.siw-main-view.terminal';
 export default class TerminalPageObject extends BasePageObject {
@@ -30,5 +31,13 @@ export default class TerminalPageObject extends BasePageObject {
 
   doesTextExist(content) {
     return this.form.getTextElement(content).exists;
+  }
+
+  // Check for go back link unique to V2
+  async goBackLinkExistsV2() {
+    if(!userVariables.v3) {
+      return super.goBackLinkExists();
+    }
+    return false;
   }
 }

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -36,7 +36,7 @@ export default class TerminalPageObject extends BasePageObject {
   // Check for go back link unique to V2
   async goBackLinkExistsV2() {
     if(!userVariables.v3) {
-      return super.goBackLinkExists();
+      return this.goBackLinkExists();
     }
     return false;
   }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -137,12 +137,21 @@ export default class BaseFormObject {
     return within(this.el).getByRole('button', options);
   }
 
+  /**
+   * @param {string} name the text of the button to click
+   */
+  async clickButton(name) {
+    const buttonToClick = this.getButton(name);
+
+    await this.t.click(buttonToClick);
+  }
+
   getAllButtons() {
     return within(this.el).getAllByRole('button');
   }
 
   /**
-   * @param {string} name the text of the button to click
+   * @param {string} name the text of the save button to click
    */
   async clickSaveButton(name = 'Next') {
     await this.clickButton(name);

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -137,15 +137,6 @@ export default class BaseFormObject {
     return within(this.el).getByRole('button', options);
   }
 
-  /**
-   * @param {string} name the text of the button to click
-   */
-  async clickButton(name) {
-    const buttonToClick = this.getButton(name);
-
-    await this.t.click(buttonToClick);
-  }
-
   getAllButtons() {
     return within(this.el).getAllByRole('button');
   }
@@ -154,9 +145,7 @@ export default class BaseFormObject {
    * @param {string} name the text of the button to click
    */
   async clickSaveButton(name = 'Next') {
-    const buttonToClick = this.getButton(name);
-
-    await this.t.click(buttonToClick);
+    await this.clickButton(name);
   }
 
   /**

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -296,7 +296,7 @@ test.meta('v3', false).requestHooks(identifyMock)('should render custom Unlock a
   });
 
   await t.expect(identityPage.getUnlockAccountLinkText()).eql('HELP I\'M LOCKED OUT');
-  await t.expect(identityPage.getCustomUnlockAccountLink()).eql('http://unlockaccount');
+  await t.expect(identityPage.getCustomUnlockAccountLinkUrl()).eql('http://unlockaccount');
 });
 
 test.meta('v3', false).requestHooks(identifyMock)('should not render custom forgot password link', async t => {

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -283,6 +283,7 @@ test.meta('v3', false).requestHooks(identifyRequestLogger, identifyMock)('should
 
 test.meta('v3', false).requestHooks(identifyMock)('should render custom Unlock account link', async t => {
   const identityPage = await setup(t);
+  const customUnlockLinkText = 'HELP I\'M LOCKED OUT';
 
   await rerenderWidget({
     helpLinks: {
@@ -290,13 +291,13 @@ test.meta('v3', false).requestHooks(identifyMock)('should render custom Unlock a
     },
     i18n: {
       en: {
-        'unlockaccount': 'HELP I\'M LOCKED OUT'
+        'unlockaccount': customUnlockLinkText
       }
     }
   });
 
-  await t.expect(identityPage.getUnlockAccountLinkText()).eql('HELP I\'M LOCKED OUT');
-  await t.expect(identityPage.getCustomUnlockAccountLinkUrl()).eql('http://unlockaccount');
+  await t.expect(identityPage.unlockAccountLinkExists(customUnlockLinkText)).eql(true);
+  await t.expect(identityPage.getCustomUnlockAccountLinkUrl(customUnlockLinkText)).eql('http://unlockaccount');
 });
 
 test.meta('v3', false).requestHooks(identifyMock)('should not render custom forgot password link', async t => {

--- a/test/testcafe/spec/UnlockAccountChallenge_spec.js
+++ b/test/testcafe/spec/UnlockAccountChallenge_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, ClientFunction } from 'testcafe';
+import { RequestMock, ClientFunction, userVariables } from 'testcafe';
 import SelectFactorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
 import ChallengeEmailPageObject from '../framework/page-objects/ChallengeEmailPageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
@@ -34,7 +34,7 @@ const rerenderWidget = ClientFunction((settings) => {
   window.renderPlaygroundWidget(settings);
 });
 
-fixture('Unlock Account');
+fixture('Unlock Account').meta('v3', true);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
@@ -48,7 +48,7 @@ test.requestHooks(identifyLockedUserMock)('should show unlock account link', asy
 });
 
 
-test.requestHooks(identifyLockedUserMock)('should render custom Unlock account link', async t => {
+test.meta('v3', false).requestHooks(identifyLockedUserMock)('should render custom Unlock account link', async t => {
   const identityPage = await setup(t);
 
   await rerenderWidget({
@@ -84,9 +84,11 @@ test.requestHooks(identifyLockedUserMock)('should show unlock account authentica
 
   const successPage = new TerminalPageObject(t);
   await t.expect(successPage.getFormTitle()).eql('Account successfully unlocked!');
-  await t.expect(successPage.getMessages()).eql('You can log in using your existing username and password.');
-  const gobackLinkExists = await successPage.goBackLinkExists();
-  await t.expect(gobackLinkExists).eql(false);
+  await t.expect(successPage.doesTextExist('You can log in using your existing username and password.')).eql(true);
+  if(!userVariables.v3) {
+    const gobackLinkExists = await successPage.goBackLinkExists();
+    await t.expect(gobackLinkExists).eql(false);
+  }
   const signoutLinkExists = await successPage.signoutLinkExists();
   await t.expect(signoutLinkExists).eql(true);
 });

--- a/test/testcafe/spec/UnlockAccountChallenge_spec.js
+++ b/test/testcafe/spec/UnlockAccountChallenge_spec.js
@@ -63,7 +63,7 @@ test.meta('v3', false).requestHooks(identifyLockedUserMock)('should render custo
   });
 
   await t.expect(identityPage.getUnlockAccountLinkText()).eql('HELP I\'M LOCKED OUT');
-  await t.expect(identityPage.getCustomUnlockAccountLink()).eql('http://unlockaccount');
+  await t.expect(identityPage.getCustomUnlockAccountLinkUrl()).eql('http://unlockaccount');
 });
 
 test.requestHooks(identifyLockedUserMock)('should show unlock account authenticator selection list', async t => {

--- a/test/testcafe/spec/UnlockAccountChallenge_spec.js
+++ b/test/testcafe/spec/UnlockAccountChallenge_spec.js
@@ -50,6 +50,7 @@ test.requestHooks(identifyLockedUserMock)('should show unlock account link', asy
 
 test.meta('v3', false).requestHooks(identifyLockedUserMock)('should render custom Unlock account link', async t => {
   const identityPage = await setup(t);
+  const customUnlockLinkText = 'HELP I\'M LOCKED OUT';
 
   await rerenderWidget({
     helpLinks: {
@@ -57,13 +58,13 @@ test.meta('v3', false).requestHooks(identifyLockedUserMock)('should render custo
     },
     i18n: {
       en: {
-        'unlockaccount': 'HELP I\'M LOCKED OUT'
+        'unlockaccount': customUnlockLinkText
       }
     }
   });
 
-  await t.expect(identityPage.getUnlockAccountLinkText()).eql('HELP I\'M LOCKED OUT');
-  await t.expect(identityPage.getCustomUnlockAccountLinkUrl()).eql('http://unlockaccount');
+  await t.expect(identityPage.unlockAccountLinkExists(customUnlockLinkText)).eql(true);
+  await t.expect(identityPage.getCustomUnlockAccountLinkUrl(customUnlockLinkText)).eql('http://unlockaccount');
 });
 
 test.requestHooks(identifyLockedUserMock)('should show unlock account authenticator selection list', async t => {

--- a/test/testcafe/spec/UnlockAccountChallenge_spec.js
+++ b/test/testcafe/spec/UnlockAccountChallenge_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, ClientFunction, userVariables } from 'testcafe';
+import { RequestMock, ClientFunction } from 'testcafe';
 import SelectFactorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
 import ChallengeEmailPageObject from '../framework/page-objects/ChallengeEmailPageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
@@ -80,15 +80,13 @@ test.requestHooks(identifyLockedUserMock)('should show unlock account authentica
   await t.expect(challengeEmailPageObject.getFormTitle()).eql('Verify with your email');
   await challengeEmailPageObject.clickEnterCodeLink();
   await challengeEmailPageObject.verifyFactor('credentials.passcode', '12345');
-  await challengeEmailPageObject.clickNextButton();
+  await challengeEmailPageObject.clickVerifyButton();
 
   const successPage = new TerminalPageObject(t);
   await t.expect(successPage.getFormTitle()).eql('Account successfully unlocked!');
   await t.expect(successPage.doesTextExist('You can log in using your existing username and password.')).eql(true);
-  if(!userVariables.v3) {
-    const gobackLinkExists = await successPage.goBackLinkExists();
-    await t.expect(gobackLinkExists).eql(false);
-  }
+  const gobackLinkExists = await successPage.goBackLinkExistsV2();
+  await t.expect(gobackLinkExists).eql(false);
   const signoutLinkExists = await successPage.signoutLinkExists();
   await t.expect(signoutLinkExists).eql(true);
 });
@@ -112,7 +110,7 @@ test.requestHooks(errorUnlockAccount)('should show error when unlock account fai
   const challengeEmailPageObject = new ChallengeEmailPageObject(t);
   await challengeEmailPageObject.clickEnterCodeLink();
   await challengeEmailPageObject.verifyFactor('credentials.passcode', '12345');
-  await challengeEmailPageObject.clickNextButton();
+  await challengeEmailPageObject.clickVerifyButton();
 
   const terminaErrorPage = new TerminalPageObject(t);
   await terminaErrorPage.waitForErrorBox();


### PR DESCRIPTION
## Description:

This PR updates the Unlock account challenge spec test for parity.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-518980](https://oktainc.atlassian.net/browse/OKTA-518980)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



