### PR TITLE
Adds downstream build from monolith

### DIFF
--- a/scripts/downstream/create-downstream-for-monolith.sh
+++ b/scripts/downstream/create-downstream-for-monolith.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -xe
+
+setup_service node v14.18.0
+# Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
+setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
+
+# Get monolith build version based on commit sha
+source ./scripts/monolith/install-dockolith.sh
+pushd ./scripts/dockolith > /dev/null
+  yarn # install dependencies and build TS
+  mono_build_version=`./scripts/api/get-build-version.sh "${upstream_artifact_sha}"`
+popd > /dev/null
+
+# Update script: MONOLITH_BUILDVERSION in e2e-monolith.sh
+pushd ./scripts > /dev/null
+  sed -i "s/\(MONOLITH_BUILDVERSION\=\).*/\1\"${mono_build_version}\"/g" e2e-monolith.sh
+popd > /dev/null


### PR DESCRIPTION
## Description:

Example output:

https://github.com/okta/okta-signin-widget/commit/c41ddf7c5b18c60178268884297d6de2ff2d1cd4

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-540531](https://oktainc.atlassian.net/browse/OKTA-540531)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



