### PR TITLE
OKTA-551068 : Disabled email magic link implementation

### DIFF
--- a/src/v3/src/mocks/scenario/authenticator-verification-email-magiclink-false.ts
+++ b/src/v3/src/mocks/scenario/authenticator-verification-email-magiclink-false.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { scenario } from '../registry';
+
+scenario('authenticator-verification-email-magiclink-false', (rest) => ([
+  // bootstrap
+  rest.get('*/oauth2/default/.well-known/openid-configuration', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/well-known/openid-configuration/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  rest.post('*/oauth2/default/v1/interact', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/v1/interact/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  rest.post('*/idp/idx/introspect', async (req, res, ctx) => {
+    const { default: body } = await import('../response/idp/idx/introspect/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // send email/pw, return mfa challenge response remediation
+  rest.post('*/idp/idx/identify', async (req, res, ctx) => {
+    const { default: body } = await import('../response/idp/idx/identify/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // send mfa type, return ask for mfa code
+  rest.post('*/idp/idx/challenge', async (req, res, ctx) => {
+    const { default: body } = await import('@okta/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-false.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // polling request
+  rest.post('*/idp/idx/challenge/poll', async (req, res, ctx) => {
+    const { default: body } = await import('@okta/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-false.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // handles when 'send again' link is clicked
+  rest.post('*/idp/idx/challenge/resend', async (req, res, ctx) => {
+    const { default: body } = await import('@okta/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-false.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // send mfa code,
+  rest.post('*/idp/idx/challenge/answer', async (req, res, ctx) => {
+    const { default: body } = await import('../response/idp/idx/challenge/answer/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // get oauth2 token
+  rest.post('*/oauth2/default/v1/token', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/v1/token/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // get oauth2 keys
+  rest.get('*/oauth2/default/v1/keys', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/v1/keys/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+]));

--- a/src/v3/src/mocks/scenario/index.ts
+++ b/src/v3/src/mocks/scenario/index.ts
@@ -19,6 +19,7 @@ import './authenticator-expired-password';
 import './authenticator-expired-password-no-complexity';
 import './authenticator-expiry-warning-password';
 import './authenticator-expired-password-with-enrollment-authenticator';
+import './authenticator-verification-email-magiclink-false';
 import './email-challenge-consent';
 import './enroll-okta-verify-mfa';
 import './enroll-ov-version-upgrade';

--- a/src/v3/src/transformer/layout/email/__snapshots__/emailChallengeTransformer.test.ts.snap
+++ b/src/v3/src/transformer/layout/email/__snapshots__/emailChallengeTransformer.test.ts.snap
@@ -1,6 +1,177 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EmailChallengeTransformer Tests should create email challenge UI elements when profile email is NOT available 1`] = `
+exports[`EmailChallengeTransformer Tests Email Magic Link = false should create email challenge UI elements when profile email is NOT available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "actionParams": Object {
+            "resend": true,
+          },
+          "buttonText": "email.button.resend",
+          "content": "email.code.not.received",
+          "isActionStep": true,
+          "step": "resend",
+        },
+        "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.verificationCode.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "focus": true,
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "step": "mock-step",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`EmailChallengeTransformer Tests Email Magic Link = false should create email challenge UI elements when resend code is NOT available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.verificationCode.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "focus": true,
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "step": "mock-step",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`EmailChallengeTransformer Tests Email Magic Link = false should create email challenge UI elements when resend code is available 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "actionParams": Object {
+            "resend": true,
+          },
+          "buttonText": "email.button.resend",
+          "content": "email.code.not.received",
+          "isActionStep": true,
+          "step": "resend",
+        },
+        "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.verificationCode.instructions",
+        },
+        "type": "Description",
+      },
+      Object {
+        "focus": true,
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "step": "",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`EmailChallengeTransformer Tests Email Magic Link = true should create email challenge UI elements when profile email is NOT available 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -109,7 +280,7 @@ Object {
 }
 `;
 
-exports[`EmailChallengeTransformer Tests should create email challenge UI elements when resend code is NOT available 1`] = `
+exports[`EmailChallengeTransformer Tests Email Magic Link = true should create email challenge UI elements when resend code is NOT available 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -194,7 +365,7 @@ Object {
 }
 `;
 
-exports[`EmailChallengeTransformer Tests should create email challenge UI elements when resend code is available 1`] = `
+exports[`EmailChallengeTransformer Tests Email Magic Link = true should create email challenge UI elements when resend code is available 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.test.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.test.ts
@@ -40,192 +40,321 @@ describe('EmailChallengeTransformer Tests', () => {
     ];
   });
 
-  it('should create email challenge UI elements when resend code is available', () => {
-    transaction.nextStep = {
-      name: '',
-      canResend: true,
-      relatesTo: {
-        value: {
-          profile: {
-            email: redactedEmail,
-          },
-        } as unknown as IdxAuthenticator,
-      },
-    };
-    transaction.availableSteps = [{ name: 'resend', action: jest.fn() }];
-    const updatedFormBag = transformEmailChallenge({
-      transaction, formBag, widgetProps,
+  describe('Email Magic Link = true', () => {
+    it('should create email challenge UI elements when resend code is available', () => {
+      transaction.nextStep = {
+        name: '',
+        canResend: true,
+        relatesTo: {
+          value: {
+            profile: {
+              email: redactedEmail,
+            },
+          } as unknown as IdxAuthenticator,
+        },
+      };
+      transaction.availableSteps = [{ name: 'resend', action: jest.fn() }];
+      const updatedFormBag = transformEmailChallenge({
+        transaction, formBag, widgetProps,
+      });
+
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(1);
+      expect(updatedFormBag.uischema.elements[0].type).toBe('Stepper');
+
+      const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
+
+      const layoutOne = stepperElements[0];
+
+      expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
+      expect(layoutOne.elements.length).toBe(4);
+
+      expect((layoutOne.elements[0] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutOne.elements[0] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
+        .toBe(true);
+      expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.email.mfa.title');
+      expect(layoutOne.elements[2].type).toBe('Description');
+      expect((layoutOne.elements[2] as DescriptionElement).options?.content)
+        .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+      expect(layoutOne.elements[3].type).toBe('StepperButton');
+      expect((layoutOne.elements[3] as StepperButtonElement).label)
+        .toBe('oie.email.verify.alternate.showCodeTextField');
+
+      const layoutTwo = stepperElements[1];
+
+      expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
+      expect(layoutTwo.elements.length).toBe(5);
+      expect((layoutTwo.elements[0] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutTwo.elements[0] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
+        .toBe(true);
+      expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.email.mfa.title');
+      expect(layoutTwo.elements[2].type).toBe('Description');
+      expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
+        .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+
+      expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.name)
+        .toBe('credentials.passcode');
+
+      expect((layoutTwo.elements[4] as ButtonElement).type).toBe('Button');
+      expect((layoutTwo.elements[4] as ButtonElement).label).toBe('mfa.challenge.verify');
+      expect((layoutTwo.elements[4] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
     });
 
-    expect(updatedFormBag).toMatchSnapshot();
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Stepper');
+    it('should create email challenge UI elements when profile email is NOT available', () => {
+      transaction.nextStep = {
+        name: 'mock-step',
+        canResend: true,
+        relatesTo: {
+          value: {} as IdxAuthenticator,
+        },
+      };
+      transaction.availableSteps = [{ name: 'resend', action: jest.fn() }];
+      const updatedFormBag = transformEmailChallenge({
+        transaction, formBag, widgetProps,
+      });
 
-    const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
+      expect(updatedFormBag).toMatchSnapshot();
+      const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
 
-    const layoutOne = stepperElements[0];
+      const layoutOne = stepperElements[0];
 
-    expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutOne.elements.length).toBe(4);
+      expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
+      expect(layoutOne.elements.length).toBe(4);
 
-    expect((layoutOne.elements[0] as ReminderElement).options?.content)
-      .toBe('email.code.not.received');
-    expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
-      .toBe(true);
-    expect((layoutOne.elements[0] as ReminderElement).options?.step)
-      .toBe('resend');
-    expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
-      .toBe(true);
-    expect((layoutOne.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.mfa.title');
-    expect(layoutOne.elements[2].type).toBe('Description');
-    expect((layoutOne.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
-    expect(layoutOne.elements[3].type).toBe('StepperButton');
-    expect((layoutOne.elements[3] as StepperButtonElement).label)
-      .toBe('oie.email.verify.alternate.showCodeTextField');
+      expect((layoutOne.elements[0] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutOne.elements[0] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
+        .toBe(true);
+      expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.email.mfa.title');
+      expect(layoutOne.elements[2].type).toBe('Description');
+      expect((layoutOne.elements[2] as DescriptionElement).options?.content)
+        .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
+      expect(layoutOne.elements[3].type).toBe('StepperButton');
+      expect((layoutOne.elements[3] as StepperButtonElement).label)
+        .toBe('oie.email.verify.alternate.showCodeTextField');
 
-    const layoutTwo = stepperElements[1];
+      const layoutTwo = stepperElements[1];
 
-    expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutTwo.elements.length).toBe(5);
-    expect((layoutTwo.elements[0] as ReminderElement).options?.content)
-      .toBe('email.code.not.received');
-    expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
-      .toBe(true);
-    expect((layoutTwo.elements[0] as ReminderElement).options?.step)
-      .toBe('resend');
-    expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
-      .toBe(true);
-    expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.mfa.title');
-    expect(layoutTwo.elements[2].type).toBe('Description');
-    expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+      expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
+      expect(layoutTwo.elements.length).toBe(5);
+      expect((layoutTwo.elements[0] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutTwo.elements[0] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
+        .toBe(true);
+      expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.email.mfa.title');
+      expect(layoutTwo.elements[2].type).toBe('Description');
+      expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
+        .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
 
-    expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.name)
-      .toBe('credentials.passcode');
+      expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.name)
+        .toBe('credentials.passcode');
 
-    expect((layoutTwo.elements[4] as ButtonElement).type).toBe('Button');
-    expect((layoutTwo.elements[4] as ButtonElement).label).toBe('mfa.challenge.verify');
-    expect((layoutTwo.elements[4] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
+      expect((layoutTwo.elements[4] as ButtonElement).type).toBe('Button');
+      expect((layoutTwo.elements[4] as ButtonElement).label).toBe('mfa.challenge.verify');
+      expect((layoutTwo.elements[4] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
+    });
+
+    it('should create email challenge UI elements when resend code is NOT available', () => {
+      transaction.availableSteps = [];
+      transaction.nextStep = {
+        name: 'mock-step',
+        relatesTo: {
+          value: {
+            profile: {
+              email: redactedEmail,
+            },
+          } as unknown as IdxAuthenticator,
+        },
+      };
+      const updatedFormBag = transformEmailChallenge({
+        transaction, formBag, widgetProps,
+      });
+
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(1);
+      expect(updatedFormBag.uischema.elements[0].type).toBe('Stepper');
+
+      const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
+
+      const layoutOne = stepperElements[0];
+
+      expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
+      expect(layoutOne.elements.length).toBe(3);
+
+      expect((layoutOne.elements[0] as DescriptionElement).options?.content)
+        .toBe('oie.email.mfa.title');
+      expect(layoutOne.elements[1].type).toBe('Description');
+      expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+      expect(layoutOne.elements[2].type).toBe('StepperButton');
+      expect((layoutOne.elements[2] as StepperButtonElement).label)
+        .toBe('oie.email.verify.alternate.showCodeTextField');
+
+      const layoutTwo = stepperElements[1];
+
+      expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
+      expect(layoutTwo.elements.length).toBe(4);
+      expect((layoutTwo.elements[0] as DescriptionElement).options?.content)
+        .toBe('oie.email.mfa.title');
+      expect(layoutTwo.elements[1].type).toBe('Description');
+      expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+
+      expect((layoutTwo.elements[2] as FieldElement).options.inputMeta.name)
+        .toBe('credentials.passcode');
+
+      expect((layoutTwo.elements[3] as ButtonElement).type).toBe('Button');
+      expect((layoutTwo.elements[3] as ButtonElement).label).toBe('mfa.challenge.verify');
+      expect((layoutTwo.elements[3] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
+    });
   });
 
-  it('should create email challenge UI elements when profile email is NOT available', () => {
-    transaction.nextStep = {
-      name: 'mock-step',
-      canResend: true,
-      relatesTo: {
-        value: {} as IdxAuthenticator,
-      },
-    };
-    transaction.availableSteps = [{ name: 'resend', action: jest.fn() }];
-    const updatedFormBag = transformEmailChallenge({
-      transaction, formBag, widgetProps,
+  describe('Email Magic Link = false', () => {
+    beforeEach(() => {
+      transaction.rawIdxState = {
+        ...transaction.rawIdxState,
+        currentAuthenticator: {
+          type: '',
+          value: {
+            contextualData: { useEmailMagicLink: false },
+          } as unknown as IdxAuthenticator,
+        },
+      };
     });
 
-    expect(updatedFormBag).toMatchSnapshot();
-    const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
+    it('should create email challenge UI elements when resend code is available', () => {
+      transaction.nextStep = {
+        name: '',
+        canResend: true,
+        relatesTo: {
+          value: {
+            profile: {
+              email: redactedEmail,
+            },
+          } as unknown as IdxAuthenticator,
+        },
+      };
+      transaction.availableSteps = [{ name: 'resend', action: jest.fn() }];
+      const updatedFormBag = transformEmailChallenge({
+        transaction, formBag, widgetProps,
+      });
 
-    const layoutOne = stepperElements[0];
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.isActionStep)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.email.mfa.title');
+      expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
+      expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+        .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.verificationCode.instructions');
 
-    expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutOne.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+        .toBe('credentials.passcode');
 
-    expect((layoutOne.elements[0] as ReminderElement).options?.content)
-      .toBe('email.code.not.received');
-    expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
-      .toBe(true);
-    expect((layoutOne.elements[0] as ReminderElement).options?.step)
-      .toBe('resend');
-    expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
-      .toBe(true);
-    expect((layoutOne.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.mfa.title');
-    expect(layoutOne.elements[2].type).toBe('Description');
-    expect((layoutOne.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
-    expect(layoutOne.elements[3].type).toBe('StepperButton');
-    expect((layoutOne.elements[3] as StepperButtonElement).label)
-      .toBe('oie.email.verify.alternate.showCodeTextField');
-
-    const layoutTwo = stepperElements[1];
-
-    expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutTwo.elements.length).toBe(5);
-    expect((layoutTwo.elements[0] as ReminderElement).options?.content)
-      .toBe('email.code.not.received');
-    expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
-      .toBe(true);
-    expect((layoutTwo.elements[0] as ReminderElement).options?.step)
-      .toBe('resend');
-    expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
-      .toBe(true);
-    expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.mfa.title');
-    expect(layoutTwo.elements[2].type).toBe('Description');
-    expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
-
-    expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.name)
-      .toBe('credentials.passcode');
-
-    expect((layoutTwo.elements[4] as ButtonElement).type).toBe('Button');
-    expect((layoutTwo.elements[4] as ButtonElement).label).toBe('mfa.challenge.verify');
-    expect((layoutTwo.elements[4] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
-  });
-
-  it('should create email challenge UI elements when resend code is NOT available', () => {
-    transaction.availableSteps = [];
-    transaction.nextStep = {
-      name: 'mock-step',
-      relatesTo: {
-        value: {
-          profile: {
-            email: redactedEmail,
-          },
-        } as unknown as IdxAuthenticator,
-      },
-    };
-    const updatedFormBag = transformEmailChallenge({
-      transaction, formBag, widgetProps,
+      expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
+      expect((updatedFormBag.uischema.elements[4] as ButtonElement).label).toBe('mfa.challenge.verify');
+      expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
+        .toBe(ButtonType.SUBMIT);
     });
 
-    expect(updatedFormBag).toMatchSnapshot();
-    expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect(updatedFormBag.uischema.elements[0].type).toBe('Stepper');
+    it('should create email challenge UI elements when profile email is NOT available', () => {
+      transaction.nextStep = {
+        name: 'mock-step',
+        canResend: true,
+        relatesTo: {
+          value: {} as IdxAuthenticator,
+        },
+      };
+      transaction.availableSteps = [{ name: 'resend', action: jest.fn() }];
+      const updatedFormBag = transformEmailChallenge({
+        transaction, formBag, widgetProps,
+      });
 
-    const stepperElements = (updatedFormBag.uischema.elements[0] as StepperLayout).elements;
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.isActionStep)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.email.mfa.title');
+      expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
+      expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
+        .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.verificationCode.instructions');
 
-    const layoutOne = stepperElements[0];
+      expect((updatedFormBag.uischema.elements[3] as FieldElement).options.inputMeta.name)
+        .toBe('credentials.passcode');
 
-    expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutOne.elements.length).toBe(3);
+      expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
+      expect((updatedFormBag.uischema.elements[4] as ButtonElement).label).toBe('mfa.challenge.verify');
+      expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
+        .toBe(ButtonType.SUBMIT);
+    });
 
-    expect((layoutOne.elements[0] as DescriptionElement).options?.content)
-      .toBe('oie.email.mfa.title');
-    expect(layoutOne.elements[1].type).toBe('Description');
-    expect((layoutOne.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
-    expect(layoutOne.elements[2].type).toBe('StepperButton');
-    expect((layoutOne.elements[2] as StepperButtonElement).label)
-      .toBe('oie.email.verify.alternate.showCodeTextField');
+    it('should create email challenge UI elements when resend code is NOT available', () => {
+      transaction.availableSteps = [];
+      transaction.nextStep = {
+        name: 'mock-step',
+        relatesTo: {
+          value: {
+            profile: {
+              email: redactedEmail,
+            },
+          } as unknown as IdxAuthenticator,
+        },
+      };
+      const updatedFormBag = transformEmailChallenge({
+        transaction, formBag, widgetProps,
+      });
 
-    const layoutTwo = stepperElements[1];
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
+        .toBe('oie.email.mfa.title');
+      expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.verificationCode.instructions');
 
-    expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
-    expect(layoutTwo.elements.length).toBe(4);
-    expect((layoutTwo.elements[0] as DescriptionElement).options?.content)
-      .toBe('oie.email.mfa.title');
-    expect(layoutTwo.elements[1].type).toBe('Description');
-    expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
-      .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
+      expect((updatedFormBag.uischema.elements[2] as FieldElement).options.inputMeta.name)
+        .toBe('credentials.passcode');
 
-    expect((layoutTwo.elements[2] as FieldElement).options.inputMeta.name)
-      .toBe('credentials.passcode');
-
-    expect((layoutTwo.elements[3] as ButtonElement).type).toBe('Button');
-    expect((layoutTwo.elements[3] as ButtonElement).label).toBe('mfa.challenge.verify');
-    expect((layoutTwo.elements[3] as ButtonElement).options?.type).toBe(ButtonType.SUBMIT);
+      expect((updatedFormBag.uischema.elements[3] as ButtonElement).type).toBe('Button');
+      expect((updatedFormBag.uischema.elements[3] as ButtonElement).label).toBe('mfa.challenge.verify');
+      expect((updatedFormBag.uischema.elements[3] as ButtonElement).options?.type)
+        .toBe(ButtonType.SUBMIT);
+    });
   });
 });

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
@@ -84,7 +84,7 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
     },
   };
 
-  const submitButtonControl: ButtonElement = {
+  const submitButtonElement: ButtonElement = {
     type: 'Button',
     label: loc('mfa.challenge.verify', 'login'),
     options: {
@@ -98,7 +98,7 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
     titleElement,
     informationalText,
     passcodeElement!,
-    submitButtonControl,
+    submitButtonElement,
   ];
 
   // If Email Magic link is disabled, render single form instead of stepper

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
@@ -32,7 +32,7 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
   const { nextStep = {} as NextStep, availableSteps } = transaction;
   const { uischema } = formBag;
   const authenticatorContextualData = getCurrentAuthenticator(transaction)?.value?.contextualData;
-  // @ts-ignore OKTA-XXXXXX - useEmailMagicLink property missing from interface
+  // @ts-ignore OKTA-551247 - useEmailMagicLink property missing from interface
   const useEmailMagicLinkValue = authenticatorContextualData?.useEmailMagicLink;
   const useEmailMagicLink = typeof useEmailMagicLinkValue !== 'undefined'
     ? useEmailMagicLinkValue

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
@@ -64,16 +64,16 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
   }
 
   const redactedEmailAddress = nextStep.relatesTo?.value?.profile?.email;
-  const instructionBaseText = redactedEmailAddress
+  const instructionPrefixText = redactedEmailAddress
     ? loc('oie.email.verify.alternate.magicLinkToEmailAddress', 'login', [redactedEmailAddress])
     : loc('oie.email.verify.alternate.magicLinkToYourEmail', 'login');
-  const instrText = useEmailMagicLink
+  const instructionPostfixText = useEmailMagicLink
     ? loc('oie.email.verify.alternate.instructions', 'login')
     : loc('oie.email.verify.alternate.verificationCode.instructions', 'login');
   const informationalText: DescriptionElement = {
     type: 'Description',
     options: {
-      content: `${instructionBaseText}${instrText}`,
+      content: `${instructionPrefixText}${instructionPostfixText}`,
     },
   };
 

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
@@ -64,7 +64,7 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
   }
 
   const redactedEmailAddress = nextStep.relatesTo?.value?.profile?.email;
-  const maginLinkText = redactedEmailAddress
+  const descriptionBaseText = redactedEmailAddress
     ? loc('oie.email.verify.alternate.magicLinkToEmailAddress', 'login', [redactedEmailAddress])
     : loc('oie.email.verify.alternate.magicLinkToYourEmail', 'login');
   const instrText = useEmailMagicLink
@@ -73,7 +73,7 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
   const informationalText: DescriptionElement = {
     type: 'Description',
     options: {
-      content: `${maginLinkText}${instrText}`,
+      content: `${descriptionBaseText}${instrText}`,
     },
   };
 

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
@@ -25,12 +25,18 @@ import {
   UISchemaLayout,
   UISchemaLayoutType,
 } from '../../../types';
-import { loc } from '../../../util';
+import { getCurrentAuthenticator, loc } from '../../../util';
 import { getUIElementWithName } from '../../utils';
 
 export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formBag }) => {
   const { nextStep = {} as NextStep, availableSteps } = transaction;
   const { uischema } = formBag;
+  const authenticatorContextualData = getCurrentAuthenticator(transaction)?.value?.contextualData;
+  // @ts-ignore OKTA-XXXXXX - useEmailMagicLink property missing from interface
+  const useEmailMagicLinkValue = authenticatorContextualData?.useEmailMagicLink;
+  const useEmailMagicLink = typeof useEmailMagicLinkValue !== 'undefined'
+    ? useEmailMagicLinkValue
+    : true;
 
   let reminderElement: ReminderElement | undefined;
 
@@ -61,7 +67,9 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
   const maginLinkText = redactedEmailAddress
     ? loc('oie.email.verify.alternate.magicLinkToEmailAddress', 'login', [redactedEmailAddress])
     : loc('oie.email.verify.alternate.magicLinkToYourEmail', 'login');
-  const instrText = loc('oie.email.verify.alternate.instructions', 'login');
+  const instrText = useEmailMagicLink
+    ? loc('oie.email.verify.alternate.instructions', 'login')
+    : loc('oie.email.verify.alternate.verificationCode.instructions', 'login');
   const informationalText: DescriptionElement = {
     type: 'Description',
     options: {
@@ -84,6 +92,20 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
       step: transaction.nextStep!.name,
     },
   };
+
+  const codeEntryDisplayElements: UISchemaElement[] = [
+    ...(reminderElement ? [reminderElement] : []),
+    titleElement,
+    informationalText,
+    passcodeElement!,
+    submitButtonControl,
+  ];
+
+  // If Email Magic link is disabled, render single form instead of stepper
+  if (!useEmailMagicLink) {
+    uischema.elements = codeEntryDisplayElements;
+    return formBag;
+  }
 
   const showCodeStepperButton: StepperButtonElement = {
     type: 'StepperButton',
@@ -109,13 +131,7 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
       } as UISchemaLayout,
       {
         type: UISchemaLayoutType.VERTICAL,
-        elements: [
-          ...(reminderElement ? [reminderElement] : []),
-          titleElement,
-          informationalText,
-          passcodeElement,
-          submitButtonControl,
-        ],
+        elements: codeEntryDisplayElements,
       } as UISchemaLayout,
     ],
   };

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
@@ -64,7 +64,7 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
   }
 
   const redactedEmailAddress = nextStep.relatesTo?.value?.profile?.email;
-  const descriptionBaseText = redactedEmailAddress
+  const instructionBaseText = redactedEmailAddress
     ? loc('oie.email.verify.alternate.magicLinkToEmailAddress', 'login', [redactedEmailAddress])
     : loc('oie.email.verify.alternate.magicLinkToYourEmail', 'login');
   const instrText = useEmailMagicLink
@@ -73,7 +73,7 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
   const informationalText: DescriptionElement = {
     type: 'Description',
     options: {
-      content: `${descriptionBaseText}${instrText}`,
+      content: `${instructionBaseText}${instrText}`,
     },
   };
 

--- a/src/v3/src/util/getCurrentAuthenticator.ts
+++ b/src/v3/src/util/getCurrentAuthenticator.ts
@@ -10,16 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxTransaction } from '@okta/okta-auth-js';
+import { IdxTransaction, RawIdxResponse } from '@okta/okta-auth-js';
 
-import { getCurrentAuthenticator } from './getCurrentAuthenticator';
-
-export const getAuthenticatorMethod = (
+export const getCurrentAuthenticator = (
   transaction: IdxTransaction,
-  index = 0,
-): string | undefined => {
-  const currentAuthenticator = getCurrentAuthenticator(transaction);
-  const currentAuthenticatorMethods = currentAuthenticator?.value?.methods;
+): RawIdxResponse['currentAuthenticator'] | undefined => {
+  // currentAuthenticator is from enrollment flows and currentAuthenticatorEnrollment is from verify flows
+  const { rawIdxState: { currentAuthenticator, currentAuthenticatorEnrollment } } = transaction;
 
-  return currentAuthenticatorMethods?.[index]?.type;
+  return currentAuthenticator || currentAuthenticatorEnrollment;
 };

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -19,6 +19,7 @@ export * from './formatError';
 export * from './formUtils';
 export * from './generateRandomString';
 export * from './getAuthenticatorKey';
+export * from './getCurrentAuthenticator';
 export * from './getElementKey';
 export * from './getImmutableData';
 export * from './getTranslation';

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -1275,6 +1275,226 @@ exports[`authenticator-verification-email renders correct form should render ses
 </div>
 `;
 
+exports[`authenticator-verification-email renders correct form should render the OTP code entry form when Magic Link is disabled 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-4"
+              data-se="factor-beacon"
+            >
+              <svg
+                aria-labelledby="mfa-okta-email"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="mfa-okta-email"
+                >
+                  Email Authentication
+                </title>
+                <circle
+                  class="siwFillBg"
+                  cx="24"
+                  cy="24"
+                  fill="#F5F5F6"
+                  r="24"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M32 18v1h5.3L32 24.29v1.42l6-6.01v12.8a1.5 1.5 0 0 1-1.5 1.5h-17a1.5 1.5 0 0 1-1.5-1.5V31h-1v1.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V18h-7Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M9 13v14.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V13H9Zm20.293 1-8.81 8.81L10.794 14h18.499ZM28.5 29h-17a1.5 1.5 0 0 1-1.5-1.5V14.63l10.517 9.56L30 14.707V27.5a1.5 1.5 0 0 1-1.5 1.5Z"
+                  fill="#00297A"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="o-form"
+              novalidate=""
+              style="max-width: 100%; word-break: break-word;"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                />
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-13"
+                  >
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-14"
+                      data-se="o-form-head"
+                    >
+                      Verify with your email
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-13"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                      data-se="o-form-explain"
+                    >
+                      We sent you a verification email. Enter the verification code in the text box.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                      for="credentials.passcode"
+                    >
+                      Enter Code
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-21"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="off"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
+                        data-se="credentials.passcode"
+                        id="credentials.passcode"
+                        inputmode="numeric"
+                        name="credentials.passcode"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-23"
+                      >
+                        <legend
+                          class="emotion-24"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Verify
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`authenticator-verification-email should have autocomplete attribute on otp input element when in ios browser 1`] = `
 <div>
   <div

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -91,7 +91,7 @@ describe('authenticator-verification-email', () => {
       expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
         ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
           credentials: { passcode: verificationCode },
-        }),
+        }, 'application/ion+json; okta-version=1.0.0'),
       );
     });
 


### PR DESCRIPTION
## Description:

The purpose of this PR is to fix an issue where the Email Magic Link UI would always display even when the feature is disabled. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-551068](https://oktainc.atlassian.net/browse/OKTA-551068)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



