### PR TITLE
OKTA-534444 update ansi regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,8 @@
     "wait-on/axios": "^0.27.2",
     "**/request/qs": "^6.11.0",
     "grunt/minimatch": "^3.1.2",
-    "**/globule/minimatch": "^3.1.2"
+    "**/globule/minimatch": "^3.1.2",
+    "ansi-regex": "^5.0.1"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,28 +1718,8 @@
     safe-flat "^2.0.2"
 
 "@okta/okta-signin-widget@link:dist":
-  version "7.1.0"
-  dependencies:
-    "@okta/okta-auth-js" "~7.0.0"
-    "@sindresorhus/to-milliseconds" "^1.0.0"
-    "@types/backbone" "^1.4.15"
-    "@types/jquery" "^3.5.14"
-    "@types/jqueryui" "^1.12.16"
-    "@types/q" "^1.5.5"
-    "@types/selectize" "^0.12.35"
-    "@types/underscore" "^1.11.4"
-    chokidar "^3.5.1"
-    clipboard "^1.5.16"
-    cross-fetch "^3.1.5"
-    ejs "^3.1.7"
-    handlebars "^4.7.7"
-    jquery "^3.6.0"
-    parse-ms "^2.0.0"
-    q "1.4.1"
-    u2f-api-polyfill "0.4.3"
-    underscore "1.13.1"
-  optionalDependencies:
-    fsevents "*"
+  version "0.0.0"
+  uid ""
 
 "@peculiar/asn1-schema@^2.1.6", "@peculiar/asn1-schema@^2.3.0":
   version "2.3.3"
@@ -3152,22 +3132,7 @@ ansi-html-community@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
-
-ansi-regex@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
-  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
-
-ansi-regex@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
-  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
-
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==


### PR DESCRIPTION
## Description:

Resolves `ansi-regex` to `^5.0.1` for its dependent packages.

We were using four different versions of `ansi-regex` as a transitive dependency:

- `ansi-regex@5.0.1`
- `ansi-regex@3.0.1`
- `ansi-regex@2.1.1`
- `ansi-regex@4.1.1`

This PR resolves all of them to `ansi-regex@^5.0.1` which includes a [fix for ReDOS](https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9). 

NOTE: Although the semver difference from `2.1.1` → `5.0.1` suggests there should be breaking changes, a review of the _few and infrequent_ commits to the package show that there are no backwards-incompatible changes aside from the node version requirement (we are on `node@v14`).

https://github.com/chalk/ansi-regex/compare/2.1.1...v5.0.1

Before:

```
$ yarn why ansi-regex | grep Found
=> Found "ansi-regex@5.0.1"
=> Found "karma-mocha-reporter#ansi-regex@3.0.1"
=> Found "has-ansi#ansi-regex@2.1.1"
=> Found "time-grunt#ansi-regex@2.1.1"
=> Found "grunt-contrib-copy#ansi-regex@2.1.1"
=> Found "webdriver-manager#ansi-regex@2.1.1"
=> Found "@okta/e2e#ansi-regex@5.0.1"
=> Found "i18n-lint#ansi-regex@2.1.1"
=> Found "@okta/e2e#has-ansi#ansi-regex@4.1.1"
=> Found "concurrently#ansi-regex@4.1.1"
=> Found "@okta/e2e#yarn-install#ansi-regex@2.1.1"
=> Found "@okta/e2e#cliui#ansi-regex@3.0.1"
=> Found "@okta/e2e#string-width#ansi-regex@3.0.1"
=> Found "@okta/e2e#cac#ansi-regex@2.1.1"
=> Found "@okta/e2e#cliui#wrap-ansi#ansi-regex@2.1.1"
```

After:

```
$ yarn why ansi-regex | grep Found
=> Found "ansi-regex@5.0.1"
=> Found "@okta/e2e#ansi-regex@5.0.1"
```

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below) NO

### Issue:

- [OKTA-534444](https://oktainc.atlassian.net/browse/OKTA-534444)
- [OKTA-534445](https://oktainc.atlassian.net/browse/OKTA-534445)
- [OKTA-534446](https://oktainc.atlassian.net/browse/OKTA-534446)
- [OKTA-534448](https://oktainc.atlassian.net/browse/OKTA-534448)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



