### PR TITLE
OKTA-552792 : Yubikey field data carryover fix

### DIFF
--- a/src/v3/src/mocks/response/idp/idx/identify/error-invalid-username.json
+++ b/src/v3/src/mocks/response/idp/idx/identify/error-invalid-username.json
@@ -125,7 +125,7 @@
       },
       "type": "password",
       "key": "okta_password",
-      "id": "aut2h3ffszv3me6O31d7",
+      "id": "aut1egri5t7iomJ3l1d7",
       "displayName": "Password",
       "methods": [{ "type": "password" }]
     }

--- a/src/v3/src/transformer/uischema/__snapshots__/updateElementKeys.test.ts.snap
+++ b/src/v3/src/transformer/uischema/__snapshots__/updateElementKeys.test.ts.snap
@@ -1,0 +1,539 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`updateElementKeys Tests should create unique element key for Reminder Element types 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "key": "challenge-authenticator_0987654321abc",
+        "options": Object {
+          "content": "See errors below",
+        },
+        "type": "Reminder",
+      },
+      Object {
+        "key": "challenge-authenticator_Title",
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "key": "challenge-authenticator_Field",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Field",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Button",
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "key": "challenge-authenticator_Link",
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`updateElementKeys Tests should create unique element key when key value is not set and transaction contains authID 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "key": "challenge-authenticator_Title_abc1234",
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_abc1234",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_abc1234",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Button_abc1234",
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "key": "challenge-authenticator_Link_abc1234",
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`updateElementKeys Tests should create unique element key when key value is not set and transaction contains authKey & authID 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "key": "challenge-authenticator_Title_okta_email_abc1234",
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_okta_email_abc1234",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_okta_email_abc1234",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Button_okta_email_abc1234",
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "key": "challenge-authenticator_Link_okta_email_abc1234",
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`updateElementKeys Tests should create unique element key when key value is not set and transaction contains authKey 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "key": "challenge-authenticator_Title_okta_email",
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_okta_email",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_okta_email",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Button_okta_email",
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "key": "challenge-authenticator_Link_okta_email",
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`updateElementKeys Tests should create unique element key when key value is not set and transaction does not contain authKey/authID 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "key": "challenge-authenticator_Title",
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "key": "challenge-authenticator_Field",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Field",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Button",
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "key": "challenge-authenticator_Link",
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`updateElementKeys Tests should create unique element key when key value is preset and transaction contains authID 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "key": "challenge-authenticator_Title_element_key0_abc1234",
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_element_key1_abc1234",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_element_key2_abc1234",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Button_element_key3_abc1234",
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "key": "challenge-authenticator_Link_element_key4_abc1234",
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`updateElementKeys Tests should create unique element key when key value is preset and transaction contains authKey & authID 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "key": "challenge-authenticator_Title_element_key0_okta_email_abc1234",
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_element_key1_okta_email_abc1234",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_element_key2_okta_email_abc1234",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Button_element_key3_okta_email_abc1234",
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "key": "challenge-authenticator_Link_element_key4_okta_email_abc1234",
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`updateElementKeys Tests should create unique element key when key value is preset and transaction contains authKey 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "key": "challenge-authenticator_Title_element_key0_okta_email",
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_element_key1_okta_email",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_element_key2_okta_email",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Button_element_key3_okta_email",
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "key": "challenge-authenticator_Link_element_key4_okta_email",
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`updateElementKeys Tests should create unique element key when key value is preset and transaction does not contain authKey/authID 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "key": "challenge-authenticator_Title_element_key0",
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_element_key1",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Field_element_key2",
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "key": "challenge-authenticator_Button_element_key3",
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "key": "challenge-authenticator_Link_element_key4",
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/uischema/addKeyToElement.ts
+++ b/src/v3/src/transformer/uischema/addKeyToElement.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  TransformStepFnWithOptions,
+} from '../../types';
+import {
+  generateRandomString,
+  getAuthenticatorKey,
+  getCurrentAuthenticator,
+} from '../../util';
+import { traverseLayout } from '../util';
+
+export const addKeyToElement: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
+  traverseLayout({
+    layout: formbag.uischema,
+    predicate: (element) => !!element.type,
+    callback: (element) => {
+      const { nextStep: { name } = {} } = transaction;
+      const authKey = getAuthenticatorKey(transaction);
+      const authId = getCurrentAuthenticator(transaction)?.value?.id;
+
+      // We need Reminder Elements to unmount from view when new transaction
+      // is set, this prevents this alert and error alerts from both displaying
+      // at the same time
+      if (element.type === 'Reminder') {
+        // eslint-disable-next-line no-param-reassign
+        element.key = `${name}_${generateRandomString()}`;
+      } else {
+        let elementKey = element.key
+          ? `${name}_${element.type}_${element.key}`
+          : `${name}_${element.type}`;
+        elementKey += [
+          authKey,
+          authId,
+        ].filter(Boolean).map((str) => `_${str}`).join('');
+        // eslint-disable-next-line no-param-reassign
+        element.key = elementKey;
+      }
+    },
+  });
+  return formbag;
+};

--- a/src/v3/src/transformer/uischema/createTextElementKeys.ts
+++ b/src/v3/src/transformer/uischema/createTextElementKeys.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  DescriptionElement,
+  HeadingElement,
+  TitleElement,
+  TransformStepFn,
+} from '../../types';
+import { traverseLayout } from '../util';
+
+const textElementTypes = new Set([
+  'Title',
+  'Heading',
+  'Description',
+]);
+
+export const createTextElementKeys: TransformStepFn = (formbag) => {
+  traverseLayout({
+    layout: formbag.uischema,
+    predicate: (element) => textElementTypes.has(element.type),
+    callback: (element) => {
+      const titleEle = element as (DescriptionElement | TitleElement | HeadingElement);
+      // eslint-disable-next-line no-param-reassign
+      titleEle.key = titleEle.options.content.split(' ').join('_');
+    },
+  });
+  return formbag;
+};

--- a/src/v3/src/transformer/uischema/setFocusOnFirstElement.ts
+++ b/src/v3/src/transformer/uischema/setFocusOnFirstElement.ts
@@ -10,5 +10,25 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export * from './setFocusOnFirstElement';
-export * from './transform';
+import {
+  TransformStepFn,
+  UISchemaElement,
+} from '../../types';
+import {
+  isInteractiveType,
+} from '../../util';
+import { traverseLayout } from '../util';
+
+export const setFocusOnFirstElement: TransformStepFn = (formbag) => {
+  let firstFieldFound = false;
+  traverseLayout({
+    layout: formbag.uischema,
+    predicate: (el) => (!firstFieldFound && isInteractiveType(el.type)),
+    callback: (el) => {
+      const uischemaElement = (el as UISchemaElement);
+      uischemaElement.focus = true;
+      firstFieldFound = true;
+    },
+  });
+  return formbag;
+};

--- a/src/v3/src/transformer/uischema/transform.ts
+++ b/src/v3/src/transformer/uischema/transform.ts
@@ -15,15 +15,17 @@ import { flow } from 'lodash';
 import {
   TransformStepFnWithOptions,
 } from '../../types';
-import { addKeyToElement } from './addKeyToElement';
+import { createTextElementKeys } from './createTextElementKeys';
 import { setFocusOnFirstElement } from './setFocusOnFirstElement';
 import { updateCustomFields } from './updateCustomFields';
+import { updateElementKeys } from './updateElementKeys';
 import { updateRequiredFields } from './updateRequiredFields';
 
 export const transformUISchema: TransformStepFnWithOptions = (
   options,
 ) => (formbag) => flow(
-  addKeyToElement(options),
+  createTextElementKeys,
+  updateElementKeys(options),
   updateCustomFields,
   setFocusOnFirstElement,
   // TODO: OKTA-524769 - temporary solution for custom fields in profile enrollment

--- a/src/v3/src/transformer/uischema/updateCustomFields.ts
+++ b/src/v3/src/transformer/uischema/updateCustomFields.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';
+
+import CountryUtil from '../../../../util/CountryUtil';
+import TimeZone from '../../../../v2/view-builder/utils/TimeZone';
+import {
+  FieldElement,
+  TransformStepFn,
+} from '../../types';
+import { traverseLayout } from '../util';
+
+export const updateCustomFields: TransformStepFn = (formbag) => {
+  traverseLayout({
+    layout: formbag.uischema,
+    predicate: (el) => (el.type === 'Field'),
+    callback: (el) => {
+      const fieldElement = (el as FieldElement);
+      const { options: { inputMeta: { options } } } = fieldElement;
+
+      if (fieldElement.options.inputMeta.name === 'userProfile.timezone') {
+        fieldElement.options.format = 'select';
+        fieldElement.options.customOptions = Object.entries(TimeZone).map(([code, label]) => ({
+          label,
+          value: code,
+        } as IdxOption));
+      }
+
+      if (Array.isArray(options) && options[0]?.value) {
+        const [option] = options;
+        if (option.label === 'display') {
+          // TODO: OKTA-538689 Missing type in interface, have to cast to any
+          const input = (option.value as any)?.value;
+          fieldElement.options.format = input.inputType;
+          fieldElement.options.customOptions = input.options;
+          if (input.inputType === 'select' && input.format === 'country-code') {
+            const countryCodeObj = CountryUtil.getCountryCode();
+            const countryOptions = Object.entries(countryCodeObj).map(([code, label]) => ({
+              label,
+              value: code,
+            } as IdxOption));
+            fieldElement.options.customOptions = countryOptions;
+          } else if (input.inputType === 'text') {
+            // Text type that has options must remove options for renderers.tsx
+            // to map to correct element
+            fieldElement.options.inputMeta.options = undefined;
+          }
+        }
+      }
+    },
+  });
+  return formbag;
+};

--- a/src/v3/src/transformer/uischema/updateElementKeys.test.ts
+++ b/src/v3/src/transformer/uischema/updateElementKeys.test.ts
@@ -58,13 +58,15 @@ describe('updateElementKeys Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(elements[0].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_element_key0`);
+      .toBe('challenge-authenticator_Title_element_key0');
     expect(elements[1].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_element_key1`);
+      .toBe('challenge-authenticator_Field_element_key1');
     expect(elements[2].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_element_key2`);
