### PR TITLE
Waits until widget DOM paint before calling `afterRender`

### DIFF
--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -30,7 +30,6 @@ const Form: FunctionComponent<{
     idxTransaction: currTransaction,
     setMessage,
     dataSchemaRef,
-    widgetRendered,
     setWidgetRendered,
   } = useWidgetContext();
   const onSubmitHandler = useOnSubmit();

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -30,6 +30,7 @@ const Form: FunctionComponent<{
     idxTransaction: currTransaction,
     setMessage,
     dataSchemaRef,
+    widgetRendered,
     setWidgetRendered,
   } = useWidgetContext();
   const onSubmitHandler = useOnSubmit();
@@ -37,10 +38,11 @@ const Form: FunctionComponent<{
 
   useEffect(() => {
     setWidgetRendered(true);
-  });
+  }, [currTransaction]);
 
   const handleSubmit = useCallback(async (e: SubmitEvent) => {
     e.preventDefault();
+    setWidgetRendered(false);
     setMessage(undefined);
 
     const {

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -76,7 +76,15 @@ const Form: FunctionComponent<{
       params,
       step,
     });
-  }, [currTransaction, data, dataSchemaRef, onSubmitHandler, onValidationHandler, setMessage, setWidgetRendered]);
+  }, [
+    currTransaction,
+    data,
+    dataSchemaRef,
+    onSubmitHandler,
+    onValidationHandler,
+    setMessage,
+    setWidgetRendered,
+  ]);
 
   return (
     <form

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -11,7 +11,7 @@
  */
 
 import { FunctionComponent, h } from 'preact';
-import { useCallback } from 'preact/hooks';
+import { useCallback, useEffect } from 'preact/hooks';
 
 import { useWidgetContext } from '../../contexts';
 import { useOnSubmit, useOnSubmitValidation } from '../../hooks';
@@ -30,9 +30,14 @@ const Form: FunctionComponent<{
     idxTransaction: currTransaction,
     setMessage,
     dataSchemaRef,
+    setWidgetRendered,
   } = useWidgetContext();
   const onSubmitHandler = useOnSubmit();
   const onValidationHandler = useOnSubmitValidation();
+
+  useEffect(() => {
+    setWidgetRendered(true);
+  });
 
   const handleSubmit = useCallback(async (e: SubmitEvent) => {
     e.preventDefault();

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -37,7 +37,7 @@ const Form: FunctionComponent<{
 
   useEffect(() => {
     setWidgetRendered(true);
-  }, [currTransaction]);
+  }, [currTransaction, setWidgetRendered]);
 
   const handleSubmit = useCallback(async (e: SubmitEvent) => {
     e.preventDefault();
@@ -76,7 +76,7 @@ const Form: FunctionComponent<{
       params,
       step,
     });
-  }, [currTransaction, data, dataSchemaRef, onSubmitHandler, onValidationHandler, setMessage]);
+  }, [currTransaction, data, dataSchemaRef, onSubmitHandler, onValidationHandler, setMessage, setWidgetRendered]);
 
   return (
     <form

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -90,6 +90,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const pollingTransaction = usePolling(idxTransaction, widgetProps, data);
   const dataSchemaRef = useRef<FormBag['dataSchema']>();
   const [loading, setLoading] = useState<boolean>(false);
+  const [widgetRendered, setWidgetRendered] = useState<boolean>(false);
 
   useEffect(() => {
     // If we need to load a language (or apply custom i18n overrides), do
@@ -240,7 +241,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
     const { messages: newMessages = [] } = idxTransaction;
 
-    events?.afterRender?.(getEventContext(idxTransaction));
+    if (widgetRendered && typeof idxTransaction !== 'undefined') {
+      events?.afterRender?.(getEventContext(idxTransaction));
+    }
 
     // for multiple error messages
     newMessages?.forEach((newMessage) => {
@@ -254,7 +257,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     });
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [idxTransaction, bootstrap]);
+  }, [widgetRendered, idxTransaction]);
 
   return (
     <WidgetContextProvider value={{
@@ -273,6 +276,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       dataSchemaRef,
       loading,
       setLoading,
+      setWidgetRendered,
     }}
     >
       {/* Note that we need two theme providers until we fully migrate to odyssey-mui */}

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -276,7 +276,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       dataSchemaRef,
       loading,
       setLoading,
-      widgetRendered,
       setWidgetRendered,
     }}
     >

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -276,6 +276,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       dataSchemaRef,
       loading,
       setLoading,
+      widgetRendered,
       setWidgetRendered,
     }}
     >

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -40,4 +40,5 @@ export type IWidgetContext = {
   dataSchemaRef: MutableRef<FormBag['dataSchema'] | undefined>;
   loading: boolean;
   setLoading: StateUpdater<boolean>;
+  setWidgetRendered: StateUpdater<boolean>;
 };

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -40,6 +40,5 @@ export type IWidgetContext = {
   dataSchemaRef: MutableRef<FormBag['dataSchema'] | undefined>;
   loading: boolean;
   setLoading: StateUpdater<boolean>;
-  widgetRendered: boolean;
   setWidgetRendered: StateUpdater<boolean>;
 };

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -40,5 +40,6 @@ export type IWidgetContext = {
   dataSchemaRef: MutableRef<FormBag['dataSchema'] | undefined>;
   loading: boolean;
   setLoading: StateUpdater<boolean>;
+  widgetRendered: boolean;
   setWidgetRendered: StateUpdater<boolean>;
 };

--- a/test/testcafe/spec/Smoke_spec.js
+++ b/test/testcafe/spec/Smoke_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, RequestLogger } from 'testcafe';
+import { RequestMock, RequestLogger, Selector } from 'testcafe';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import { checkConsoleMessages, renderWidget } from '../framework/shared';
 import xhrIdentifyWithPassword from '../../../playground/mocks/data/idp/idx/identify-with-password.json';
@@ -21,6 +21,7 @@ fixture('Smoke Test')
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
   await identityPage.navigateToPage();
+  await t.expect(Selector('form').exists).eql(true);
   await checkConsoleMessages({
     controller: 'primary-auth',
     formName: 'identify',


### PR DESCRIPTION
## Description:

`afterRender` fix applied as part of https://github.com/okta/okta-signin-widget/pull/2882 for `0.0` beta branch

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-541518](https://oktainc.atlassian.net/browse/OKTA-541518)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



