### PR TITLE
OKTA-518973 : Reset authenticator password view spec test update

### DIFF
--- a/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
+++ b/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
@@ -3,6 +3,7 @@ import BasePageObject from './BasePageObject';
 const passwordFieldName = 'credentials\\.passcode';
 const confirmPasswordFieldName = 'confirmPassword';
 const requirementsSelector = '[data-se="password-authenticator--rules"]';
+const resetPasswordButtonName = 'Reset Password';
 
 /**
  * This page object will be used by 
@@ -36,6 +37,10 @@ export default class EnrollPasswordPageObject extends BasePageObject {
 
   clickNextButton() {
     return this.form.clickSaveButton();
+  }
+
+  clickResetPasswordButton() {
+    this.form.clickButton(resetPasswordButtonName);
   }
 
   waitForErrorBox() {
@@ -89,5 +94,9 @@ export default class EnrollPasswordPageObject extends BasePageObject {
 
   doesTextExist(content) {
     return this.form.getTextElement(content).exists;
+  }
+
+  resetPasswordButtonExists() {
+    return this.form.getButton(resetPasswordButtonName).exists;
   }
 }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -140,6 +140,15 @@ export default class BaseFormObject {
   /**
    * @param {string} name the text of the button to click
    */
+  async clickButton(name) {
+    const buttonToClick = this.getButton(name);
+
+    await this.t.click(buttonToClick);
+  }
+
+  /**
+   * @param {string} name the text of the button to click
+   */
   async clickSaveButton(name = 'Next') {
     const buttonToClick = this.getButton(name);
 

--- a/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
@@ -1,4 +1,5 @@
 import { RequestMock, RequestLogger } from 'testcafe';
+import { oktaDashboardContent } from '../framework/shared';
 import FactorEnrollPasswordPageObject from '../framework/page-objects/FactorEnrollPasswordPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import { checkConsoleMessages } from '../framework/shared';
@@ -16,7 +17,9 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorResetPassword)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
-  .respond(xhrSuccess);
+  .respond(xhrSuccess)
+  .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
+  .respond(oktaDashboardContent);
 
 fixture('Authenticator Reset Password').meta('v3', true);
 

--- a/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
@@ -18,7 +18,7 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrSuccess);
 
-fixture('Authenticator Reset Password');
+fixture('Authenticator Reset Password').meta('v3', true);
 
 async function setup(t) {
   const resetPasswordPage = new FactorEnrollPasswordPageObject(t);
@@ -33,11 +33,11 @@ async function setup(t) {
   return resetPasswordPage;
 }
 
-test
+test.meta('v3', false)
   .requestHooks(logger, mock)('Should have the correct labels', async t => {
     const resetPasswordPage = await setup(t);
     await t.expect(resetPasswordPage.getFormTitle()).eql('Reset your password');
-    await t.expect(resetPasswordPage.getSaveButtonLabel()).eql('Reset Password');
+    await t.expect(resetPasswordPage.resetPasswordButtonExists()).eql(true);
     await t.expect(resetPasswordPage.getRequirements()).contains('Password requirements:');
     await t.expect(resetPasswordPage.getRequirements()).contains('At least 8 characters');
     await t.expect(resetPasswordPage.getRequirements()).contains('An uppercase letter');
@@ -55,7 +55,7 @@ test
     await t.expect(resetPasswordPage.confirmPasswordFieldExists()).eql(true);
 
     // fields are required
-    await resetPasswordPage.clickNextButton();
+    await resetPasswordPage.clickResetPasswordButton();
     await resetPasswordPage.waitForErrorBox();
     await t.expect(resetPasswordPage.getPasswordError()).eql('This field cannot be left blank');
     await t.expect(resetPasswordPage.getConfirmPasswordError()).eql('This field cannot be left blank');
@@ -63,7 +63,7 @@ test
     // password must match
     await resetPasswordPage.fillPassword('abcd');
     await resetPasswordPage.fillConfirmPassword('1234');
-    await resetPasswordPage.clickNextButton();
+    await resetPasswordPage.clickResetPasswordButton();
     await resetPasswordPage.waitForErrorBox();
     await t.expect(resetPasswordPage.hasPasswordError()).eql(false);
     await t.expect(resetPasswordPage.getConfirmPasswordError()).eql('New passwords must match');
@@ -78,7 +78,7 @@ test
 
     await resetPasswordPage.fillPassword('abcdabcd');
     await resetPasswordPage.fillConfirmPassword('abcdabcd');
-    await resetPasswordPage.clickNextButton();
+    await resetPasswordPage.clickResetPasswordButton();
 
     const pageUrl = await successPage.getPageUrl();
     await t.expect(pageUrl)


### PR DESCRIPTION
## Description:

This PR updates the Reset authenticator password view spec test for parity.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-518973](https://oktainc.atlassian.net/browse/OKTA-518973)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



