### PR TITLE
Fixed user enumeration problem in SSPR by removing wording that contains masked email

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -946,11 +946,7 @@ oie.email.authenticator.description = Verify with a link or code sent to your em
 oie.email.mfa.title = Verify with your email
 oie.email.challenge.mfa.title = Get a verification email
 oie.email.verify.primaryButton = Send me an email
-# {0} is a user's email address
-oie.email.verify.subtitle.text.with.email = Send a verification email to <$1>{0}</$1> by clicking on "Send me an email".
 oie.email.verify.subtitle.text.without.email = Send a verification email by clicking on "Send me an email".
-# {0} is a user's email address
-oie.email.verify.alternate.magicLinkToEmailAddress = We sent an email to <$1>{0}</$1>. 
 oie.email.verify.alternate.magicLinkToYourEmail = We sent you a verification email. 
 oie.email.verify.alternate.instructions = Click the verification link in your email to continue or enter the code below.
 oie.email.verify.alternate.show.verificationCode.text = Enter a verification code instead

--- a/src/v2/view-builder/views/email/AuthenticatorEmailViewUtil.js
+++ b/src/v2/view-builder/views/email/AuthenticatorEmailViewUtil.js
@@ -8,19 +8,10 @@ const CheckYourEmailTitle = View.extend({
     'data-se': 'o-form-explain',
   },
   template: hbs`
-      {{#if email}}
-        {{i18n 
-            code="oie.email.verify.alternate.magicLinkToEmailAddress" 
-            bundle="login" 
-            arguments="email" 
-            $1="<span class='strong'>$1</span>"
-        }}
-      {{else}}
-        {{i18n 
-          code="oie.email.verify.alternate.magicLinkToYourEmail" 
-          bundle="login"
-        }}
-      {{/if}}
+      {{i18n 
+        code="oie.email.verify.alternate.magicLinkToYourEmail" 
+        bundle="login"
+      }}
       
       {{#if useEmailMagicLinkValue}}
         {{i18n 

--- a/src/v2/view-builder/views/email/ChallengeAuthenticatorDataEmailView.js
+++ b/src/v2/view-builder/views/email/ChallengeAuthenticatorDataEmailView.js
@@ -7,19 +7,10 @@ const BaseAuthenticatorEmailForm = BaseAuthenticatorView.prototype.Body;
 const SubtitleView = View.extend({
   template: hbs`
     <div class="okta-form-subtitle" data-se="o-form-explain">
-      {{#if email}}
-        {{i18n
-          code="oie.email.verify.subtitle.text.with.email"
-          bundle="login"
-          arguments="email"
-          $1="<span class='strong no-translate'>$1</span>"
-        }}
-      {{else}}
-        {{i18n
-          code="oie.email.verify.subtitle.text.without.email"
-          bundle="login"
-        }}
-      {{/if}}
+      {{i18n
+        code="oie.email.verify.subtitle.text.without.email"
+        bundle="login"
+      }}
     </div>
   `,
 

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -223,7 +223,7 @@ test
 
     const emailAddress = emailVerificationSendEmailData.currentAuthenticatorEnrollment.value.profile.email;
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .eql(`Send a verification email to ${emailAddress} by clicking on "Send me an email".`);
+      .eql(`Send a verification email by clicking on "Send me an email".`);
 
     // Verify links (switch authenticator link not present since there are no other authenticators available)
     await t.expect(await challengeEmailPageObject.switchAuthenticatorLinkExists()).notOk();
@@ -279,7 +279,7 @@ test
 
     const emailAddress = emailVerification.currentAuthenticatorEnrollment.value.profile.email;
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .eql(`We sent an email to ${emailAddress}. Click the verification link in your email to continue or enter the code below.`);
+      .eql(`We sent you a verification email. Click the verification link in your email to continue or enter the code below.`);
     const enterVerificationCodeText = challengeEmailPageObject.getEnterVerificationCodeText();
     await t.expect(enterVerificationCodeText).eql(enterVerificationCode);
 
@@ -298,7 +298,7 @@ test
 
     const emailAddress = emailVerification.currentAuthenticatorEnrollment.value.profile.email;
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .eql(`We sent an email to ${emailAddress}. Enter the verification code in the text box.`);
+      .eql(`We sent you a verification email. Enter the verification code in the text box.`);
 
     // Verify links (switch authenticator link not present since there are no other authenticators available)
     await t.expect(await challengeEmailPageObject.switchAuthenticatorLinkExists()).notOk();
@@ -326,7 +326,7 @@ test
 
     const emailAddress = emailVerification.currentAuthenticatorEnrollment.value.profile.email;
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .eql(`We sent an email to ${emailAddress}. Click the verification link in your email to continue or enter the code below.`);
+      .eql(`We sent you a verification email. Click the verification link in your email to continue or enter the code below.`);
 
     // Verify links (switch authenticator link not present since there are no other authenticators available)
     await t.expect(await challengeEmailPageObject.switchAuthenticatorLinkExists()).notOk();

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -221,9 +221,8 @@ test
     await t.expect(pageTitle).eql(getVerificationEmailTitle);
     await t.expect(saveBtnText).eql(saveBtnLabelText);
 
-    const emailAddress = emailVerificationSendEmailData.currentAuthenticatorEnrollment.value.profile.email;
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .eql(`Send a verification email by clicking on "Send me an email".`);
+      .eql('Send a verification email by clicking on "Send me an email".');
 
     // Verify links (switch authenticator link not present since there are no other authenticators available)
     await t.expect(await challengeEmailPageObject.switchAuthenticatorLinkExists()).notOk();
@@ -277,9 +276,8 @@ test
     const pageTitle = challengeEmailPageObject.getFormTitle();
     await t.expect(pageTitle).eql('Verify with your email');
 
-    const emailAddress = emailVerification.currentAuthenticatorEnrollment.value.profile.email;
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .eql(`We sent you a verification email. Click the verification link in your email to continue or enter the code below.`);
+      .eql('We sent you a verification email. Click the verification link in your email to continue or enter the code below.');
     const enterVerificationCodeText = challengeEmailPageObject.getEnterVerificationCodeText();
     await t.expect(enterVerificationCodeText).eql(enterVerificationCode);
 
@@ -296,9 +294,8 @@ test
     const pageTitle = challengeEmailPageObject.getFormTitle();
     await t.expect(pageTitle).eql('Verify with your email');
 
-    const emailAddress = emailVerification.currentAuthenticatorEnrollment.value.profile.email;
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .eql(`We sent you a verification email. Enter the verification code in the text box.`);
+      .eql('We sent you a verification email. Enter the verification code in the text box.');
 
     // Verify links (switch authenticator link not present since there are no other authenticators available)
     await t.expect(await challengeEmailPageObject.switchAuthenticatorLinkExists()).notOk();
@@ -324,9 +321,8 @@ test
     await t.expect(pageTitle).eql('Verify with your email');
     await t.expect(saveBtnText).eql('Verify');
 
-    const emailAddress = emailVerification.currentAuthenticatorEnrollment.value.profile.email;
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .eql(`We sent you a verification email. Click the verification link in your email to continue or enter the code below.`);
+      .eql('We sent you a verification email. Click the verification link in your email to continue or enter the code below.');
 
     // Verify links (switch authenticator link not present since there are no other authenticators available)
     await t.expect(await challengeEmailPageObject.switchAuthenticatorLinkExists()).notOk();

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -145,7 +145,7 @@ test
     
     const emailAddress = xhrEnrollEmailWithoutEmailMagicLink.user.value.identifier;
     await t.expect(enrollEmailPageObject.getFormSubtitle())
-      .eql(`We sent an email to ${emailAddress}. Enter the verification code in the text box.`);
+      .eql(`We sent you a verification email. Enter the verification code in the text box.`);
 
     await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).notOk();
     await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
@@ -160,7 +160,7 @@ test
 
     const emailAddress = xhrEnrollEmailWithEmailMagicLink.user.value.identifier;
     await t.expect(enrollEmailPageObject.getFormSubtitle())
-      .eql(`We sent an email to ${emailAddress}. Click the verification link in your email to continue or enter the code below.`);
+      .eql(`We sent you a verification email. Click the verification link in your email to continue or enter the code below.`);
 
     await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).ok();
     await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
@@ -214,7 +214,7 @@ test
     await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
     const emailAddress = xhrEnrollEmailWithEmailMagicLink.user.value.identifier;
     await t.expect(enrollEmailPageObject.getFormSubtitle())
-      .eql(`We sent an email to ${emailAddress}. Click the verification link in your email to continue or enter the code below.`);
+      .eql(`We sent you a verification email. Click the verification link in your email to continue or enter the code below.`);
     await enrollEmailPageObject.clickElement('.enter-auth-code-instead-link');
     await t.expect(enrollEmailPageObject.form.getSaveButtonLabel()).eql('Verify');
 
@@ -256,7 +256,7 @@ test
     await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
     const emailAddress = xhrEnrollEmailWithoutEmailMagicLink.user.value.identifier;
     await t.expect(enrollEmailPageObject.getFormSubtitle())
-      .eql(`We sent an email to ${emailAddress}. Enter the verification code in the text box.`);
+      .eql(`We sent you a verification email. Enter the verification code in the text box.`);
     await t.expect(enrollEmailPageObject.form.getSaveButtonLabel()).eql('Verify');
 
     // Verify links

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -143,9 +143,8 @@ test
 
     await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
     
-    const emailAddress = xhrEnrollEmailWithoutEmailMagicLink.user.value.identifier;
     await t.expect(enrollEmailPageObject.getFormSubtitle())
-      .eql(`We sent you a verification email. Enter the verification code in the text box.`);
+      .eql('We sent you a verification email. Enter the verification code in the text box.');
 
     await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).notOk();
     await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
@@ -158,9 +157,8 @@ test
 
     await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
 
-    const emailAddress = xhrEnrollEmailWithEmailMagicLink.user.value.identifier;
     await t.expect(enrollEmailPageObject.getFormSubtitle())
-      .eql(`We sent you a verification email. Click the verification link in your email to continue or enter the code below.`);
+      .eql('We sent you a verification email. Click the verification link in your email to continue or enter the code below.');
 
     await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).ok();
     await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
@@ -212,9 +210,8 @@ test
     const enrollEmailPageObject = await setup(t);
 
     await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
-    const emailAddress = xhrEnrollEmailWithEmailMagicLink.user.value.identifier;
     await t.expect(enrollEmailPageObject.getFormSubtitle())
-      .eql(`We sent you a verification email. Click the verification link in your email to continue or enter the code below.`);
+      .eql('We sent you a verification email. Click the verification link in your email to continue or enter the code below.');
     await enrollEmailPageObject.clickElement('.enter-auth-code-instead-link');
     await t.expect(enrollEmailPageObject.form.getSaveButtonLabel()).eql('Verify');
 
@@ -254,9 +251,8 @@ test
     const enrollEmailPageObject = await setup(t);
 
     await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
-    const emailAddress = xhrEnrollEmailWithoutEmailMagicLink.user.value.identifier;
     await t.expect(enrollEmailPageObject.getFormSubtitle())
-      .eql(`We sent you a verification email. Enter the verification code in the text box.`);
+      .eql('We sent you a verification email. Enter the verification code in the text box.');
     await t.expect(enrollEmailPageObject.form.getSaveButtonLabel()).eql('Verify');
 
     // Verify links


### PR DESCRIPTION
## Description:
- Fixed user enumeration problem in SSPR by removing the if condition that displays the wording with masked email if emails exists.
- The problem happens when going to /signin/forgot-password directly with a valid user identifier, or when adding/removing a phone authenticator in settings


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-525791](https://oktainc.atlassian.net/browse/OKTA-525791)

### Reviewers:
@okta/ciamx @jaredperreault-okta 
### Screenshot/Video:
Please note that there is a known SIW rendering issue that causes the extra spaces that is not related to this PR
NoMaskedEmailInAuthenticatorEnrollment https://okta.box.com/s/nyp77d2puq6sdy0mz3yhj82eiudis7e0
NoMaskedEmailInSSPR https://okta.box.com/s/oyme05nu5r18354j2xf7t48v4kyr7n0a


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-442c6d7-6375782a&page=1&pageSize=6&sha=d98454d0d6f180a484e64d525b7bc6edb79fcdd3&tab=main


