### PR TITLE
Support multiple custom domains with PIV

### DIFF
--- a/docs/classic.md
+++ b/docs/classic.md
@@ -1472,14 +1472,16 @@ Settings for authentication with a Smart Card `X509` type IdP.
 
 - `className` *(optional)* - Class that can be added to the Smart Card IdP button.
 
-- `isCustomDomain` *(optional)* - Boolean that indicates if the request is coming from a [custom domain](https://developer.okta.com/docs/guides/custom-url-domain/overview). If omitted, it will indicate that the request is not coming from a custom domain.
+- `isCustomDomain` *(optional)* - Boolean that indicates if the request is coming from a [custom domain](https://developer.okta.com/docs/guides/custom-url-domain/overview). This is now deprecated, use `customDomain` instead to specify the hostname.
+
+- `customDomain` *(optional)* - The [custom domain](https://developer.okta.com/docs/guides/custom-url-domain/overview) from where the request is originating. This is used to correctly redirect back to the originating domain after PIV authentication completes.
 
     ```javascript
     piv: {
       certAuthUrl: '/your/cert/validation/endpoint',
       text: 'Authenticate with a Smart Card',
       className: 'custom-style',
-      isCustomDomain: true,
+      customDomain: 'example.com',
     }
     ```
 

--- a/src/v1/controllers/VerifyPIVController.js
+++ b/src/v1/controllers/VerifyPIVController.js
@@ -27,6 +27,7 @@ export default FormController.extend({
       const data = {
         fromURI: this.settings.get('relayState'),
         isCustomDomain: pivConfig.isCustomDomain,
+        customDomain: pivConfig.customDomain,
       };
 
       try {

--- a/test/unit/spec/v1/VerifyPIV_spec.js
+++ b/test/unit/spec/v1/VerifyPIV_spec.js
@@ -25,6 +25,7 @@ function setup(errorResponse, pivConfig) {
   const defaultConfig = {
     certAuthUrl: 'https://foo.com',
     isCustomDomain: true,
+    customDomain: 'bar.com',
   };
   const router = new Router(
     _.extend({
@@ -112,6 +113,7 @@ Expect.describe('PIV', function() {
           expect(JSON.parse(argsForPost.params)).toEqual({
             fromURI: '%2Fapp%2FUserHome',
             isCustomDomain: true,
+            customDomain: 'bar.com',
           });
         });
     });
@@ -135,10 +137,93 @@ Expect.describe('PIV', function() {
           });
         });
     });
+    itp('makes post call with correct data when isCustomDomain is false and customDomain is set', function() {
+      const config = {
+        certAuthUrl: 'https://foo.com',
+        isCustomDomain: false,
+        customDomain: 'bar.com',
+      };
+
+      return setup(null, config)
+        .then(function() {
+          return Expect.waitForSpyCall(SharedUtil.redirect);
+        })
+        .then(function() {
+          expect(Util.numAjaxRequests()).toBe(2);
+          const argsForPost = Util.getAjaxRequest(1);
+
+          expect(JSON.parse(argsForPost.params)).toEqual({
+            fromURI: '%2Fapp%2FUserHome',
+            isCustomDomain: false,
+            customDomain: 'bar.com',
+          });
+        });
+    });
+    itp('makes post call with correct data when isCustomDomain is false and customDomain is undefined', function() {
+      const config = {
+        certAuthUrl: 'https://foo.com',
+        isCustomDomain: false,
+        customDomain: undefined,
+      };
+
+      return setup(null, config)
+        .then(function() {
+          return Expect.waitForSpyCall(SharedUtil.redirect);
+        })
+        .then(function() {
+          expect(Util.numAjaxRequests()).toBe(2);
+          const argsForPost = Util.getAjaxRequest(1);
+
+          expect(JSON.parse(argsForPost.params)).toEqual({
+            fromURI: '%2Fapp%2FUserHome',
+            isCustomDomain: false,
+          });
+        });
+    });
     itp('makes post call with correct data when isCustomDomain is undefined', function() {
       const config = {
         certAuthUrl: 'https://foo.com',
         isCustomDomain: undefined,
+      };
+
+      return setup(null, config)
+        .then(function() {
+          return Expect.waitForSpyCall(SharedUtil.redirect);
+        })
+        .then(function() {
+          expect(Util.numAjaxRequests()).toBe(2);
+          const argsForPost = Util.getAjaxRequest(1);
+
+          expect(JSON.parse(argsForPost.params)).toEqual({
+            fromURI: '%2Fapp%2FUserHome',
+          });
+        });
+    });
+    itp('makes post call with correct data when isCustomDomain is undefined and customDomain is set', function() {
+      const config = {
+        certAuthUrl: 'https://foo.com',
+        isCustomDomain: undefined,
+        customDomain: 'bar.com',
+      };
+
+      return setup(null, config)
+        .then(function() {
+          return Expect.waitForSpyCall(SharedUtil.redirect);
+        })
+        .then(function() {
+          expect(Util.numAjaxRequests()).toBe(2);
+          const argsForPost = Util.getAjaxRequest(1);
+
+          expect(JSON.parse(argsForPost.params)).toEqual({
+            fromURI: '%2Fapp%2FUserHome',
+            customDomain: 'bar.com',
+          });
+        });
+    });
+    itp('makes post call with correct data when customDomain is undefined', function() {
+      const config = {
+        certAuthUrl: 'https://foo.com',
+        customDomain: undefined,
       };
 
       return setup(null, config)


### PR DESCRIPTION
## Description:

The dependency ticket for multiple custom domain support [OKTA-499994: PIV support for multiple custom domains per org](https://oktainc.atlassian.net/browse/OKTA-499994) requires small change to the request body of an XHR call made by the sign-in widget.

The endpoint that is invoked is `/api/internal/v1/authn/cert`: [https://github.com/okta/okta-core/blob/839556e350940d4e55ea5e4a380c82481b353b13/co[…]/saasure/controller/enduser/login/X509BasedLoginController.java](https://github.com/okta/okta-core/blob/839556e350940d4e55ea5e4a380c82481b353b13/components/web/login/web/src/main/java/com/saasure/controller/enduser/login/X509BasedLoginController.java#L382-L387)

This call is documented at https://github.com/okta/okta-signin-widget/blob/6fbd0c8a100c828f59dc5f194b3220f6c4a9dcc1/docs/classic.md?plain=1#L1498-L1507

In order to support multiple custom domains, I’ve added a new parameter called `customDomain` which will contain the actual name of the custom domain, instead of a boolean. I've also added a note that the existing `isCustomDomain` property is now deprecated.

This will be a backward compatible change until we finally decide to remove `isCustomDomain`, if ever.

### Corresponding backend PRs:

- https://github.com/okta/okta-core/pull/71896
- https://github.com/okta/okta-core/pull/72428


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-543914](https://oktainc.atlassian.net/browse/OKTA-543914)

### Reviewers:

- @gauthamgowrishankar-okta
- @nikolaystoilov-okta 
- @valberbenetz-okta 

### Screenshot/Video:

https://user-images.githubusercontent.com/34038751/199089886-be2ebcd9-1564-4c44-b3f0-ccd150192357.mov

https://user-images.githubusercontent.com/34038751/199089882-589a5bc1-24b8-4bad-a352-17b769a1c987.mov

### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=abdullah-OKTA-544405-update-okta-core-with-new-siw-for-multiple-custom-domain&page=1&pageSize=6&tab=main