### PR TITLE
OKTA-557864-fix-verify-registry-install-script

### DIFF
--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -31,7 +31,8 @@ artifact_version="$(ci-pkginfo -t pkgname)-$(ci-pkginfo -t pkgsemver)"
 git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/angular-sample
 pushd test/package/angular-sample/custom-login
 
-if ! npm i; then
+# use the default npm registry
+if ! npm i --registry=https://registry.npmjs.org; then
   echo "install failed! Exiting..."
   exit ${FAILED_SETUP}
 fi


### PR DESCRIPTION
## Description:

- fixes the `verify-registry-install` script by setting registry to `https://registry.npmjs.org`

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-557864](https://oktainc.atlassian.net/browse/OKTA-557864)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



