### PR TITLE
fix: Allow autocomplete of usernames

### DIFF
--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -140,7 +140,7 @@ const Body = BaseForm.extend({
         // because we want to allow the user to choose from previously used identifiers.
         newSchema = {
           ...newSchema,
-          autoComplete: 'identifier'
+          autoComplete: 'username'
         };
       } else if (schema.name === 'credentials.passcode') {
         newSchema = {

--- a/src/v2/view-builder/views/IdentifyRecoveryView.js
+++ b/src/v2/view-builder/views/IdentifyRecoveryView.js
@@ -20,7 +20,7 @@ const Body = BaseForm.extend({
         // because we want to allow the user to choose from previously used identifiers.
         newSchema = {
           ...newSchema,
-          autoComplete: 'identifier'
+          autoComplete: 'username'
         };
       }
       return newSchema;

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -181,7 +181,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
 
     currentViewState = { 
       uiSchema: [{
-        'autoComplete': 'identifier',
+        'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
         'label': 'Username',
         'label-top': true,
@@ -208,7 +208,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
 
     currentViewState = { 
       uiSchema: [{
-        'autoComplete': 'identifier',
+        'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
         'label': 'Username',
         'label-top': true,
@@ -221,7 +221,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     testContext.init(XHRIdentifyWithPassword.remediation.value);
     expect(testContext.view.model.get('identifier')).toEqual('testUsername');
     expect(testContext.view.$el.find('.o-form-input-name-identifier input').val()).toEqual('testUsername');
-    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('identifier');
+    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('username');
   });
 
   it('does not pre-fill identifier form with username from cookie when rememberMe feature is disabled', function() {
@@ -236,7 +236,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
 
     currentViewState = { 
       uiSchema: [{
-        'autoComplete': 'identifier',
+        'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
         'label': 'Username',
         'label-top': true,
@@ -249,7 +249,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     testContext.init(XHRIdentifyWithPassword.remediation.value);
     expect(testContext.view.model.get('identifier')).not.toEqual('testUsername');
     expect(testContext.view.$el.find('.o-form-input-name-identifier input').val()).toEqual('');
-    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('identifier');    
+    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('username');    
   });
 
   it('should customize username/password required messages', function() {
@@ -271,7 +271,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     
     currentViewState = { 
       uiSchema: [{
-        'autoComplete': 'identifier',
+        'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
         'label': 'Username',
         'label-top': true,


### PR DESCRIPTION
Copy of #2929



## Description:

Native browser autocomplete for username doesn't work for MS Edge and some other environments (iOS Safari, 1Password, as stated by original PR author).
This PR fixes this by changing `autocomplete` attribute value from `identifier` to `username` which corresponds to [whatwg standard](https://html.spec.whatwg.org/multipage/forms.html#autofill).



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-552442](https://oktainc.atlassian.net/browse/OKTA-552442)
- [OKTA-552271](https://oktainc.atlassian.net/browse/OKTA-552271)

### Reviewers:

### Screenshot/Video:

MS Edge
before:
<img width="393" alt="Screenshot 2022-12-05 at 16 34 52" src="https://user-images.githubusercontent.com/72614880/205663348-9dc9205f-f5d7-468c-b327-271c689836a0.png">

after:
<img width="380" alt="Screenshot 2022-12-05 at 16 26 08" src="https://user-images.githubusercontent.com/72614880/205663371-ede52580-3d4e-425d-9f46-ea713d267495.png">

### Downstream Monolith Build:



