### PR TITLE
OKTA-518968 : Profile Enrollment with string options parity spec

### DIFF
--- a/src/v3/src/components/Radio/Radio.tsx
+++ b/src/v3/src/components/Radio/Radio.tsx
@@ -70,6 +70,7 @@ const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProp
       <RadioGroup
         name={name}
         id={name}
+        data-se={name}
         aria-describedby={error && `${name}-error`}
         value={value as string ?? ''}
         onChange={handleChange}

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -329,6 +329,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </label>
                     <div
                       class="MuiFormGroup-root emotion-17"
+                      data-se="authenticator.channel"
                       id="authenticator.channel"
                       role="radiogroup"
                     >
@@ -1085,6 +1086,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </label>
                     <div
                       class="MuiFormGroup-root emotion-17"
+                      data-se="authenticator.channel"
                       id="authenticator.channel"
                       role="radiogroup"
                     >
@@ -1756,6 +1758,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </label>
                     <div
                       class="MuiFormGroup-root emotion-17"
+                      data-se="authenticator.channel"
                       id="authenticator.channel"
                       role="radiogroup"
                     >
@@ -3781,6 +3784,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </label>
                     <div
                       class="MuiFormGroup-root emotion-17"
+                      data-se="authenticator.channel"
                       id="authenticator.channel"
                       role="radiogroup"
                     >

--- a/test/testcafe/framework/page-objects/ProfileEnrollmentStringOptionsViewPageObject.js
+++ b/test/testcafe/framework/page-objects/ProfileEnrollmentStringOptionsViewPageObject.js
@@ -21,6 +21,10 @@ export default class ProfileEnrollmentStringOptionsViewPageObject extends BasePa
     return this.form.clickSaveButton();
   }
 
+  clickSignUpButton() {
+    return this.form.clickSaveButton('Sign Up');
+  }
+
   fillEmailField(value) {
     return this.form.setTextBoxValue('userProfile.email', value);
   }

--- a/test/testcafe/framework/page-objects/ProfileEnrollmentStringOptionsViewPageObject.js
+++ b/test/testcafe/framework/page-objects/ProfileEnrollmentStringOptionsViewPageObject.js
@@ -40,4 +40,8 @@ export default class ProfileEnrollmentStringOptionsViewPageObject extends BasePa
   fillOptionalField(value) {
     return this.form.setTextBoxValue('userProfile.string1', value);
   }
+
+  dropDownFieldByLabelExists(label) {
+    return this.form.fieldByLabelExists(label, { selector: 'select' });
+  }
 }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -31,6 +31,10 @@ export default class BaseFormObject {
     return this.el.find(selector).exists;
   }
 
+  fieldByLabelExists(label) {
+    return within(this.el).getByLabelText(new RegExp(label)).exists;
+  }
+
   getElement(selector) {
     return this.el.find(selector);
   }
