### PR TITLE
Pd okta 545966 smart card icon

### DIFF
--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -698,7 +698,8 @@
     }
   }
 
-  .smartcard, .mfa-smartcard {
+  .smartcard,
+  .mfa-smartcard {
     /* -- Factor Icons (large): PIV -- */
     background-image: url('../img/icons/login/smartcard_70x70.png');
 

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -698,7 +698,7 @@
     }
   }
 
-  .smartcard {
+  .smartcard, .mfa-smartcard {
     /* -- Factor Icons (large): PIV -- */
     background-image: url('../img/icons/login/smartcard_70x70.png');
 

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1163,6 +1163,9 @@ oie.yubikey.passcode.label = Insert then tap your YubiKey
 oie.custom.app.authenticator.title = Get a push notification
 oie.custom.app.authenticator.description = {0} is an authenticator app, installed on your phone, used to prove your identity
 
+## Smart Card Authenticator
+oie.smartcard.authenticator.description = Use a physical smart card, such as PIV or CAC, to sign in
+
 ## Select authenticator enrollment
 oie.select.authenticators.enroll.title = Set up security methods
 oie.select.authenticators.enroll.subtitle = Security methods help protect your account by ensuring only you have access.

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -850,6 +850,7 @@ oie.yubikey.description = 》Îñšéŕţ ţĥé ÝûƀîĶéý îñţö å ÛŠ
 oie.yubikey.passcode.label = 》Îñšéŕţ ţĥéñ ţåþ ýöûŕ ÝûƀîĶéý ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.custom.app.authenticator.title = 》Ĝéţ å þûšĥ ñöţîƒîçåţîöñ 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.custom.app.authenticator.description = 》{0} îš åñ åûţĥéñţîçåţöŕ åþþ، îñšţåļļéð öñ ýöûŕ þĥöñé، ûšéð ţö þŕöṽé ýöûŕ îðéñţîţý 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+oie.smartcard.authenticator.description = 》Ûšé å þĥýšîçåļ šɱåŕţ çåŕð، šûçĥ åš ÞÎṼ öŕ ÇÅÇ، ţö šîĝñ îñ ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.select.authenticators.enroll.title = 》Šéţ ûþ šéçûŕîţý ɱéţĥöðš 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.select.authenticators.enroll.subtitle = 》Šéçûŕîţý ɱéţĥöðš ĥéļþ þŕöţéçţ ýöûŕ åççöûñţ ƀý éñšûŕîñĝ öñļý ýöû ĥåṽé åççéšš· 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.select.authenticators.enroll.subtitle.custom = 》Šéçûŕîţý ɱéţĥöðš ĥéļþ þŕöţéçţ ýöûŕ ヸ€홝한Ӝฐโ {0} åççöûñţ ƀý éñšûŕîñĝ öñļý ýöû ĥåṽé åççéšš· 䀕ヸ€홝한Ӝฐโ《

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -1069,6 +1069,13 @@ const selectOktaVerifyMethod = {
   ],
 };
 
+const smartCardEnrollOrVerify = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-smartcard',
+    // 'authenticator-verification-smartcard',
+  ],
+};
+
 module.exports = {
   mocks: idx
 };

--- a/playground/mocks/data/idp/idx/authenticator-enroll-smartcard.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-smartcard.json
@@ -1,0 +1,156 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02.id.VDwicgRXRn-ztfJ20RImA28OS1M3DtaK2IYQSVoZ",
+  "expiresAt": "2022-11-01T16:05:02.000Z",
+  "intent": "CREDENTIAL_ENROLLMENT",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": ["create-form"],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Smart Card IdP",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut10ehrE4fRd197J0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "cert",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.VDwicgRXRn-ztfJ20RImA28OS1M3DtaK2IYQSVoZ",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "federated",
+        "key": "smart_card_idp",
+        "id": "aut10ehrE4fRd197J0g4",
+        "displayName": "Smart Card IdP",
+        "methods": [
+          {
+            "type": "cert"
+          }
+        ],
+        "allowedFor": "sso"
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "type": "email",
+        "key": "okta_email",
+        "id": "eae10fdQbwwOnqxse0g4",
+        "displayName": "Email",
+        "methods": [
+          {
+            "type": "email"
+          }
+        ]
+      },
+      {
+        "type": "password",
+        "key": "okta_password",
+        "id": "lae4hoDWWQbcQmt7b0g3",
+        "displayName": "Password",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
+      },
+      {
+        "type": "phone",
+        "key": "phone_number",
+        "id": "sms10d0xAGjRoMvBS0g4",
+        "displayName": "Phone",
+        "methods": [
+          {
+            "type": "sms"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u109kCSTkqiKSjx0g4",
+      "identifier": "admin@piv.org",
+      "profile": {
+        "firstName": "admin",
+        "lastName": "admin",
+        "timeZone": "America/Los_Angeles",
+        "locale": "en_US"
+      }
+    }
+  },
+  "cancel": {
+    "rel": ["create-form"],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02.id.VDwicgRXRn-ztfJ20RImA28OS1M3DtaK2IYQSVoZ",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "okta_enduser",
+      "label": "Okta Dashboard",
+      "id": "DEFAULT_APP"
+    }
+  },
+  "authentication": {
+    "type": "object",
+    "value": {
+      "protocol": "URL",
+      "request": {}
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-verification-smartcard.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-smartcard.json
@@ -1,0 +1,173 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02.id.6wWfVgQhFEqRf-NrQikI_al3YyJGF0KZ8a0L66aR~c",
+  "expiresAt": "2022-11-01T15:54:00.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": ["create-form"],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Smart Card IdP",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut10ehrE4fRd197J0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "cert",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.6wWfVgQhFEqRf-NrQikI_al3YyJGF0KZ8a0L66aR~c",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "password",
+        "key": "okta_password",
+        "id": "aut10abwKds1Igi4e0g4",
+        "displayName": "Password",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ],
+        "allowedFor": "sso"
+      },
+      {
+        "type": "phone",
+        "key": "phone_number",
+        "id": "aut10adPNGMGHYfir0g4",
+        "displayName": "Phone",
+        "methods": [
+          {
+            "type": "sms"
+          }
+        ],
+        "allowedFor": "sso"
+      },
+      {
+        "type": "federated",
+        "key": "smart_card_idp",
+        "id": "aut10ehrE4fRd197J0g4",
+        "displayName": "Smart Card IdP",
+        "methods": [
+          {
+            "type": "cert"
+          }
+        ],
+        "allowedFor": "sso"
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "type": "federated",
+        "key": "smart_card_idp",
+        "id": "piv10j4PLSl0XUvmj0g4",
+        "displayName": "Smart Card IdP",
+        "methods": [
+          {
+            "type": "cert"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u109kCSTkqiKSjx0g4",
+      "identifier": "admin",
+      "profile": {
+        "firstName": "admin",
+        "lastName": "admin",
+        "timeZone": "America/Los_Angeles",
+        "locale": "en_US"
+      }
+    }
+  },
+  "cancel": {
+    "rel": ["create-form"],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02.id.6wWfVgQhFEqRf-NrQikI_al3YyJGF0KZ8a0L66aR~c",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "okta_enduser",
+      "label": "Okta Dashboard",
+      "id": "0oa106uqli1L3jzgs0g4"
+    }
+  },
+  "authentication": {
+    "type": "object",
+    "value": {
+      "protocol": "OAUTH2.0",
+      "issuer": {
+        "name": "PIV",
+        "uri": "http://localhost:3000"
+      },
+      "request": {
+        "max_age": -1,
+        "scope": "openid profile email okta.users.read.self okta.users.manage.self okta.internal.enduser.read okta.internal.enduser.manage",
+        "display": "page",
+        "response_type": "code",
+        "redirect_uri": "http://localhost:3000/enduser/callback",
+        "state": "Kop68VQgRMluTpxs4IoZuK0in0979t5nYAkNzy8zZ93gojN0RH1aYD756z175Gd2",
+        "code_challenge_method": "S256",
+        "nonce": "34HijW9xt2CRrJhOSod0VvW9knouoWSRUgeQvyybg0Kk07fuLw8l9bbCVZXyC3kC",
+        "code_challenge": "TlKC3KD5zeBp-49VNwThvrLuYhtgu5jdxr--GJrq8rE",
+        "response_mode": "query"
+      }
+    }
+  }
+}

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -113,6 +113,7 @@ const AUTHENTICATOR_KEY = {
   SYMANTEC_VIP: 'symantec_vip',
   YUBIKEY: 'yubikey_token',
   CUSTOM_APP: 'custom_app',
+  SMARTCARD: 'smart_card_idp'
 };
 
 const AUTHENTICATOR_METHODS = {

--- a/src/v2/view-builder/utils/AuthenticatorUtil.js
+++ b/src/v2/view-builder/utils/AuthenticatorUtil.js
@@ -24,7 +24,7 @@ const getButtonDataSeAttr = function(authenticator) {
   return '';
 };
 
-/* eslint complexity: [0, 0] */
+/* eslint complexity: [0, 0], max-statements: [2, 24] */
 const getAuthenticatorData = function(authenticator, isVerifyAuthenticator) {
   const authenticatorKey = authenticator.authenticatorKey;
   const key = _.isString(authenticatorKey) ? authenticatorKey.toLowerCase() : '';
@@ -188,6 +188,17 @@ const getAuthenticatorData = function(authenticator, isVerifyAuthenticator) {
       buttonDataSeAttr: getButtonDataSeAttr(authenticator),
       iconClassName: 'mfa-custom-app-logo',
       logoUri : authenticator?.relatesTo?.logoUri || ''
+    });
+    break;
+  }
+
+  case AUTHENTICATOR_KEY.SMARTCARD: {
+    Object.assign(authenticatorData, {
+      description: isVerifyAuthenticator
+        ? ''  
+        : loc('oie.smartcard.authenticator.description', 'login'),
+      iconClassName: 'mfa-smartcard',
+      buttonDataSeAttr: getButtonDataSeAttr(authenticator),
     });
     break;
   }

