### PR TITLE
Fix csp issue in EnrollAuthenticatorGoogleAuthenticatorView

### DIFF
--- a/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
@@ -35,9 +35,6 @@ const Body = BaseForm.extend({
     const nextButton = addCustomButton({
       className: 'google-authenticator-next',
       title: loc('oform.next', 'login'),
-      attributes: {
-        style: 'display: block',
-      },
       click: () => {
         this.model.set(VIEW_TO_DISPLAY, viewToDisplayState.ENTER_CODE);
       }
@@ -122,5 +119,9 @@ export default BaseAuthenticatorView.extend({
     return ModelClass.extend({
       local,
     });
+  },
+  postRender() {
+    BaseAuthenticatorView.prototype.postRender.apply(this, arguments);
+    this.el.querySelector('.google-authenticator-next').style.display = 'block';
   },
 });

--- a/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
@@ -120,8 +120,4 @@ export default BaseAuthenticatorView.extend({
       local,
     });
   },
-  postRender() {
-    BaseAuthenticatorView.prototype.postRender.apply(this, arguments);
-    this.el.querySelector('.google-authenticator-next').style.display = 'block';
-  },
 });

--- a/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
@@ -58,7 +58,7 @@ export default class EnrollGoogleAuthenticatorPageObject extends BasePageObject 
     return this.form.getTextBoxErrorMessage(CODE_FIELD_NAME);
   }
 
-  getNextButtonClass() {
-    return this.form.getElement('.google-authenticator-next').getAttribute('class');
+  getNextButton() {
+    return this.form.getElement('.google-authenticator-next');
   }
 }

--- a/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
@@ -57,8 +57,4 @@ export default class EnrollGoogleAuthenticatorPageObject extends BasePageObject 
   getCodeFieldError() {
     return this.form.getTextBoxErrorMessage(CODE_FIELD_NAME);
   }
-
-  getPrimaryButtonNext() {
-    return this.form.getElement('.google-authenticator-next');
-  }
 }

--- a/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
@@ -57,4 +57,8 @@ export default class EnrollGoogleAuthenticatorPageObject extends BasePageObject 
   getCodeFieldError() {
     return this.form.getTextBoxErrorMessage(CODE_FIELD_NAME);
   }
+
+  getNextButtonClass() {
+    return this.form.getElement('.google-authenticator-next').getAttribute('class');
+  }
 }

--- a/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
@@ -57,4 +57,8 @@ export default class EnrollGoogleAuthenticatorPageObject extends BasePageObject 
   getCodeFieldError() {
     return this.form.getTextBoxErrorMessage(CODE_FIELD_NAME);
   }
+
+  getPrimaryButtonNext() {
+    return this.form.getElement('.google-authenticator-next');
+  }
 }

--- a/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
@@ -56,6 +56,7 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.getSetUpDescription())
       .eql('Launch Google Authenticator, tap the "+" icon, then select "Scan barcode".');
     await t.expect(enrollGoogleAuthenticatorPageObject.hasQRcode).ok();
+    await t.expect(enrollGoogleAuthenticatorPageObject.getPrimaryButtonNext().getStyleProperty('display')).eql('block');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
@@ -76,6 +77,7 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
     await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
     await t.expect(enrollGoogleAuthenticatorPageObject.getSharedSecret()).eql('ZR74DHZTG43NBULV');
+    await t.expect(enrollGoogleAuthenticatorPageObject.getPrimaryButtonNext().getStyleProperty('display')).eql('block');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
@@ -99,6 +101,7 @@ test
     // Verify links (switch authenticator link is present even if there is just one authenticator available))
     await t.expect(await enrollGoogleAuthenticatorPageObject.switchAuthenticatorLinkExists()).ok();
     await t.expect(await enrollGoogleAuthenticatorPageObject.signoutLinkExists()).ok();
+    await t.expect(enrollGoogleAuthenticatorPageObject.getPrimaryButtonNext().getStyleProperty('display')).eql('block');
 
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
@@ -122,6 +125,7 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
     await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
     await t.expect(enrollGoogleAuthenticatorPageObject.getSharedSecret()).eql('ZR74DHZTG43NBULV');
+    await t.expect(enrollGoogleAuthenticatorPageObject.getPrimaryButtonNext().getStyleProperty('display')).eql('block');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     // Verify links (switch authenticator link is present even if there is just one authenticator available))

--- a/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
@@ -56,7 +56,6 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.getSetUpDescription())
       .eql('Launch Google Authenticator, tap the "+" icon, then select "Scan barcode".');
     await t.expect(enrollGoogleAuthenticatorPageObject.hasQRcode).ok();
-    await t.expect(enrollGoogleAuthenticatorPageObject.getPrimaryButtonNext().getStyleProperty('display')).eql('block');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
@@ -77,7 +76,6 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
     await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
     await t.expect(enrollGoogleAuthenticatorPageObject.getSharedSecret()).eql('ZR74DHZTG43NBULV');
-    await t.expect(enrollGoogleAuthenticatorPageObject.getPrimaryButtonNext().getStyleProperty('display')).eql('block');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
@@ -101,7 +99,6 @@ test
     // Verify links (switch authenticator link is present even if there is just one authenticator available))
     await t.expect(await enrollGoogleAuthenticatorPageObject.switchAuthenticatorLinkExists()).ok();
     await t.expect(await enrollGoogleAuthenticatorPageObject.signoutLinkExists()).ok();
