### PR TITLE
feat: Adds checkbox to Reset Password page to revoke all sessions

### DIFF
--- a/docs/classic.md
+++ b/docs/classic.md
@@ -1537,6 +1537,8 @@ features: {
 
 - **features.prefillUsernameFromIdpDiscovery** - If `router` and `idpDiscovery` features are enabled, use route `signin/okta/:username` instead of `signin` for redirect from [IdP Discovery](#idp-discovery) page to primary auth page if IdP is your Okta org. Defaults to `false`.
 
+- **features.showSessionRevocation** - If set to `true`, it will show a checkbox that allows the user to revoke all of their active sessions during a Self Service Password Reset.
+
 ### Hooks
 
 > **Note**: Hooks are only supported when using the [Okta Identity Engine](#okta-identity-engine)

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -645,6 +645,7 @@ password.complexity.minAgeHours = At least {0} hour(s) must have elapsed since y
 # {0} is a number
 password.complexity.minAgeDays = At least {0} day(s) must have elapsed since you last changed your password.
 password.reset.verification = Verify with one of the following factors to reset your password.
+password.reset.revokeSessions = Sign me out of all other devices.
 
 # The actual description consists of the password length message + one or more list elements
 # {0} is a number

--- a/playground/mocks/data/api/v1/authn/recovery-answer.json
+++ b/playground/mocks/data/api/v1/authn/recovery-answer.json
@@ -1,0 +1,42 @@
+{
+    "stateToken": "00RCzpqu-u2eck3wufQ2_qwRmRUUGF5TlIHF7Wy-Wb",
+    "expiresAt": "2022-10-21T20:20:15.000Z",
+    "status": "PASSWORD_RESET",
+    "recoveryType": "PASSWORD",
+    "_embedded": {
+      "user": {
+        "id": "00u1ejh1oq5ChfLqk0g4",
+        "passwordChanged": "2022-10-17T19:59:32.000Z",
+        "profile": {
+          "login": "test.user@okta.com",
+          "firstName": "Test",
+          "lastName": "User",
+          "locale": "en_US",
+          "timeZone": "America/Los_Angeles"
+        }
+      },
+      "policy": {
+        "complexity": {
+          "minLength": 8,
+          "minLowerCase": 1,
+          "minUpperCase": 1,
+          "minNumber": 1,
+          "minSymbol": 0,
+          "excludeUsername": true
+        },
+        "age": { "minAgeMinutes": 0, "historyCount": 0 }
+      }
+    },
+    "_links": {
+      "next": {
+        "name": "resetPassword",
+        "href": "http://localhost:3000/api/v1/authn/credentials/reset_password",
+        "hints": { "allow": ["POST"] }
+      },
+      "cancel": {
+        "href": "http://localhost:3000/api/v1/authn/cancel",
+        "hints": { "allow": ["POST"] }
+      }
+    }
+  }
+  

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -108,6 +108,7 @@ const local: Record<string, ModelProperty> = {
   'features.showIdentifier': ['boolean', false, true],
   'features.autoFocus': ['boolean', false, true],
   'features.rememberMyUsernameOnOIE': ['boolean', false, false],
+  'features.showSessionRevocation': ['boolean', false, false],
   
   defaultCountryCode: ['string', false, 'US'],
 

--- a/test/testcafe/framework/page-objects-v1/ResetPasswordPageObject.js
+++ b/test/testcafe/framework/page-objects-v1/ResetPasswordPageObject.js
@@ -2,6 +2,12 @@ import { Selector, ClientFunction } from 'testcafe';
 import BasePageObject from '../page-objects/BasePageObject';
 
 const BACK_TO_SIGN_IN_SELECTOR = '[data-se="signout-link"]';
+const REVOKE_SESSIONS_WRAPPER = '.o-form-input-name-revokeSessions';
+const ANSWER_INPUT_NAME = 'answer';
+const NEW_PASSWORD_INPUT_NAME = 'newPassword';
+const CONFIRM_PASSWORD_INPUT_NAME = 'confirmPassword';
+const REVOKE_SESSIONS_CHECKBOX_NAME = 'revokeSessions';
+const RESET_PASSWORD_BUTTON = '.o-form-button-bar .button-primary';
 
 export default class ResetPasswordPageObject extends BasePageObject {
   constructor(t) {
@@ -13,11 +19,35 @@ export default class ResetPasswordPageObject extends BasePageObject {
     return Selector(BACK_TO_SIGN_IN_SELECTOR).exists;
   }
 
+  isRevokeSessionsPresent() {
+    return Selector(REVOKE_SESSIONS_WRAPPER).exists;
+  }
+
   async clickBackToSignInLink() {
     await this.t.click(Selector(BACK_TO_SIGN_IN_SELECTOR));
   }
 
   async getPageUrl() {
     return await ClientFunction(() => window.location.href)();
+  }
+
+  answerChallenge(answer) {
+    return this.form.setTextBoxValue(ANSWER_INPUT_NAME, answer);
+  }
+
+  setNewPassword(newPassword) {
+    return this.form.setTextBoxValue(NEW_PASSWORD_INPUT_NAME, newPassword);
+  }
+
+  setConfirmPassword(confirmPassword) {
+    return this.form.setTextBoxValue(CONFIRM_PASSWORD_INPUT_NAME, confirmPassword);
+  }
+
+  async clickResetPasswordButton() {
+    await this.t.click(Selector(RESET_PASSWORD_BUTTON));
+  }
+
+  async setRevokeSessionsCheckbox(value) {
+    return this.form.setCheckbox(REVOKE_SESSIONS_CHECKBOX_NAME, value);
   }
 }

--- a/test/testcafe/spec/v1/ResetPassword_spec.js
+++ b/test/testcafe/spec/v1/ResetPassword_spec.js
@@ -2,6 +2,7 @@ import { RequestMock, RequestLogger, ClientFunction } from 'testcafe';
 import { checkConsoleMessages } from '../../framework/shared';
 import ResetPasswordPageObject from '../../framework/page-objects-v1/ResetPasswordPageObject';
 import recoveryPasswordResponse from '../../../../playground/mocks/data/api/v1/authn/recovery-password';
+import recoveryAnswerResponse from '../../../../playground/mocks/data/api/v1/authn/recovery-answer';
 import cancelResponse from '../../../../playground/mocks/data/api/v1/authn/cancel';
 
 const renderWidget = ClientFunction((settings) => {
@@ -9,36 +10,47 @@ const renderWidget = ClientFunction((settings) => {
   window.renderPlaygroundWidget(settings);
 });
 
-const resetPasswordMock = RequestMock()
+const cancelResetPasswordMock = RequestMock()
   .onRequestTo('http://localhost:3000/api/v1/authn/recovery/token')
   .respond(recoveryPasswordResponse)
   .onRequestTo('http://localhost:3000/api/v1/authn/cancel')
   .respond(cancelResponse);
 
+const resetPasswordMock = RequestMock()
+  .onRequestTo('http://localhost:3000/api/v1/authn/recovery/token')
+  .respond(recoveryPasswordResponse)
+  .onRequestTo('http://localhost:3000/api/v1/authn/recovery/answer')
+  .respond(recoveryAnswerResponse)
+  .onRequestTo('http://localhost:3000/api/v1/authn/credentials/reset_password')
+  .respond(null);
+
 fixture('Reset Password');
 
-const logger = RequestLogger(/token|cancel/, {
+const logger = RequestLogger(/token|cancel|reset_password/, {
   logRequestBody: true,
   stringifyRequestBody: true,
   logResponseBody: true
 });
 
-async function setup(t) {
+const defaultConfig = {
+  stateToken: null, // setting stateToken to null to trigger the V1 flow
+  features: {
+    router: true,
+    showSessionRevocation: false
+  },
+  useClassicEngine: true
+};
+
+async function setup(t, config = defaultConfig) {
   const resetPasswordPage = new ResetPasswordPageObject(t);
   await resetPasswordPage.navigateToPage({ render: false });
   
   await resetPasswordPage.mockCrypto();
-  await renderWidget({
-    stateToken: null, // setting stateToken to null to trigger the V1 flow
-    features: {
-      router: true,
-    },
-    useClassicEngine: true
-  });
+  await renderWidget(config);
   return resetPasswordPage;
 }
 
-test.requestHooks(logger, resetPasswordMock)(
+test.requestHooks(logger, cancelResetPasswordMock)(
   'should clear the reset password transaction after going back to sign in and not navigate back to the security question after clicking the browser back button',
   async (t) => {
     let resetPasswordPage = await setup(t);
@@ -65,5 +77,88 @@ test.requestHooks(logger, resetPasswordMock)(
     const req2 = logger.requests[1].request;
     await t.expect(req2.url).eql('http://localhost:3000/api/v1/authn/cancel');
     await t.expect(req2.method).eql('post');
+  }
+);
+
+test.requestHooks(logger, resetPasswordMock)(
+  'should show the session revocation checkbox and properly handle its state by sending the value in the body of the request',
+  async (t) => {
+    let resetPasswordPage = await setup(t, {
+      ...defaultConfig,
+      features: {
+        ...defaultConfig.features,
+        showSessionRevocation: true
+      }
+    });
+
+    await checkConsoleMessages({ controller: 'recovery-loading' });
+    let pageUrl = await resetPasswordPage.getPageUrl();
+    await t.expect(pageUrl).eql('http://localhost:3000/signin/recovery-question');
+
+    await resetPasswordPage.answerChallenge('okta');
+    await resetPasswordPage.clickResetPasswordButton();
+
+    pageUrl = await resetPasswordPage.getPageUrl();
+    await t.expect(pageUrl).eql('http://localhost:3000/signin/password-reset');
+
+    await t.expect(resetPasswordPage.isRevokeSessionsPresent()).eql(true);
+
+    const newPassword = 'Abcd1234';
+    await resetPasswordPage.setNewPassword(newPassword);
+    await resetPasswordPage.setConfirmPassword(newPassword);
+    await resetPasswordPage.setRevokeSessionsCheckbox(true);
+
+    await resetPasswordPage.clickResetPasswordButton();
+
+    await t.expect(logger.requests.length).eql(2);
+
+    await resetPasswordPage.setRevokeSessionsCheckbox(false);
+    
+    const req1 = logger.requests[0].request;
+    await t.expect(req1.url).eql('http://localhost:3000/api/v1/authn/recovery/token');
+    await t.expect(req1.method).eql('post');
+
+    const req2 = logger.requests[1].request;
+    await t.expect(req2.url).eql('http://localhost:3000/api/v1/authn/credentials/reset_password');
+    await t.expect(req2.method).eql('post');
+    const requestBody = JSON.parse(req2.body);
+    await t.expect(requestBody.revokeSessions).eql(true);
+  }
+);
+
+test.requestHooks(logger, resetPasswordMock)(
+  'should not show the session revocation checkbox and should not send it in the body of the request',
+  async (t) => {
+    let resetPasswordPage = await setup(t);
+
+    await checkConsoleMessages({ controller: 'recovery-loading' });
+    let pageUrl = await resetPasswordPage.getPageUrl();
+    await t.expect(pageUrl).eql('http://localhost:3000/signin/recovery-question');
+
+    await resetPasswordPage.answerChallenge('okta');
+    await resetPasswordPage.clickResetPasswordButton();
+
+    pageUrl = await resetPasswordPage.getPageUrl();
+    await t.expect(pageUrl).eql('http://localhost:3000/signin/password-reset');
+
+    await t.expect(resetPasswordPage.isRevokeSessionsPresent()).eql(false);
+
+    const newPassword = 'Abcd1234';
+    await resetPasswordPage.setNewPassword(newPassword);
+    await resetPasswordPage.setConfirmPassword(newPassword);
+
+    await resetPasswordPage.clickResetPasswordButton();
+
+    await t.expect(logger.requests.length).eql(2);
+    
+    const req1 = logger.requests[0].request;
+    await t.expect(req1.url).eql('http://localhost:3000/api/v1/authn/recovery/token');
+    await t.expect(req1.method).eql('post');
+
+    const req2 = logger.requests[1].request;
+    await t.expect(req2.url).eql('http://localhost:3000/api/v1/authn/credentials/reset_password');
+    await t.expect(req2.method).eql('post');
+    const requestBody = JSON.parse(req2.body);
+    await t.expect(requestBody.revokeSessions).eql(undefined);
   }
 );


### PR DESCRIPTION
## Description:

Adds a checkbox that toggles whether or not we should revoke all of the user's sessions during Self Service Password Reset flow in classic mode.
The feature is behind the `showSessionRevocation` configuration.

bacon build: https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=OKTA-532208-add-session-revocation-to-classic-SSPR&page=1&pageSize=6&sha=a93883bca8ab8afa898b0d9cf8fe7d7968764f16&tab=main

okta-core pr exposing the feature:
https://github.com/okta/okta-core/pull/72580

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-532208](https://oktainc.atlassian.net/browse/OKTA-532208)

### Reviewers:

### Video:

https://okta.box.com/s/22rxmu2iv3lryw17lt8xfz8ntl3et4i5

### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-a93883b-6373dc01&page=1&pageSize=6&sha=ed6fd1059b36391da1bee92da1c1746ecfec43af&tab=main