+      .toBe('challenge-authenticator_Field_element_key2');
     expect(elements[3].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_element_key3`);
+      .toBe('challenge-authenticator_Button_element_key3');
+    expect(elements[4].key)
+      .toBe('challenge-authenticator_Link_element_key4');
   });
 
   it('should create unique element key when key value is not set and transaction does not contain authKey/authID', async () => {
@@ -73,22 +75,23 @@ describe('updateElementKeys Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(elements[0].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}`);
+      .toBe('challenge-authenticator_Title');
     expect(elements[1].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}`);
+      .toBe('challenge-authenticator_Field');
     expect(elements[2].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}`);
+      .toBe('challenge-authenticator_Field');
     expect(elements[3].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}`);
+      .toBe('challenge-authenticator_Button');
+    expect(elements[4].key)
+      .toBe('challenge-authenticator_Link');
   });
 
   it('should create unique element key when key value is preset and transaction contains authKey', async () => {
     formBag.uischema.elements = formBag.uischema.elements.map(
       (ele: UISchemaElement, index: number) => ({ ...ele, key: `element_key${index}` }),
     );
-    const authKey = AUTHENTICATOR_KEY.EMAIL;
     transaction.nextStep!.relatesTo = {
-      value: { key: authKey } as unknown as IdxAuthenticator,
+      value: { key: AUTHENTICATOR_KEY.EMAIL } as unknown as IdxAuthenticator,
     };
 
     const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
@@ -96,13 +99,15 @@ describe('updateElementKeys Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(elements[0].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_element_key0_${authKey}`);
+      .toBe('challenge-authenticator_Title_element_key0_okta_email');
     expect(elements[1].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_element_key1_${authKey}`);
+      .toBe('challenge-authenticator_Field_element_key1_okta_email');
     expect(elements[2].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_element_key2_${authKey}`);
