### PR TITLE
fail downstream build if no published courage version

### DIFF
--- a/scripts/downstream/create-downstream-for-courage.sh
+++ b/scripts/downstream/create-downstream-for-courage.sh
@@ -12,7 +12,11 @@ if [[ -z "${upstream_artifact_version}" ]]; then
   echo "okta-ui publish receipt: ${upstream_publish_receipt}"
 
   # Get the Courage version
-  local -r courage_version="$(echo ${upstream_publish_receipt} | cut -d'@' -f3)"
+  local -r courage_version=$(echo "$upstream_publish_receipt" | grep "@okta/courage" | sed 's/.*@//')
+  if [ -z ${courage_version} ]; then
+      echo "No courage version was published from this build. Cannot generate downstream branch."
+      exit ${BUILD_FAILURE}
+  fi
 
   echo "courage version: ${courage_version}"
 fi


### PR DESCRIPTION
## Description:
Not every build okta-ui build produces a new courage version. 
Updates downstream build script (courage -> siw) to fail if no courage version was published from the build


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [N] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-540789](https://oktainc.atlassian.net/browse/OKTA-540789)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