@@ -274,6 +278,15 @@ export default class BaseFormObject {
   }
 
   async selectValueChozenDropdown(fieldName, index) {
+    if (userVariables.v3) {
+      const selectEle = await this.el.find(`[data-se="${fieldName}"]`);
+
+      await this.t.click(selectEle);
+      
+      const option = selectEle.child().nth(index);
+      await this.t.click(option);
+      return;
+    }
     const selectContainer = await this.findFormFieldInput(fieldName)
       .find('.chzn-container');
     const containerId = await selectContainer.getAttribute('id');
@@ -284,12 +297,20 @@ export default class BaseFormObject {
     await this.t.click(option);
   }
 
-
   // =====================================
   // radio button
   // =====================================
 
   async selectRadioButtonOption(fieldName, index) {
+    if (userVariables.v3) {
+      const radioEle = await this.el.find(`[data-se="${fieldName}"]`);
+
+      const radioOpt = await radioEle.child().nth(index);
+      await this.t.click(radioOpt);
+      const optionLabel = await radioOpt.textContent;
+
+      return optionLabel;
+    }
     const radioOption = await this.findFormFieldInput(fieldName)
       .find('.radio-label')
       .nth(index);

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -31,8 +31,8 @@ export default class BaseFormObject {
     return this.el.find(selector).exists;
   }
 
-  fieldByLabelExists(label) {
-    return within(this.el).getByLabelText(new RegExp(label)).exists;
+  fieldByLabelExists(label, options = undefined) {
+    return within(this.el).getByLabelText(new RegExp(label), options).exists;
   }
 
   getElement(selector) {

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -66,7 +66,8 @@ const requestLogger = RequestLogger(
   }
 );
 
-fixture('Enroll Profile');
+fixture('Enroll Profile')
+  .meta('v3', true);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -66,8 +66,7 @@ const requestLogger = RequestLogger(
   }
 );
 
-fixture('Enroll Profile')
-  .meta('v3', true);
+fixture('Enroll Profile');
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);

--- a/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
+++ b/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
@@ -42,10 +42,10 @@ test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('s
   await t.expect(await profileEnrollmentString.form.fieldByLabelExists('Last name')).eql(true);
   await t.expect(await profileEnrollmentString.form.fieldByLabelExists('Email')).eql(true);
 
-  await t.expect(await profileEnrollmentString.form.fieldByLabelExists('Colors')).eql(true);
+  await t.expect(await profileEnrollmentString.dropDownFieldByLabelExists('Colors')).eql(true);
   await profileEnrollmentString.selectValueFromDropdown('userProfile.colores', 1);
 
-  await t.expect(await profileEnrollmentString.form.fieldByLabelExists('Favorite Song')).eql(true);
+  await t.expect(await profileEnrollmentString.dropDownFieldByLabelExists('Favorite Song')).eql(true);
   await profileEnrollmentString.selectValueFromDropdown('userProfile.favsong', 1);
 
   const favPizza = await profileEnrollmentString.clickRadioButton('userProfile.favpizza', 1);

--- a/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
+++ b/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
@@ -21,7 +21,8 @@ const requestLogger = RequestLogger(
   }
 );
 
-fixture('Enroll Profile');
+fixture('Enroll Profile')
+  .meta('v3', true);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
@@ -37,22 +38,20 @@ test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('s
   requestLogger.clear();
   await t.expect(profileEnrollmentString.getFormTitle()).eql('Sign up');
 
-  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.firstName')).eql('First name');
-  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.lastName')).eql('Last name');
-  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.email')).eql('Email');
+  await t.expect(await profileEnrollmentString.form.fieldByLabelExists('First name')).eql(true);
+  await t.expect(await profileEnrollmentString.form.fieldByLabelExists('Last name')).eql(true);
+  await t.expect(await profileEnrollmentString.form.fieldByLabelExists('Email')).eql(true);
 
-  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.colores')).eql('Colors');
-  await t.expect(await profileEnrollmentString.getDropDownComponent('userProfile.colores')).ok();
+  await t.expect(await profileEnrollmentString.form.fieldByLabelExists('Colors')).eql(true);
   await profileEnrollmentString.selectValueFromDropdown('userProfile.colores', 1);
 
-  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.favsong')).eql('Favorite Song');
-  await t.expect(await profileEnrollmentString.getDropDownComponent('userProfile.favsong')).ok();
+  await t.expect(await profileEnrollmentString.form.fieldByLabelExists('Favorite Song')).eql(true);
   await profileEnrollmentString.selectValueFromDropdown('userProfile.favsong', 1);
 
   const favPizza = await profileEnrollmentString.clickRadioButton('userProfile.favpizza', 1);
   await t.expect(favPizza).eql('Razza');
 
-  await t.expect(await profileEnrollmentString.getSaveButtonLabel()).eql('Sign Up');
+  await t.expect(await profileEnrollmentString.form.getButton('Sign Up').exists).eql(true);
 });
 
 test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('should submit form when all optional fields are empty', async t => {
@@ -66,7 +65,7 @@ test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('s
   await profileEnrollmentString.fillOptionalField('');
 
   requestLogger.clear();
-  await profileEnrollmentString.clickFinishButton();
+  await profileEnrollmentString.clickSignUpButton();
 
   const req = requestLogger.requests[0].request;
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/enroll/new');


### PR DESCRIPTION
## Description:

The purpose of this PR is to enable v3 parity for Profile enrollment with string options spec test.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-518968](https://oktainc.atlassian.net/browse/OKTA-518968)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



