### PR TITLE
OKTA-539161 : Login redirect L10 error fix

### DIFF
--- a/src/v3/src/transformer/redirect/redirectTransformer.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.ts
@@ -40,8 +40,6 @@ export const redirectTransformer = (
   const appInfo = getAppInfo(transaction);
   const userInfo = getUserInfo(transaction);
 
-  let titleContent = 'oie.success.text.signingIn';
-
   if (interstitialBeforeLoginRedirect === InterstitialRedirectView.DEFAULT) {
     uischema.elements.push({
       type: 'Spinner',
@@ -62,22 +60,25 @@ export const redirectTransformer = (
   const { label, name } = appInfo;
   const appName = label ?? name;
   const { identifier } = userInfo;
-  const contentParams: string[] = [];
 
   // features.showIdentifier=true indicates we are already displaying identifier at the top of the form,
   // so no need to display again in the login text
   if (appName && identifier && !features?.showIdentifier) {
-    titleContent = 'oie.success.text.signingIn.with.appName.and.identifier';
-    contentParams.push(appName, identifier);
+    uischema.elements.unshift({
+      type: 'Description',
+      options: { content: loc('oie.success.text.signingIn.with.appName.and.identifier', 'login', [appName, identifier]) },
+    } as DescriptionElement);
   } else if (appName) {
-    titleContent = 'oie.success.text.signingIn.with.appName';
-    contentParams.push(appName);
+    uischema.elements.unshift({
+      type: 'Description',
+      options: { content: loc('oie.success.text.signingIn.with.appName', 'login', [appName]) },
+    } as DescriptionElement);
+  } else {
+    uischema.elements.unshift({
+      type: 'Description',
+      options: { content: loc('oie.success.text.signingIn', 'login') },
+    } as DescriptionElement);
   }
-
-  uischema.elements.unshift({
-    type: 'Description',
-    options: { content: loc(titleContent, 'login', contentParams.length > 0 ? contentParams : undefined) },
-  } as DescriptionElement);
 
   return formBag;
 };

--- a/src/v3/src/transformer/redirect/redirectTransformer.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.ts
@@ -41,7 +41,6 @@ export const redirectTransformer = (
   const userInfo = getUserInfo(transaction);
 
   let titleContent = 'oie.success.text.signingIn';
-  const contentParams: string[] = [];
 
   if (interstitialBeforeLoginRedirect === InterstitialRedirectView.DEFAULT) {
     uischema.elements.push({
@@ -63,6 +62,7 @@ export const redirectTransformer = (
   const { label, name } = appInfo;
   const appName = label ?? name;
   const { identifier } = userInfo;
+  const contentParams: string[] = [];
 
   // features.showIdentifier=true indicates we are already displaying identifier at the top of the form,
   // so no need to display again in the login text
@@ -76,7 +76,7 @@ export const redirectTransformer = (
 
   uischema.elements.unshift({
     type: 'Description',
-    options: { content: loc(titleContent, 'login', [contentParams]) },
+    options: { content: loc(titleContent, 'login', contentParams.length > 0 ? contentParams : undefined) },
   } as DescriptionElement);
 
   return formBag;


### PR DESCRIPTION
## Description:

This PR fixes the issue where an L10 error appears during the redirect when trying to login via bookmark app.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-539161](https://oktainc.atlassian.net/browse/OKTA-539161)

### Reviewers:

### Screenshot/Video:
**Before**: 
<img width="608" alt="Screen Shot 2022-11-02 at 11 05 17 AM" src="https://user-images.githubusercontent.com/107433508/199568347-335f5c27-baf7-41b3-9647-e91d72bfaf8a.png">

**After**:
<img width="651" alt="Screen Shot 2022-11-02 at 11 08 28 AM" src="https://user-images.githubusercontent.com/107433508/199568380-739a6b15-c4ea-4e64-aed8-d2218fd7fe91.png">

### Downstream Monolith Build:



