### PR TITLE
OKTA-547439 : Password requirements subheader fix

### DIFF
--- a/src/v3/src/components/PasswordRequirements/Icon.tsx
+++ b/src/v3/src/components/PasswordRequirements/Icon.tsx
@@ -11,21 +11,25 @@
  */
 
 import { Box } from '@mui/material';
-import { Icon } from '@okta/odyssey-react';
+import { Icon as OdyIcon } from '@okta/odyssey-react';
 import { withTheme } from '@okta/odyssey-react-theme';
 import classNames from 'classnames/bind';
 import { FunctionComponent, h } from 'preact';
 
-import { PasswordRequirementProps } from '../../types';
+import { PasswordRequirementStatus } from '../../types';
 import { theme } from './PasswordRequirements.theme';
 import style from './style.module.css';
 
 const cx = classNames.bind(style);
 
-const PasswordRequirement: FunctionComponent<PasswordRequirementProps> = (
+type PasswordRequirementIconProps = {
+  status: PasswordRequirementStatus;
+};
+
+const Icon: FunctionComponent<PasswordRequirementIconProps> = (
   props,
 ) => {
-  const { status, text } = props;
+  const { status } = props;
   const statusToIconName = {
     incomplete: 'close',
     complete: 'check-circle-filled',
@@ -38,23 +42,13 @@ const PasswordRequirement: FunctionComponent<PasswordRequirementProps> = (
   });
 
   return (
-    <Box>
-      {
-        status && (
-          <Box
-            display="inline-block"
-            marginRight={1}
-            className={iconClasses}
-          >
-            <Icon
-              title={status}
-              name={statusToIconName[status]}
-            />
-          </Box>
-        )
-      }
-      <Box component="span">{text}</Box>
+    <Box className={iconClasses}>
+      <OdyIcon
+        // TODO: OKTA-556721 - Create and use loc string here for requirement status
+        title={status}
+        name={statusToIconName[status]}
+      />
     </Box>
   );
 };
-export default withTheme(theme, style)(PasswordRequirement);
+export default withTheme(theme, style)(Icon);

--- a/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
@@ -28,7 +28,7 @@ import {
   UISchemaElementComponent,
 } from '../../types';
 import { getTranslation } from '../../util';
-import PasswordRequirementItem from './PasswordRequirementListItem';
+import PasswordRequirementListItem from './PasswordRequirementListItem';
 
 const PasswordMatches: UISchemaElementComponent<{
   uischema: PasswordMatchesElement
@@ -65,7 +65,7 @@ const PasswordMatches: UISchemaElementComponent<{
         unstyled
       >
         <List.Item>
-          <PasswordRequirementItem
+          <PasswordRequirementListItem
             status={isMatching ? 'complete' : 'incomplete'}
             label={label ?? ''}
           />

--- a/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
@@ -10,10 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box } from '@mui/material';
-import {
-  List,
-} from '@okta/odyssey-react';
+import { Box, List } from '@mui/material';
 import debounce from 'lodash/debounce';
 import { h } from 'preact';
 import {
@@ -64,12 +61,10 @@ const PasswordMatches: UISchemaElementComponent<{
         listType="unordered"
         unstyled
       >
-        <List.Item>
-          <PasswordRequirementListItem
-            status={isMatching ? 'complete' : 'incomplete'}
-            label={label ?? ''}
-          />
-        </List.Item>
+        <PasswordRequirementListItem
+          status={isMatching ? 'complete' : 'incomplete'}
+          label={label ?? ''}
+        />
       </List>
     </Box>
   );

--- a/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
@@ -28,7 +28,7 @@ import {
   UISchemaElementComponent,
 } from '../../types';
 import { getTranslation } from '../../util';
-import PasswordRequirementItem from './PasswordRequirementItem';
+import PasswordRequirementItem from './PasswordRequirementListItem';
 
 const PasswordMatches: UISchemaElementComponent<{
   uischema: PasswordMatchesElement
@@ -67,7 +67,7 @@ const PasswordMatches: UISchemaElementComponent<{
         <List.Item>
           <PasswordRequirementItem
             status={isMatching ? 'complete' : 'incomplete'}
-            text={label ?? ''}
+            label={label ?? ''}
           />
         </List.Item>
       </List>

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  ListItem, ListItemIcon, ListItemText,
+} from '@mui/material';
+import { withTheme } from '@okta/odyssey-react-theme';
+import { FunctionComponent, h } from 'preact';
+
+import { PasswordRequirementProps } from '../../types';
+import Icon from './Icon';
+import { theme } from './PasswordRequirements.theme';
+import style from './style.module.css';
+
+const PasswordRequirementListItem: FunctionComponent<PasswordRequirementProps> = (
+  props,
+) => {
+  const { status, label } = props;
+
+  return (
+    <ListItem
+      disablePadding
+      disableGutters
+    >
+      <ListItemIcon sx={{ minWidth: '1.5rem' }}>
+        <Icon status={status} />
+      </ListItemIcon>
+      <ListItemText primary={label} />
+    </ListItem>
+  );
+};
+export default withTheme(theme, style)(PasswordRequirementListItem);

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirements.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirements.tsx
@@ -10,10 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box } from '@mui/material';
-import {
-  List,
-} from '@okta/odyssey-react';
+import { Box, List } from '@mui/material';
 import debounce from 'lodash/debounce';
 import { h } from 'preact';
 import {
@@ -30,7 +27,7 @@ import {
   UISchemaElementComponent,
 } from '../../types';
 import { validatePassword } from '../../util';
-import PasswordRequirementItem from './PasswordRequirementItem';
+import PasswordRequirementListItem from './PasswordRequirementListItem';
 
 const PasswordRequirements: UISchemaElementComponent<{
   uischema: PasswordRequirementsElement
@@ -55,11 +52,7 @@ const PasswordRequirements: UISchemaElementComponent<{
   const getPasswordStatus = (
     ruleKey: string,
     passwordValidation: PasswordValidation,
-  ): PasswordRequirementStatus | undefined => {
-    if (!passwordValidation) {
-      return undefined;
-    }
-
+  ): PasswordRequirementStatus => {
     const ruleValue = passwordValidation[ruleKey];
     if (ruleValue) {
       return 'complete';
@@ -95,27 +88,27 @@ const PasswordRequirements: UISchemaElementComponent<{
   }, [password]);
 
   return requirements?.length > 0 ? (
-    <Box data-se="password-authenticator--rules">
-      <Box marginBottom={2}>
-        <Box
-          as="span"
-          className="password-authenticator--heading"
-        >
-          {header}
-        </Box>
+    <Box
+      component="figure"
+      margin={0}
+      data-se="password-authenticator--rules"
+    >
+      <Box
+        component="figcaption"
+        className="password-authenticator--heading"
+      >
+        {header}
       </Box>
       <List
         id={id}
-        listType="unordered"
-        unstyled
+        dense
       >
         {requirements.map(({ ruleKey, label }) => (
-          <List.Item key={label}>
-            <PasswordRequirementItem
-              status={getPasswordStatus(ruleKey, passwordValidations)}
-              text={label}
-            />
-          </List.Item>
+          <PasswordRequirementListItem
+            key={label}
+            status={getPasswordStatus(ruleKey, passwordValidations)}
+            label={label}
+          />
         ))}
       </List>
     </Box>

--- a/src/v3/src/types/password.ts
+++ b/src/v3/src/types/password.ts
@@ -14,8 +14,8 @@ import { PASSWORD_REQUIREMENTS_KEYS } from '../constants';
 
 export type PasswordRequirementStatus = 'incomplete' | 'complete' | 'info';
 export type PasswordRequirementProps = {
-  status?: PasswordRequirementStatus;
-  text: string;
+  status: PasswordRequirementStatus;
+  label: string;
 };
 
 export interface GetAgeFromMinutes {

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -120,31 +120,27 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-4"
+                  <figure
+                    class="MuiBox-root emotion-15"
                     data-se="password-authenticator--rules"
                   >
-                    <div
-                      class="MuiBox-root emotion-16"
+                    <figcaption
+                      class="password-authenticator--heading MuiBox-root emotion-4"
                     >
-                      <span
-                        class="password-authenticator--heading MuiBox-root emotion-4"
-                      >
-                        Password requirements:
-                      </span>
-                    </div>
+                      Password requirements:
+                    </figcaption>
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding MuiList-dense emotion-17"
                       id="generated"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -167,21 +163,25 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             At least 8 characters
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -204,21 +204,25 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A lowercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -241,21 +245,25 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             An uppercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -278,21 +286,25 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A number
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -315,21 +327,25 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             No parts of your username
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -352,21 +368,25 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             Does not include your first name
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -389,15 +409,19 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             Does not include your last name
                           </span>
                         </div>
                       </li>
                     </ul>
-                  </div>
+                  </figure>
                 </div>
                 <div
                   class="MuiBox-root emotion-4"
@@ -419,37 +443,37 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-43"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-57"
                         for="credentials.passcode"
                       >
                         Enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-44"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-58"
                       >
                         <input
                           aria-describedby="credentials.passcode-error"
                           aria-invalid="true"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-45"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-59"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-46"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-60"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-47"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-61"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-48"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-62"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -462,10 +486,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-49"
+                          class="MuiOutlinedInput-notchedOutline emotion-63"
                         >
                           <legend
-                            class="emotion-50"
+                            class="emotion-64"
                           >
                             <span
                               class="notranslate"
@@ -480,7 +504,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <p
-                        class="MuiFormHelperText-root Mui-error emotion-52"
+                        class="MuiFormHelperText-root Mui-error emotion-66"
                         data-se="credentials.passcode-error"
                         id="generated"
                         role="alert"
@@ -500,36 +524,36 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-43"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-57"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-44"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-58"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-45"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-59"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-46"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-60"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-47"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-61"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-48"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-62"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -542,10 +566,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-49"
+                          class="MuiOutlinedInput-notchedOutline emotion-63"
                         >
                           <legend
-                            class="emotion-50"
+                            class="emotion-64"
                           >
                             <span
                               class="notranslate"
@@ -571,39 +595,47 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       <li
                         class="ods-5vIIsH"
                       >
-                        <div
-                          class="MuiBox-root emotion-4"
+                        <li
+                          class="MuiListItem-root emotion-18"
                         >
                           <div
-                            class="passwordRequirementIcon incomplete MuiBox-root emotion-19"
+                            class="MuiListItemIcon-root emotion-19"
                           >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                             >
-                              <title
-                                id="generated"
+                              <svg
+                                aria-labelledby="generated"
+                                class="ods-2icygl"
+                                fill="none"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                incomplete
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
+                                <title
+                                  id="generated"
+                                >
+                                  incomplete
+                                </title>
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                           </div>
-                          <span
-                            class="MuiBox-root emotion-4"
+                          <div
+                            class="MuiListItemText-root emotion-21"
                           >
-                            Passwords must match
-                          </span>
-                        </div>
+                            <span
+                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-84"
+                            >
+                              Passwords must match
+                            </span>
+                          </div>
+                        </li>
                       </li>
                     </ul>
                   </div>
@@ -612,7 +644,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-70"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-86"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -624,7 +656,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-72"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-88"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -635,7 +667,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-72"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-88"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -590,52 +590,50 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                     data-se="password-authenticator--matches"
                   >
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding emotion-17"
+                      listtype="unordered"
+                      unstyled="true"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root emotion-18"
                       >
-                        <li
-                          class="MuiListItem-root emotion-18"
+                        <div
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="MuiListItemIcon-root emotion-19"
+                            class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                           >
-                            <div
-                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-labelledby="generated"
-                                class="ods-2icygl"
-                                fill="none"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                xmlns="http://www.w3.org/2000/svg"
+                              <title
+                                id="generated"
                               >
-                                <title
-                                  id="generated"
-                                >
-                                  incomplete
-                                </title>
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
+                                incomplete
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
                           </div>
-                          <div
-                            class="MuiListItemText-root emotion-21"
+                        </div>
+                        <div
+                          class="MuiListItemText-root emotion-21"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-85"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-84"
-                            >
-                              Passwords must match
-                            </span>
-                          </div>
-                        </li>
+                            Passwords must match
+                          </span>
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -644,7 +642,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-86"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-87"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -656,7 +654,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-88"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-89"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -667,7 +665,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-88"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-89"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -271,52 +271,50 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                     data-se="password-authenticator--matches"
                   >
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding emotion-39"
+                      listtype="unordered"
+                      unstyled="true"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root emotion-40"
                       >
-                        <li
-                          class="MuiListItem-root emotion-39"
+                        <div
+                          class="MuiListItemIcon-root emotion-41"
                         >
                           <div
-                            class="MuiListItemIcon-root emotion-40"
+                            class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                           >
-                            <div
-                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-labelledby="generated"
-                                class="ods-2icygl"
-                                fill="none"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                xmlns="http://www.w3.org/2000/svg"
+                              <title
+                                id="generated"
                               >
-                                <title
-                                  id="generated"
-                                >
-                                  incomplete
-                                </title>
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
+                                incomplete
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
                           </div>
-                          <div
-                            class="MuiListItemText-root emotion-42"
+                        </div>
+                        <div
+                          class="MuiListItemText-root emotion-43"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-44"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-43"
-                            >
-                              Passwords must match
-                            </span>
-                          </div>
-                        </li>
+                            Passwords must match
+                          </span>
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -325,7 +323,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-45"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-46"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -337,7 +335,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -276,39 +276,47 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                       <li
                         class="ods-5vIIsH"
                       >
-                        <div
-                          class="MuiBox-root emotion-4"
+                        <li
+                          class="MuiListItem-root emotion-39"
                         >
                           <div
-                            class="passwordRequirementIcon incomplete MuiBox-root emotion-40"
+                            class="MuiListItemIcon-root emotion-40"
                           >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                             >
-                              <title
-                                id="generated"
+                              <svg
+                                aria-labelledby="generated"
+                                class="ods-2icygl"
+                                fill="none"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                incomplete
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
+                                <title
+                                  id="generated"
+                                >
+                                  incomplete
+                                </title>
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                           </div>
-                          <span
-                            class="MuiBox-root emotion-4"
+                          <div
+                            class="MuiListItemText-root emotion-42"
                           >
-                            Passwords must match
-                          </span>
-                        </div>
+                            <span
+                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-43"
+                            >
+                              Passwords must match
+                            </span>
+                          </div>
+                        </li>
                       </li>
                     </ul>
                   </div>
@@ -317,7 +325,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-43"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-45"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -329,7 +337,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-45"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -495,52 +495,50 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                     data-se="password-authenticator--matches"
                   >
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding emotion-17"
+                      listtype="unordered"
+                      unstyled="true"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root emotion-18"
                       >
-                        <li
-                          class="MuiListItem-root emotion-18"
+                        <div
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="MuiListItemIcon-root emotion-19"
+                            class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                           >
-                            <div
-                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-labelledby="generated"
-                                class="ods-2icygl"
-                                fill="none"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                xmlns="http://www.w3.org/2000/svg"
+                              <title
+                                id="generated"
                               >
-                                <title
-                                  id="generated"
-                                >
-                                  incomplete
-                                </title>
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
+                                incomplete
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
                           </div>
-                          <div
-                            class="MuiListItemText-root emotion-21"
+                        </div>
+                        <div
+                          class="MuiListItemText-root emotion-21"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-73"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-72"
-                            >
-                              Passwords must match
-                            </span>
-                          </div>
-                        </li>
+                            Passwords must match
+                          </span>
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -549,7 +547,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-74"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-75"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -561,7 +559,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-77"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -572,7 +570,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-77"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -120,31 +120,27 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-4"
+                  <figure
+                    class="MuiBox-root emotion-15"
                     data-se="password-authenticator--rules"
                   >
-                    <div
-                      class="MuiBox-root emotion-16"
+                    <figcaption
+                      class="password-authenticator--heading MuiBox-root emotion-4"
                     >
-                      <span
-                        class="password-authenticator--heading MuiBox-root emotion-4"
-                      >
-                        Password requirements:
-                      </span>
-                    </div>
+                      Password requirements:
+                    </figcaption>
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding MuiList-dense emotion-17"
                       id="generated"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -167,21 +163,25 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             At least 8 characters
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -204,21 +204,25 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A lowercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -241,21 +245,25 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             An uppercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -278,21 +286,25 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A number
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -315,15 +327,19 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             No parts of your username
                           </span>
                         </div>
                       </li>
                     </ul>
-                  </div>
+                  </figure>
                 </div>
                 <div
                   class="MuiBox-root emotion-4"
@@ -345,36 +361,36 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-42"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -387,10 +403,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-43"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-44"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -413,36 +429,36 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-42"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -455,10 +471,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-43"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-44"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -484,39 +500,47 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       <li
                         class="ods-5vIIsH"
                       >
-                        <div
-                          class="MuiBox-root emotion-4"
+                        <li
+                          class="MuiListItem-root emotion-18"
                         >
                           <div
-                            class="passwordRequirementIcon incomplete MuiBox-root emotion-19"
+                            class="MuiListItemIcon-root emotion-19"
                           >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                             >
-                              <title
-                                id="generated"
+                              <svg
+                                aria-labelledby="generated"
+                                class="ods-2icygl"
+                                fill="none"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                incomplete
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
+                                <title
+                                  id="generated"
+                                >
+                                  incomplete
+                                </title>
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                           </div>
-                          <span
-                            class="MuiBox-root emotion-4"
+                          <div
+                            class="MuiListItemText-root emotion-21"
                           >
-                            Passwords must match
-                          </span>
-                        </div>
+                            <span
+                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-72"
+                            >
+                              Passwords must match
+                            </span>
+                          </div>
+                        </li>
                       </li>
                     </ul>
                   </div>
@@ -525,7 +549,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-62"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-74"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -537,7 +561,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -548,7 +572,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -495,52 +495,50 @@ exports[`authenticator-expired-password should render form 1`] = `
                     data-se="password-authenticator--matches"
                   >
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding emotion-17"
+                      listtype="unordered"
+                      unstyled="true"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root emotion-18"
                       >
-                        <li
-                          class="MuiListItem-root emotion-18"
+                        <div
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="MuiListItemIcon-root emotion-19"
+                            class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                           >
-                            <div
-                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-labelledby="generated"
-                                class="ods-2icygl"
-                                fill="none"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                xmlns="http://www.w3.org/2000/svg"
+                              <title
+                                id="generated"
                               >
-                                <title
-                                  id="generated"
-                                >
-                                  incomplete
-                                </title>
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
+                                incomplete
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
                           </div>
-                          <div
-                            class="MuiListItemText-root emotion-21"
+                        </div>
+                        <div
+                          class="MuiListItemText-root emotion-21"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-73"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-72"
-                            >
-                              Passwords must match
-                            </span>
-                          </div>
-                        </li>
+                            Passwords must match
+                          </span>
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -549,7 +547,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-74"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-75"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -561,7 +559,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-77"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -120,31 +120,27 @@ exports[`authenticator-expired-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-4"
+                  <figure
+                    class="MuiBox-root emotion-15"
                     data-se="password-authenticator--rules"
                   >
-                    <div
-                      class="MuiBox-root emotion-16"
+                    <figcaption
+                      class="password-authenticator--heading MuiBox-root emotion-4"
                     >
-                      <span
-                        class="password-authenticator--heading MuiBox-root emotion-4"
-                      >
-                        Password requirements:
-                      </span>
-                    </div>
+                      Password requirements:
+                    </figcaption>
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding MuiList-dense emotion-17"
                       id="generated"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -167,21 +163,25 @@ exports[`authenticator-expired-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             At least 8 characters
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -204,21 +204,25 @@ exports[`authenticator-expired-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A lowercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -241,21 +245,25 @@ exports[`authenticator-expired-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             An uppercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -278,21 +286,25 @@ exports[`authenticator-expired-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A number
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -315,15 +327,19 @@ exports[`authenticator-expired-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             No parts of your username
                           </span>
                         </div>
                       </li>
                     </ul>
-                  </div>
+                  </figure>
                 </div>
                 <div
                   class="MuiBox-root emotion-4"
@@ -345,36 +361,36 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-42"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -387,10 +403,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-43"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-44"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -413,36 +429,36 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-42"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -455,10 +471,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-43"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-44"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -484,39 +500,47 @@ exports[`authenticator-expired-password should render form 1`] = `
                       <li
                         class="ods-5vIIsH"
                       >
-                        <div
-                          class="MuiBox-root emotion-4"
+                        <li
+                          class="MuiListItem-root emotion-18"
                         >
                           <div
-                            class="passwordRequirementIcon incomplete MuiBox-root emotion-19"
+                            class="MuiListItemIcon-root emotion-19"
                           >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                             >
-                              <title
-                                id="generated"
+                              <svg
+                                aria-labelledby="generated"
+                                class="ods-2icygl"
+                                fill="none"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                incomplete
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
+                                <title
+                                  id="generated"
+                                >
+                                  incomplete
+                                </title>
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                           </div>
-                          <span
-                            class="MuiBox-root emotion-4"
+                          <div
+                            class="MuiListItemText-root emotion-21"
                           >
-                            Passwords must match
-                          </span>
-                        </div>
+                            <span
+                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-72"
+                            >
+                              Passwords must match
+                            </span>
+                          </div>
+                        </li>
                       </li>
                     </ul>
                   </div>
@@ -525,7 +549,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-62"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-74"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -537,7 +561,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -632,52 +632,50 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                     data-se="password-authenticator--matches"
                   >
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding emotion-20"
+                      listtype="unordered"
+                      unstyled="true"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root emotion-21"
                       >
-                        <li
-                          class="MuiListItem-root emotion-21"
+                        <div
+                          class="MuiListItemIcon-root emotion-22"
                         >
                           <div
-                            class="MuiListItemIcon-root emotion-22"
+                            class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                           >
-                            <div
-                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-labelledby="generated"
-                                class="ods-2icygl"
-                                fill="none"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                xmlns="http://www.w3.org/2000/svg"
+                              <title
+                                id="generated"
                               >
-                                <title
-                                  id="generated"
-                                >
-                                  incomplete
-                                </title>
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
+                                incomplete
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
                           </div>
-                          <div
-                            class="MuiListItemText-root emotion-24"
+                        </div>
+                        <div
+                          class="MuiListItemText-root emotion-24"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-91"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-90"
-                            >
-                              Passwords must match
-                            </span>
-                          </div>
-                        </li>
+                            Passwords must match
+                          </span>
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -686,7 +684,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-92"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-93"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -698,7 +696,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-94"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-95"
                     data-se="skip"
                     href="javascript:void(0)"
                   >
@@ -709,7 +707,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-94"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-95"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -134,31 +134,27 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-4"
+                  <figure
+                    class="MuiBox-root emotion-18"
                     data-se="password-authenticator--rules"
                   >
-                    <div
-                      class="MuiBox-root emotion-19"
+                    <figcaption
+                      class="password-authenticator--heading MuiBox-root emotion-4"
                     >
-                      <span
-                        class="password-authenticator--heading MuiBox-root emotion-4"
-                      >
-                        Password requirements:
-                      </span>
-                    </div>
+                      Password requirements:
+                    </figcaption>
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding MuiList-dense emotion-20"
                       id="generated"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-22"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-22"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -181,21 +177,25 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-24"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-25"
                           >
                             At least 8 characters
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-22"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-22"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -218,21 +218,25 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-24"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-25"
                           >
                             A lowercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-22"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-22"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -255,21 +259,25 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-24"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-25"
                           >
                             An uppercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-22"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-22"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -292,21 +300,25 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-24"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-25"
                           >
                             A number
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-22"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-22"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -329,21 +341,25 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-24"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-25"
                           >
                             A symbol
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-22"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-22"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -366,21 +382,25 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-24"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-25"
                           >
                             No parts of your username
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-22"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-22"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -403,21 +423,25 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-24"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-25"
                           >
                             Does not include your first name
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-22"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-22"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -440,15 +464,19 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-24"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-25"
                           >
                             Does not include your last name
                           </span>
                         </div>
                       </li>
                     </ul>
-                  </div>
+                  </figure>
                 </div>
                 <div
                   class="MuiBox-root emotion-4"
@@ -470,36 +498,36 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-49"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-65"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-50"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-51"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-67"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-52"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-68"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-53"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-69"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-54"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-70"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -512,10 +540,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-55"
+                          class="MuiOutlinedInput-notchedOutline emotion-71"
                         >
                           <legend
-                            class="emotion-56"
+                            class="emotion-72"
                           >
                             <span
                               class="notranslate"
@@ -538,36 +566,36 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-49"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-65"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-50"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-51"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-67"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-52"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-68"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-53"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-69"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-54"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-70"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -580,10 +608,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-55"
+                          class="MuiOutlinedInput-notchedOutline emotion-71"
                         >
                           <legend
-                            class="emotion-56"
+                            class="emotion-72"
                           >
                             <span
                               class="notranslate"
@@ -609,39 +637,47 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       <li
                         class="ods-5vIIsH"
                       >
-                        <div
-                          class="MuiBox-root emotion-4"
+                        <li
+                          class="MuiListItem-root emotion-21"
                         >
                           <div
-                            class="passwordRequirementIcon incomplete MuiBox-root emotion-22"
+                            class="MuiListItemIcon-root emotion-22"
                           >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                             >
-                              <title
-                                id="generated"
+                              <svg
+                                aria-labelledby="generated"
+                                class="ods-2icygl"
+                                fill="none"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                incomplete
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
+                                <title
+                                  id="generated"
+                                >
+                                  incomplete
+                                </title>
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                           </div>
-                          <span
-                            class="MuiBox-root emotion-4"
+                          <div
+                            class="MuiListItemText-root emotion-24"
                           >
-                            Passwords must match
-                          </span>
-                        </div>
+                            <span
+                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-90"
+                            >
+                              Passwords must match
+                            </span>
+                          </div>
+                        </li>
                       </li>
                     </ul>
                   </div>
@@ -650,7 +686,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-74"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-92"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -662,7 +698,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-94"
                     data-se="skip"
                     href="javascript:void(0)"
                   >
@@ -673,7 +709,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-94"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -495,52 +495,50 @@ exports[`authenticator-reset-password should render form 1`] = `
                     data-se="password-authenticator--matches"
                   >
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding emotion-17"
+                      listtype="unordered"
+                      unstyled="true"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root emotion-18"
                       >
-                        <li
-                          class="MuiListItem-root emotion-18"
+                        <div
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="MuiListItemIcon-root emotion-19"
+                            class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                           >
-                            <div
-                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-labelledby="generated"
-                                class="ods-2icygl"
-                                fill="none"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                xmlns="http://www.w3.org/2000/svg"
+                              <title
+                                id="generated"
                               >
-                                <title
-                                  id="generated"
-                                >
-                                  incomplete
-                                </title>
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
+                                incomplete
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
                           </div>
-                          <div
-                            class="MuiListItemText-root emotion-21"
+                        </div>
+                        <div
+                          class="MuiListItemText-root emotion-21"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-73"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-72"
-                            >
-                              Passwords must match
-                            </span>
-                          </div>
-                        </li>
+                            Passwords must match
+                          </span>
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -549,7 +547,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-74"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-75"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -561,7 +559,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-77"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
@@ -1073,52 +1071,50 @@ exports[`authenticator-reset-password should render form with custom brand name 
                     data-se="password-authenticator--matches"
                   >
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding emotion-17"
+                      listtype="unordered"
+                      unstyled="true"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root emotion-18"
                       >
-                        <li
-                          class="MuiListItem-root emotion-18"
+                        <div
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="MuiListItemIcon-root emotion-19"
+                            class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                           >
-                            <div
-                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <svg
-                                aria-labelledby="generated"
-                                class="ods-2icygl"
-                                fill="none"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                xmlns="http://www.w3.org/2000/svg"
+                              <title
+                                id="generated"
                               >
-                                <title
-                                  id="generated"
-                                >
-                                  incomplete
-                                </title>
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
+                                incomplete
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
                           </div>
-                          <div
-                            class="MuiListItemText-root emotion-21"
+                        </div>
+                        <div
+                          class="MuiListItemText-root emotion-21"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-73"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-72"
-                            >
-                              Passwords must match
-                            </span>
-                          </div>
-                        </li>
+                            Passwords must match
+                          </span>
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -1127,7 +1123,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-74"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-75"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -1139,7 +1135,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-77"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -120,31 +120,27 @@ exports[`authenticator-reset-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-4"
+                  <figure
+                    class="MuiBox-root emotion-15"
                     data-se="password-authenticator--rules"
                   >
-                    <div
-                      class="MuiBox-root emotion-16"
+                    <figcaption
+                      class="password-authenticator--heading MuiBox-root emotion-4"
                     >
-                      <span
-                        class="password-authenticator--heading MuiBox-root emotion-4"
-                      >
-                        Password requirements:
-                      </span>
-                    </div>
+                      Password requirements:
+                    </figcaption>
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding MuiList-dense emotion-17"
                       id="generated"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -167,21 +163,25 @@ exports[`authenticator-reset-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             At least 8 characters
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -204,21 +204,25 @@ exports[`authenticator-reset-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A lowercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -241,21 +245,25 @@ exports[`authenticator-reset-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             An uppercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -278,21 +286,25 @@ exports[`authenticator-reset-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A number
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -315,15 +327,19 @@ exports[`authenticator-reset-password should render form 1`] = `
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             No parts of your username
                           </span>
                         </div>
                       </li>
                     </ul>
-                  </div>
+                  </figure>
                 </div>
                 <div
                   class="MuiBox-root emotion-4"
@@ -345,36 +361,36 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-42"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -387,10 +403,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-43"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-44"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -413,36 +429,36 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-42"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -455,10 +471,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-43"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-44"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -484,39 +500,47 @@ exports[`authenticator-reset-password should render form 1`] = `
                       <li
                         class="ods-5vIIsH"
                       >
-                        <div
-                          class="MuiBox-root emotion-4"
+                        <li
+                          class="MuiListItem-root emotion-18"
                         >
                           <div
-                            class="passwordRequirementIcon incomplete MuiBox-root emotion-19"
+                            class="MuiListItemIcon-root emotion-19"
                           >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                             >
-                              <title
-                                id="generated"
+                              <svg
+                                aria-labelledby="generated"
+                                class="ods-2icygl"
+                                fill="none"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                incomplete
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
+                                <title
+                                  id="generated"
+                                >
+                                  incomplete
+                                </title>
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                           </div>
-                          <span
-                            class="MuiBox-root emotion-4"
+                          <div
+                            class="MuiListItemText-root emotion-21"
                           >
-                            Passwords must match
-                          </span>
-                        </div>
+                            <span
+                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-72"
+                            >
+                              Passwords must match
+                            </span>
+                          </div>
+                        </li>
                       </li>
                     </ul>
                   </div>
@@ -525,7 +549,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-62"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-74"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -537,7 +561,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
@@ -674,31 +698,27 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-4"
+                  <figure
+                    class="MuiBox-root emotion-15"
                     data-se="password-authenticator--rules"
                   >
-                    <div
-                      class="MuiBox-root emotion-16"
+                    <figcaption
+                      class="password-authenticator--heading MuiBox-root emotion-4"
                     >
-                      <span
-                        class="password-authenticator--heading MuiBox-root emotion-4"
-                      >
-                        Password requirements:
-                      </span>
-                    </div>
+                      Password requirements:
+                    </figcaption>
                     <ul
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      class="MuiList-root MuiList-padding MuiList-dense emotion-17"
                       id="generated"
                     >
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -721,21 +741,25 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             At least 8 characters
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -758,21 +782,25 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A lowercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -795,21 +823,25 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             An uppercase letter
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -832,21 +864,25 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             A number
                           </span>
                         </div>
                       </li>
                       <li
-                        class="ods-5vIIsH"
+                        class="MuiListItem-root MuiListItem-dense emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-4"
+                          class="MuiListItemIcon-root emotion-19"
                         >
                           <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-19"
+                            class="passwordRequirementIcon info MuiBox-root emotion-4"
                           >
                             <svg
                               aria-labelledby="generated"
@@ -869,15 +905,19 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               />
                             </svg>
                           </div>
+                        </div>
+                        <div
+                          class="MuiListItemText-root MuiListItemText-dense emotion-21"
+                        >
                           <span
-                            class="MuiBox-root emotion-4"
+                            class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary emotion-22"
                           >
                             No parts of your username
                           </span>
                         </div>
                       </li>
                     </ul>
-                  </div>
+                  </figure>
                 </div>
                 <div
                   class="MuiBox-root emotion-4"
@@ -899,36 +939,36 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-42"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -941,10 +981,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-43"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-44"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -967,36 +1007,36 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-42"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -1009,10 +1049,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-43"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-44"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -1038,39 +1078,47 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       <li
                         class="ods-5vIIsH"
                       >
-                        <div
-                          class="MuiBox-root emotion-4"
+                        <li
+                          class="MuiListItem-root emotion-18"
                         >
                           <div
-                            class="passwordRequirementIcon incomplete MuiBox-root emotion-19"
+                            class="MuiListItemIcon-root emotion-19"
                           >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <div
+                              class="passwordRequirementIcon incomplete MuiBox-root emotion-4"
                             >
-                              <title
-                                id="generated"
+                              <svg
+                                aria-labelledby="generated"
+                                class="ods-2icygl"
+                                fill="none"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg"
                               >
-                                incomplete
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
+                                <title
+                                  id="generated"
+                                >
+                                  incomplete
+                                </title>
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
                           </div>
-                          <span
-                            class="MuiBox-root emotion-4"
+                          <div
+                            class="MuiListItemText-root emotion-21"
                           >
-                            Passwords must match
-                          </span>
-                        </div>
+                            <span
+                              class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary emotion-72"
+                            >
+                              Passwords must match
+                            </span>
+                          </div>
+                        </li>
                       </li>
                     </ul>
                   </div>
@@ -1079,7 +1127,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-62"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-74"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -1091,7 +1139,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-76"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >


### PR DESCRIPTION
## Description:

The purpose of this PR is to utilize the `figure` and `figcaption` elements with the Password Requirements List and subheader. Additionally, I updated the List component from ODY to MUI. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-547439](https://oktainc.atlassian.net/browse/OKTA-547439)

### Reviewers:

### Screenshot/Video:
OLD (ODY component):
<img width="562" alt="Screen Shot 2022-12-07 at 10 26 27 AM" src="https://user-images.githubusercontent.com/97472729/206243055-bf44ad79-576b-47c5-8c25-2abe8f1773a3.png">

NEW (MUI component):
<img width="460" alt="Screen Shot 2022-12-07 at 11 45 05 AM" src="https://user-images.githubusercontent.com/97472729/206243150-7704155a-0c0a-4ba7-84e3-f66bfa3bca52.png">

cc: @alexdahl-okta For review of the changes to the List component (I left the Icons the same - ODY React Icons - but the MUI lists seems to have added a little more space).

### Downstream Monolith Build:



