### PR TITLE
OKTA-521284 : Re-Enabling skipped test due to AuthJS upgrade

### DIFF
--- a/src/v3/test/integration/error-authenticator-enrollment-not-allowed.test.tsx
+++ b/src/v3/test/integration/error-authenticator-enrollment-not-allowed.test.tsx
@@ -21,8 +21,7 @@ describe('error-authenticator-enrollment-not-allowed', () => {
     expect(container).toMatchSnapshot();
   });
 
-  // TODO: OKTA-528448 : Re-enable once this auth-js bug is fixed
-  it.skip('should send correct payload when clicking back to sign in link', async () => {
+  it('should send correct payload when clicking back to sign in link', async () => {
     const {
       authClient, user, findByText,
     } = await setup({ mockResponse });


### PR DESCRIPTION
## Description:

Now that auth-js has been upgraded (which fixed the original bug), the purpose of this PR is to enable the test to prevent rergression.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521284](https://oktainc.atlassian.net/browse/OKTA-521284)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



