### PR TITLE
OKTA-544790 Address CSP unsafe inline issue with BaseDropDown component

### DIFF
--- a/packages/@okta/courage-dist/esm/src/courage/views/components/BaseDropDown.js
+++ b/packages/@okta/courage-dist/esm/src/courage/views/components/BaseDropDown.js
@@ -369,7 +369,7 @@ var BaseDropDown = BaseView.extend({
             "column": 327
           }
         }
-      }) : helper)) + "</span><span class=\"icon-dm\"></span></a><div id=\"okta-dropdown-options\" class=\"options clearfix\" style=\"display: none;\"><ul class=\"okta-dropdown-list options-wrap clearfix\"></ul></div>";
+      }) : helper)) + "</span><span class=\"icon-dm\"></span></a><div id=\"okta-dropdown-options\" class=\"options clearfix\"><ul class=\"okta-dropdown-list options-wrap clearfix\"></ul></div>";
     },
     "useData": true
   }),

--- a/packages/@okta/courage-for-signin-widget/package.json
+++ b/packages/@okta/courage-for-signin-widget/package.json
@@ -37,7 +37,7 @@
     "@babel/plugin-transform-shorthand-properties": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@okta/babel-plugin-handlebars-inline-precompile": "3.1.0-beta.4200.gf3d0a27",
-    "@okta/courage": "4.5.0-7417-gee15656",
+    "@okta/courage": "4.5.0-7457-g6ef032e",
     "@okta/eslint-plugin-okta-ui": "0.1.0-beta.4181.g1f38f27",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.1",

--- a/packages/@okta/courage-for-signin-widget/yarn.lock
+++ b/packages/@okta/courage-for-signin-widget/yarn.lock
@@ -487,10 +487,10 @@
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
 
-"@okta/courage@4.5.0-7417-gee15656":
-  version "4.5.0-7417-gee15656"
-  resolved "https://artifacts.aue1e.internal:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-7417-gee15656.tgz#96f1ab1dc890da7afb2319429e60c770c3ac7554"
-  integrity sha1-lvGrHciQ2nr7IxlCnmDHcMOsdVQ=
+"@okta/courage@4.5.0-7457-g6ef032e":
+  version "4.5.0-7457-g6ef032e"
+  resolved "https://artifacts.aue1e.internal:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-7457-g6ef032e.tgz#257472231e14b54503ac373e36ff1ee5268ea8c5"
+  integrity sha1-JXRyIx4UtUUDrDc+Nv8e5SaOqMU=
   dependencies:
     "@okta/jquery.simplemodal" "1.4.19-g8b711ea"
     "@types/backbone" "^1.4.10"


### PR DESCRIPTION
## Description:

Address CSP unsafe inline issue with BaseDropDown component
https://github.com/okta/okta-ui/pull/5867

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-544790](https://oktainc.atlassian.net/browse/OKTA-544790)

### Reviewers:
@ganeshsomasundaram-okta 

### Screenshot/Video:


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-58d7aa9-6363f640&page=1&pageSize=6&tab=main