+      .toBe('challenge-authenticator_Field_element_key2_okta_email');
     expect(elements[3].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_element_key3_${authKey}`);
+      .toBe('challenge-authenticator_Button_element_key3_okta_email');
+    expect(elements[4].key)
+      .toBe('challenge-authenticator_Link_element_key4_okta_email');
   });
 
   it('should create unique element key when key value is not set and transaction contains authKey', async () => {
@@ -116,24 +121,25 @@ describe('updateElementKeys Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(elements[0].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_${authKey}`);
+      .toBe('challenge-authenticator_Title_okta_email');
     expect(elements[1].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_${authKey}`);
+      .toBe('challenge-authenticator_Field_okta_email');
     expect(elements[2].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_${authKey}`);
+      .toBe('challenge-authenticator_Field_okta_email');
     expect(elements[3].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_${authKey}`);
+      .toBe('challenge-authenticator_Button_okta_email');
+    expect(elements[4].key)
+      .toBe('challenge-authenticator_Link_okta_email');
   });
 
   it('should create unique element key when key value is preset and transaction contains authID', async () => {
     formBag.uischema.elements = formBag.uischema.elements.map(
       (ele: UISchemaElement, index: number) => ({ ...ele, key: `element_key${index}` }),
     );
-    const authId = 'abc1234';
     transaction.rawIdxState.currentAuthenticator = {
       type: '',
       value: {
-        id: authId,
+        id: 'abc1234',
       } as unknown as IdxAuthenticator,
     };
 
@@ -142,13 +148,15 @@ describe('updateElementKeys Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(elements[0].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_element_key0_${authId}`);
+      .toBe('challenge-authenticator_Title_element_key0_abc1234');
     expect(elements[1].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_element_key1_${authId}`);
+      .toBe('challenge-authenticator_Field_element_key1_abc1234');
     expect(elements[2].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_element_key2_${authId}`);
