### PR TITLE
fix: fixes #2968 defaultCountryCode does not have any effect on widget

### DIFF
--- a/src/v2/view-builder/views/phone/EnrollAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/EnrollAuthenticatorDataPhoneView.js
@@ -130,11 +130,12 @@ export default BaseAuthenticatorView.extend({
 
   createModelClass() {
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
+    const defaultCountryCode = this.options.settings.get('defaultCountryCode');
     const local = Object.assign(
       {
         country: {
-          // Set default country to "US"
-          'value': 'US',
+          // Set default country
+          'value': CountryUtil.getCallingCodeForCountry(defaultCountryCode)?defaultCountryCode:'US',
           'type': 'string',
         },
         extension: {


### PR DESCRIPTION
## Description:
fix: fixes #2968 defaultCountryCode does not have any effect on widget

Resolves: #2968 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [#29682968](https://github.com/okta/okta-signin-widget/issues/2968)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