--- a/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
@@ -251,6 +251,24 @@ describe('v2/view-builder/internals/FormInputFactory', function() {
           },
           authenticatorKey: 'custom_app',
         },
+        {
+          label: 'Smart Card IdP',
+          value: {
+            id: 'aut10ehrE4fRd197J0g4',
+          },
+          relatesTo: {
+            type: 'federated',
+            key: 'smart_card_idp',
+            id: 'piv10j4PLSl0XUvmj0g4',
+            displayName: 'Smart Card IdP',
+            methods: [
+              {
+                type: 'cert',
+              },
+            ],
+          },
+          authenticatorKey: 'smart_card_idp',
+        },
       ],
     };
     // Create a copy of input object.
@@ -528,6 +546,27 @@ describe('v2/view-builder/internals/FormInputFactory', function() {
         buttonDataSeAttr: 'custom_app',
         logoUri: 'https://cdn.okta1.com/bc/globalFileStoreRecord?id=gfs3sti6DQ7A9vS3h0g4',
         noTranslateClassName: 'no-translate',
+      },
+      {
+        label: 'Smart Card IdP',
+        value: {
+          id: 'aut10ehrE4fRd197J0g4',
+        },
+        relatesTo: {
+          displayName: 'Smart Card IdP',
+          type: 'federated',
+          key: 'smart_card_idp',
+          id: 'piv10j4PLSl0XUvmj0g4',
+          methods: [
+            {
+              type: 'cert'
+            }
+          ]
+        },
+        authenticatorKey:'smart_card_idp',
+        description:'',
+        iconClassName:'mfa-smartcard',
+        buttonDataSeAttr: 'smart_card_idp',
       },
     ]);
     // make sure input parameter is not mutated.
@@ -878,7 +917,25 @@ describe('v2/view-builder/internals/FormInputFactory', function() {
             ]
           },
           authenticatorKey:'google_otp',
-        }
+        },
+        {
+          label: 'Smart Card IdP',
+          value: {
+            id: 'aut10ehrE4fRd197J0g4',
+          },
+          relatesTo: {
+            type: 'federated',
+            key: 'smart_card_idp',
+            id: 'piv10j4PLSl0XUvmj0g4',
+            displayName: 'Smart Card IdP',
+            methods: [
+              {
+                type: 'cert',
+              },
+            ],
+          },
+          authenticatorKey: 'smart_card_idp',
+        },
       ],
       'label-top': true,
     };
@@ -1028,6 +1085,27 @@ describe('v2/view-builder/internals/FormInputFactory', function() {
         description:'Enter a temporary code generated from the Google Authenticator app.',
         iconClassName:'mfa-google-auth',
         buttonDataSeAttr: 'google_otp',
+      },
+      {
+        label: 'Smart Card IdP',
+        value: {
+          id: 'aut10ehrE4fRd197J0g4',
+        },
+        relatesTo: {
+          displayName: 'Smart Card IdP',
+          type: 'federated',
+          key: 'smart_card_idp',
+          id: 'piv10j4PLSl0XUvmj0g4',
+          methods: [
+            {
+              type: 'cert'
+            }
+          ]
+        },
+        authenticatorKey:'smart_card_idp',
+        description:'Use a physical smart card, such as PIV or CAC, to sign in',
+        iconClassName:'mfa-smartcard',
+        buttonDataSeAttr: 'smart_card_idp',
       }
     ]);
     // make sure input parameter is not mutated.


### PR DESCRIPTION
## Description:

Incremental Change. 

Added description and icon to smart card IDP Authenticator during enrollment and verification flow.

## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-545966](https://oktainc.atlassian.net/browse/OKTA-545966)

### Reviewers:
@mauriciocastillosilva-okta @indirathirumalaimurugan-okta @valberbenetz-okta 

### Screenshot/Video:

#### Enrollment 
<img width="550" alt="Screen Shot 2022-11-02 at 10 45 43 AM" src="https://user-images.githubusercontent.com/94395085/199535664-32a0e06f-64ae-46db-bfda-9f8b483f0e7b.png">

#### Verification:
<img width="527" alt="Screen Shot 2022-11-02 at 10 45 57 AM" src="https://user-images.githubusercontent.com/94395085/199535542-06fb7d71-ccac-43be-bb2e-9f587b036ff4.png">

### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-89874bf-63628a8a&page=1&pageSize=6&sha=57082d77a3b634d3a05e8d2ede0706db1f6f3c6a&tab=main

