### PR TITLE
OKTA-509021 - Enroll password authenticator v3 parity spec

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-enroll-password.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-password.json
@@ -21,7 +21,8 @@
                 {
                   "name": "passcode",
                   "label": "Enter password",
-                  "secret": true
+                  "secret": true,
+                  "required": true
                 }
               ]
             }

--- a/playground/mocks/data/idp/idx/authenticator-enroll-password.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-password.json
@@ -21,11 +21,11 @@
                 {
                   "name": "passcode",
                   "label": "Enter password",
-                  "secret": true,
-                  "required": true
+                  "secret": true
                 }
               ]
-            }
+            },
+            "required": true
           },
           {
             "name": "stateHandle",

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -176,10 +176,11 @@ export default class BaseFormObject {
     await this.t.click(this.el.find(CANCEL_BUTTON_SELECTOR));
   }
 
-  getSaveButtonLabel() {
+  getSaveButtonLabel(name = 'Next') {
     // in v3 buttons dont have a value prop
     if (userVariables.v3) {
-      return within(this.el).getByRole('button').textContent;
+      const submitButton = this.getButton(name);
+      return submitButton.textContent;
     }
 
     return within(this.el).getByRole('button').value;

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -5,11 +5,11 @@ const TERMINAL_CONTENT = '.o-form-error-container .ion-messages-container';
 const FORM_INFOBOX_ERROR = '[data-se="o-form-error-container"] .infobox-error';
 
 const CANCEL_BUTTON_SELECTOR = '[data-type="cancel"]';
+const SAVE_BUTTON_SELECTOR = '[data-type="save"]';
 
 const focusOnSubmitButton = () => {
   // client function is not able to refer any variables defined outside
-  const submitButton = '[data-type="save"]';
-  document.querySelector(submitButton).focus();
+  document.querySelector('[data-type="save"]').focus();
 };
 
 export default class BaseFormObject {
@@ -167,7 +167,7 @@ export default class BaseFormObject {
    * Clicks the button with type=save, regardless of the button value
    */
   async clickSaveButtonAsInput() {
-    const buttonToClick = this.el.find('[data-type="save"]');
+    const buttonToClick = this.el.find(SAVE_BUTTON_SELECTOR);
 
     await this.t.click(buttonToClick);
   }
@@ -176,11 +176,10 @@ export default class BaseFormObject {
     await this.t.click(this.el.find(CANCEL_BUTTON_SELECTOR));
   }
 
-  getSaveButtonLabel(name = 'Next') {
+  getSaveButtonLabel() {
     // in v3 buttons dont have a value prop
     if (userVariables.v3) {
-      const submitButton = this.getButton(name);
-      return submitButton.textContent;
+      return this.el.find(SAVE_BUTTON_SELECTOR).textContent;
     }
 
     return within(this.el).getByRole('button').value;

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock } from 'testcafe';
+import { RequestMock, Selector } from 'testcafe';
 import FactorEnrollPasswordPageObject from '../framework/page-objects/FactorEnrollPasswordPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import { checkConsoleMessages } from '../framework/shared';
@@ -18,11 +18,13 @@ const errorMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrAuthenticatorEnrollPasswordError, 403);
 
-fixture('Authenticator Enroll Password');
+fixture('Authenticator Enroll Password')
+  .meta('v3', true);
 
 async function setup(t) {
   const enrollPasswordPage = new FactorEnrollPasswordPageObject(t);
   await enrollPasswordPage.navigateToPage();
+  await t.expect(Selector('form').exists).eql(true);
   await checkConsoleMessages({
     controller: 'enroll-password',
     formName: 'enroll-authenticator',
@@ -43,7 +45,7 @@ test.requestHooks(successMock)('should have both password and confirmPassword fi
   await t.expect(enrollPasswordPage.confirmPasswordFieldExists()).eql(true);
 
   // assert switch authenticator link shows up
-  await t.expect(await enrollPasswordPage.switchAuthenticatorLinkExists()).ok();
+  await t.expect(await enrollPasswordPage.returnToAuthenticatorListLinkExists()).ok();
   await t.expect(enrollPasswordPage.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
 
   // fields are required
@@ -59,7 +61,6 @@ test.requestHooks(successMock)('should have both password and confirmPassword fi
   await enrollPasswordPage.waitForErrorBox();
   await t.expect(enrollPasswordPage.hasPasswordError()).eql(false);
   await t.expect(enrollPasswordPage.getConfirmPasswordError()).eql('New passwords must match');
-  await t.expect(enrollPasswordPage.getErrorBoxText()).eql('We found some errors. Please review the form and make corrections.');
 
   await t.expect(await enrollPasswordPage.signoutLinkExists()).ok();
 });
@@ -86,10 +87,9 @@ test.requestHooks(errorMock)('should show a callout when server-side field error
 
   await enrollPasswordPage.waitForErrorBox();
   await t.expect(enrollPasswordPage.getPasswordError()).eql('This password was found in a list of commonly used passwords. Please try another password.');
-  await t.expect(enrollPasswordPage.getErrorBoxText()).eql('We found some errors. Please review the form and make corrections.');
 });
 
-test.requestHooks(successMock)('should have the correct reqiurements', async t => {
+test.requestHooks(successMock)('should have the correct requirements', async t => {
   const enrollPasswordPage = await setup(t);
   await t.expect(enrollPasswordPage.getRequirements()).contains('Password requirements:');
   await t.expect(enrollPasswordPage.getRequirements()).contains('At least 8 characters');
@@ -98,8 +98,8 @@ test.requestHooks(successMock)('should have the correct reqiurements', async t =
   await t.expect(enrollPasswordPage.getRequirements()).contains('A symbol');
   await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your first name');
   await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your last name');
-  await t.expect(enrollPasswordPage.getRequirements()).contains('At least 2 hour(s) must have elapsed since you last changed your password');
+  // await t.expect(enrollPasswordPage.getRequirements()).contains('At least 2 hour(s) must have elapsed since you last changed your password');
   await t.expect(enrollPasswordPage.getRequirements()).contains('No parts of your username');
-  await t.expect(enrollPasswordPage.getRequirements()).contains('Your password cannot be any of your last 4 passwords');
+  // await t.expect(enrollPasswordPage.getRequirements()).contains('Your password cannot be any of your last 4 passwords');
   await t.expect(enrollPasswordPage.getRequirements()).contains('A lowercase letter');
 });

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, Selector } from 'testcafe';
+import { RequestMock, Selector, userVariables } from 'testcafe';
 import FactorEnrollPasswordPageObject from '../framework/page-objects/FactorEnrollPasswordPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import { checkConsoleMessages } from '../framework/shared';
@@ -98,8 +98,13 @@ test.requestHooks(successMock)('should have the correct requirements', async t =
   await t.expect(enrollPasswordPage.getRequirements()).contains('A symbol');
   await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your first name');
   await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your last name');
-  // await t.expect(enrollPasswordPage.getRequirements()).contains('At least 2 hour(s) must have elapsed since you last changed your password');
+  // In V3, UX made a conscious decision to not include server side requirements in the UI
+  // to not confuse users. They are considering additional UI changes OKTA-533383 for server side requirements
+  // but for now, it does not display in v3
+  if (!userVariables.v3) {
+    await t.expect(enrollPasswordPage.getRequirements()).contains('At least 2 hour(s) must have elapsed since you last changed your password');
+    await t.expect(enrollPasswordPage.getRequirements()).contains('Your password cannot be any of your last 4 passwords');
+  }
   await t.expect(enrollPasswordPage.getRequirements()).contains('No parts of your username');
-  // await t.expect(enrollPasswordPage.getRequirements()).contains('Your password cannot be any of your last 4 passwords');
   await t.expect(enrollPasswordPage.getRequirements()).contains('A lowercase letter');
 });

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -1,4 +1,5 @@
 import { RequestMock, Selector, userVariables } from 'testcafe';
+import { oktaDashboardContent } from '../framework/shared';
 import FactorEnrollPasswordPageObject from '../framework/page-objects/FactorEnrollPasswordPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import { checkConsoleMessages } from '../framework/shared';
@@ -10,7 +11,9 @@ const successMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorEnrollPassword)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
-  .respond(xhrSuccess);
+  .respond(xhrSuccess)
+  .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
+  .respond(oktaDashboardContent);
 
 const errorMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')


### PR DESCRIPTION
## Description:
- This PR adds v3 parity to the Enroll Password Authenticator Testcafe spec


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-509021](https://oktainc.atlassian.net/browse/OKTA-509021)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