+      .toBe('challenge-authenticator_Field_element_key2_abc1234');
     expect(elements[3].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_element_key3_${authId}`);
+      .toBe('challenge-authenticator_Button_element_key3_abc1234');
+    expect(elements[4].key)
+      .toBe('challenge-authenticator_Link_element_key4_abc1234');
   });
 
   it('should create unique element key when key value is not set and transaction contains authID', async () => {
@@ -165,13 +173,15 @@ describe('updateElementKeys Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(elements[0].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_${authId}`);
+      .toBe('challenge-authenticator_Title_abc1234');
     expect(elements[1].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_${authId}`);
+      .toBe('challenge-authenticator_Field_abc1234');
     expect(elements[2].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_${authId}`);
+      .toBe('challenge-authenticator_Field_abc1234');
     expect(elements[3].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_${authId}`);
+      .toBe('challenge-authenticator_Button_abc1234');
+    expect(elements[4].key)
+      .toBe('challenge-authenticator_Link_abc1234');
   });
 
   it('should create unique element key when key value is preset and transaction contains authKey & authID', async () => {
@@ -195,13 +205,15 @@ describe('updateElementKeys Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(elements[0].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_element_key0_${authKey}_${authId}`);
+      .toBe('challenge-authenticator_Title_element_key0_okta_email_abc1234');
     expect(elements[1].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_element_key1_${authKey}_${authId}`);
+      .toBe('challenge-authenticator_Field_element_key1_okta_email_abc1234');
     expect(elements[2].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_element_key2_${authKey}_${authId}`);
+      .toBe('challenge-authenticator_Field_element_key2_okta_email_abc1234');
     expect(elements[3].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_element_key3_${authKey}_${authId}`);
+      .toBe('challenge-authenticator_Button_element_key3_okta_email_abc1234');
+    expect(elements[4].key)
+      .toBe('challenge-authenticator_Link_element_key4_okta_email_abc1234');
   });
 
   it('should create unique element key when key value is not set and transaction contains authKey & authID', async () => {
@@ -222,18 +234,19 @@ describe('updateElementKeys Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(elements[0].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_${authKey}_${authId}`);
+      .toBe('challenge-authenticator_Title_okta_email_abc1234');
     expect(elements[1].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_${authKey}_${authId}`);
+      .toBe('challenge-authenticator_Field_okta_email_abc1234');
     expect(elements[2].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_${authKey}_${authId}`);
+      .toBe('challenge-authenticator_Field_okta_email_abc1234');
     expect(elements[3].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_${authKey}_${authId}`);
+      .toBe('challenge-authenticator_Button_okta_email_abc1234');
+    expect(elements[4].key)
+      .toBe('challenge-authenticator_Link_okta_email_abc1234');
   });
 
   it('should create unique element key for Reminder Element types', async () => {
-    const randomString = '0987654321abc';
-    jest.spyOn(randomStringUtil, 'generateRandomString').mockReturnValue(randomString);
+    jest.spyOn(randomStringUtil, 'generateRandomString').mockReturnValue('0987654321abc');
     formBag.uischema.elements.unshift({ type: 'Reminder', options: { content: 'See errors below' } } as ReminderElement);
 
     const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
@@ -241,6 +254,6 @@ describe('updateElementKeys Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(elements[0].key)
-      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${randomString}`);
+      .toBe('challenge-authenticator_0987654321abc');
   });
 });

--- a/src/v3/src/transformer/uischema/updateElementKeys.test.ts
+++ b/src/v3/src/transformer/uischema/updateElementKeys.test.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxAuthenticator, IdxTransaction } from '@okta/okta-auth-js';
+import { AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
+import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
+import {
+  ButtonElement,
+  ButtonType,
+  FieldElement,
+  FormBag,
+  LinkElement,
+  ReminderElement,
+  TitleElement,
+  UISchemaElement,
+  WidgetProps,
+} from 'src/types';
+
+import * as randomStringUtil from '../../util/generateRandomString';
+import { updateElementKeys } from './updateElementKeys';
+
+describe('updateElementKeys Tests', () => {
+  let transaction: IdxTransaction;
+  let formBag: FormBag;
+  let widgetProps: WidgetProps;
+
+  beforeEach(() => {
+    transaction = getStubTransactionWithNextStep();
+    formBag = getStubFormBag();
+
+    transaction.nextStep!.name = IDX_STEP.CHALLENGE_AUTHENTICATOR;
+    formBag.uischema.elements = [
+      { type: 'Title', options: { content: 'Sign in' } } as TitleElement,
+      { type: 'Field', options: { inputMeta: { name: 'identifier' } } } as FieldElement,
+      { type: 'Field', options: { inputMeta: { name: 'credentials.passcode' } } } as FieldElement,
+      { type: 'Button', options: { type: ButtonType.SUBMIT } } as ButtonElement,
+      { type: 'Link', options: { label: 'Forgot Password' } } as LinkElement,
+    ];
+    widgetProps = {};
+  });
+
+  it('should create unique element key when key value is preset and transaction does not contain authKey/authID', async () => {
+    formBag.uischema.elements = formBag.uischema.elements.map(
+      (ele: UISchemaElement, index: number) => ({ ...ele, key: `element_key${index}` }),
+    );
+
+    const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(elements[0].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_element_key0`);
+    expect(elements[1].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_element_key1`);
+    expect(elements[2].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_element_key2`);
+    expect(elements[3].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_element_key3`);
+  });
+
+  it('should create unique element key when key value is not set and transaction does not contain authKey/authID', async () => {
+    const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(elements[0].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}`);
+    expect(elements[1].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}`);
+    expect(elements[2].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}`);
+    expect(elements[3].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}`);
+  });
+
+  it('should create unique element key when key value is preset and transaction contains authKey', async () => {
+    formBag.uischema.elements = formBag.uischema.elements.map(
+      (ele: UISchemaElement, index: number) => ({ ...ele, key: `element_key${index}` }),
+    );
+    const authKey = AUTHENTICATOR_KEY.EMAIL;
+    transaction.nextStep!.relatesTo = {
+      value: { key: authKey } as unknown as IdxAuthenticator,
+    };
+
+    const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(elements[0].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_element_key0_${authKey}`);
+    expect(elements[1].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_element_key1_${authKey}`);
+    expect(elements[2].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_element_key2_${authKey}`);
+    expect(elements[3].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_element_key3_${authKey}`);
+  });
+
+  it('should create unique element key when key value is not set and transaction contains authKey', async () => {
+    const authKey = AUTHENTICATOR_KEY.EMAIL;
+    transaction.nextStep!.relatesTo = {
+      value: { key: authKey } as unknown as IdxAuthenticator,
+    };
+
+    const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(elements[0].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_${authKey}`);
+    expect(elements[1].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_${authKey}`);
+    expect(elements[2].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_${authKey}`);
+    expect(elements[3].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_${authKey}`);
+  });
+
+  it('should create unique element key when key value is preset and transaction contains authID', async () => {
+    formBag.uischema.elements = formBag.uischema.elements.map(
+      (ele: UISchemaElement, index: number) => ({ ...ele, key: `element_key${index}` }),
+    );
+    const authId = 'abc1234';
+    transaction.rawIdxState.currentAuthenticator = {
+      type: '',
+      value: {
+        id: authId,
+      } as unknown as IdxAuthenticator,
+    };
+
+    const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(elements[0].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_element_key0_${authId}`);
+    expect(elements[1].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_element_key1_${authId}`);
+    expect(elements[2].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_element_key2_${authId}`);
+    expect(elements[3].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_element_key3_${authId}`);
+  });
+
+  it('should create unique element key when key value is not set and transaction contains authID', async () => {
+    const authId = 'abc1234';
+    transaction.rawIdxState.currentAuthenticator = {
+      type: '',
+      value: {
+        id: authId,
+      } as unknown as IdxAuthenticator,
+    };
+
+    const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(elements[0].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_${authId}`);
+    expect(elements[1].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_${authId}`);
+    expect(elements[2].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_${authId}`);
+    expect(elements[3].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_${authId}`);
+  });
+
+  it('should create unique element key when key value is preset and transaction contains authKey & authID', async () => {
+    formBag.uischema.elements = formBag.uischema.elements.map(
+      (ele: UISchemaElement, index: number) => ({ ...ele, key: `element_key${index}` }),
+    );
+    const authKey = AUTHENTICATOR_KEY.EMAIL;
+    transaction.nextStep!.relatesTo = {
+      value: { key: authKey } as unknown as IdxAuthenticator,
+    };
+    const authId = 'abc1234';
+    transaction.rawIdxState.currentAuthenticator = {
+      type: '',
+      value: {
+        id: authId,
+      } as unknown as IdxAuthenticator,
+    };
+
+    const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(elements[0].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_element_key0_${authKey}_${authId}`);
+    expect(elements[1].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_element_key1_${authKey}_${authId}`);
+    expect(elements[2].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_element_key2_${authKey}_${authId}`);
+    expect(elements[3].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_element_key3_${authKey}_${authId}`);
+  });
+
+  it('should create unique element key when key value is not set and transaction contains authKey & authID', async () => {
+    const authKey = AUTHENTICATOR_KEY.EMAIL;
+    transaction.nextStep!.relatesTo = {
+      value: { key: authKey } as unknown as IdxAuthenticator,
+    };
+    const authId = 'abc1234';
+    transaction.rawIdxState.currentAuthenticator = {
+      type: '',
+      value: {
+        id: authId,
+      } as unknown as IdxAuthenticator,
+    };
+
+    const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(elements[0].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[0].type}_${authKey}_${authId}`);
+    expect(elements[1].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[1].type}_${authKey}_${authId}`);
+    expect(elements[2].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[2].type}_${authKey}_${authId}`);
+    expect(elements[3].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${elements[3].type}_${authKey}_${authId}`);
+  });
+
+  it('should create unique element key for Reminder Element types', async () => {
+    const randomString = '0987654321abc';
+    jest.spyOn(randomStringUtil, 'generateRandomString').mockReturnValue(randomString);
+    formBag.uischema.elements.unshift({ type: 'Reminder', options: { content: 'See errors below' } } as ReminderElement);
+
+    const updatedFormBag = updateElementKeys({ transaction, widgetProps, step: '' })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(elements[0].key)
+      .toBe(`${IDX_STEP.CHALLENGE_AUTHENTICATOR}_${randomString}`);
+  });
+});

