### PR TITLE
OKTA-547443 : Reformatting Authenticator Buttons into a List

### DIFF
--- a/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
+++ b/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
@@ -61,10 +61,10 @@ const AuthenticatorButton: UISchemaElementComponent<{
   const onValidationHandler = useOnSubmitValidation();
   const focusRef = useAutoFocus<HTMLButtonElement>(focus);
   const describedByIds = [
-    `${iconName}-ctaLabel`,
+    ariaDescribedBy,
     description && `${iconName}-description`,
     usageDescription && `${iconName}-usageDescription`,
-    ariaDescribedBy,
+    `${iconName}-ctaLabel`,
   ].filter(Boolean).join(' ');
 
   const onClick: ClickHandler = async () => {

--- a/src/v3/src/components/AuthenticatorButton/AuthenticatorButtonList.tsx
+++ b/src/v3/src/components/AuthenticatorButton/AuthenticatorButtonList.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { List, ListItem } from '@mui/material';
+import { h } from 'preact';
+
+import {
+  AuthenticatorButtonElement,
+  AuthenticatorButtonListElement,
+  UISchemaElementComponent,
+} from '../../types';
+import AuthenticatorButton from './AuthenticatorButton';
+
+const AuthenticatorButtonList: UISchemaElementComponent<{
+  uischema: AuthenticatorButtonListElement
+}> = ({ uischema }) => {
+  const { buttons } = uischema.options;
+
+  return (
+    <List>
+      {
+        buttons.map((button: AuthenticatorButtonElement, index: number) => (
+          <ListItem
+            key={button.id}
+            disableGutters
+          >
+            <AuthenticatorButton
+              uischema={{
+                ...button,
+                focus: index === 0 ? uischema.focus : false,
+                ariaDescribedBy: uischema.ariaDescribedBy,
+              }}
+            />
+          </ListItem>
+        ))
+      }
+    </List>
+  );
+};
+export default AuthenticatorButtonList;

--- a/src/v3/src/components/AuthenticatorButton/index.tsx
+++ b/src/v3/src/components/AuthenticatorButton/index.tsx
@@ -10,6 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import AuthenticatorButton from './AuthenticatorButton';
+import AuthenticatorButtonList from './AuthenticatorButtonList';
 
-export default AuthenticatorButton;
+export default AuthenticatorButtonList;

--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -13,7 +13,8 @@
 import { Input } from '@okta/okta-auth-js';
 
 import { FieldElement, Renderer } from '../../types';
-import AuthenticatorButton from '../AuthenticatorButton';
+// import AuthenticatorButton from '../AuthenticatorButton';
+import AuthenticatorButtonList from '../AuthenticatorButton';
 import AutoSubmit from '../AutoSubmit';
 import Button from '../Button';
 import Checkbox from '../Checkbox';
@@ -72,6 +73,10 @@ export default [
   {
     tester: ({ type }) => type === 'Heading',
     renderer: Heading,
+  },
+  {
+    tester: ({ type }) => type === 'AuthenticatorButtonList',
+    renderer: AuthenticatorButtonList,
   },
   {
     tester: ({ type }) => type === 'PasswordRequirements',
@@ -193,10 +198,6 @@ export default [
   {
     tester: ({ options: { inputMeta: { type } = {} as Input } }: FieldElement) => type === 'boolean',
     renderer: Checkbox,
-  },
-  {
-    tester: ({ type }) => type === 'AuthenticatorButton',
-    renderer: AuthenticatorButton,
   },
   {
     tester: ({ type }) => type === 'Button',

--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -13,7 +13,6 @@
 import { Input } from '@okta/okta-auth-js';
 
 import { FieldElement, Renderer } from '../../types';
-// import AuthenticatorButton from '../AuthenticatorButton';
 import AuthenticatorButtonList from '../AuthenticatorButton';
 import AutoSubmit from '../AutoSubmit';
 import Button from '../Button';

--- a/src/v3/src/transformer/i18n/__snapshots__/transformAuthenticatorButton.test.ts.snap
+++ b/src/v3/src/transformer/i18n/__snapshots__/transformAuthenticatorButton.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Verify Authenticator Selector Transformer Tests should add UI elements for verification authenticator selector when in password recovery flow 1`] = `
+exports[`Authenticator Button transformer tests should add translations for Custom Authenticator button 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -16,36 +16,37 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "password.reset.title.generic",
+          "content": "Sign in",
         },
         "type": "Title",
-      },
-      Object {
-        "contentType": "subtitle",
-        "options": Object {
-          "content": "oie.password.reset.verification",
-        },
-        "type": "Description",
       },
       Object {
         "options": Object {
           "buttons": Array [
             Object {
-              "label": "Email",
+              "label": "My custom authenticator app",
               "options": Object {
-                "actionParams": Object {
-                  "authenticator.id": "123abc",
-                },
-                "ctaLabel": "Select",
-                "key": "okta_email",
-                "step": "select-authenticator-authenticate",
-                "type": "button",
+                "ctaLabel": "Verify",
+                "key": "custom_app",
               },
+              "translations": Array [
+                Object {
+                  "i18nKey": "",
+                  "name": "label",
+                  "value": "My custom authenticator app",
+                },
+              ],
               "type": "AuthenticatorButton",
             },
           ],
         },
         "type": "AuthenticatorButtonList",
+      },
+      Object {
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
       },
     ],
     "type": "VerticalLayout",
@@ -53,7 +54,7 @@ Object {
 }
 `;
 
-exports[`Verify Authenticator Selector Transformer Tests should add UI elements for verification authenticator selector when in password recovery flow and brand name is provided 1`] = `
+exports[`Authenticator Button transformer tests should add translations for Email Authenticator button 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -69,36 +70,37 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "password.reset.title.specific",
+          "content": "Sign in",
         },
         "type": "Title",
-      },
-      Object {
-        "contentType": "subtitle",
-        "options": Object {
-          "content": "oie.password.reset.verification",
-        },
-        "type": "Description",
       },
       Object {
         "options": Object {
           "buttons": Array [
             Object {
-              "label": "Email",
+              "label": "Okta Email",
               "options": Object {
-                "actionParams": Object {
-                  "authenticator.id": "123abc",
-                },
-                "ctaLabel": "Select",
+                "ctaLabel": "Verify",
                 "key": "okta_email",
-                "step": "select-authenticator-authenticate",
-                "type": "button",
               },
+              "translations": Array [
+                Object {
+                  "i18nKey": "oie.email.label",
+                  "name": "label",
+                  "value": "oie.email.label",
+                },
+              ],
               "type": "AuthenticatorButton",
             },
           ],
         },
         "type": "AuthenticatorButtonList",
+      },
+      Object {
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
       },
     ],
     "type": "VerticalLayout",
@@ -106,7 +108,7 @@ Object {
 }
 `;
 
-exports[`Verify Authenticator Selector Transformer Tests should add UI elements for verification authenticator selector when not in password recovery flow 1`] = `
+exports[`Authenticator Button transformer tests should add translations for OV button with Method type 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -122,36 +124,40 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "oie.select.authenticators.verify.title",
+          "content": "Sign in",
         },
         "type": "Title",
-      },
-      Object {
-        "contentType": "subtitle",
-        "options": Object {
-          "content": "oie.select.authenticators.verify.subtitle",
-        },
-        "type": "Description",
       },
       Object {
         "options": Object {
           "buttons": Array [
             Object {
-              "label": "Email",
+              "label": "Okta Verify",
               "options": Object {
                 "actionParams": Object {
-                  "authenticator.id": "123abc",
+                  "authenticator.methodType": "push",
                 },
-                "ctaLabel": "Select",
-                "key": "okta_email",
-                "step": "select-authenticator-authenticate",
-                "type": "button",
+                "ctaLabel": "Verify",
+                "key": "okta_verify",
               },
+              "translations": Array [
+                Object {
+                  "i18nKey": "oie.okta_verify.push.title",
+                  "name": "label",
+                  "value": "oie.okta_verify.push.title",
+                },
+              ],
               "type": "AuthenticatorButton",
             },
           ],
         },
         "type": "AuthenticatorButtonList",
+      },
+      Object {
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
       },
     ],
     "type": "VerticalLayout",

--- a/src/v3/src/transformer/i18n/transformAuthenticatorButton.test.ts
+++ b/src/v3/src/transformer/i18n/transformAuthenticatorButton.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxAuthenticator, IdxTransaction } from '@okta/okta-auth-js';
+import { AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
+import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
+import {
+  AuthenticatorButtonElement,
+  AuthenticatorButtonListElement,
+  ButtonElement,
+  ButtonType,
+  FormBag,
+  TitleElement,
+  TranslationInfo,
+  WidgetProps,
+} from 'src/types';
+
+import { transformAuthenticatorButton } from './transformAuthenticatorButton';
+
+describe('Authenticator Button transformer tests', () => {
+  let transaction: IdxTransaction;
+  let formBag: FormBag;
+  let widgetProps: WidgetProps;
+
+  beforeEach(() => {
+    transaction = getStubTransactionWithNextStep();
+    formBag = getStubFormBag();
+    formBag.uischema.elements = [
+      { type: 'Title', options: { content: 'Sign in' } } as TitleElement,
+      {
+        type: 'AuthenticatorButtonList',
+        options: {
+          buttons: [
+            {
+              type: 'AuthenticatorButton',
+              label: 'Okta Email',
+              options: { key: AUTHENTICATOR_KEY.EMAIL, ctaLabel: 'Verify' },
+            } as AuthenticatorButtonElement,
+          ],
+        },
+      } as AuthenticatorButtonListElement,
+      { type: 'Button', options: { type: ButtonType.SUBMIT } } as ButtonElement,
+    ];
+    widgetProps = {};
+  });
+
+  it('should add translations for Email Authenticator button', () => {
+    transaction.nextStep = {
+      name: IDX_STEP.SELECT_AUTHENTICATOR_ENROLL,
+      relatesTo: { type: '', value: { key: AUTHENTICATOR_KEY.EMAIL } as IdxAuthenticator },
+    };
+    const updatedFormBag = transformAuthenticatorButton(
+      { transaction, widgetProps, step: '' },
+    )(formBag);
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(((updatedFormBag.uischema.elements[1] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).translations?.length)
+      .toBe(1);
+    expect(((updatedFormBag.uischema.elements[1] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).translations)
+      .toEqual([{ name: 'label', i18nKey: 'oie.email.label', value: 'oie.email.label' } as TranslationInfo]);
+  });
+
+  it('should add translations for OV button with Method type', () => {
+    transaction.nextStep = {
+      name: IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE,
+      relatesTo: { type: '', value: { key: AUTHENTICATOR_KEY.OV } as IdxAuthenticator },
+    };
+    formBag.uischema.elements = [
+      { type: 'Title', options: { content: 'Sign in' } } as TitleElement,
+      {
+        type: 'AuthenticatorButtonList',
+        options: {
+          buttons: [
+            {
+              type: 'AuthenticatorButton',
+              label: 'Okta Verify',
+              options: {
+                key: AUTHENTICATOR_KEY.OV,
+                ctaLabel: 'Verify',
+                actionParams: { 'authenticator.methodType': 'push' },
+              } as unknown as AuthenticatorButtonElement['options'],
+            } as AuthenticatorButtonElement,
+          ],
+        },
+      } as AuthenticatorButtonListElement,
+      { type: 'Button', options: { type: ButtonType.SUBMIT } } as ButtonElement,
+    ];
+    const updatedFormBag = transformAuthenticatorButton(
+      { transaction, widgetProps, step: '' },
+    )(formBag);
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(((updatedFormBag.uischema.elements[1] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).translations?.length)
+      .toBe(1);
+    expect(((updatedFormBag.uischema.elements[1] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).translations)
+      .toEqual([{
+        name: 'label', i18nKey: 'oie.okta_verify.push.title', value: 'oie.okta_verify.push.title',
+      } as TranslationInfo]);
+  });
+
+  it('should add translations for Custom Authenticator button', () => {
+    transaction.nextStep = {
+      name: IDX_STEP.SELECT_AUTHENTICATOR_ENROLL,
+      relatesTo: { type: '', value: { key: AUTHENTICATOR_KEY.CUSTOM_APP } as IdxAuthenticator },
+    };
+    formBag.uischema.elements = [
+      { type: 'Title', options: { content: 'Sign in' } } as TitleElement,
+      {
+        type: 'AuthenticatorButtonList',
+        options: {
+          buttons: [
+            {
+              type: 'AuthenticatorButton',
+              label: 'My custom authenticator app',
+              options: {
+                key: AUTHENTICATOR_KEY.CUSTOM_APP,
+                ctaLabel: 'Verify',
+              } as unknown as AuthenticatorButtonElement['options'],
+            } as AuthenticatorButtonElement,
+          ],
+        },
+      } as AuthenticatorButtonListElement,
+      { type: 'Button', options: { type: ButtonType.SUBMIT } } as ButtonElement,
+    ];
+    const updatedFormBag = transformAuthenticatorButton(
+      { transaction, widgetProps, step: '' },
+    )(formBag);
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(((updatedFormBag.uischema.elements[1] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).translations?.length)
+      .toBe(1);
+    expect(((updatedFormBag.uischema.elements[1] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).translations)
+      .toEqual([{
+        name: 'label', i18nKey: '', value: 'My custom authenticator app',
+      } as TranslationInfo]);
+  });
+});

--- a/src/v3/src/transformer/i18n/transformAuthenticatorButton.ts
+++ b/src/v3/src/transformer/i18n/transformAuthenticatorButton.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../v2/ion/i18nTransformer';
 import {
   AuthenticatorButtonElement,
+  AuthenticatorButtonListElement,
   TransformStepFnWithOptions,
 } from '../../types';
 import { traverseLayout } from '../util';
@@ -28,40 +29,42 @@ export const transformAuthenticatorButton: TransformStepFnWithOptions = ({
 ) => {
   traverseLayout({
     layout: formbag.uischema,
-    predicate: (element) => element.type === 'AuthenticatorButton',
-    callback: (element) => {
+    predicate: (element) => element.type === 'AuthenticatorButtonList',
+    callback: (ele) => {
       const { nextStep } = transaction;
       const { relatesTo, name: stepName } = nextStep!;
       const authenticatorKey = relatesTo?.value?.key;
       const params = getI18NParams(nextStep, authenticatorKey);
 
-      // try get i18nKey without methodType
-      let i18nKey = getI18nKey(`${stepName}.authenticator.${(element as AuthenticatorButtonElement).options.key}`);
-      if (i18nKey) {
-        addTranslation({
-          element, name: 'label', i18nKey, params,
-        });
-        return;
-      }
+      (ele as AuthenticatorButtonListElement).options.buttons.forEach((element) => {
+        const authenticatorButtonEle = element as AuthenticatorButtonElement;
+        // try get i18nKey without methodType
+        let i18nKey = getI18nKey(`${stepName}.authenticator.${authenticatorButtonEle.options.key}`);
+        if (i18nKey) {
+          addTranslation({
+            element, name: 'label', i18nKey, params,
+          });
+          return;
+        }
 
-      const authenticatorButtonEle = (element as AuthenticatorButtonElement);
-      // try get i18nKey with methodType
-      const methodType = authenticatorButtonEle.options.authenticator?.methods?.[0]?.type
-        || authenticatorButtonEle.options.actionParams?.['authenticator.methodType'];
-      i18nKey = getI18nKey(`${stepName}.authenticator.${(element as AuthenticatorButtonElement).options.key}.${methodType}`);
-      if (i18nKey) {
-        addTranslation({
-          element, name: 'label', i18nKey, params,
-        });
-        return;
-      }
+        // try get i18nKey with methodType
+        const methodType = authenticatorButtonEle.options.authenticator?.methods?.[0]?.type
+          || authenticatorButtonEle.options.actionParams?.['authenticator.methodType'];
+        i18nKey = getI18nKey(`${stepName}.authenticator.${authenticatorButtonEle.options.key}.${methodType}`);
+        if (i18nKey) {
+          addTranslation({
+            element, name: 'label', i18nKey, params,
+          });
+          return;
+        }
 
-      // missing i18nKey, fallback to string in response
-      addTranslation({
-        element,
-        name: 'label',
-        i18nKey: '',
-        defaultValue: element.label,
+        // missing i18nKey, fallback to string in response
+        addTranslation({
+          element,
+          name: 'label',
+          i18nKey: '',
+          defaultValue: element.label,
+        });
       });
     },
   });

--- a/src/v3/src/transformer/i18n/transformAuthenticatorButton.ts
+++ b/src/v3/src/transformer/i18n/transformAuthenticatorButton.ts
@@ -35,37 +35,38 @@ export const transformAuthenticatorButton: TransformStepFnWithOptions = ({
       const { relatesTo, name: stepName } = nextStep!;
       const authenticatorKey = relatesTo?.value?.key;
       const params = getI18NParams(nextStep, authenticatorKey);
+      const buttonListElement = ele as AuthenticatorButtonListElement;
+      buttonListElement.options.buttons.forEach(
+        (authenticatorButtonElement: AuthenticatorButtonElement) => {
+          // try get i18nKey without methodType
+          let i18nKey = getI18nKey(`${stepName}.authenticator.${authenticatorButtonElement.options.key}`);
+          if (i18nKey) {
+            addTranslation({
+              element: authenticatorButtonElement, name: 'label', i18nKey, params,
+            });
+            return;
+          }
 
-      (ele as AuthenticatorButtonListElement).options.buttons.forEach((element) => {
-        const authenticatorButtonEle = element as AuthenticatorButtonElement;
-        // try get i18nKey without methodType
-        let i18nKey = getI18nKey(`${stepName}.authenticator.${authenticatorButtonEle.options.key}`);
-        if (i18nKey) {
+          // try get i18nKey with methodType
+          const methodType = authenticatorButtonElement.options.authenticator?.methods?.[0]?.type
+          || authenticatorButtonElement.options.actionParams?.['authenticator.methodType'];
+          i18nKey = getI18nKey(`${stepName}.authenticator.${authenticatorButtonElement.options.key}.${methodType}`);
+          if (i18nKey) {
+            addTranslation({
+              element: authenticatorButtonElement, name: 'label', i18nKey, params,
+            });
+            return;
+          }
+
+          // missing i18nKey, fallback to string in response
           addTranslation({
-            element, name: 'label', i18nKey, params,
+            element: authenticatorButtonElement,
+            name: 'label',
+            i18nKey: '',
+            defaultValue: authenticatorButtonElement.label,
           });
-          return;
-        }
-
-        // try get i18nKey with methodType
-        const methodType = authenticatorButtonEle.options.authenticator?.methods?.[0]?.type
-          || authenticatorButtonEle.options.actionParams?.['authenticator.methodType'];
-        i18nKey = getI18nKey(`${stepName}.authenticator.${authenticatorButtonEle.options.key}.${methodType}`);
-        if (i18nKey) {
-          addTranslation({
-            element, name: 'label', i18nKey, params,
-          });
-          return;
-        }
-
-        // missing i18nKey, fallback to string in response
-        addTranslation({
-          element,
-          name: 'label',
-          i18nKey: '',
-          defaultValue: element.label,
-        });
-      });
+        },
+      );
     },
   });
   return formbag;

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorEnroll.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorEnroll.test.ts.snap
@@ -35,18 +35,25 @@ Object {
         "type": "Description",
       },
       Object {
-        "label": "Email",
         "options": Object {
-          "actionParams": Object {
-            "authenticator.id": "123abc",
-          },
-          "ctaLabel": "Select",
-          "description": "Enroll in email authenticator",
-          "key": "okta_email",
-          "step": "select-authenticator-enroll",
-          "type": "button",
+          "buttons": Array [
+            Object {
+              "label": "Email",
+              "options": Object {
+                "actionParams": Object {
+                  "authenticator.id": "123abc",
+                },
+                "ctaLabel": "Select",
+                "description": "Enroll in email authenticator",
+                "key": "okta_email",
+                "step": "select-authenticator-enroll",
+                "type": "button",
+              },
+              "type": "AuthenticatorButton",
+            },
+          ],
         },
-        "type": "AuthenticatorButton",
+        "type": "AuthenticatorButtonList",
       },
     ],
     "type": "VerticalLayout",
@@ -89,18 +96,25 @@ Object {
         "type": "Description",
       },
       Object {
-        "label": "Email",
         "options": Object {
-          "actionParams": Object {
-            "authenticator.id": "123abc",
-          },
-          "ctaLabel": "Select",
-          "description": "Enroll in email authenticator",
-          "key": "okta_email",
-          "step": "select-authenticator-enroll",
-          "type": "button",
+          "buttons": Array [
+            Object {
+              "label": "Email",
+              "options": Object {
+                "actionParams": Object {
+                  "authenticator.id": "123abc",
+                },
+                "ctaLabel": "Select",
+                "description": "Enroll in email authenticator",
+                "key": "okta_email",
+                "step": "select-authenticator-enroll",
+                "type": "button",
+              },
+              "type": "AuthenticatorButton",
+            },
+          ],
         },
-        "type": "AuthenticatorButton",
+        "type": "AuthenticatorButtonList",
       },
       Object {
         "label": "oie.optional.authenticator.button.title",
@@ -151,18 +165,25 @@ Object {
         "type": "Description",
       },
       Object {
-        "label": "Email",
         "options": Object {
-          "actionParams": Object {
-            "authenticator.id": "123abc",
-          },
-          "ctaLabel": "Select",
-          "description": "Enroll in email authenticator",
-          "key": "okta_email",
-          "step": "select-authenticator-enroll",
-          "type": "button",
+          "buttons": Array [
+            Object {
+              "label": "Email",
+              "options": Object {
+                "actionParams": Object {
+                  "authenticator.id": "123abc",
+                },
+                "ctaLabel": "Select",
+                "description": "Enroll in email authenticator",
+                "key": "okta_email",
+                "step": "select-authenticator-enroll",
+                "type": "button",
+              },
+              "type": "AuthenticatorButton",
+            },
+          ],
         },
-        "type": "AuthenticatorButton",
+        "type": "AuthenticatorButtonList",
       },
       Object {
         "label": "oie.optional.authenticator.button.title",

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorUnlockVerify.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorUnlockVerify.test.ts.snap
@@ -29,17 +29,24 @@ Object {
         "type": "Field",
       },
       Object {
-        "label": "Email",
         "options": Object {
-          "actionParams": Object {
-            "authenticator.id": "123abc",
-          },
-          "ctaLabel": "Select",
-          "key": "okta_email",
-          "step": "select-authenticator-unlock-account",
-          "type": "button",
+          "buttons": Array [
+            Object {
+              "label": "Email",
+              "options": Object {
+                "actionParams": Object {
+                  "authenticator.id": "123abc",
+                },
+                "ctaLabel": "Select",
+                "key": "okta_email",
+                "step": "select-authenticator-unlock-account",
+                "type": "button",
+              },
+              "type": "AuthenticatorButton",
+            },
+          ],
         },
-        "type": "AuthenticatorButton",
+        "type": "AuthenticatorButtonList",
       },
     ],
     "type": "VerticalLayout",

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectOVMethodVerify.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectOVMethodVerify.test.ts.snap
@@ -31,30 +31,37 @@ Object {
         "type": "Description",
       },
       Object {
-        "label": "Get a push notification",
         "options": Object {
-          "actionParams": Object {
-            "authenticator.methodType": "push",
-          },
-          "ctaLabel": "Select",
-          "key": "okta_verify",
-          "step": "select-authenticator-authenticate",
-          "type": "button",
+          "buttons": Array [
+            Object {
+              "label": "Get a push notification",
+              "options": Object {
+                "actionParams": Object {
+                  "authenticator.methodType": "push",
+                },
+                "ctaLabel": "Select",
+                "key": "okta_verify",
+                "step": "select-authenticator-authenticate",
+                "type": "button",
+              },
+              "type": "AuthenticatorButton",
+            },
+            Object {
+              "label": "Enter a code",
+              "options": Object {
+                "actionParams": Object {
+                  "authenticator.methodType": "totp",
+                },
+                "ctaLabel": "Select",
+                "key": "okta_verify",
+                "step": "select-authenticator-authenticate",
+                "type": "button",
+              },
+              "type": "AuthenticatorButton",
+            },
+          ],
         },
-        "type": "AuthenticatorButton",
-      },
-      Object {
-        "label": "Enter a code",
-        "options": Object {
-          "actionParams": Object {
-            "authenticator.methodType": "totp",
-          },
-          "ctaLabel": "Select",
-          "key": "okta_verify",
-          "step": "select-authenticator-authenticate",
-          "type": "button",
-        },
-        "type": "AuthenticatorButton",
+        "type": "AuthenticatorButtonList",
       },
     ],
     "type": "VerticalLayout",

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/utils.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/utils.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Select Authenticator Utility Tests getAuthenticatorEnrollButtonElements Tests should format on_prem authenticator option when display name exists 1`] = `
 Array [
   Object {
+    "id": "auth_btn_onprem_mfa_undefined",
     "label": "On Prem",
     "options": Object {
       "actionParams": Object {
@@ -41,6 +42,7 @@ Array [
 exports[`Select Authenticator Utility Tests getAuthenticatorEnrollButtonElements Tests should return formatted Okta Verify method type options when raw options are provided 1`] = `
 Array [
   Object {
+    "id": "auth_btn_okta_verify_totp",
     "label": "Code",
     "options": Object {
       "actionParams": Object {
@@ -61,6 +63,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_okta_verify_push",
     "label": "Push",
     "options": Object {
       "actionParams": Object {
@@ -86,6 +89,7 @@ Array [
 exports[`Select Authenticator Utility Tests getAuthenticatorVerifyButtonElements Tests should not reorder OV option when fastpass is not an option 1`] = `
 Array [
   Object {
+    "id": "auth_btn_okta_verify_totp",
     "label": "Code",
     "options": Object {
       "actionParams": Object {
@@ -106,6 +110,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_okta_verify_push",
     "label": "Push",
     "options": Object {
       "actionParams": Object {
@@ -126,6 +131,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_phone_number_undefined",
     "label": "phone_number",
     "options": Object {
       "actionParams": Object {
@@ -167,6 +173,7 @@ Array [
 exports[`Select Authenticator Utility Tests getAuthenticatorVerifyButtonElements Tests should not reorder OV option when method types are not set in IDX response 1`] = `
 Array [
   Object {
+    "id": "auth_btn_okta_verify_abc234",
     "label": "Okta Verify",
     "options": Object {
       "actionParams": Object {
@@ -200,6 +207,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_phone_number_undefined",
     "label": "phone_number",
     "options": Object {
       "actionParams": Object {
@@ -241,6 +249,7 @@ Array [
 exports[`Select Authenticator Utility Tests getAuthenticatorVerifyButtonElements Tests should return formatted Okta Verify method type options when raw options are provided 1`] = `
 Array [
   Object {
+    "id": "auth_btn_okta_verify_totp",
     "label": "Code",
     "options": Object {
       "actionParams": Object {
@@ -261,6 +270,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_okta_verify_push",
     "label": "Push",
     "options": Object {
       "actionParams": Object {
@@ -286,6 +296,7 @@ Array [
 exports[`Select Authenticator Utility Tests getAuthenticatorVerifyButtonElements Tests should set fastpass at beginning of array when deviceKnown = true with multiple OV method types 1`] = `
 Array [
   Object {
+    "id": "auth_btn_okta_verify_signed_nonce",
     "label": "Fastpass",
     "options": Object {
       "actionParams": Object {
@@ -306,6 +317,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_okta_verify_totp",
     "label": "Code",
     "options": Object {
       "actionParams": Object {
@@ -326,6 +338,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_okta_verify_push",
     "label": "Push",
     "options": Object {
       "actionParams": Object {
@@ -346,6 +359,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_phone_number_undefined",
     "label": "phone_number",
     "options": Object {
       "actionParams": Object {
@@ -387,6 +401,7 @@ Array [
 exports[`Select Authenticator Utility Tests getAuthenticatorVerifyButtonElements Tests should set fastpass at end of array when deviceKnown is not set with multiple OV method types 1`] = `
 Array [
   Object {
+    "id": "auth_btn_okta_verify_totp",
     "label": "Code",
     "options": Object {
       "actionParams": Object {
@@ -407,6 +422,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_okta_verify_push",
     "label": "Push",
     "options": Object {
       "actionParams": Object {
@@ -427,6 +443,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_phone_number_undefined",
     "label": "phone_number",
     "options": Object {
       "actionParams": Object {
@@ -463,6 +480,7 @@ Array [
     "type": "AuthenticatorButton",
   },
   Object {
+    "id": "auth_btn_okta_verify_signed_nonce",
     "label": "Fastpass",
     "options": Object {
       "actionParams": Object {

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.test.ts
@@ -15,6 +15,7 @@ import { AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   AuthenticatorButtonElement,
+  AuthenticatorButtonListElement,
   ButtonElement,
   ButtonType,
   DescriptionElement,
@@ -105,10 +106,12 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
       .toBe('oie.select.authenticators.enroll.subtitle');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
       .toBe('oie.setup.optional');
-    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
-
+    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButtonList');
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonListElement)
+      .options.buttons.length)).toBe(1);
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).options.actionParams?.['authenticator.id'])
+      .toBe('123abc');
     expect(updatedFormBag.uischema.elements[4].type).toBe('Button');
     expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
       .toBe('oie.optional.authenticator.button.title');
@@ -133,13 +136,17 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
       .toBe('oie.select.authenticators.enroll.subtitle');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
       .toBe('oie.setup.required');
-    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButton');
-    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).options.step)
+    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButtonList');
+    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonListElement)
+      .options.buttons.length).toBe(1);
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).options.step)
       .toBe('select-authenticator-enroll');
-    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).options.type)
-      .toBe(ButtonType.BUTTON);
-    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).options.type).toBe(ButtonType.BUTTON);
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).options.actionParams?.['authenticator.id'])
+      .toBe('123abc');
   });
 
   it('should transform authenticator elements when step is skippable and brandName is provided', () => {
@@ -160,12 +167,15 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
       .toBe('oie.select.authenticators.enroll.subtitle.custom');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
       .toBe('oie.setup.optional');
-    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
-    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).options.step)
+    expect(updatedFormBag.uischema.elements[3].type).toBe('AuthenticatorButtonList');
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id']).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).options.step)
       .toBe('select-authenticator-enroll');
-    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).options.type)
+    expect(((updatedFormBag.uischema.elements[3] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).options.type)
       .toBe(ButtonType.BUTTON);
     expect(updatedFormBag.uischema.elements[4].type).toBe('Button');
     expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.ts
@@ -13,6 +13,7 @@
 import { NextStep } from '@okta/okta-auth-js';
 
 import {
+  AuthenticatorButtonListElement,
   ButtonElement,
   ButtonType,
   DescriptionElement,
@@ -68,6 +69,10 @@ export const transformSelectAuthenticatorEnroll: IdxStepTransformer = ({
       content: skipStep ? loc('oie.setup.optional', 'login') : loc('oie.setup.required', 'login'),
     },
   };
+  const authenticatorListElement: AuthenticatorButtonListElement = {
+    type: 'AuthenticatorButtonList',
+    options: { buttons: authenticatorButtons },
+  };
   const skipButton: ButtonElement = {
     type: 'Button',
     label: loc('oie.optional.authenticator.button.title', 'login'),
@@ -81,7 +86,7 @@ export const transformSelectAuthenticatorEnroll: IdxStepTransformer = ({
     title,
     informationalText,
     description,
-    ...authenticatorButtons,
+    authenticatorListElement,
     ...(skipStep ? [skipButton] : []),
   ];
 

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.test.ts
@@ -15,6 +15,7 @@ import { AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   AuthenticatorButtonElement,
+  AuthenticatorButtonListElement,
   ButtonType,
   FieldElement,
   TitleElement,
@@ -102,12 +103,17 @@ describe('Unlock Verification Authenticator Selector Tests', () => {
       .toBe('unlockaccount');
     expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
       .toBe('identifier');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.step)).toBe('select-authenticator-unlock-account');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.type)).toBe(ButtonType.BUTTON);
+    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButtonList');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons.length)).toBe(1);
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id']).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.step).toBe('select-authenticator-unlock-account');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.type).toBe(ButtonType.BUTTON);
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.ts
@@ -13,6 +13,7 @@
 import { NextStep } from '@okta/okta-auth-js';
 
 import {
+  AuthenticatorButtonListElement,
   FieldElement,
   IdxStepTransformer,
   TitleElement,
@@ -46,10 +47,15 @@ export const transformSelectAuthenticatorUnlockVerify: IdxStepTransformer = ({
 
   const identifier = getUIElementWithName('identifier', uischema.elements) as FieldElement;
 
+  const authenticatorListElement: AuthenticatorButtonListElement = {
+    type: 'AuthenticatorButtonList',
+    options: { buttons: authenticatorButtons },
+  };
+
   uischema.elements = [
     title,
     identifier,
-    ...authenticatorButtons,
+    authenticatorListElement,
   ];
 
   return formBag;

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.test.ts
@@ -15,6 +15,7 @@ import { AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   AuthenticatorButtonElement,
+  AuthenticatorButtonListElement,
   ButtonType,
   DescriptionElement,
   TitleElement,
@@ -94,13 +95,18 @@ describe('Verify Authenticator Selector Transformer Tests', () => {
       .toBe('oie.select.authenticators.verify.title');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
       .toBe('oie.select.authenticators.verify.subtitle');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.step)).toBe('select-authenticator-authenticate');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.type)).toBe(ButtonType.BUTTON);
+    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButtonList');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons.length)).toBe(1);
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id']).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.step).toBe('select-authenticator-authenticate');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.type).toBe(ButtonType.BUTTON);
   });
 
   it('should add UI elements for verification authenticator selector'
@@ -124,13 +130,18 @@ describe('Verify Authenticator Selector Transformer Tests', () => {
       .toBe('password.reset.title.generic');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
       .toBe('oie.password.reset.verification');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.step)).toBe('select-authenticator-authenticate');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.type)).toBe(ButtonType.BUTTON);
+    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButtonList');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons.length)).toBe(1);
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id']).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.step).toBe('select-authenticator-authenticate');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.type).toBe(ButtonType.BUTTON);
   });
 
   it('should add UI elements for verification authenticator selector'
@@ -157,12 +168,17 @@ describe('Verify Authenticator Selector Transformer Tests', () => {
       .toBe('password.reset.title.specific');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
       .toBe('oie.password.reset.verification');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButton');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.actionParams?.['authenticator.id'])).toBe('123abc');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.step)).toBe('select-authenticator-authenticate');
-    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
-      .options.type)).toBe(ButtonType.BUTTON);
+    expect(updatedFormBag.uischema.elements[2].type).toBe('AuthenticatorButtonList');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons.length)).toBe(1);
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.actionParams?.['authenticator.id']).toBe('123abc');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.step).toBe('select-authenticator-authenticate');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
+      .options.type).toBe(ButtonType.BUTTON);
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.ts
@@ -11,13 +11,14 @@
  */
 
 import { NextStep } from '@okta/okta-auth-js';
+
 import {
+  AuthenticatorButtonListElement,
   DescriptionElement,
   IdxStepTransformer,
   TitleElement,
   UISchemaElement,
-} from 'src/types';
-
+} from '../../types';
 import { isPasswordRecovery, loc } from '../../util';
 import { removeUIElementWithName } from '../utils';
 import { getAuthenticatorVerifyButtonElements } from './utils';
@@ -59,7 +60,12 @@ export const transformSelectAuthenticatorVerify: IdxStepTransformer = ({
     'authenticator',
     uischema.elements as UISchemaElement[],
   );
-  uischema.elements = uischema.elements.concat(authenticatorButtonElements);
+
+  const authenticatorListElement: AuthenticatorButtonListElement = {
+    type: 'AuthenticatorButtonList',
+    options: { buttons: authenticatorButtonElements },
+  };
+  uischema.elements = uischema.elements.concat([authenticatorListElement]);
 
   const isPwRecovery = isPasswordRecovery(transaction);
   const titleElement: TitleElement = {

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.ts
@@ -65,7 +65,7 @@ export const transformSelectAuthenticatorVerify: IdxStepTransformer = ({
     type: 'AuthenticatorButtonList',
     options: { buttons: authenticatorButtonElements },
   };
-  uischema.elements = uischema.elements.concat([authenticatorListElement]);
+  uischema.elements.push(authenticatorListElement);
 
   const isPwRecovery = isPasswordRecovery(transaction);
   const titleElement: TitleElement = {

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.test.ts
@@ -15,6 +15,7 @@ import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   AuthenticatorButtonElement,
+  AuthenticatorButtonListElement,
   ButtonElement,
   ButtonType,
   DescriptionElement,
@@ -152,21 +153,26 @@ describe('Transform Select OV Method Verify Tests', () => {
     const updatedFormBag = transformSelectOVMethodVerify({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
-    expect(updatedFormBag.uischema.elements.length).toBe(4);
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.select.authenticators.verify.title');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).type).toBe('Description');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
       .toBe('oie.select.authenticators.verify.subtitle');
-    expect((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement).type).toBe('AuthenticatorButton');
-    expect((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement)
+    expect((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement).type).toBe('AuthenticatorButtonList');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons.length)).toBe(2);
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement)
       .options.actionParams?.['authenticator.methodType']).toBe('push');
-    expect((updatedFormBag.uischema.elements[2] as AuthenticatorButtonElement).label)
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[0] as AuthenticatorButtonElement).label)
       .toBe('Get a push notification');
-    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).type).toBe('AuthenticatorButton');
-    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement)
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[1] as AuthenticatorButtonElement)
       .options.actionParams?.['authenticator.methodType']).toBe('totp');
-    expect((updatedFormBag.uischema.elements[3] as AuthenticatorButtonElement).label).toBe('Enter a code');
+    expect(((updatedFormBag.uischema.elements[2] as AuthenticatorButtonListElement)
+      .options.buttons[1] as AuthenticatorButtonElement).label).toBe('Enter a code');
   });
 });

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.ts
@@ -81,7 +81,7 @@ export const transformSelectOVMethodVerify: IdxStepTransformer = ({ transaction,
       type: 'AuthenticatorButtonList',
       options: { buttons: buttonElements },
     };
-    uischema.elements = uischema.elements.concat([authenticatorListElement]);
+    uischema.elements.push(authenticatorListElement);
 
     const titleElement: TitleElement = {
       type: 'Title',

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.ts
@@ -13,6 +13,7 @@
 import { Input, NextStep } from '@okta/okta-auth-js';
 
 import {
+  AuthenticatorButtonListElement,
   ButtonElement,
   ButtonType,
   DescriptionElement,
@@ -76,7 +77,11 @@ export const transformSelectOVMethodVerify: IdxStepTransformer = ({ transaction,
       'authenticator.methodType',
       uischema.elements as UISchemaElement[],
     );
-    uischema.elements = uischema.elements.concat(buttonElements);
+    const authenticatorListElement: AuthenticatorButtonListElement = {
+      type: 'AuthenticatorButtonList',
+      options: { buttons: buttonElements },
+    };
+    uischema.elements = uischema.elements.concat([authenticatorListElement]);
 
     const titleElement: TitleElement = {
       type: 'Title',

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -39,6 +39,7 @@ describe('Select Authenticator Utility Tests', () => {
         {
           type: 'AuthenticatorButton',
           label: options[0].label,
+          id: 'auth_btn_okta_verify_totp',
           options: {
             key: AUTHENTICATOR_KEY.OV,
             ctaLabel: 'oie.verify.authenticator.button.text',
@@ -54,6 +55,7 @@ describe('Select Authenticator Utility Tests', () => {
         {
           type: 'AuthenticatorButton',
           label: options[1].label,
+          id: 'auth_btn_okta_verify_push',
           options: {
             key: AUTHENTICATOR_KEY.OV,
             ctaLabel: 'oie.verify.authenticator.button.text',

--- a/src/v3/src/transformer/selectAuthenticator/utils.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.ts
@@ -88,6 +88,7 @@ const buildOktaVerifyOptions = (
     const authenticatorButton: AuthenticatorButtonElement = {
       type: 'AuthenticatorButton',
       label: option.label,
+      id: `auth_btn_${AUTHENTICATOR_KEY.OV}_${option.value || id}`,
       options: {
         type: ButtonType.BUTTON,
         key: AUTHENTICATOR_KEY.OV,
@@ -241,6 +242,7 @@ const formatAuthenticatorOptions = (
       return {
         type: 'AuthenticatorButton',
         label: option.label,
+        id: `auth_btn_${authenticatorKey}_${enrollmentId || id}`,
         options: {
           type: ButtonType.BUTTON,
           key: authenticatorKey,
@@ -306,6 +308,7 @@ export const getOVMethodTypeAuthenticatorButtonElements = (
   return options.map((option) => ({
     type: 'AuthenticatorButton',
     label: option.label,
+    id: `auth_btn_${AUTHENTICATOR_KEY.OV}_${option.value as string}`,
     options: {
       type: ButtonType.BUTTON,
       key: AUTHENTICATOR_KEY.OV,

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -220,6 +220,11 @@ export interface AuthenticatorButtonElement extends UISchemaElement {
   };
 }
 
+export interface AuthenticatorButtonListElement extends UISchemaElement {
+  type: 'AuthenticatorButtonList';
+  options: { buttons: AuthenticatorButtonElement[] };
+}
+
 export interface WebAuthNButtonElement extends UISchemaElement {
   type: 'WebAuthNSubmitButton';
   options: {

--- a/src/v3/src/util/isInteractiveElement.ts
+++ b/src/v3/src/util/isInteractiveElement.ts
@@ -14,7 +14,7 @@ const interactiveTypes = new Set([
   'Field',
   'StepperRadio',
   'Button',
-  'AuthenticatorButton',
+  'AuthenticatorButtonList',
   'WebAuthNSubmitButton',
   'Link',
   'StepperButton',

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -115,297 +115,305 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <button
-                    aria-describedby="okta_password_0-ctaLabel okta_password_0-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_optional_3"
-                    aria-labelledby="okta_password_0-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
+                  <ul
+                    class="MuiList-root MuiList-padding emotion-20"
                   >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <div
-                        class="iconContainer mfa-okta-password authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_optional_3 okta_password_0-description okta_password_0-ctaLabel"
+                        aria-labelledby="okta_password_0-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="okta_password_0"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="okta_password_0"
+                          <div
+                            class="iconContainer mfa-okta-password authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="okta_password_0"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="okta_password_0"
+                              >
+                                Password
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="okta_password_0-label"
                           >
                             Password
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="okta_password_0-label"
-                      >
-                        Password
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="okta_password_0-description"
-                      >
-                        Choose a password for your account
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="okta_password"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="okta_password_0-ctaLabel"
-                        >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="phone_number_1-ctaLabel phone_number_1-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_optional_3"
-                    aria-labelledby="phone_number_1-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="phone_number_1"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="phone_number_1"
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="okta_password_0-description"
                           >
-                            Voice Call Authentication
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            Choose a password for your account
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="okta_password"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="okta_password_0-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="phone_number_1-label"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_optional_3 phone_number_1-description phone_number_1-ctaLabel"
+                        aria-labelledby="phone_number_1-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Phone
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="phone_number_1-description"
-                      >
-                        Verify with a code sent to your phone
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="phone_number"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="phone_number_1-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="webauthn_2-ctaLabel webauthn_2-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_optional_3"
-                    aria-labelledby="webauthn_2-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                          <div
+                            class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="phone_number_1"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="phone_number_1"
+                              >
+                                Voice Call Authentication
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="phone_number_1-label"
+                          >
+                            Phone
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="phone_number_1-description"
+                          >
+                            Verify with a code sent to your phone
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="phone_number"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="phone_number_1-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <div
-                        class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_optional_3 webauthn_2-description webauthn_2-ctaLabel"
+                        aria-labelledby="webauthn_2-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="webauthn_2"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="webauthn_2"
+                          <div
+                            class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="webauthn_2"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="webauthn_2"
+                              >
+                                Security Key or Biometric Authenticator
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M24 17V9h-9v8h-3v15.5a2.5 2.5 0 0 0 2.5 2.5h6.34a8.58 8.58 0 0 1-.38-1H14.5a1.5 1.5 0 0 1-1.5-1.5V18h13v3.84a8.58 8.58 0 0 1 1-.38V17h-3Zm-8 0v-7h7v7h-7Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M19.5 25a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M30 40a9 9 0 1 1 9-9 9.01 9.01 0 0 1-9 9Zm0-17a8 8 0 1 0 8 8 8.009 8.009 0 0 0-8-8Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M32.084 36.019a.472.472 0 0 1-.319-.112.501.501 0 0 1-.159-.532c.43-1.389 1.274-4.787-.119-6.352a1.962 1.962 0 0 0-1.946-.6 1.93 1.93 0 0 0-1.387 2.354c.007.024.666 2.823-.966 4.55a.5.5 0 1 1-.727-.685c1.24-1.314.728-3.6.723-3.622a2.933 2.933 0 0 1 2.106-3.566 2.977 2.977 0 0 1 2.944.906c1.67 1.875.922 5.386.328 7.312a.5.5 0 0 1-.478.347Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M28.63 37.25a.5.5 0 0 1-.359-.849c2.235-2.3 1.345-5.782 1.336-5.817a.5.5 0 0 1 .966-.259c.045.165 1.052 4.067-1.586 6.774a.5.5 0 0 1-.358.151Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M34.88 35.2a.5.5 0 0 1-.488-.612c.493-2.2.716-5.235-1.03-7.2a4.508 4.508 0 0 0-4.455-1.357 4.416 4.416 0 0 0-2.72 2.069 4.2 4.2 0 0 0-.468 3.2 3.1 3.1 0 0 1-.355 2.347.5.5 0 1 1-.728-.685 2.37 2.37 0 0 0 .11-1.434 5.174 5.174 0 0 1 .577-3.939 5.42 5.42 0 0 1 3.333-2.518 5.524 5.524 0 0 1 5.453 1.66c1.628 1.832 2.051 4.551 1.257 8.082a.5.5 0 0 1-.487.387Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="webauthn_2-label"
                           >
                             Security Key or Biometric Authenticator
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M24 17V9h-9v8h-3v15.5a2.5 2.5 0 0 0 2.5 2.5h6.34a8.58 8.58 0 0 1-.38-1H14.5a1.5 1.5 0 0 1-1.5-1.5V18h13v3.84a8.58 8.58 0 0 1 1-.38V17h-3Zm-8 0v-7h7v7h-7Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M19.5 25a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M30 40a9 9 0 1 1 9-9 9.01 9.01 0 0 1-9 9Zm0-17a8 8 0 1 0 8 8 8.009 8.009 0 0 0-8-8Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M32.084 36.019a.472.472 0 0 1-.319-.112.501.501 0 0 1-.159-.532c.43-1.389 1.274-4.787-.119-6.352a1.962 1.962 0 0 0-1.946-.6 1.93 1.93 0 0 0-1.387 2.354c.007.024.666 2.823-.966 4.55a.5.5 0 1 1-.727-.685c1.24-1.314.728-3.6.723-3.622a2.933 2.933 0 0 1 2.106-3.566 2.977 2.977 0 0 1 2.944.906c1.67 1.875.922 5.386.328 7.312a.5.5 0 0 1-.478.347Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M28.63 37.25a.5.5 0 0 1-.359-.849c2.235-2.3 1.345-5.782 1.336-5.817a.5.5 0 0 1 .966-.259c.045.165 1.052 4.067-1.586 6.774a.5.5 0 0 1-.358.151Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M34.88 35.2a.5.5 0 0 1-.488-.612c.493-2.2.716-5.235-1.03-7.2a4.508 4.508 0 0 0-4.455-1.357 4.416 4.416 0 0 0-2.72 2.069 4.2 4.2 0 0 0-.468 3.2 3.1 3.1 0 0 1-.355 2.347.5.5 0 1 1-.728-.685 2.37 2.37 0 0 0 .11-1.434 5.174 5.174 0 0 1 .577-3.939 5.42 5.42 0 0 1 3.333-2.518 5.524 5.524 0 0 1 5.453 1.66c1.628 1.832 2.051 4.551 1.257 8.082a.5.5 0 0 1-.487.387Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="webauthn_2-label"
-                      >
-                        Security Key or Biometric Authenticator
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="webauthn_2-description"
-                      >
-                        Use a security key or a biometric authenticator to sign in
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="webauthn"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="webauthn_2-ctaLabel"
-                        >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="webauthn_2-description"
+                          >
+                            Use a security key or a biometric authenticator to sign in
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="webauthn"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="webauthn_2-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  </ul>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
                   <button
                     aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_optional_3"
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-47"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-49"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -417,7 +425,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   class="MuiBox-root emotion-10"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-51"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -115,1229 +115,1237 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <button
-                    aria-describedby="okta_password_0-ctaLabel okta_password_0-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="okta_password_0-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
+                  <ul
+                    class="MuiList-root MuiList-padding emotion-20"
                   >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <div
-                        class="iconContainer mfa-okta-password authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 okta_password_0-description okta_password_0-ctaLabel"
+                        aria-labelledby="okta_password_0-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="okta_password_0"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="okta_password_0"
+                          <div
+                            class="iconContainer mfa-okta-password authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="okta_password_0"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="okta_password_0"
+                              >
+                                Password
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="okta_password_0-label"
                           >
                             Password
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="okta_password_0-label"
-                      >
-                        Password
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="okta_password_0-description"
-                      >
-                        Choose a password for your account
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="okta_password"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="okta_password_0-ctaLabel"
-                        >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="phone_number_1-ctaLabel phone_number_1-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="phone_number_1-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="phone_number_1"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="phone_number_1"
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="okta_password_0-description"
                           >
-                            Voice Call Authentication
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            Choose a password for your account
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="okta_password"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="okta_password_0-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="phone_number_1-label"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 phone_number_1-description phone_number_1-ctaLabel"
+                        aria-labelledby="phone_number_1-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Phone
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="phone_number_1-description"
-                      >
-                        Verify with a code sent to your phone
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="phone_number"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="phone_number_1-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="webauthn_2-ctaLabel webauthn_2-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="webauthn_2-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                          <div
+                            class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="phone_number_1"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="phone_number_1"
+                              >
+                                Voice Call Authentication
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="phone_number_1-label"
+                          >
+                            Phone
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="phone_number_1-description"
+                          >
+                            Verify with a code sent to your phone
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="phone_number"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="phone_number_1-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <div
-                        class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 webauthn_2-description webauthn_2-ctaLabel"
+                        aria-labelledby="webauthn_2-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="webauthn_2"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="webauthn_2"
+                          <div
+                            class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="webauthn_2"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="webauthn_2"
+                              >
+                                Security Key or Biometric Authenticator
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M24 17V9h-9v8h-3v15.5a2.5 2.5 0 0 0 2.5 2.5h6.34a8.58 8.58 0 0 1-.38-1H14.5a1.5 1.5 0 0 1-1.5-1.5V18h13v3.84a8.58 8.58 0 0 1 1-.38V17h-3Zm-8 0v-7h7v7h-7Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M19.5 25a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M30 40a9 9 0 1 1 9-9 9.01 9.01 0 0 1-9 9Zm0-17a8 8 0 1 0 8 8 8.009 8.009 0 0 0-8-8Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M32.084 36.019a.472.472 0 0 1-.319-.112.501.501 0 0 1-.159-.532c.43-1.389 1.274-4.787-.119-6.352a1.962 1.962 0 0 0-1.946-.6 1.93 1.93 0 0 0-1.387 2.354c.007.024.666 2.823-.966 4.55a.5.5 0 1 1-.727-.685c1.24-1.314.728-3.6.723-3.622a2.933 2.933 0 0 1 2.106-3.566 2.977 2.977 0 0 1 2.944.906c1.67 1.875.922 5.386.328 7.312a.5.5 0 0 1-.478.347Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M28.63 37.25a.5.5 0 0 1-.359-.849c2.235-2.3 1.345-5.782 1.336-5.817a.5.5 0 0 1 .966-.259c.045.165 1.052 4.067-1.586 6.774a.5.5 0 0 1-.358.151Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M34.88 35.2a.5.5 0 0 1-.488-.612c.493-2.2.716-5.235-1.03-7.2a4.508 4.508 0 0 0-4.455-1.357 4.416 4.416 0 0 0-2.72 2.069 4.2 4.2 0 0 0-.468 3.2 3.1 3.1 0 0 1-.355 2.347.5.5 0 1 1-.728-.685 2.37 2.37 0 0 0 .11-1.434 5.174 5.174 0 0 1 .577-3.939 5.42 5.42 0 0 1 3.333-2.518 5.524 5.524 0 0 1 5.453 1.66c1.628 1.832 2.051 4.551 1.257 8.082a.5.5 0 0 1-.487.387Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="webauthn_2-label"
                           >
                             Security Key or Biometric Authenticator
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M24 17V9h-9v8h-3v15.5a2.5 2.5 0 0 0 2.5 2.5h6.34a8.58 8.58 0 0 1-.38-1H14.5a1.5 1.5 0 0 1-1.5-1.5V18h13v3.84a8.58 8.58 0 0 1 1-.38V17h-3Zm-8 0v-7h7v7h-7Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M19.5 25a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M30 40a9 9 0 1 1 9-9 9.01 9.01 0 0 1-9 9Zm0-17a8 8 0 1 0 8 8 8.009 8.009 0 0 0-8-8Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M32.084 36.019a.472.472 0 0 1-.319-.112.501.501 0 0 1-.159-.532c.43-1.389 1.274-4.787-.119-6.352a1.962 1.962 0 0 0-1.946-.6 1.93 1.93 0 0 0-1.387 2.354c.007.024.666 2.823-.966 4.55a.5.5 0 1 1-.727-.685c1.24-1.314.728-3.6.723-3.622a2.933 2.933 0 0 1 2.106-3.566 2.977 2.977 0 0 1 2.944.906c1.67 1.875.922 5.386.328 7.312a.5.5 0 0 1-.478.347Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M28.63 37.25a.5.5 0 0 1-.359-.849c2.235-2.3 1.345-5.782 1.336-5.817a.5.5 0 0 1 .966-.259c.045.165 1.052 4.067-1.586 6.774a.5.5 0 0 1-.358.151Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M34.88 35.2a.5.5 0 0 1-.488-.612c.493-2.2.716-5.235-1.03-7.2a4.508 4.508 0 0 0-4.455-1.357 4.416 4.416 0 0 0-2.72 2.069 4.2 4.2 0 0 0-.468 3.2 3.1 3.1 0 0 1-.355 2.347.5.5 0 1 1-.728-.685 2.37 2.37 0 0 0 .11-1.434 5.174 5.174 0 0 1 .577-3.939 5.42 5.42 0 0 1 3.333-2.518 5.524 5.524 0 0 1 5.453 1.66c1.628 1.832 2.051 4.551 1.257 8.082a.5.5 0 0 1-.487.387Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="webauthn_2-description"
+                          >
+                            Use a security key or a biometric authenticator to sign in
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="webauthn"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="webauthn_2-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="webauthn_2-label"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 security_question_3-description security_question_3-ctaLabel"
+                        aria-labelledby="security_question_3-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Security Key or Biometric Authenticator
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="webauthn_2-description"
-                      >
-                        Use a security key or a biometric authenticator to sign in
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="webauthn"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="webauthn_2-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="security_question_3-ctaLabel security_question_3-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="security_question_3-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-okta-security-question authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="security_question_3"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="iconContainer mfa-okta-security-question authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="security_question_3"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="security_question_3"
+                              >
+                                Security Question
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="m24.25 39.123-4.615-3.433a21.799 21.799 0 0 1-8.827-16.259l-.329-5.738 12.84-4.534a2.818 2.818 0 0 1 1.862 0l12.84 4.534-.329 5.738a21.8 21.8 0 0 1-8.827 16.259l-4.615 3.433ZM11.521 14.387l.285 4.987a20.811 20.811 0 0 0 8.425 15.514l4.019 2.989 4.019-2.989a20.81 20.81 0 0 0 8.425-15.514l.285-4.987L24.848 10.1a1.792 1.792 0 0 0-1.2 0l-12.127 4.287Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M29.44 19.729a5.007 5.007 0 0 0-8.846-2.356 4.484 4.484 0 0 0-.827 4.385l.929-.367A3.48 3.48 0 0 1 21.369 18a4.027 4.027 0 1 1 5.244 5.972C25 25 23.5 26.252 23.5 28.528h1c0-1.691 1.058-2.7 2.646-3.707a5.067 5.067 0 0 0 2.294-5.092Zm-5.454 12.246a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          <title
-                            id="security_question_3"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="security_question_3-label"
                           >
                             Security Question
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="m24.25 39.123-4.615-3.433a21.799 21.799 0 0 1-8.827-16.259l-.329-5.738 12.84-4.534a2.818 2.818 0 0 1 1.862 0l12.84 4.534-.329 5.738a21.8 21.8 0 0 1-8.827 16.259l-4.615 3.433ZM11.521 14.387l.285 4.987a20.811 20.811 0 0 0 8.425 15.514l4.019 2.989 4.019-2.989a20.81 20.81 0 0 0 8.425-15.514l.285-4.987L24.848 10.1a1.792 1.792 0 0 0-1.2 0l-12.127 4.287Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M29.44 19.729a5.007 5.007 0 0 0-8.846-2.356 4.484 4.484 0 0 0-.827 4.385l.929-.367A3.48 3.48 0 0 1 21.369 18a4.027 4.027 0 1 1 5.244 5.972C25 25 23.5 26.252 23.5 28.528h1c0-1.691 1.058-2.7 2.646-3.707a5.067 5.067 0 0 0 2.294-5.092Zm-5.454 12.246a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="security_question_3-description"
+                          >
+                            Choose a security question and answer that will be used for signing in
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="security_question"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="security_question_3-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="security_question_3-label"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 okta_verify_4-description okta_verify_4-ctaLabel"
+                        aria-labelledby="okta_verify_4-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Security Question
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="security_question_3-description"
-                      >
-                        Choose a security question and answer that will be used for signing in
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="security_question"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="security_question_3-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="okta_verify_4-ctaLabel okta_verify_4-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="okta_verify_4-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="okta_verify_4"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="okta_verify_4"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="okta_verify_4"
+                              >
+                                Okta Verify
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                clip-rule="evenodd"
+                                d="M32.872 22.853a8.947 8.947 0 1 1-2.288-4.91L24 24.498l-3.205-3.19c-.482-.48-1.322-.48-1.804 0a1.26 1.26 0 0 0-.374.898c0 .34.133.659.374.898l4.107 4.09c.24.239.561.371.902.371.336 0 .664-.136.902-.372L38.636 13.52a18.089 18.089 0 0 0-1.634-1.967A17.947 17.947 0 0 0 24 6C14.059 6 6 14.059 6 24s8.059 18 18 18 18-8.059 18-18c0-2.972-.722-5.775-1.998-8.245l-7.13 7.098Z"
+                                fill="#00297A"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          <title
-                            id="okta_verify_4"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="okta_verify_4-label"
                           >
                             Okta Verify
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            clip-rule="evenodd"
-                            d="M32.872 22.853a8.947 8.947 0 1 1-2.288-4.91L24 24.498l-3.205-3.19c-.482-.48-1.322-.48-1.804 0a1.26 1.26 0 0 0-.374.898c0 .34.133.659.374.898l4.107 4.09c.24.239.561.371.902.371.336 0 .664-.136.902-.372L38.636 13.52a18.089 18.089 0 0 0-1.634-1.967A17.947 17.947 0 0 0 24 6C14.059 6 6 14.059 6 24s8.059 18 18 18 18-8.059 18-18c0-2.972-.722-5.775-1.998-8.245l-7.13 7.098Z"
-                            fill="#00297A"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="okta_verify_4-description"
+                          >
+                            Okta Verify is an authenticator app, installed on your phone, used to prove your identity
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="okta_verify"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="okta_verify_4-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="okta_verify_4-label"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 google_otp_5-description google_otp_5-ctaLabel"
+                        aria-labelledby="google_otp_5-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Okta Verify
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="okta_verify_4-description"
-                      >
-                        Okta Verify is an authenticator app, installed on your phone, used to prove your identity
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="okta_verify"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="okta_verify_4-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="google_otp_5-ctaLabel google_otp_5-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="google_otp_5-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-google-auth authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="google_otp_5"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="iconContainer mfa-google-auth authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="google_otp_5"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="google_otp_5"
+                              >
+                                Google Authenticator
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
+                                fill="#616161"
+                              />
+                              <path
+                                d="M24 34.182c-5.623 0-10.181-4.557-10.181-10.181 0-5.624 4.558-10.182 10.182-10.182 2.81 0 5.355 1.14 7.2 2.982l4.114-4.114A15.952 15.952 0 0 0 24 8C15.163 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001 4.42 0 8.419-1.79 11.316-4.685l-4.114-4.114A10.164 10.164 0 0 1 24 34.182Z"
+                                fill="#9E9E9E"
+                              />
+                              <path
+                                d="M34.183 24H29.09a5.09 5.09 0 1 0-8.76 3.528l-.004.004 6.304 6.304.001.001c4.348-1.16 7.55-5.124 7.55-9.836Z"
+                                fill="#424242"
+                              />
+                              <path
+                                d="M40 24h-5.82c0 4.713-3.204 8.676-7.549 9.837l4.493 4.493C36.385 35.71 40 30.277 40 24Z"
+                                fill="#616161"
+                              />
+                              <path
+                                d="M24 39.818c-8.806 0-15.948-7.114-15.999-15.909L8 24.001c0 8.837 7.164 16 16 16 8.838 0 16.001-7.163 16.001-16L40 23.909c-.05 8.795-7.194 15.91-16 15.91Z"
+                                fill="#212121"
+                                fill-opacity=".1"
+                              />
+                              <path
+                                d="m26.634 33.837.141.142c4.273-1.207 7.408-5.134 7.408-9.797v-.181c0 4.712-3.204 8.675-7.55 9.836Z"
+                                fill="#fff"
+                                fill-opacity=".05"
+                              />
+                              <path
+                                d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
+                                fill="#9E9E9E"
+                              />
+                              <path
+                                d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
+                                fill="#BDBDBD"
+                                opacity=".5"
+                              />
+                              <path
+                                d="M10.909 25.091a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181ZM24 12a1.09 1.09 0 1 0 0-2.182A1.09 1.09 0 0 0 24 12Zm0 26.182a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Zm-9.272-22.348a1.09 1.09 0 1 0 0-2.182 1.09 1.09 0 0 0 0 2.182Zm0 18.53a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
+                                fill="#BDBDBD"
+                              />
+                              <path
+                                d="M33.274 34.364a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
+                                fill="#757575"
+                              />
+                              <path
+                                d="M24 22.728h13.091c.773 0 1.404.603 1.45 1.364 0-.03.005-.06.005-.091 0-.804-.651-1.455-1.455-1.455h-13.09a1.454 1.454 0 0 0-1.45 1.546 1.451 1.451 0 0 1 1.45-1.364Z"
+                                fill="#fff"
+                                fill-opacity=".2"
+                              />
+                              <path
+                                d="M38.54 24.09a1.456 1.456 0 0 1-1.449 1.365h-13.09a1.452 1.452 0 0 1-1.45-1.364 1.454 1.454 0 0 0 1.45 1.545h13.09a1.454 1.454 0 0 0 1.45-1.545Z"
+                                fill="#212121"
+                                fill-opacity=".2"
+                              />
+                              <path
+                                d="M24 14c2.811 0 5.357 1.14 7.2 2.983l4.204-4.206-.09-.092L31.2 16.8a10.154 10.154 0 0 0-7.2-2.982c-5.623 0-10.181 4.557-10.181 10.181l.001.092C13.87 18.509 18.408 14 24 14Z"
+                                fill="#212121"
+                                fill-opacity=".1"
+                              />
+                              <path
+                                d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
+                                fill="url(#paint0_radial_5_581)"
+                              />
+                              <defs>
+                                <radialgradient
+                                  cx="0"
+                                  cy="0"
+                                  gradientTransform="translate(12.692 12.656) scale(31.946)"
+                                  gradientUnits="userSpaceOnUse"
+                                  id="paint0_radial_5_581"
+                                  r="1"
+                                >
+                                  <stop
+                                    stop-color="#fff"
+                                    stop-opacity=".1"
+                                  />
+                                  <stop
+                                    offset="1"
+                                    stop-color="#fff"
+                                    stop-opacity="0"
+                                  />
+                                </radialgradient>
+                              </defs>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          <title
-                            id="google_otp_5"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="google_otp_5-label"
                           >
                             Google Authenticator
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
-                            fill="#616161"
-                          />
-                          <path
-                            d="M24 34.182c-5.623 0-10.181-4.557-10.181-10.181 0-5.624 4.558-10.182 10.182-10.182 2.81 0 5.355 1.14 7.2 2.982l4.114-4.114A15.952 15.952 0 0 0 24 8C15.163 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001 4.42 0 8.419-1.79 11.316-4.685l-4.114-4.114A10.164 10.164 0 0 1 24 34.182Z"
-                            fill="#9E9E9E"
-                          />
-                          <path
-                            d="M34.183 24H29.09a5.09 5.09 0 1 0-8.76 3.528l-.004.004 6.304 6.304.001.001c4.348-1.16 7.55-5.124 7.55-9.836Z"
-                            fill="#424242"
-                          />
-                          <path
-                            d="M40 24h-5.82c0 4.713-3.204 8.676-7.549 9.837l4.493 4.493C36.385 35.71 40 30.277 40 24Z"
-                            fill="#616161"
-                          />
-                          <path
-                            d="M24 39.818c-8.806 0-15.948-7.114-15.999-15.909L8 24.001c0 8.837 7.164 16 16 16 8.838 0 16.001-7.163 16.001-16L40 23.909c-.05 8.795-7.194 15.91-16 15.91Z"
-                            fill="#212121"
-                            fill-opacity=".1"
-                          />
-                          <path
-                            d="m26.634 33.837.141.142c4.273-1.207 7.408-5.134 7.408-9.797v-.181c0 4.712-3.204 8.675-7.55 9.836Z"
-                            fill="#fff"
-                            fill-opacity=".05"
-                          />
-                          <path
-                            d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
-                            fill="#9E9E9E"
-                          />
-                          <path
-                            d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
-                            fill="#BDBDBD"
-                            opacity=".5"
-                          />
-                          <path
-                            d="M10.909 25.091a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181ZM24 12a1.09 1.09 0 1 0 0-2.182A1.09 1.09 0 0 0 24 12Zm0 26.182a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Zm-9.272-22.348a1.09 1.09 0 1 0 0-2.182 1.09 1.09 0 0 0 0 2.182Zm0 18.53a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
-                            fill="#BDBDBD"
-                          />
-                          <path
-                            d="M33.274 34.364a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
-                            fill="#757575"
-                          />
-                          <path
-                            d="M24 22.728h13.091c.773 0 1.404.603 1.45 1.364 0-.03.005-.06.005-.091 0-.804-.651-1.455-1.455-1.455h-13.09a1.454 1.454 0 0 0-1.45 1.546 1.451 1.451 0 0 1 1.45-1.364Z"
-                            fill="#fff"
-                            fill-opacity=".2"
-                          />
-                          <path
-                            d="M38.54 24.09a1.456 1.456 0 0 1-1.449 1.365h-13.09a1.452 1.452 0 0 1-1.45-1.364 1.454 1.454 0 0 0 1.45 1.545h13.09a1.454 1.454 0 0 0 1.45-1.545Z"
-                            fill="#212121"
-                            fill-opacity=".2"
-                          />
-                          <path
-                            d="M24 14c2.811 0 5.357 1.14 7.2 2.983l4.204-4.206-.09-.092L31.2 16.8a10.154 10.154 0 0 0-7.2-2.982c-5.623 0-10.181 4.557-10.181 10.181l.001.092C13.87 18.509 18.408 14 24 14Z"
-                            fill="#212121"
-                            fill-opacity=".1"
-                          />
-                          <path
-                            d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
-                            fill="url(#paint0_radial_5_581)"
-                          />
-                          <defs>
-                            <radialgradient
-                              cx="0"
-                              cy="0"
-                              gradientTransform="translate(12.692 12.656) scale(31.946)"
-                              gradientUnits="userSpaceOnUse"
-                              id="paint0_radial_5_581"
-                              r="1"
-                            >
-                              <stop
-                                stop-color="#fff"
-                                stop-opacity=".1"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#fff"
-                                stop-opacity="0"
-                              />
-                            </radialgradient>
-                          </defs>
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="google_otp_5-label"
-                      >
-                        Google Authenticator
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="google_otp_5-description"
-                      >
-                        Enter a temporary code generated from the Google Authenticator app.
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="google_otp"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="google_otp_5-ctaLabel"
-                        >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="onprem_mfa_6-ctaLabel onprem_mfa_6-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="onprem_mfa_6-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-onprem authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="onprem_mfa_6"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="onprem_mfa_6"
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="google_otp_5-description"
                           >
-                            Enter a single-use code from a hardware token.
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M39 20h-8v-3H16.5a7.5 7.5 0 0 0 0 15H31v-3h8v-9Zm-9 11H16.5a6.5 6.5 0 1 1 0-13H30v13Zm8-3h-7v-7h7v7Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M15.5 28a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0-6a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            Enter a temporary code generated from the Google Authenticator app.
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="google_otp"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="google_otp_5-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="onprem_mfa_6-label"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 onprem_mfa_6-description onprem_mfa_6-ctaLabel"
+                        aria-labelledby="onprem_mfa_6-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Atko Custom On-prem
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="onprem_mfa_6-description"
-                      >
-                        Verify by entering a code generated by Atko Custom On-prem.
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="onprem_mfa-otp"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="onprem_mfa_6-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="rsa_token_7-ctaLabel rsa_token_7-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="rsa_token_7-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                          <div
+                            class="iconContainer mfa-onprem authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="onprem_mfa_6"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="onprem_mfa_6"
+                              >
+                                Enter a single-use code from a hardware token.
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M39 20h-8v-3H16.5a7.5 7.5 0 0 0 0 15H31v-3h8v-9Zm-9 11H16.5a6.5 6.5 0 1 1 0-13H30v13Zm8-3h-7v-7h7v7Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M15.5 28a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0-6a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="onprem_mfa_6-label"
+                          >
+                            Atko Custom On-prem
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="onprem_mfa_6-description"
+                          >
+                            Verify by entering a code generated by Atko Custom On-prem.
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="onprem_mfa-otp"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="onprem_mfa_6-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <div
-                        class="iconContainer mfa-rsa authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 rsa_token_7-description rsa_token_7-ctaLabel"
+                        aria-labelledby="rsa_token_7-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="rsa_token_7"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="rsa_token_7"
+                          <div
+                            class="iconContainer mfa-rsa authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="rsa_token_7"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="rsa_token_7"
+                              >
+                                RSA SecurID
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                d="m40 29.725-4.93-11.438h.002-.002v-.002.001h-1.98L28.27 29.73h2.124l3.669-8.974 3.825 8.974L40 29.725Zm-25.757-4.897c1.547-.588 2.287-1.886 2.27-3.21-.028-2.009-1.579-3.41-3.771-3.41H8V29.71h1.727v-9.824h2.916c.978 0 2.028.517 2.045 1.755.014 1.104-.796 1.793-2.169 1.852l-.027.001-1.046.01 3.484 6.225 2.04-.005-2.727-4.898Zm4.61-3.65c0 2.29 2.237 2.937 3.976 3.435 1.812.52 2.443 1.107 2.443 1.997 0 1.484-1.481 1.715-2.397 1.715-1.257 0-2.295-.357-3.31-.994l-.867 1.492C19.98 29.626 21.307 30 22.875 30c2.62 0 4.36-1.38 4.36-3.514 0-2.385-2.117-3.045-3.897-3.556-1.813-.52-2.522-.961-2.522-1.851 0-1.348 1.623-1.479 2.204-1.479.915 0 2.077.311 2.766.672l.729-1.458c-.929-.488-2.353-.814-3.543-.814-2.533 0-4.119 1.172-4.119 3.178Z"
+                                fill="#D9222A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="rsa_token_7-label"
                           >
                             RSA SecurID
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="m40 29.725-4.93-11.438h.002-.002v-.002.001h-1.98L28.27 29.73h2.124l3.669-8.974 3.825 8.974L40 29.725Zm-25.757-4.897c1.547-.588 2.287-1.886 2.27-3.21-.028-2.009-1.579-3.41-3.771-3.41H8V29.71h1.727v-9.824h2.916c.978 0 2.028.517 2.045 1.755.014 1.104-.796 1.793-2.169 1.852l-.027.001-1.046.01 3.484 6.225 2.04-.005-2.727-4.898Zm4.61-3.65c0 2.29 2.237 2.937 3.976 3.435 1.812.52 2.443 1.107 2.443 1.997 0 1.484-1.481 1.715-2.397 1.715-1.257 0-2.295-.357-3.31-.994l-.867 1.492C19.98 29.626 21.307 30 22.875 30c2.62 0 4.36-1.38 4.36-3.514 0-2.385-2.117-3.045-3.897-3.556-1.813-.52-2.522-.961-2.522-1.851 0-1.348 1.623-1.479 2.204-1.479.915 0 2.077.311 2.766.672l.729-1.458c-.929-.488-2.353-.814-3.543-.814-2.533 0-4.119 1.172-4.119 3.178Z"
-                            fill="#D9222A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="rsa_token_7-description"
+                          >
+                            Verify by entering a code generated by RSA SecurID
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="rsa_token-otp"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="rsa_token_7-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="rsa_token_7-label"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 duo_8-description duo_8-ctaLabel"
+                        aria-labelledby="duo_8-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        RSA SecurID
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="rsa_token_7-description"
-                      >
-                        Verify by entering a code generated by RSA SecurID
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="rsa_token-otp"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="rsa_token_7-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="duo_8-ctaLabel duo_8-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="duo_8-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-duo authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="duo_8"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="iconContainer mfa-duo authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="duo_8"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="duo_8"
+                              >
+                                Duo Security
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                clip-rule="evenodd"
+                                d="M10.632 17H4v6.13h13.25c-.197-3.418-3.085-6.13-6.618-6.13Zm7.242 0v6.506c0 3.466 2.766 6.3 6.25 6.494V17h-6.25Zm13.886 6.13c.2-3.418 3.087-6.13 6.62-6.13s6.42 2.712 6.62 6.13H31.76Zm-6.873 6.859h6.238v-6.114a6.32 6.32 0 0 0 .012-.375V17h-6.25v12.989Zm-14.255.01H4v-6.124h13.25C17.054 27.291 14.166 30 10.633 30ZM38.38 30c-3.533 0-6.42-2.709-6.62-6.125H45C44.801 27.291 41.913 30 38.38 30Z"
+                                fill="#77AF54"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          <title
-                            id="duo_8"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="duo_8-label"
                           >
                             Duo Security
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            clip-rule="evenodd"
-                            d="M10.632 17H4v6.13h13.25c-.197-3.418-3.085-6.13-6.618-6.13Zm7.242 0v6.506c0 3.466 2.766 6.3 6.25 6.494V17h-6.25Zm13.886 6.13c.2-3.418 3.087-6.13 6.62-6.13s6.42 2.712 6.62 6.13H31.76Zm-6.873 6.859h6.238v-6.114a6.32 6.32 0 0 0 .012-.375V17h-6.25v12.989Zm-14.255.01H4v-6.124h13.25C17.054 27.291 14.166 30 10.633 30ZM38.38 30c-3.533 0-6.42-2.709-6.62-6.125H45C44.801 27.291 41.913 30 38.38 30Z"
-                            fill="#77AF54"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="duo_8-label"
-                      >
-                        Duo Security
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="duo_8-description"
-                      >
-                        Verify your identity using Duo Security.
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="duo"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="duo_8-ctaLabel"
-                        >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="external_idp_9-ctaLabel external_idp_9-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="external_idp_9-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-custom-factor authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="external_idp_9"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="external_idp_9"
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="duo_8-description"
                           >
-                            Redirect to a third party MFA provider to sign in.
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M15 29.5a5 5 0 1 1 4.78-6.5h1.03a6 6 0 1 0 0 3h-1.03A5.013 5.013 0 0 1 15 29.5Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M27.5 36a11.433 11.433 0 0 1-6.61-2.088l-.186-.134.592-.806.17.123a10.5 10.5 0 1 0-.166-17.066l-.592-.806A11.5 11.5 0 1 1 27.5 36Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="m29.354 19.646-.708.708L32.293 24H14.707l1.647-1.646-.708-.708-2.853 2.854 2.853 2.854.708-.708L14.707 25h17.586l-3.647 3.646.708.708 4.853-4.854-4.853-4.854Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="external_idp_9-label"
-                      >
-                        IDP Authenticator
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="external_idp_9-description"
-                      >
-                        Redirect to verify with IDP Authenticator.
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="external_idp"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="external_idp_9-ctaLabel"
-                        >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="custom_otp_10-ctaLabel custom_otp_10-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="custom_otp_10-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-hotp authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="custom_otp_10"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="custom_otp_10"
+                            Verify your identity using Duo Security.
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="duo"
                           >
-                            Enter a single-use code from an authenticator.
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M28 23h-6v-6h1v5h5v1Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="m29.39 14.32 1.46-1.47-.7-.7-1.6 1.59A11.323 11.323 0 0 0 23 12.03V10h2V9h-5v1h2v2.03c-1.967.078-3.88.667-5.55 1.71l-1.6-1.59-.7.7 1.46 1.47A11.459 11.459 0 0 0 13.79 31h1.37a10.5 10.5 0 1 1 14.68 0h1.37a11.459 11.459 0 0 0-1.82-16.68Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="m21.257 33.929-.514-.858L19 34.117V32h-1v2.117l-1.743-1.046-.514.858L17.528 35l-1.785 1.071.514.858L18 35.883V38h1v-2.117l1.743 1.046.514-.858L19.472 35l1.785-1.071Zm8 0-.514-.858L27 34.117V32h-1v2.117l-1.743-1.046-.514.858L25.528 35l-1.785 1.071.514.858L26 35.883V38h1v-2.117l1.743 1.046.514-.858L27.472 35l1.785-1.071Zm8 0-.514-.858L35 34.117V32h-1v2.117l-1.743-1.046-.514.858L33.528 35l-1.785 1.071.514.858L34 35.883V38h1v-2.117l1.743 1.046.514-.858L35.472 35l1.785-1.071Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="duo_8-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="custom_otp_10-label"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 external_idp_9-description external_idp_9-ctaLabel"
+                        aria-labelledby="external_idp_9-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Atko Custom OTP Authenticator
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="custom_otp_10-description"
-                      >
-                        Enter a temporary code generated from an authenticator device.
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="custom_otp"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="custom_otp_10-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="symantec_vip_11-ctaLabel symantec_vip_11-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="symantec_vip_11-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                          <div
+                            class="iconContainer mfa-custom-factor authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="external_idp_9"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="external_idp_9"
+                              >
+                                Redirect to a third party MFA provider to sign in.
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M15 29.5a5 5 0 1 1 4.78-6.5h1.03a6 6 0 1 0 0 3h-1.03A5.013 5.013 0 0 1 15 29.5Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M27.5 36a11.433 11.433 0 0 1-6.61-2.088l-.186-.134.592-.806.17.123a10.5 10.5 0 1 0-.166-17.066l-.592-.806A11.5 11.5 0 1 1 27.5 36Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="m29.354 19.646-.708.708L32.293 24H14.707l1.647-1.646-.708-.708-2.853 2.854 2.853 2.854.708-.708L14.707 25h17.586l-3.647 3.646.708.708 4.853-4.854-4.853-4.854Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="external_idp_9-label"
+                          >
+                            IDP Authenticator
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="external_idp_9-description"
+                          >
+                            Redirect to verify with IDP Authenticator.
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="external_idp"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="external_idp_9-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <div
-                        class="iconContainer mfa-symantec authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 custom_otp_10-description custom_otp_10-ctaLabel"
+                        aria-labelledby="custom_otp_10-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="symantec_vip_11"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="symantec_vip_11"
+                          <div
+                            class="iconContainer mfa-hotp authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="custom_otp_10"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="custom_otp_10"
+                              >
+                                Enter a single-use code from an authenticator.
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M28 23h-6v-6h1v5h5v1Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="m29.39 14.32 1.46-1.47-.7-.7-1.6 1.59A11.323 11.323 0 0 0 23 12.03V10h2V9h-5v1h2v2.03c-1.967.078-3.88.667-5.55 1.71l-1.6-1.59-.7.7 1.46 1.47A11.459 11.459 0 0 0 13.79 31h1.37a10.5 10.5 0 1 1 14.68 0h1.37a11.459 11.459 0 0 0-1.82-16.68Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="m21.257 33.929-.514-.858L19 34.117V32h-1v2.117l-1.743-1.046-.514.858L17.528 35l-1.785 1.071.514.858L18 35.883V38h1v-2.117l1.743 1.046.514-.858L19.472 35l1.785-1.071Zm8 0-.514-.858L27 34.117V32h-1v2.117l-1.743-1.046-.514.858L25.528 35l-1.785 1.071.514.858L26 35.883V38h1v-2.117l1.743 1.046.514-.858L27.472 35l1.785-1.071Zm8 0-.514-.858L35 34.117V32h-1v2.117l-1.743-1.046-.514.858L33.528 35l-1.785 1.071.514.858L34 35.883V38h1v-2.117l1.743 1.046.514-.858L35.472 35l1.785-1.071Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="custom_otp_10-label"
+                          >
+                            Atko Custom OTP Authenticator
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="custom_otp_10-description"
+                          >
+                            Enter a temporary code generated from an authenticator device.
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="custom_otp"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="custom_otp_10-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
+                    >
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 symantec_vip_11-description symantec_vip_11-ctaLabel"
+                        aria-labelledby="symantec_vip_11-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
+                        >
+                          <div
+                            class="iconContainer mfa-symantec authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="symantec_vip_11"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="symantec_vip_11"
+                              >
+                                Symantec VIP
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                d="M40.92 5v1.046H42V5h-1.08Zm0 2.092v1.046H42V7.092h-1.08Zm-3.243 1.046v1.047h1.08V8.138h-1.08Zm-14.141.784C14.954 8.922 8 15.654 8 23.96 8 32.267 14.954 39 23.536 39c8.581 0 15.536-6.732 15.536-15.04 0-8.307-6.955-15.038-15.535-15.038h-.001Zm0 4.796c5.839 0 10.583 4.59 10.583 10.242 0 5.652-4.744 10.244-10.583 10.244-5.84 0-10.537-4.591-10.537-10.244 0-5.652 4.698-10.242 10.537-10.242Z"
+                                fill="#FDB511"
+                              />
+                              <path
+                                d="M39.839 6.046v1.046h1.08V6.046h-1.08Zm0 1.046h-2.162v1.046h2.162V7.092Zm-2.162 1.046h-1.08v2.093h1.08V8.138Zm0 2.093v1.046h1.08V10.23h-1.08Zm1.08 0h1.082V9.185h-1.081v1.046Zm-1.08 1.046h-1.08v1.046h-1.082v-1.046h-2.161v1.046h-1.08v1.046h1.08v1.046h-1.08V13.37h-1.082v1.046h-1.08v1.046H29.03v4.185h2.161V18.6h1.081v-1.046h1.08v-1.046h-1.08V15.46h1.08v1.047h1.082V15.46h1.08v-1.046h1.081V13.37h1.08v-2.092Zm-2.162 0h1.081V10.23h-1.08v1.046Zm0-1.046V9.185h-1.08v1.046h1.08Z"
+                                fill="#000"
+                              />
+                              <path
+                                d="M23.294 24.178c1.124-2.76 1.834-4.259 4.656-7.67l2.162-.002v4.185c-3.005 2.77-3.643 5.076-4.136 7.306-.304 1.36-.304 2.145-1.898 2.328-.298 0-1.076-.254-1.398-.828-.403-.724-1.602-3.501-2.566-5.188-.822-1.438-2.008-2.61-3.063-3.879-.402-.484-.608-.895-.27-1.352.337-.456.582-.385 1.08-.26 2.636 1.14 4.158 2.863 5.433 5.36Z"
+                                fill="#000"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="symantec_vip_11-label"
                           >
                             Symantec VIP
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="M40.92 5v1.046H42V5h-1.08Zm0 2.092v1.046H42V7.092h-1.08Zm-3.243 1.046v1.047h1.08V8.138h-1.08Zm-14.141.784C14.954 8.922 8 15.654 8 23.96 8 32.267 14.954 39 23.536 39c8.581 0 15.536-6.732 15.536-15.04 0-8.307-6.955-15.038-15.535-15.038h-.001Zm0 4.796c5.839 0 10.583 4.59 10.583 10.242 0 5.652-4.744 10.244-10.583 10.244-5.84 0-10.537-4.591-10.537-10.244 0-5.652 4.698-10.242 10.537-10.242Z"
-                            fill="#FDB511"
-                          />
-                          <path
-                            d="M39.839 6.046v1.046h1.08V6.046h-1.08Zm0 1.046h-2.162v1.046h2.162V7.092Zm-2.162 1.046h-1.08v2.093h1.08V8.138Zm0 2.093v1.046h1.08V10.23h-1.08Zm1.08 0h1.082V9.185h-1.081v1.046Zm-1.08 1.046h-1.08v1.046h-1.082v-1.046h-2.161v1.046h-1.08v1.046h1.08v1.046h-1.08V13.37h-1.082v1.046h-1.08v1.046H29.03v4.185h2.161V18.6h1.081v-1.046h1.08v-1.046h-1.08V15.46h1.08v1.047h1.082V15.46h1.08v-1.046h1.081V13.37h1.08v-2.092Zm-2.162 0h1.081V10.23h-1.08v1.046Zm0-1.046V9.185h-1.08v1.046h1.08Z"
-                            fill="#000"
-                          />
-                          <path
-                            d="M23.294 24.178c1.124-2.76 1.834-4.259 4.656-7.67l2.162-.002v4.185c-3.005 2.77-3.643 5.076-4.136 7.306-.304 1.36-.304 2.145-1.898 2.328-.298 0-1.076-.254-1.398-.828-.403-.724-1.602-3.501-2.566-5.188-.822-1.438-2.008-2.61-3.063-3.879-.402-.484-.608-.895-.27-1.352.337-.456.582-.385 1.08-.26 2.636 1.14 4.158 2.863 5.433 5.36Z"
-                            fill="#000"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="symantec_vip_11-label"
-                      >
-                        Symantec VIP
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="symantec_vip_11-description"
-                      >
-                        Verify by entering a temporary code from the Symantec VIP app.
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="symantec_vip"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="symantec_vip_11-ctaLabel"
-                        >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="yubikey_token_12-ctaLabel yubikey_token_12-description select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3"
-                    aria-labelledby="yubikey_token_12-label"
-                    class="authenticator-row authButton MuiBox-root emotion-20"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-yubikey authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="yubikey_token_12"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="yubikey_token_12"
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="symantec_vip_11-description"
                           >
-                            YubiKey
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <circle
-                            cx="24"
-                            cy="24"
-                            fill="#fff"
-                            r="18.5"
-                            stroke="#A3C753"
-                            stroke-width="3"
-                          />
-                          <path
-                            d="m24.406 23.977 1.416-3.996c.723-2.04 1.454-4.08 2.16-6.127.13-.382.328-.525.722-.52 1.466.014 2.933.004 4.4.006.7.001.748.064.49.701-.66 1.62-1.33 3.236-1.988 4.856-1.165 2.872-2.319 5.748-3.486 8.618-1.098 2.7-2.205 5.397-3.315 8.092-.396.961-.405.957-1.472.958-1.417.001-2.833.004-4.25 0-.605-.002-.646-.077-.407-.636.746-1.747 1.482-3.497 2.236-5.24.15-.345.16-.658.022-1.009-1.836-4.666-3.664-9.334-5.494-14.002-.23-.589-.468-1.176-.695-1.767-.164-.425-.084-.564.361-.567 1.6-.01 3.2 0 4.8-.01.38-.002.52.227.63.527.5 1.36 1.004 2.72 1.506 4.08l2.095 5.671c.045.122.101.241.151.361l.118.004Z"
-                            fill="#A3C753"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            Verify by entering a temporary code from the Symantec VIP app.
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="symantec_vip"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="symantec_vip_11-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-21"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-24"
-                        data-se="authenticator-button-label"
-                        id="yubikey_token_12-label"
+                      <button
+                        aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_2 select-authenticator-enroll_Description_Set_up_required_3 yubikey_token_12-description yubikey_token_12-ctaLabel"
+                        aria-labelledby="yubikey_token_12-label"
+                        class="authenticator-row authButton MuiBox-root emotion-22"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        YubiKey Authenticator
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-25"
-                        data-se="authenticator-button-description"
-                        id="yubikey_token_12-description"
-                      >
-                        Verify your identity using YubiKey
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="yubikey_token"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-27"
-                          data-se="cta-button-label"
-                          id="yubikey_token_12-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Set up
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
+                          <div
+                            class="iconContainer mfa-yubikey authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="yubikey_token_12"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="yubikey_token_12"
+                              >
+                                YubiKey
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <circle
+                                cx="24"
+                                cy="24"
+                                fill="#fff"
+                                r="18.5"
+                                stroke="#A3C753"
+                                stroke-width="3"
+                              />
+                              <path
+                                d="m24.406 23.977 1.416-3.996c.723-2.04 1.454-4.08 2.16-6.127.13-.382.328-.525.722-.52 1.466.014 2.933.004 4.4.006.7.001.748.064.49.701-.66 1.62-1.33 3.236-1.988 4.856-1.165 2.872-2.319 5.748-3.486 8.618-1.098 2.7-2.205 5.397-3.315 8.092-.396.961-.405.957-1.472.958-1.417.001-2.833.004-4.25 0-.605-.002-.646-.077-.407-.636.746-1.747 1.482-3.497 2.236-5.24.15-.345.16-.658.022-1.009-1.836-4.666-3.664-9.334-5.494-14.002-.23-.589-.468-1.176-.695-1.767-.164-.425-.084-.564.361-.567 1.6-.01 3.2 0 4.8-.01.38-.002.52.227.63.527.5 1.36 1.004 2.72 1.506 4.08l2.095 5.671c.045.122.101.241.151.361l.118.004Z"
+                                fill="#A3C753"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-26"
+                            data-se="authenticator-button-label"
+                            id="yubikey_token_12-label"
+                          >
+                            YubiKey Authenticator
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-27"
+                            data-se="authenticator-button-description"
+                            id="yubikey_token_12-description"
+                          >
+                            Verify your identity using YubiKey
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="yubikey_token"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-29"
+                              data-se="cta-button-label"
+                              id="yubikey_token_12-ctaLabel"
+                            >
+                              Set up
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  </ul>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-137"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-139"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -100,1386 +100,1394 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <button
-                    aria-describedby="okta_password_0-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="okta_password_0-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
+                  <ul
+                    class="MuiList-root MuiList-padding emotion-17"
                   >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <div
-                        class="iconContainer mfa-okta-password authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 okta_password_0-ctaLabel"
+                        aria-labelledby="okta_password_0-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="okta_password_0"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="okta_password_0"
+                          <div
+                            class="iconContainer mfa-okta-password authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="okta_password_0"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="okta_password_0"
+                              >
+                                Password
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="okta_password_0-label"
                           >
                             Password
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="okta_password"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="okta_password_0-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="okta_password_0-label"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 webauthn_1-ctaLabel"
+                        aria-labelledby="webauthn_1-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Password
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="okta_password"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="okta_password_0-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="webauthn_1-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="webauthn_1-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="webauthn_1"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="webauthn_1"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="webauthn_1"
+                              >
+                                Security Key or Biometric Authenticator
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M24 17V9h-9v8h-3v15.5a2.5 2.5 0 0 0 2.5 2.5h6.34a8.58 8.58 0 0 1-.38-1H14.5a1.5 1.5 0 0 1-1.5-1.5V18h13v3.84a8.58 8.58 0 0 1 1-.38V17h-3Zm-8 0v-7h7v7h-7Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M19.5 25a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M30 40a9 9 0 1 1 9-9 9.01 9.01 0 0 1-9 9Zm0-17a8 8 0 1 0 8 8 8.009 8.009 0 0 0-8-8Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M32.084 36.019a.472.472 0 0 1-.319-.112.501.501 0 0 1-.159-.532c.43-1.389 1.274-4.787-.119-6.352a1.962 1.962 0 0 0-1.946-.6 1.93 1.93 0 0 0-1.387 2.354c.007.024.666 2.823-.966 4.55a.5.5 0 1 1-.727-.685c1.24-1.314.728-3.6.723-3.622a2.933 2.933 0 0 1 2.106-3.566 2.977 2.977 0 0 1 2.944.906c1.67 1.875.922 5.386.328 7.312a.5.5 0 0 1-.478.347Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M28.63 37.25a.5.5 0 0 1-.359-.849c2.235-2.3 1.345-5.782 1.336-5.817a.5.5 0 0 1 .966-.259c.045.165 1.052 4.067-1.586 6.774a.5.5 0 0 1-.358.151Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M34.88 35.2a.5.5 0 0 1-.488-.612c.493-2.2.716-5.235-1.03-7.2a4.508 4.508 0 0 0-4.455-1.357 4.416 4.416 0 0 0-2.72 2.069 4.2 4.2 0 0 0-.468 3.2 3.1 3.1 0 0 1-.355 2.347.5.5 0 1 1-.728-.685 2.37 2.37 0 0 0 .11-1.434 5.174 5.174 0 0 1 .577-3.939 5.42 5.42 0 0 1 3.333-2.518 5.524 5.524 0 0 1 5.453 1.66c1.628 1.832 2.051 4.551 1.257 8.082a.5.5 0 0 1-.487.387Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          <title
-                            id="webauthn_1"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="webauthn_1-label"
                           >
                             Security Key or Biometric Authenticator
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M24 17V9h-9v8h-3v15.5a2.5 2.5 0 0 0 2.5 2.5h6.34a8.58 8.58 0 0 1-.38-1H14.5a1.5 1.5 0 0 1-1.5-1.5V18h13v3.84a8.58 8.58 0 0 1 1-.38V17h-3Zm-8 0v-7h7v7h-7Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M19.5 25a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M30 40a9 9 0 1 1 9-9 9.01 9.01 0 0 1-9 9Zm0-17a8 8 0 1 0 8 8 8.009 8.009 0 0 0-8-8Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M32.084 36.019a.472.472 0 0 1-.319-.112.501.501 0 0 1-.159-.532c.43-1.389 1.274-4.787-.119-6.352a1.962 1.962 0 0 0-1.946-.6 1.93 1.93 0 0 0-1.387 2.354c.007.024.666 2.823-.966 4.55a.5.5 0 1 1-.727-.685c1.24-1.314.728-3.6.723-3.622a2.933 2.933 0 0 1 2.106-3.566 2.977 2.977 0 0 1 2.944.906c1.67 1.875.922 5.386.328 7.312a.5.5 0 0 1-.478.347Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M28.63 37.25a.5.5 0 0 1-.359-.849c2.235-2.3 1.345-5.782 1.336-5.817a.5.5 0 0 1 .966-.259c.045.165 1.052 4.067-1.586 6.774a.5.5 0 0 1-.358.151Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M34.88 35.2a.5.5 0 0 1-.488-.612c.493-2.2.716-5.235-1.03-7.2a4.508 4.508 0 0 0-4.455-1.357 4.416 4.416 0 0 0-2.72 2.069 4.2 4.2 0 0 0-.468 3.2 3.1 3.1 0 0 1-.355 2.347.5.5 0 1 1-.728-.685 2.37 2.37 0 0 0 .11-1.434 5.174 5.174 0 0 1 .577-3.939 5.42 5.42 0 0 1 3.333-2.518 5.524 5.524 0 0 1 5.453 1.66c1.628 1.832 2.051 4.551 1.257 8.082a.5.5 0 0 1-.487.387Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="webauthn_1-label"
-                      >
-                        Security Key or Biometric Authenticator
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="webauthn"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="webauthn_1-ctaLabel"
-                        >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="okta_email_2-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="okta_email_2-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-okta-email authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="okta_email_2"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="okta_email_2"
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="webauthn"
                           >
-                            Email Authentication
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M32 18v1h5.3L32 24.29v1.42l6-6.01v12.8a1.5 1.5 0 0 1-1.5 1.5h-17a1.5 1.5 0 0 1-1.5-1.5V31h-1v1.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V18h-7Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M9 13v14.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V13H9Zm20.293 1-8.81 8.81L10.794 14h18.499ZM28.5 29h-17a1.5 1.5 0 0 1-1.5-1.5V14.63l10.517 9.56L30 14.707V27.5a1.5 1.5 0 0 1-1.5 1.5Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="webauthn_1-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="okta_email_2-label"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 okta_email_2-ctaLabel"
+                        aria-labelledby="okta_email_2-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Email
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="okta_email"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="okta_email_2-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="phone_number_3-ctaLabel phone_number_3-description select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="phone_number_3-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="phone_number_3"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="phone_number_3"
+                          <div
+                            class="iconContainer mfa-okta-email authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
                           >
-                            Voice Call Authentication
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="phone_number_3-label"
-                      >
-                        Phone
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-46"
-                        data-se="authenticator-button-description"
-                        id="phone_number_3-description"
-                      >
-                        +1 XXX-XXX-5309
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="phone_number"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="phone_number_3-ctaLabel"
+                            <svg
+                              aria-labelledby="okta_email_2"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="okta_email_2"
+                              >
+                                Email Authentication
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M32 18v1h5.3L32 24.29v1.42l6-6.01v12.8a1.5 1.5 0 0 1-1.5 1.5h-17a1.5 1.5 0 0 1-1.5-1.5V31h-1v1.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V18h-7Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M9 13v14.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V13H9Zm20.293 1-8.81 8.81L10.794 14h18.499ZM28.5 29h-17a1.5 1.5 0 0 1-1.5-1.5V14.63l10.517 9.56L30 14.707V27.5a1.5 1.5 0 0 1-1.5 1.5Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="phone_number_4-ctaLabel phone_number_4-description select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="phone_number_4-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="phone_number_4"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="phone_number_4"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="okta_email_2-label"
                           >
-                            Voice Call Authentication
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            Email
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="okta_email"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="okta_email_2-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="phone_number_4-label"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 phone_number_3-description phone_number_3-ctaLabel"
+                        aria-labelledby="phone_number_3-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Phone
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-46"
-                        data-se="authenticator-button-description"
-                        id="phone_number_4-description"
-                      >
-                        +1 XXX-XXX-5310
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="phone_number"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="phone_number_4-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="security_question_5-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="security_question_5-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                          <div
+                            class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="phone_number_3"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="phone_number_3"
+                              >
+                                Voice Call Authentication
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="phone_number_3-label"
+                          >
+                            Phone
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-48"
+                            data-se="authenticator-button-description"
+                            id="phone_number_3-description"
+                          >
+                            +1 XXX-XXX-5309
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="phone_number"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="phone_number_3-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <div
-                        class="iconContainer mfa-okta-security-question authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 phone_number_4-description phone_number_4-ctaLabel"
+                        aria-labelledby="phone_number_4-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="security_question_5"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="security_question_5"
+                          <div
+                            class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="phone_number_4"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="phone_number_4"
+                              >
+                                Voice Call Authentication
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="phone_number_4-label"
+                          >
+                            Phone
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-48"
+                            data-se="authenticator-button-description"
+                            id="phone_number_4-description"
+                          >
+                            +1 XXX-XXX-5310
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="phone_number"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="phone_number_4-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
+                    >
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 security_question_5-ctaLabel"
+                        aria-labelledby="security_question_5-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
+                        >
+                          <div
+                            class="iconContainer mfa-okta-security-question authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="security_question_5"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="security_question_5"
+                              >
+                                Security Question
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="m24.25 39.123-4.615-3.433a21.799 21.799 0 0 1-8.827-16.259l-.329-5.738 12.84-4.534a2.818 2.818 0 0 1 1.862 0l12.84 4.534-.329 5.738a21.8 21.8 0 0 1-8.827 16.259l-4.615 3.433ZM11.521 14.387l.285 4.987a20.811 20.811 0 0 0 8.425 15.514l4.019 2.989 4.019-2.989a20.81 20.81 0 0 0 8.425-15.514l.285-4.987L24.848 10.1a1.792 1.792 0 0 0-1.2 0l-12.127 4.287Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M29.44 19.729a5.007 5.007 0 0 0-8.846-2.356 4.484 4.484 0 0 0-.827 4.385l.929-.367A3.48 3.48 0 0 1 21.369 18a4.027 4.027 0 1 1 5.244 5.972C25 25 23.5 26.252 23.5 28.528h1c0-1.691 1.058-2.7 2.646-3.707a5.067 5.067 0 0 0 2.294-5.092Zm-5.454 12.246a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="security_question_5-label"
                           >
                             Security Question
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="m24.25 39.123-4.615-3.433a21.799 21.799 0 0 1-8.827-16.259l-.329-5.738 12.84-4.534a2.818 2.818 0 0 1 1.862 0l12.84 4.534-.329 5.738a21.8 21.8 0 0 1-8.827 16.259l-4.615 3.433ZM11.521 14.387l.285 4.987a20.811 20.811 0 0 0 8.425 15.514l4.019 2.989 4.019-2.989a20.81 20.81 0 0 0 8.425-15.514l.285-4.987L24.848 10.1a1.792 1.792 0 0 0-1.2 0l-12.127 4.287Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M29.44 19.729a5.007 5.007 0 0 0-8.846-2.356 4.484 4.484 0 0 0-.827 4.385l.929-.367A3.48 3.48 0 0 1 21.369 18a4.027 4.027 0 1 1 5.244 5.972C25 25 23.5 26.252 23.5 28.528h1c0-1.691 1.058-2.7 2.646-3.707a5.067 5.067 0 0 0 2.294-5.092Zm-5.454 12.246a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="security_question"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="security_question_5-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="security_question_5-label"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 okta_verify_6-description okta_verify_6-ctaLabel"
+                        aria-labelledby="okta_verify_6-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Security Question
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="security_question"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="security_question_5-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="okta_verify_6-ctaLabel okta_verify_6-description select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="okta_verify_6-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="okta_verify_6"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="okta_verify_6"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="okta_verify_6"
+                              >
+                                Okta Verify
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                clip-rule="evenodd"
+                                d="M32.872 22.853a8.947 8.947 0 1 1-2.288-4.91L24 24.498l-3.205-3.19c-.482-.48-1.322-.48-1.804 0a1.26 1.26 0 0 0-.374.898c0 .34.133.659.374.898l4.107 4.09c.24.239.561.371.902.371.336 0 .664-.136.902-.372L38.636 13.52a18.089 18.089 0 0 0-1.634-1.967A17.947 17.947 0 0 0 24 6C14.059 6 6 14.059 6 24s8.059 18 18 18 18-8.059 18-18c0-2.972-.722-5.775-1.998-8.245l-7.13 7.098Z"
+                                fill="#00297A"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          <title
-                            id="okta_verify_6"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="okta_verify_6-label"
+                          >
+                            Use Okta FastPass
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-48"
+                            data-se="authenticator-button-description"
+                            id="okta_verify_6-description"
                           >
                             Okta Verify
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            clip-rule="evenodd"
-                            d="M32.872 22.853a8.947 8.947 0 1 1-2.288-4.91L24 24.498l-3.205-3.19c-.482-.48-1.322-.48-1.804 0a1.26 1.26 0 0 0-.374.898c0 .34.133.659.374.898l4.107 4.09c.24.239.561.371.902.371.336 0 .664-.136.902-.372L38.636 13.52a18.089 18.089 0 0 0-1.634-1.967A17.947 17.947 0 0 0 24 6C14.059 6 6 14.059 6 24s8.059 18 18 18 18-8.059 18-18c0-2.972-.722-5.775-1.998-8.245l-7.13 7.098Z"
-                            fill="#00297A"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="okta_verify-signed_nonce"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="okta_verify_6-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="okta_verify_6-label"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 google_otp_7-ctaLabel"
+                        aria-labelledby="google_otp_7-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Use Okta FastPass
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-46"
-                        data-se="authenticator-button-description"
-                        id="okta_verify_6-description"
-                      >
-                        Okta Verify
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="okta_verify-signed_nonce"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="okta_verify_6-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="google_otp_7-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="google_otp_7-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-google-auth authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="google_otp_7"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="iconContainer mfa-google-auth authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="google_otp_7"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="google_otp_7"
+                              >
+                                Google Authenticator
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
+                                fill="#616161"
+                              />
+                              <path
+                                d="M24 34.182c-5.623 0-10.181-4.557-10.181-10.181 0-5.624 4.558-10.182 10.182-10.182 2.81 0 5.355 1.14 7.2 2.982l4.114-4.114A15.952 15.952 0 0 0 24 8C15.163 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001 4.42 0 8.419-1.79 11.316-4.685l-4.114-4.114A10.164 10.164 0 0 1 24 34.182Z"
+                                fill="#9E9E9E"
+                              />
+                              <path
+                                d="M34.183 24H29.09a5.09 5.09 0 1 0-8.76 3.528l-.004.004 6.304 6.304.001.001c4.348-1.16 7.55-5.124 7.55-9.836Z"
+                                fill="#424242"
+                              />
+                              <path
+                                d="M40 24h-5.82c0 4.713-3.204 8.676-7.549 9.837l4.493 4.493C36.385 35.71 40 30.277 40 24Z"
+                                fill="#616161"
+                              />
+                              <path
+                                d="M24 39.818c-8.806 0-15.948-7.114-15.999-15.909L8 24.001c0 8.837 7.164 16 16 16 8.838 0 16.001-7.163 16.001-16L40 23.909c-.05 8.795-7.194 15.91-16 15.91Z"
+                                fill="#212121"
+                                fill-opacity=".1"
+                              />
+                              <path
+                                d="m26.634 33.837.141.142c4.273-1.207 7.408-5.134 7.408-9.797v-.181c0 4.712-3.204 8.675-7.55 9.836Z"
+                                fill="#fff"
+                                fill-opacity=".05"
+                              />
+                              <path
+                                d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
+                                fill="#9E9E9E"
+                              />
+                              <path
+                                d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
+                                fill="#BDBDBD"
+                                opacity=".5"
+                              />
+                              <path
+                                d="M10.909 25.091a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181ZM24 12a1.09 1.09 0 1 0 0-2.182A1.09 1.09 0 0 0 24 12Zm0 26.182a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Zm-9.272-22.348a1.09 1.09 0 1 0 0-2.182 1.09 1.09 0 0 0 0 2.182Zm0 18.53a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
+                                fill="#BDBDBD"
+                              />
+                              <path
+                                d="M33.274 34.364a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
+                                fill="#757575"
+                              />
+                              <path
+                                d="M24 22.728h13.091c.773 0 1.404.603 1.45 1.364 0-.03.005-.06.005-.091 0-.804-.651-1.455-1.455-1.455h-13.09a1.454 1.454 0 0 0-1.45 1.546 1.451 1.451 0 0 1 1.45-1.364Z"
+                                fill="#fff"
+                                fill-opacity=".2"
+                              />
+                              <path
+                                d="M38.54 24.09a1.456 1.456 0 0 1-1.449 1.365h-13.09a1.452 1.452 0 0 1-1.45-1.364 1.454 1.454 0 0 0 1.45 1.545h13.09a1.454 1.454 0 0 0 1.45-1.545Z"
+                                fill="#212121"
+                                fill-opacity=".2"
+                              />
+                              <path
+                                d="M24 14c2.811 0 5.357 1.14 7.2 2.983l4.204-4.206-.09-.092L31.2 16.8a10.154 10.154 0 0 0-7.2-2.982c-5.623 0-10.181 4.557-10.181 10.181l.001.092C13.87 18.509 18.408 14 24 14Z"
+                                fill="#212121"
+                                fill-opacity=".1"
+                              />
+                              <path
+                                d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
+                                fill="url(#paint0_radial_5_581)"
+                              />
+                              <defs>
+                                <radialgradient
+                                  cx="0"
+                                  cy="0"
+                                  gradientTransform="translate(12.692 12.656) scale(31.946)"
+                                  gradientUnits="userSpaceOnUse"
+                                  id="paint0_radial_5_581"
+                                  r="1"
+                                >
+                                  <stop
+                                    stop-color="#fff"
+                                    stop-opacity=".1"
+                                  />
+                                  <stop
+                                    offset="1"
+                                    stop-color="#fff"
+                                    stop-opacity="0"
+                                  />
+                                </radialgradient>
+                              </defs>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          <title
-                            id="google_otp_7"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="google_otp_7-label"
                           >
                             Google Authenticator
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
-                            fill="#616161"
-                          />
-                          <path
-                            d="M24 34.182c-5.623 0-10.181-4.557-10.181-10.181 0-5.624 4.558-10.182 10.182-10.182 2.81 0 5.355 1.14 7.2 2.982l4.114-4.114A15.952 15.952 0 0 0 24 8C15.163 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001 4.42 0 8.419-1.79 11.316-4.685l-4.114-4.114A10.164 10.164 0 0 1 24 34.182Z"
-                            fill="#9E9E9E"
-                          />
-                          <path
-                            d="M34.183 24H29.09a5.09 5.09 0 1 0-8.76 3.528l-.004.004 6.304 6.304.001.001c4.348-1.16 7.55-5.124 7.55-9.836Z"
-                            fill="#424242"
-                          />
-                          <path
-                            d="M40 24h-5.82c0 4.713-3.204 8.676-7.549 9.837l4.493 4.493C36.385 35.71 40 30.277 40 24Z"
-                            fill="#616161"
-                          />
-                          <path
-                            d="M24 39.818c-8.806 0-15.948-7.114-15.999-15.909L8 24.001c0 8.837 7.164 16 16 16 8.838 0 16.001-7.163 16.001-16L40 23.909c-.05 8.795-7.194 15.91-16 15.91Z"
-                            fill="#212121"
-                            fill-opacity=".1"
-                          />
-                          <path
-                            d="m26.634 33.837.141.142c4.273-1.207 7.408-5.134 7.408-9.797v-.181c0 4.712-3.204 8.675-7.55 9.836Z"
-                            fill="#fff"
-                            fill-opacity=".05"
-                          />
-                          <path
-                            d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
-                            fill="#9E9E9E"
-                          />
-                          <path
-                            d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
-                            fill="#BDBDBD"
-                            opacity=".5"
-                          />
-                          <path
-                            d="M10.909 25.091a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181ZM24 12a1.09 1.09 0 1 0 0-2.182A1.09 1.09 0 0 0 24 12Zm0 26.182a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Zm-9.272-22.348a1.09 1.09 0 1 0 0-2.182 1.09 1.09 0 0 0 0 2.182Zm0 18.53a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
-                            fill="#BDBDBD"
-                          />
-                          <path
-                            d="M33.274 34.364a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
-                            fill="#757575"
-                          />
-                          <path
-                            d="M24 22.728h13.091c.773 0 1.404.603 1.45 1.364 0-.03.005-.06.005-.091 0-.804-.651-1.455-1.455-1.455h-13.09a1.454 1.454 0 0 0-1.45 1.546 1.451 1.451 0 0 1 1.45-1.364Z"
-                            fill="#fff"
-                            fill-opacity=".2"
-                          />
-                          <path
-                            d="M38.54 24.09a1.456 1.456 0 0 1-1.449 1.365h-13.09a1.452 1.452 0 0 1-1.45-1.364 1.454 1.454 0 0 0 1.45 1.545h13.09a1.454 1.454 0 0 0 1.45-1.545Z"
-                            fill="#212121"
-                            fill-opacity=".2"
-                          />
-                          <path
-                            d="M24 14c2.811 0 5.357 1.14 7.2 2.983l4.204-4.206-.09-.092L31.2 16.8a10.154 10.154 0 0 0-7.2-2.982c-5.623 0-10.181 4.557-10.181 10.181l.001.092C13.87 18.509 18.408 14 24 14Z"
-                            fill="#212121"
-                            fill-opacity=".1"
-                          />
-                          <path
-                            d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
-                            fill="url(#paint0_radial_5_581)"
-                          />
-                          <defs>
-                            <radialgradient
-                              cx="0"
-                              cy="0"
-                              gradientTransform="translate(12.692 12.656) scale(31.946)"
-                              gradientUnits="userSpaceOnUse"
-                              id="paint0_radial_5_581"
-                              r="1"
-                            >
-                              <stop
-                                stop-color="#fff"
-                                stop-opacity=".1"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#fff"
-                                stop-opacity="0"
-                              />
-                            </radialgradient>
-                          </defs>
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="google_otp_7-label"
-                      >
-                        Google Authenticator
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="google_otp"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="google_otp_7-ctaLabel"
-                        >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="onprem_mfa_8-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="onprem_mfa_8-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-onprem authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="onprem_mfa_8"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="onprem_mfa_8"
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="google_otp"
                           >
-                            Enter a single-use code from a hardware token.
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M39 20h-8v-3H16.5a7.5 7.5 0 0 0 0 15H31v-3h8v-9Zm-9 11H16.5a6.5 6.5 0 1 1 0-13H30v13Zm8-3h-7v-7h7v7Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M15.5 28a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0-6a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="google_otp_7-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="onprem_mfa_8-label"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 onprem_mfa_8-ctaLabel"
+                        aria-labelledby="onprem_mfa_8-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Atko Custom On-prem
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="onprem_mfa"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="onprem_mfa_8-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="rsa_token_9-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="rsa_token_9-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                          <div
+                            class="iconContainer mfa-onprem authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="onprem_mfa_8"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="onprem_mfa_8"
+                              >
+                                Enter a single-use code from a hardware token.
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M39 20h-8v-3H16.5a7.5 7.5 0 0 0 0 15H31v-3h8v-9Zm-9 11H16.5a6.5 6.5 0 1 1 0-13H30v13Zm8-3h-7v-7h7v7Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M15.5 28a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0-6a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="onprem_mfa_8-label"
+                          >
+                            Atko Custom On-prem
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="onprem_mfa"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="onprem_mfa_8-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <div
-                        class="iconContainer mfa-rsa authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 rsa_token_9-ctaLabel"
+                        aria-labelledby="rsa_token_9-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="rsa_token_9"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="rsa_token_9"
+                          <div
+                            class="iconContainer mfa-rsa authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="rsa_token_9"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="rsa_token_9"
+                              >
+                                RSA SecurID
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                d="m40 29.725-4.93-11.438h.002-.002v-.002.001h-1.98L28.27 29.73h2.124l3.669-8.974 3.825 8.974L40 29.725Zm-25.757-4.897c1.547-.588 2.287-1.886 2.27-3.21-.028-2.009-1.579-3.41-3.771-3.41H8V29.71h1.727v-9.824h2.916c.978 0 2.028.517 2.045 1.755.014 1.104-.796 1.793-2.169 1.852l-.027.001-1.046.01 3.484 6.225 2.04-.005-2.727-4.898Zm4.61-3.65c0 2.29 2.237 2.937 3.976 3.435 1.812.52 2.443 1.107 2.443 1.997 0 1.484-1.481 1.715-2.397 1.715-1.257 0-2.295-.357-3.31-.994l-.867 1.492C19.98 29.626 21.307 30 22.875 30c2.62 0 4.36-1.38 4.36-3.514 0-2.385-2.117-3.045-3.897-3.556-1.813-.52-2.522-.961-2.522-1.851 0-1.348 1.623-1.479 2.204-1.479.915 0 2.077.311 2.766.672l.729-1.458c-.929-.488-2.353-.814-3.543-.814-2.533 0-4.119 1.172-4.119 3.178Z"
+                                fill="#D9222A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="rsa_token_9-label"
                           >
                             RSA SecurID
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="m40 29.725-4.93-11.438h.002-.002v-.002.001h-1.98L28.27 29.73h2.124l3.669-8.974 3.825 8.974L40 29.725Zm-25.757-4.897c1.547-.588 2.287-1.886 2.27-3.21-.028-2.009-1.579-3.41-3.771-3.41H8V29.71h1.727v-9.824h2.916c.978 0 2.028.517 2.045 1.755.014 1.104-.796 1.793-2.169 1.852l-.027.001-1.046.01 3.484 6.225 2.04-.005-2.727-4.898Zm4.61-3.65c0 2.29 2.237 2.937 3.976 3.435 1.812.52 2.443 1.107 2.443 1.997 0 1.484-1.481 1.715-2.397 1.715-1.257 0-2.295-.357-3.31-.994l-.867 1.492C19.98 29.626 21.307 30 22.875 30c2.62 0 4.36-1.38 4.36-3.514 0-2.385-2.117-3.045-3.897-3.556-1.813-.52-2.522-.961-2.522-1.851 0-1.348 1.623-1.479 2.204-1.479.915 0 2.077.311 2.766.672l.729-1.458c-.929-.488-2.353-.814-3.543-.814-2.533 0-4.119 1.172-4.119 3.178Z"
-                            fill="#D9222A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="rsa_token"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="rsa_token_9-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="rsa_token_9-label"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 duo_10-ctaLabel"
+                        aria-labelledby="duo_10-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        RSA SecurID
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="rsa_token"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="rsa_token_9-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="duo_10-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="duo_10-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-duo authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="duo_10"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="iconContainer mfa-duo authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="duo_10"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="duo_10"
+                              >
+                                Duo Security
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                clip-rule="evenodd"
+                                d="M10.632 17H4v6.13h13.25c-.197-3.418-3.085-6.13-6.618-6.13Zm7.242 0v6.506c0 3.466 2.766 6.3 6.25 6.494V17h-6.25Zm13.886 6.13c.2-3.418 3.087-6.13 6.62-6.13s6.42 2.712 6.62 6.13H31.76Zm-6.873 6.859h6.238v-6.114a6.32 6.32 0 0 0 .012-.375V17h-6.25v12.989Zm-14.255.01H4v-6.124h13.25C17.054 27.291 14.166 30 10.633 30ZM38.38 30c-3.533 0-6.42-2.709-6.62-6.125H45C44.801 27.291 41.913 30 38.38 30Z"
+                                fill="#77AF54"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          <title
-                            id="duo_10"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="duo_10-label"
                           >
                             Duo Security
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            clip-rule="evenodd"
-                            d="M10.632 17H4v6.13h13.25c-.197-3.418-3.085-6.13-6.618-6.13Zm7.242 0v6.506c0 3.466 2.766 6.3 6.25 6.494V17h-6.25Zm13.886 6.13c.2-3.418 3.087-6.13 6.62-6.13s6.42 2.712 6.62 6.13H31.76Zm-6.873 6.859h6.238v-6.114a6.32 6.32 0 0 0 .012-.375V17h-6.25v12.989Zm-14.255.01H4v-6.124h13.25C17.054 27.291 14.166 30 10.633 30ZM38.38 30c-3.533 0-6.42-2.709-6.62-6.125H45C44.801 27.291 41.913 30 38.38 30Z"
-                            fill="#77AF54"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="duo_10-label"
-                      >
-                        Duo Security
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="duo"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="duo_10-ctaLabel"
-                        >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="external_idp_11-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="external_idp_11-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-custom-factor authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="external_idp_11"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="external_idp_11"
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="duo"
                           >
-                            Redirect to a third party MFA provider to sign in.
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M15 29.5a5 5 0 1 1 4.78-6.5h1.03a6 6 0 1 0 0 3h-1.03A5.013 5.013 0 0 1 15 29.5Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M27.5 36a11.433 11.433 0 0 1-6.61-2.088l-.186-.134.592-.806.17.123a10.5 10.5 0 1 0-.166-17.066l-.592-.806A11.5 11.5 0 1 1 27.5 36Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="m29.354 19.646-.708.708L32.293 24H14.707l1.647-1.646-.708-.708-2.853 2.854 2.853 2.854.708-.708L14.707 25h17.586l-3.647 3.646.708.708 4.853-4.854-4.853-4.854Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="duo_10-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="external_idp_11-label"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 external_idp_11-ctaLabel"
+                        aria-labelledby="external_idp_11-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        IDP Authenticator
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="external_idp"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="external_idp_11-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="custom_otp_12-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="custom_otp_12-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-hotp authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="custom_otp_12"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="custom_otp_12"
+                          <div
+                            class="iconContainer mfa-custom-factor authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
                           >
-                            Enter a single-use code from an authenticator.
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M28 23h-6v-6h1v5h5v1Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="m29.39 14.32 1.46-1.47-.7-.7-1.6 1.59A11.323 11.323 0 0 0 23 12.03V10h2V9h-5v1h2v2.03c-1.967.078-3.88.667-5.55 1.71l-1.6-1.59-.7.7 1.46 1.47A11.459 11.459 0 0 0 13.79 31h1.37a10.5 10.5 0 1 1 14.68 0h1.37a11.459 11.459 0 0 0-1.82-16.68Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="m21.257 33.929-.514-.858L19 34.117V32h-1v2.117l-1.743-1.046-.514.858L17.528 35l-1.785 1.071.514.858L18 35.883V38h1v-2.117l1.743 1.046.514-.858L19.472 35l1.785-1.071Zm8 0-.514-.858L27 34.117V32h-1v2.117l-1.743-1.046-.514.858L25.528 35l-1.785 1.071.514.858L26 35.883V38h1v-2.117l1.743 1.046.514-.858L27.472 35l1.785-1.071Zm8 0-.514-.858L35 34.117V32h-1v2.117l-1.743-1.046-.514.858L33.528 35l-1.785 1.071.514.858L34 35.883V38h1v-2.117l1.743 1.046.514-.858L35.472 35l1.785-1.071Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="custom_otp_12-label"
-                      >
-                        Atko Custom OTP Authenticator
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="custom_otp"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="custom_otp_12-ctaLabel"
+                            <svg
+                              aria-labelledby="external_idp_11"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="external_idp_11"
+                              >
+                                Redirect to a third party MFA provider to sign in.
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M15 29.5a5 5 0 1 1 4.78-6.5h1.03a6 6 0 1 0 0 3h-1.03A5.013 5.013 0 0 1 15 29.5Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M27.5 36a11.433 11.433 0 0 1-6.61-2.088l-.186-.134.592-.806.17.123a10.5 10.5 0 1 0-.166-17.066l-.592-.806A11.5 11.5 0 1 1 27.5 36Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="m29.354 19.646-.708.708L32.293 24H14.707l1.647-1.646-.708-.708-2.853 2.854 2.853 2.854.708-.708L14.707 25h17.586l-3.647 3.646.708.708 4.853-4.854-4.853-4.854Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="symantec_vip_13-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="symantec_vip_13-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="external_idp_11-label"
+                          >
+                            IDP Authenticator
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="external_idp"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="external_idp_11-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <div
-                        class="iconContainer mfa-symantec authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 custom_otp_12-ctaLabel"
+                        aria-labelledby="custom_otp_12-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="symantec_vip_13"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="symantec_vip_13"
+                          <div
+                            class="iconContainer mfa-hotp authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="custom_otp_12"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="custom_otp_12"
+                              >
+                                Enter a single-use code from an authenticator.
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M28 23h-6v-6h1v5h5v1Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="m29.39 14.32 1.46-1.47-.7-.7-1.6 1.59A11.323 11.323 0 0 0 23 12.03V10h2V9h-5v1h2v2.03c-1.967.078-3.88.667-5.55 1.71l-1.6-1.59-.7.7 1.46 1.47A11.459 11.459 0 0 0 13.79 31h1.37a10.5 10.5 0 1 1 14.68 0h1.37a11.459 11.459 0 0 0-1.82-16.68Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="m21.257 33.929-.514-.858L19 34.117V32h-1v2.117l-1.743-1.046-.514.858L17.528 35l-1.785 1.071.514.858L18 35.883V38h1v-2.117l1.743 1.046.514-.858L19.472 35l1.785-1.071Zm8 0-.514-.858L27 34.117V32h-1v2.117l-1.743-1.046-.514.858L25.528 35l-1.785 1.071.514.858L26 35.883V38h1v-2.117l1.743 1.046.514-.858L27.472 35l1.785-1.071Zm8 0-.514-.858L35 34.117V32h-1v2.117l-1.743-1.046-.514.858L33.528 35l-1.785 1.071.514.858L34 35.883V38h1v-2.117l1.743 1.046.514-.858L35.472 35l1.785-1.071Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="custom_otp_12-label"
+                          >
+                            Atko Custom OTP Authenticator
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="custom_otp"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="custom_otp_12-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
+                    >
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 symantec_vip_13-ctaLabel"
+                        aria-labelledby="symantec_vip_13-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
+                        >
+                          <div
+                            class="iconContainer mfa-symantec authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="symantec_vip_13"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="symantec_vip_13"
+                              >
+                                Symantec VIP
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                d="M40.92 5v1.046H42V5h-1.08Zm0 2.092v1.046H42V7.092h-1.08Zm-3.243 1.046v1.047h1.08V8.138h-1.08Zm-14.141.784C14.954 8.922 8 15.654 8 23.96 8 32.267 14.954 39 23.536 39c8.581 0 15.536-6.732 15.536-15.04 0-8.307-6.955-15.038-15.535-15.038h-.001Zm0 4.796c5.839 0 10.583 4.59 10.583 10.242 0 5.652-4.744 10.244-10.583 10.244-5.84 0-10.537-4.591-10.537-10.244 0-5.652 4.698-10.242 10.537-10.242Z"
+                                fill="#FDB511"
+                              />
+                              <path
+                                d="M39.839 6.046v1.046h1.08V6.046h-1.08Zm0 1.046h-2.162v1.046h2.162V7.092Zm-2.162 1.046h-1.08v2.093h1.08V8.138Zm0 2.093v1.046h1.08V10.23h-1.08Zm1.08 0h1.082V9.185h-1.081v1.046Zm-1.08 1.046h-1.08v1.046h-1.082v-1.046h-2.161v1.046h-1.08v1.046h1.08v1.046h-1.08V13.37h-1.082v1.046h-1.08v1.046H29.03v4.185h2.161V18.6h1.081v-1.046h1.08v-1.046h-1.08V15.46h1.08v1.047h1.082V15.46h1.08v-1.046h1.081V13.37h1.08v-2.092Zm-2.162 0h1.081V10.23h-1.08v1.046Zm0-1.046V9.185h-1.08v1.046h1.08Z"
+                                fill="#000"
+                              />
+                              <path
+                                d="M23.294 24.178c1.124-2.76 1.834-4.259 4.656-7.67l2.162-.002v4.185c-3.005 2.77-3.643 5.076-4.136 7.306-.304 1.36-.304 2.145-1.898 2.328-.298 0-1.076-.254-1.398-.828-.403-.724-1.602-3.501-2.566-5.188-.822-1.438-2.008-2.61-3.063-3.879-.402-.484-.608-.895-.27-1.352.337-.456.582-.385 1.08-.26 2.636 1.14 4.158 2.863 5.433 5.36Z"
+                                fill="#000"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="symantec_vip_13-label"
                           >
                             Symantec VIP
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="M40.92 5v1.046H42V5h-1.08Zm0 2.092v1.046H42V7.092h-1.08Zm-3.243 1.046v1.047h1.08V8.138h-1.08Zm-14.141.784C14.954 8.922 8 15.654 8 23.96 8 32.267 14.954 39 23.536 39c8.581 0 15.536-6.732 15.536-15.04 0-8.307-6.955-15.038-15.535-15.038h-.001Zm0 4.796c5.839 0 10.583 4.59 10.583 10.242 0 5.652-4.744 10.244-10.583 10.244-5.84 0-10.537-4.591-10.537-10.244 0-5.652 4.698-10.242 10.537-10.242Z"
-                            fill="#FDB511"
-                          />
-                          <path
-                            d="M39.839 6.046v1.046h1.08V6.046h-1.08Zm0 1.046h-2.162v1.046h2.162V7.092Zm-2.162 1.046h-1.08v2.093h1.08V8.138Zm0 2.093v1.046h1.08V10.23h-1.08Zm1.08 0h1.082V9.185h-1.081v1.046Zm-1.08 1.046h-1.08v1.046h-1.082v-1.046h-2.161v1.046h-1.08v1.046h1.08v1.046h-1.08V13.37h-1.082v1.046h-1.08v1.046H29.03v4.185h2.161V18.6h1.081v-1.046h1.08v-1.046h-1.08V15.46h1.08v1.047h1.082V15.46h1.08v-1.046h1.081V13.37h1.08v-2.092Zm-2.162 0h1.081V10.23h-1.08v1.046Zm0-1.046V9.185h-1.08v1.046h1.08Z"
-                            fill="#000"
-                          />
-                          <path
-                            d="M23.294 24.178c1.124-2.76 1.834-4.259 4.656-7.67l2.162-.002v4.185c-3.005 2.77-3.643 5.076-4.136 7.306-.304 1.36-.304 2.145-1.898 2.328-.298 0-1.076-.254-1.398-.828-.403-.724-1.602-3.501-2.566-5.188-.822-1.438-2.008-2.61-3.063-3.879-.402-.484-.608-.895-.27-1.352.337-.456.582-.385 1.08-.26 2.636 1.14 4.158 2.863 5.433 5.36Z"
-                            fill="#000"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="symantec_vip_13-label"
-                      >
-                        Symantec VIP
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="symantec_vip"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="symantec_vip_13-ctaLabel"
-                        >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="yubikey_token_14-ctaLabel select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="yubikey_token_14-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-yubikey authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="yubikey_token_14"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="yubikey_token_14"
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="symantec_vip"
                           >
-                            YubiKey
-                          </title>
-                          <path
-                            class="siwFillBg"
-                            clip-rule="evenodd"
-                            d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
-                            fill="#F5F5F6"
-                            fill-rule="evenodd"
-                          />
-                          <circle
-                            cx="24"
-                            cy="24"
-                            fill="#fff"
-                            r="18.5"
-                            stroke="#A3C753"
-                            stroke-width="3"
-                          />
-                          <path
-                            d="m24.406 23.977 1.416-3.996c.723-2.04 1.454-4.08 2.16-6.127.13-.382.328-.525.722-.52 1.466.014 2.933.004 4.4.006.7.001.748.064.49.701-.66 1.62-1.33 3.236-1.988 4.856-1.165 2.872-2.319 5.748-3.486 8.618-1.098 2.7-2.205 5.397-3.315 8.092-.396.961-.405.957-1.472.958-1.417.001-2.833.004-4.25 0-.605-.002-.646-.077-.407-.636.746-1.747 1.482-3.497 2.236-5.24.15-.345.16-.658.022-1.009-1.836-4.666-3.664-9.334-5.494-14.002-.23-.589-.468-1.176-.695-1.767-.164-.425-.084-.564.361-.567 1.6-.01 3.2 0 4.8-.01.38-.002.52.227.63.527.5 1.36 1.004 2.72 1.506 4.08l2.095 5.671c.045.122.101.241.151.361l.118.004Z"
-                            fill="#A3C753"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="symantec_vip_13-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="yubikey_token_14-label"
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 yubikey_token_14-ctaLabel"
+                        aria-labelledby="yubikey_token_14-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        YubiKey Authenticator
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="yubikey_token"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="yubikey_token_14-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <button
-                    aria-describedby="custom_app_15-ctaLabel custom_app_15-description select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2"
-                    aria-labelledby="custom_app_15-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-7"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-custom-app-logo authenticator-icon MuiBox-root emotion-7"
-                        data-se="factor-beacon"
-                      >
-                        <img
-                          alt="Redirect to a third party MFA provider to sign in."
-                          class="customAuthImage custom-logo"
-                          src="/img/logos/default.png"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-7"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="custom_app_15-label"
-                      >
-                        Get a push notification
-                      </h3>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-46"
-                        data-se="authenticator-button-description"
-                        id="custom_app_15-description"
-                      >
-                        Custom Push App
-                      </p>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-7"
-                        data-se="custom_app"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="custom_app_15-ctaLabel"
+                          <div
+                            class="iconContainer mfa-yubikey authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="yubikey_token_14"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="yubikey_token_14"
+                              >
+                                YubiKey
+                              </title>
+                              <path
+                                class="siwFillBg"
+                                clip-rule="evenodd"
+                                d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                                fill="#F5F5F6"
+                                fill-rule="evenodd"
+                              />
+                              <circle
+                                cx="24"
+                                cy="24"
+                                fill="#fff"
+                                r="18.5"
+                                stroke="#A3C753"
+                                stroke-width="3"
+                              />
+                              <path
+                                d="m24.406 23.977 1.416-3.996c.723-2.04 1.454-4.08 2.16-6.127.13-.382.328-.525.722-.52 1.466.014 2.933.004 4.4.006.7.001.748.064.49.701-.66 1.62-1.33 3.236-1.988 4.856-1.165 2.872-2.319 5.748-3.486 8.618-1.098 2.7-2.205 5.397-3.315 8.092-.396.961-.405.957-1.472.958-1.417.001-2.833.004-4.25 0-.605-.002-.646-.077-.407-.636.746-1.747 1.482-3.497 2.236-5.24.15-.345.16-.658.022-1.009-1.836-4.666-3.664-9.334-5.494-14.002-.23-.589-.468-1.176-.695-1.767-.164-.425-.084-.564.361-.567 1.6-.01 3.2 0 4.8-.01.38-.002.52.227.63.527.5 1.36 1.004 2.72 1.506 4.08l2.095 5.671c.045.122.101.241.151.361l.118.004Z"
+                                fill="#A3C753"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="yubikey_token_14-label"
+                          >
+                            YubiKey Authenticator
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="yubikey_token"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="yubikey_token_14-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
+                    >
+                      <button
+                        aria-describedby="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1 select-authenticator-authenticate_Description_Select_from_the_following_options_2 custom_app_15-description custom_app_15-ctaLabel"
+                        aria-labelledby="custom_app_15-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-7"
+                          data-se="authenticator-icon"
+                        >
+                          <div
+                            class="iconContainer mfa-custom-app-logo authenticator-icon MuiBox-root emotion-7"
+                            data-se="factor-beacon"
+                          >
+                            <img
+                              alt="Redirect to a third party MFA provider to sign in."
+                              class="customAuthImage custom-logo"
+                              src="/img/logos/default.png"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-7"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="custom_app_15-label"
+                          >
+                            Get a push notification
+                          </h3>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-48"
+                            data-se="authenticator-button-description"
+                            id="custom_app_15-description"
+                          >
+                            Custom Push App
+                          </p>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-7"
+                            data-se="custom_app"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="custom_app_15-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  </ul>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-149"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-151"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -95,176 +95,184 @@ exports[`user-unlock-account renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <button
-                    aria-describedby="okta_email_0-ctaLabel select-authenticator-unlock-account_Title_Unlock_account_1"
-                    aria-labelledby="okta_email_0-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
+                  <ul
+                    class="MuiList-root MuiList-padding emotion-17"
                   >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-10"
-                      data-se="authenticator-icon"
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <div
-                        class="iconContainer mfa-okta-email authenticator-icon MuiBox-root emotion-10"
-                        data-se="factor-beacon"
+                      <button
+                        aria-describedby="select-authenticator-unlock-account_Title_Unlock_account_1 okta_email_0-ctaLabel"
+                        aria-labelledby="okta_email_0-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        <svg
-                          aria-labelledby="okta_email_0"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-10"
+                          data-se="authenticator-icon"
                         >
-                          <title
-                            id="okta_email_0"
+                          <div
+                            class="iconContainer mfa-okta-email authenticator-icon MuiBox-root emotion-10"
+                            data-se="factor-beacon"
                           >
-                            Email Authentication
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M32 18v1h5.3L32 24.29v1.42l6-6.01v12.8a1.5 1.5 0 0 1-1.5 1.5h-17a1.5 1.5 0 0 1-1.5-1.5V31h-1v1.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V18h-7Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M9 13v14.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V13H9Zm20.293 1-8.81 8.81L10.794 14h18.499ZM28.5 29h-17a1.5 1.5 0 0 1-1.5-1.5V14.63l10.517 9.56L30 14.707V27.5a1.5 1.5 0 0 1-1.5 1.5Z"
-                            fill="#00297A"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-10"
-                    >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="okta_email_0-label"
-                      >
-                        Email
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-10"
-                        data-se="okta_email"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="okta_email_0-ctaLabel"
+                            <svg
+                              aria-labelledby="okta_email_0"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="okta_email_0"
+                              >
+                                Email Authentication
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M32 18v1h5.3L32 24.29v1.42l6-6.01v12.8a1.5 1.5 0 0 1-1.5 1.5h-17a1.5 1.5 0 0 1-1.5-1.5V31h-1v1.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V18h-7Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M9 13v14.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V13H9Zm20.293 1-8.81 8.81L10.794 14h18.499ZM28.5 29h-17a1.5 1.5 0 0 1-1.5-1.5V14.63l10.517 9.56L30 14.707V27.5a1.5 1.5 0 0 1-1.5 1.5Z"
+                                fill="#00297A"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-10"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="MuiBox-root emotion-6"
-                >
-                  <button
-                    aria-describedby="phone_number_1-ctaLabel select-authenticator-unlock-account_Title_Unlock_account_1"
-                    aria-labelledby="phone_number_1-label"
-                    class="authenticator-row authButton MuiBox-root emotion-17"
-                    data-se="authenticator-button"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <div
-                      class="authenticator-icon-container MuiBox-root emotion-10"
-                      data-se="authenticator-icon"
-                    >
-                      <div
-                        class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-10"
-                        data-se="factor-beacon"
-                      >
-                        <svg
-                          aria-labelledby="phone_number_1"
-                          fill="none"
-                          height="48"
-                          role="img"
-                          viewBox="0 0 48 48"
-                          width="48"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="phone_number_1"
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="okta_email_0-label"
                           >
-                            Voice Call Authentication
-                          </title>
-                          <circle
-                            class="siwFillBg"
-                            cx="24"
-                            cy="24"
-                            fill="#F5F5F6"
-                            r="24"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillPrimary"
-                            d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
-                            fill="#00297A"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
-                            fill="#A7B5EC"
-                          />
-                          <path
-                            class="siwFillSecondary"
-                            d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
-                            fill="#A7B5EC"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      class="authenticator-description infoSection MuiBox-root emotion-10"
+                            Email
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-10"
+                            data-se="okta_email"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="okta_email_0-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                    <li
+                      class="MuiListItem-root MuiListItem-padding emotion-18"
                     >
-                      <h3
-                        class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-21"
-                        data-se="authenticator-button-label"
-                        id="phone_number_1-label"
+                      <button
+                        aria-describedby="select-authenticator-unlock-account_Title_Unlock_account_1 phone_number_1-ctaLabel"
+                        aria-labelledby="phone_number_1-label"
+                        class="authenticator-row authButton MuiBox-root emotion-19"
+                        data-se="authenticator-button"
+                        tabindex="0"
+                        type="button"
                       >
-                        Phone
-                      </h3>
-                      <div
-                        class="cta-button authenticator-button actionName MuiBox-root emotion-10"
-                        data-se="phone_number"
-                      >
-                        <span
-                          class="button select-factor link-button MuiBox-root emotion-23"
-                          data-se="cta-button-label"
-                          id="phone_number_1-ctaLabel"
+                        <div
+                          class="authenticator-icon-container MuiBox-root emotion-10"
+                          data-se="authenticator-icon"
                         >
-                          Select
-                        </span>
-                        <mocksvgicon />
-                      </div>
-                    </div>
-                  </button>
+                          <div
+                            class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-10"
+                            data-se="factor-beacon"
+                          >
+                            <svg
+                              aria-labelledby="phone_number_1"
+                              fill="none"
+                              height="48"
+                              role="img"
+                              viewBox="0 0 48 48"
+                              width="48"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="phone_number_1"
+                              >
+                                Voice Call Authentication
+                              </title>
+                              <circle
+                                class="siwFillBg"
+                                cx="24"
+                                cy="24"
+                                fill="#F5F5F6"
+                                r="24"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillPrimary"
+                                d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
+                                fill="#00297A"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
+                                fill="#A7B5EC"
+                              />
+                              <path
+                                class="siwFillSecondary"
+                                d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
+                                fill="#A7B5EC"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="authenticator-description infoSection MuiBox-root emotion-10"
+                        >
+                          <h3
+                            class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-23"
+                            data-se="authenticator-button-label"
+                            id="phone_number_1-label"
+                          >
+                            Phone
+                          </h3>
+                          <div
+                            class="cta-button authenticator-button actionName MuiBox-root emotion-10"
+                            data-se="phone_number"
+                          >
+                            <span
+                              class="button select-factor link-button MuiBox-root emotion-25"
+                              data-se="cta-button-label"
+                              id="phone_number_1-ctaLabel"
+                            >
+                              Select
+                            </span>
+                            <mocksvgicon />
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  </ul>
                 </div>
                 <div
                   class="MuiBox-root emotion-6"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >


### PR DESCRIPTION
## Description:

The purpose of this PR is to make the Authenticator buttons display within a List. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-547443](https://oktainc.atlassian.net/browse/OKTA-547443)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



