### PR TITLE
Fixed cookie value ln get overrided by wrong identifier after MFA.

### DIFF
--- a/src/v2/client/updateAppState.ts
+++ b/src/v2/client/updateAppState.ts
@@ -24,7 +24,10 @@ function updateIdentifierCookie(appState: AppState, idxResponse: IdxResponse) {
     const user = idxResponse?.context?.user;
     const { identifier } = user?.value || {};
     if (identifier) {
-      CookieUtil.setUsernameCookie(identifier);
+      const currentCookieValue = CookieUtil.getCookieUsername();
+      if (!currentCookieValue || (currentCookieValue !== identifier && currentCookieValue !== (identifier as string).split('@')[0])) {
+        CookieUtil.setUsernameCookie(identifier);
+      }
     }
   } else {
     // We remove the cookie explicitly if this feature is disabled.


### PR DESCRIPTION
## Description:
Updated function updateIdentifierCookie to not override cookie ln, if the current value equal to the identifier or the prefix or identifier.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-552341](https://oktainc.atlassian.net/browse/OKTA-552341)

### Reviewers:

### Screenshot/Video:

### Downstream Monolith Build:



