### PR TITLE
fix: adds findIndex to IE11 polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,9 +254,9 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 
 ```html
 <!-- Latest CDN production Javascript and CSS -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.0.0/js/okta-sign-in.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.0.1/js/okta-sign-in.min.js" type="text/javascript"></script>
 
-<link href="https://global.oktacdn.com/okta-signin-widget/7.0.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/7.0.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 **NOTE:** The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](https://github.com/okta/okta-signin-widget/releases). We recommend using the latest widget version.
@@ -266,13 +266,13 @@ When using one of the bundles without the polyfill included, you may want to con
 
 ```html
 <!-- Polyfill for older browsers -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.0.0/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.0.1/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
 
 <!-- Widget bundle for Okta Identity Engine -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.0.0/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.0.1/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
 
 <!-- CSS for widget -->
-<link href="https://global.oktacdn.com/okta-signin-widget/7.0.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/7.0.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -9,13 +9,13 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 
 ```html
 <!-- Polyfill for older browsers -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.0.0/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.0.1/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
 
 <!-- Widget bundle for Okta Identity Engine -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.0.0/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.0.1/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
 
 <!-- CSS for widget -->
-<link href="https://global.oktacdn.com/okta-signin-widget/7.0.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/7.0.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 **NOTE:** The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](https://github.com/okta/okta-signin-widget/releases). We recommend using the latest widget version.

--- a/polyfill/index.js
+++ b/polyfill/index.js
@@ -15,6 +15,7 @@ require('core-js/es/typed-array/uint8-array');
 require('core-js/features/array/from');
 require('core-js/features/array/includes');
 require('core-js/features/array/find');
+require('core-js/features/array/find-index');
 require('core-js/features/string/includes');
 require('core-js/features/string/starts-with');
 require('core-js/features/string/ends-with');


### PR DESCRIPTION
## Description:

- adds `findIndex` to IE11 polyfill. Fixes issue with OV.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [No] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-549514](https://oktainc.atlassian.net/browse/OKTA-549514)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=e99ff3b9eba7d1a87dbc5e6fee8557cbc692c398&tab=main

