### PR TITLE
fix: allow autocomplete of usernames

### DIFF
--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -140,7 +140,7 @@ const Body = BaseForm.extend({
         // because we want to allow the user to choose from previously used identifiers.
         newSchema = {
           ...newSchema,
-          autoComplete: 'identifier'
+          autoComplete: 'username'
         };
       } else if (schema.name === 'credentials.passcode') {
         newSchema = {

--- a/src/v2/view-builder/views/IdentifyRecoveryView.js
+++ b/src/v2/view-builder/views/IdentifyRecoveryView.js
@@ -20,7 +20,7 @@ const Body = BaseForm.extend({
         // because we want to allow the user to choose from previously used identifiers.
         newSchema = {
           ...newSchema,
-          autoComplete: 'identifier'
+          autoComplete: 'username'
         };
       }
       return newSchema;

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -181,7 +181,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
 
     currentViewState = { 
       uiSchema: [{
-        'autoComplete': 'identifier',
+        'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
         'label': 'Username',
         'label-top': true,
@@ -208,7 +208,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
 
     currentViewState = { 
       uiSchema: [{
-        'autoComplete': 'identifier',
+        'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
         'label': 'Username',
         'label-top': true,
@@ -221,7 +221,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     testContext.init(XHRIdentifyWithPassword.remediation.value);
     expect(testContext.view.model.get('identifier')).toEqual('testUsername');
     expect(testContext.view.$el.find('.o-form-input-name-identifier input').val()).toEqual('testUsername');
-    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('identifier');
+    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('username');
   });
 
   it('does not pre-fill identifier form with username from cookie when rememberMe feature is disabled', function() {
@@ -236,7 +236,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
 
     currentViewState = { 
       uiSchema: [{
-        'autoComplete': 'identifier',
+        'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
         'label': 'Username',
         'label-top': true,
@@ -249,7 +249,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     testContext.init(XHRIdentifyWithPassword.remediation.value);
     expect(testContext.view.model.get('identifier')).not.toEqual('testUsername');
     expect(testContext.view.$el.find('.o-form-input-name-identifier input').val()).toEqual('');
-    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('identifier');    
+    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('username');    
   });
 
   it('should customize username/password required messages', function() {
@@ -271,7 +271,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     
     currentViewState = { 
       uiSchema: [{
-        'autoComplete': 'identifier',
+        'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
         'label': 'Username',
         'label-top': true,


### PR DESCRIPTION
## Description:

tl;dr change the sign on “username” field’s `autocomplete` attribute to `username` instead of `identifier`?

- `autocomplete=identifier` doesn’t trigger password autocomplete in some environments (e.g. iOS Safari, 1Password)
- Moreover, `identifier` autocompletes in some environments with a person’s name (e.g. Scott Robinson)
- `identifier` is not in the [WhatWG autofill standard](https://html.spec.whatwg.org/multipage/forms.html#autofill)

_(I wasn't able to read the test guidelines or security best practices as they're locked behind a Confluence login.)_

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- #1119
- [OKTA-552271](https://oktainc.atlassian.net/browse/OKTA-552271)
- [OKTA-293139](https://oktainc.atlassian.net/browse/OKTA-293139)

### Reviewers:

### Screenshot/Video:

### Downstream Monolith Build:



