### PR TITLE
Draft: Update courage for datetime library

### DIFF
--- a/packages/@okta/courage-dist/esm/src/courage/util/StringUtil.js
+++ b/packages/@okta/courage-dist/esm/src/courage/util/StringUtil.js
@@ -31,6 +31,14 @@ const parseLocale = locale => {
 /* eslint max-len: 0*/
 
 /**
+ * Returns the user's locale as defined by window.okta.locale
+ */
+
+
+function getRawLocale() {
+  return window && window.okta && window.okta.locale || 'en';
+}
+/**
  * Returns the language bundle based on the current locale.
  * - If a locale is not provided, default to English ('en')
  * - Legacy Support: If the named language bundle does not exist, fall back to the default named bundle.
@@ -44,7 +52,7 @@ function getBundle(bundleName) {
     return Bundles[oktaUnderscore.keys(Bundles)[0]];
   }
 
-  const locale = parseLocale(window && window.okta && window.okta.locale) || 'en';
+  const locale = parseLocale(getRawLocale());
   return Bundles[`${bundleName}_${locale}`] || Bundles[bundleName];
 }
 /**
@@ -95,6 +103,17 @@ function emitL10nError(key, bundleName, reason) {
 const StringUtil =
 /** @lends module:Okta.internal.util.StringUtil */
 {
+  /** @static */
+  getRawLocale: function () {
+    return getRawLocale();
+  },
+
+  /** @static */
+  isLocaleBundleExist: function (bundleName, locale) {
+    const parsedLocale = parseLocale(locale);
+    return !!Bundles[`${bundleName}_${parsedLocale}`];
+  },
+
   /** @static */
   sprintf: function () {
     const args = Array.prototype.slice.apply(arguments);

--- a/packages/@okta/courage-dist/types/courage/util/StringUtil.d.ts
+++ b/packages/@okta/courage-dist/types/courage/util/StringUtil.d.ts
@@ -1,5 +1,9 @@
 declare const StringUtil: {
     /** @static */
+    getRawLocale: () => string;
+    /** @static */
+    isLocaleBundleExist(bundleName: any, locale: string): boolean;
+    /** @static */
     sprintf: () => any;
     /**
      * Converts a URI encoded query string into a hash map

--- a/packages/@okta/courage-for-signin-widget/package.json
+++ b/packages/@okta/courage-for-signin-widget/package.json
@@ -37,7 +37,7 @@
     "@babel/plugin-transform-shorthand-properties": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@okta/babel-plugin-handlebars-inline-precompile": "3.1.0-beta.4200.gf3d0a27",
-    "@okta/courage": "4.5.0-7508-g9ac6f5c",
+    "@okta/courage": "4.5.0-7523-g7d26524",
     "@okta/eslint-plugin-okta-ui": "0.1.0-beta.4181.g1f38f27",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.1",

--- a/packages/@okta/courage-for-signin-widget/yarn.lock
+++ b/packages/@okta/courage-for-signin-widget/yarn.lock
@@ -487,10 +487,10 @@
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
 
-"@okta/courage@4.5.0-7508-g9ac6f5c":
-  version "4.5.0-7508-g9ac6f5c"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-7508-g9ac6f5c.tgz#cb440be63dc73b9c8a6c89efb66b9a0a311be3a4"
-  integrity sha1-y0QL5j3HO5yKbInvtmuaCjEb46Q=
+"@okta/courage@4.5.0-7523-g7d26524":
+  version "4.5.0-7523-g7d26524"
+  resolved "https://artifacts.aue1e.internal:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-7523-g7d26524.tgz#1ef244255532fc81d3138bbe91a3644f43311967"
+  integrity sha1-HvJEJVUy/IHTE4u+kaNkT0MxGWc=
   dependencies:
     "@okta/jquery.simplemodal" "1.4.19-g8b711ea"
     "@types/backbone" "^1.4.10"


### PR DESCRIPTION
## Description:

Draft: Update courage for datetime library
- okta-ui https://github.com/okta/okta-ui/pull/5797

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-549803](https://oktainc.atlassian.net/browse/OKTA-549803)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:

https://github.com/okta/okta-core/pull/73797
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=OKTA-549803&page=1&pageSize=6&tab=main



