### PR TITLE
latest courage update

### DIFF
--- a/packages/@okta/courage-dist/esm/src/courage/models/SchemaProperty.js
+++ b/packages/@okta/courage-dist/esm/src/courage/models/SchemaProperty.js
@@ -91,7 +91,10 @@ const SchemaPropertySchemaProperty = BaseModel.extend({
     unique: undefined,
     __metadata__: undefined,
     __isSensitive__: BaseModel.ComputedProperty(['settings'], function (settings) {
-      return !!(settings && settings.sensitive);
+      return !!(settings && settings.sensitive && settings.sensitive !== 'NOT_SENSITIVE');
+    }),
+    __isPendingSensitive__: BaseModel.ComputedProperty(['settings'], function (settings) {
+      return !!(settings && settings.sensitive && settings.sensitive === 'PENDING_SENSITIVE');
     }),
     __unique__: false,
     __isUniqueValidated__: BaseModel.ComputedProperty(['unique'], function (unique) {

--- a/packages/@okta/courage-dist/esm/src/courage/vendor/lib/jquery-1.12.4.js
+++ b/packages/@okta/courage-dist/esm/src/courage/vendor/lib/jquery-1.12.4.js
@@ -4125,9 +4125,8 @@ import { j as jquery1_12_4 } from '../../../../_virtual/jquery-1.12.4.js';
   }
 
   (function () {
-    var i,
-        eventName,
-        div = document.createElement("div"); // Support: IE<9 (lack submit/change bubble), Firefox (lack focus(in | out) events)
+    var i, eventName; // Support: IE<9 (lack submit/change bubble), Firefox (lack focus(in | out) events)
+    // OKTA-542169 - fix for csp violation - Removed IE<9 only logic
 
     for (i in {
       submit: true,
@@ -4135,16 +4134,8 @@ import { j as jquery1_12_4 } from '../../../../_virtual/jquery-1.12.4.js';
       focusin: true
     }) {
       eventName = "on" + i;
-
-      if (!(support[i] = eventName in window)) {
-        // Beware of CSP restrictions (https://developer.mozilla.org/en/Security/CSP)
-        div.setAttribute(eventName, "t");
-        support[i] = div.attributes[eventName].expando === false;
-      }
-    } // Null elements to avoid leaks in IE.
-
-
-    div = null;
+      support[i] = eventName in window;
+    }
   })();
 
   var rformElems = /^(?:input|select|textarea)$/i,

--- a/packages/@okta/courage-dist/esm/src/courage/vendor/plugins/chosen.jquery.js
+++ b/packages/@okta/courage-dist/esm/src/courage/vendor/plugins/chosen.jquery.js
@@ -210,7 +210,7 @@ import jQuery from '../lib/jquery-1.12.4.js';
         classes.push(option.classes);
       }
 
-      style = option.style.cssText !== "" ? " style=\"" + option.style + "\"" : "";
+      style = option.style.cssText !== "" && option.style !== "" ? " style=\"" + option.style + "\"" : "";
       return "<li id=\"" + option.dom_id + "\" class=\"" + classes.join(" ") + "\"" + style + ">" + option.html + "</li>";
     };
 

--- a/packages/@okta/courage-for-signin-widget/package.json
+++ b/packages/@okta/courage-for-signin-widget/package.json
@@ -37,7 +37,7 @@
     "@babel/plugin-transform-shorthand-properties": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@okta/babel-plugin-handlebars-inline-precompile": "3.1.0-beta.4200.gf3d0a27",
-    "@okta/courage": "4.5.0-7361-g7533d49",
+    "@okta/courage": "4.5.0-7417-gee15656",
     "@okta/eslint-plugin-okta-ui": "0.1.0-beta.4181.g1f38f27",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.1",

--- a/packages/@okta/courage-for-signin-widget/yarn.lock
+++ b/packages/@okta/courage-for-signin-widget/yarn.lock
@@ -487,10 +487,10 @@
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
 
-"@okta/courage@4.5.0-7361-g7533d49":
-  version "4.5.0-7361-g7533d49"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-7361-g7533d49.tgz#2b00efdfb3c57ec4bb26ed79718e7bc28b82b076"
-  integrity sha1-KwDv37PFfsS7Ju15cY57wouCsHY=
+"@okta/courage@4.5.0-7417-gee15656":
+  version "4.5.0-7417-gee15656"
+  resolved "https://artifacts.aue1e.internal:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-7417-gee15656.tgz#96f1ab1dc890da7afb2319429e60c770c3ac7554"
+  integrity sha1-lvGrHciQ2nr7IxlCnmDHcMOsdVQ=
   dependencies:
     "@okta/jquery.simplemodal" "1.4.19-g8b711ea"
     "@types/backbone" "^1.4.10"


### PR DESCRIPTION
## Description:

Brings in latest changes of Courage version which has [Vulns fixes ](https://github.com/okta/okta-ui/pull/5824)in jQuery.



This also brings in 
https://github.com/okta/okta-ui/pull/5646 by @alexma-okta 
https://github.com/okta/okta-ui/pull/5798 by @ganeshsomasundaram-okta 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-542169](https://oktainc.atlassian.net/browse/OKTA-542169)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=e2ae06682026e0b8e7f93804bb375f06ce15116a&tab=main