--- a/src/v3/src/transformer/uischema/updateElementKeys.ts
+++ b/src/v3/src/transformer/uischema/updateElementKeys.ts
@@ -20,7 +20,7 @@ import {
 } from '../../util';
 import { traverseLayout } from '../util';
 
-export const addKeyToElement: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
+export const updateElementKeys: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
   traverseLayout({
     layout: formbag.uischema,
     predicate: (element) => !!element.type,
@@ -36,7 +36,7 @@ export const addKeyToElement: TransformStepFnWithOptions = ({ transaction }) => 
         // eslint-disable-next-line no-param-reassign
         element.key = `${name}_${generateRandomString()}`;
       } else {
-        let elementKey = element.key
+        let elementKey = typeof element.key !== 'undefined'
           ? `${name}_${element.type}_${element.key}`
           : `${name}_${element.type}`;
         elementKey += [

--- a/src/v3/src/transformer/uischema/updateRequiredFields.ts
+++ b/src/v3/src/transformer/uischema/updateRequiredFields.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IDX_STEP } from '../../constants';
+import {
+  FieldElement,
+  TransformStepFnWithOptions,
+} from '../../types';
+import { traverseLayout } from '../util';
+
+// TODO: OKTA-524769 - temporary solution for custom fields in profile enrollment
+export const updateRequiredFields: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
+  const { nextStep: { name = '' } = {} } = transaction;
+  if (![IDX_STEP.ENROLL_PROFILE, IDX_STEP.ENROLL_PROFILE_UPDATE].includes(name)) {
+    return formbag;
+  }
+  traverseLayout({
+    layout: formbag.uischema,
+    predicate: (el) => (el.type === 'Field'),
+    callback: (el) => {
+      const fieldElement = (el as FieldElement);
+      const { options: { inputMeta: { required } } } = fieldElement;
+      fieldElement.required = required;
+    },
+  });
+  return formbag;
+};

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -1094,7 +1094,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         Enter Code
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-34"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-34"
                       >
                         <input
                           aria-describedby="credentials.passcode-error"

--- a/src/v3/test/integration/flow-yubikey-otp-to-password-verification.test.tsx
+++ b/src/v3/test/integration/flow-yubikey-otp-to-password-verification.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import yubikeyVerificationResponse from '@okta/mocks/data/idp/idx/authenticator-verification-yubikey.json';
+
+import identifyWithPassword from '@okta/mocks/data/idp/idx/authenticator-verification-password.json';
+import { createAuthJsPayloadArgs, setup } from './util';
+
+describe('Flow transition from YubiKey verification to Password MFA', () => {
+  it('clears field data when transition from yubikey verification to password MFA', async () => {
+    const {
+      authClient,
+      user,
+      findByTestId,
+      findByText,
+    } = await setup({
+      mockResponses: {
+        '/introspect': {
+          data: yubikeyVerificationResponse,
+          status: 200,
+        },
+        '/idx/challenge/answer': {
+          data: identifyWithPassword,
+          status: 200,
+        },
+      },
+    });
+
+    // form: Yubikey code entry
+    const yubikeyCodeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    await user.type(yubikeyCodeEl, '1234abcd8520');
+    expect(yubikeyCodeEl.value).toEqual('1234abcd8520');
+    await user.click(await findByText('Verify', { selector: 'button' }));
+
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', { credentials: { passcode: '1234abcd8520' } }),
+    );
+
+    // form: verify with password MFA
+    await findByText(/Verify with your password/);
+    const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    expect(passwordEl.value).toEqual('');
+  });
+});


### PR DESCRIPTION
## Description:

The purpose of this PR is to prevent the field data carry over from one flow (Yubikey verification) to another (Challenge-authenticator w/ credentials.passcode field) by ensuring the React Element keys are unique between flows.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-552792](https://oktainc.atlassian.net/browse/OKTA-552792)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