-    await t.expect(enrollGoogleAuthenticatorPageObject.getPrimaryButtonNext().getStyleProperty('display')).eql('block');
 
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
@@ -125,7 +122,6 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
     await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
     await t.expect(enrollGoogleAuthenticatorPageObject.getSharedSecret()).eql('ZR74DHZTG43NBULV');
-    await t.expect(enrollGoogleAuthenticatorPageObject.getPrimaryButtonNext().getStyleProperty('display')).eql('block');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     // Verify links (switch authenticator link is present even if there is just one authenticator available))

--- a/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
@@ -56,6 +56,8 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.getSetUpDescription())
       .eql('Launch Google Authenticator, tap the "+" icon, then select "Scan barcode".');
     await t.expect(enrollGoogleAuthenticatorPageObject.hasQRcode).ok();
+    const nextButtonClass = enrollGoogleAuthenticatorPageObject.getNextButtonClass();
+    await t.expect(nextButtonClass).contains('google-authenticator-next default-custom-button button-primary link-button');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
@@ -76,6 +78,8 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
     await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
     await t.expect(enrollGoogleAuthenticatorPageObject.getSharedSecret()).eql('ZR74DHZTG43NBULV');
+    const nextButtonClass = enrollGoogleAuthenticatorPageObject.getNextButtonClass();
+    await t.expect(nextButtonClass).contains('google-authenticator-next default-custom-button button-primary link-button');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
@@ -99,6 +103,8 @@ test
     // Verify links (switch authenticator link is present even if there is just one authenticator available))
     await t.expect(await enrollGoogleAuthenticatorPageObject.switchAuthenticatorLinkExists()).ok();
     await t.expect(await enrollGoogleAuthenticatorPageObject.signoutLinkExists()).ok();
+    const nextButtonClass = enrollGoogleAuthenticatorPageObject.getNextButtonClass();
+    await t.expect(nextButtonClass).contains('google-authenticator-next default-custom-button button-primary link-button');
 
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
@@ -122,6 +128,8 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
     await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
     await t.expect(enrollGoogleAuthenticatorPageObject.getSharedSecret()).eql('ZR74DHZTG43NBULV');
+    const nextButtonClass = enrollGoogleAuthenticatorPageObject.getNextButtonClass();
+    await t.expect(nextButtonClass).contains('google-authenticator-next default-custom-button button-primary link-button');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     // Verify links (switch authenticator link is present even if there is just one authenticator available))

--- a/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
@@ -56,8 +56,7 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.getSetUpDescription())
       .eql('Launch Google Authenticator, tap the "+" icon, then select "Scan barcode".');
     await t.expect(enrollGoogleAuthenticatorPageObject.hasQRcode).ok();
-    const nextButtonClass = enrollGoogleAuthenticatorPageObject.getNextButtonClass();
-    await t.expect(nextButtonClass).contains('google-authenticator-next default-custom-button button-primary link-button');
+    await t.expect(enrollGoogleAuthenticatorPageObject.getNextButton().getStyleProperty('display')).eql('block');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
@@ -78,8 +77,7 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
     await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
     await t.expect(enrollGoogleAuthenticatorPageObject.getSharedSecret()).eql('ZR74DHZTG43NBULV');
-    const nextButtonClass = enrollGoogleAuthenticatorPageObject.getNextButtonClass();
-    await t.expect(nextButtonClass).contains('google-authenticator-next default-custom-button button-primary link-button');
+    await t.expect(enrollGoogleAuthenticatorPageObject.getNextButton().getStyleProperty('display')).eql('block');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
@@ -103,8 +101,7 @@ test
     // Verify links (switch authenticator link is present even if there is just one authenticator available))
     await t.expect(await enrollGoogleAuthenticatorPageObject.switchAuthenticatorLinkExists()).ok();
     await t.expect(await enrollGoogleAuthenticatorPageObject.signoutLinkExists()).ok();
-    const nextButtonClass = enrollGoogleAuthenticatorPageObject.getNextButtonClass();
-    await t.expect(nextButtonClass).contains('google-authenticator-next default-custom-button button-primary link-button');
+    await t.expect(enrollGoogleAuthenticatorPageObject.getNextButton().getStyleProperty('display')).eql('block');
 
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
@@ -128,8 +125,7 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
     await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
     await t.expect(enrollGoogleAuthenticatorPageObject.getSharedSecret()).eql('ZR74DHZTG43NBULV');
-    const nextButtonClass = enrollGoogleAuthenticatorPageObject.getNextButtonClass();
-    await t.expect(nextButtonClass).contains('google-authenticator-next default-custom-button button-primary link-button');
+    await t.expect(enrollGoogleAuthenticatorPageObject.getNextButton().getStyleProperty('display')).eql('block');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     // Verify links (switch authenticator link is present even if there is just one authenticator available))


### PR DESCRIPTION
## Description:

Fix csp issue in EnrollAuthenticatorGoogleAuthenticatorView
Added test

Removed the attributes prop because`display: block` css is already being set on the next button via [_btns.scss](https://github.com/okta/okta-signin-widget/blob/master/assets/sass/modules/_btns.scss#L143). 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-555191](https://oktainc.atlassian.net/browse/OKTA-555191)

### Reviewers:

### Screenshot/Video:
Before
![Screen Shot 2022-12-12 at 11 25 02 AM](https://user-images.githubusercontent.com/91922055/207169009-77b7318c-150c-4b3d-9723-67cc3ef6928a.png)

After
![Screen Shot 2022-12-12 at 11 22 56 AM](https://user-images.githubusercontent.com/91922055/207169005-d4f65776-9cf2-463d-9f47-659a862c631d.png)


### Downstream Monolith Build:



