### PR TITLE
Adds transformer for `device-challenge-poll` for `LOOPBACK`

### DIFF
--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -66,6 +66,7 @@
     "babel-jest": "^27.3.1",
     "chroma-js": "^2.4.2",
     "classnames": "^2.3.1",
+    "cross-fetch": "^3.1.5",
     "deepmerge": "^4.2.2",
     "i18next": "^21.6.0",
     "i18next-browser-languagedetector": "^6.1.2",

--- a/src/v3/src/components/AuthCoin/AuthCoinConfig.ts
+++ b/src/v3/src/components/AuthCoin/AuthCoinConfig.ts
@@ -161,6 +161,13 @@ const AuthCoinByAuthenticatorKey: Record<string, AuthCoinConfig> = {
     description: loc('factor.totpSoft.oktaVerify', 'login'),
     iconClassName: 'mfa-okta-verify',
   },
+  [CHALLENGE_METHOD.LOOPBACK]: {
+    icon: OktaVerifyIcon,
+    name: 'mfa-okta-verify',
+    customizable: false,
+    description: loc('factor.totpSoft.oktaVerify', 'login'),
+    iconClassName: 'mfa-okta-verify',
+  },
 };
 
 export default AuthCoinByAuthenticatorKey;

--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -28,6 +28,7 @@ import InputText from '../InputText';
 import LaunchAuthenticatorButton from '../LaunchAuthenticatorButton';
 import Link from '../Link';
 import List from '../List';
+import LoopbackProbe from '../LoopbackProbe';
 import OpenOktaVerifyFPButton from '../OpenOktaVerifyFPButton';
 import PasswordRequirements from '../PasswordRequirements';
 import PasswordMatches from '../PasswordRequirements/PasswordMatches';
@@ -118,6 +119,10 @@ export default [
   {
     tester: ({ type }) => type === 'WebAuthNSubmitButton',
     renderer: WebAuthNSubmitButton,
+  },
+  {
+    tester: ({ type }) => type === 'LoopbackProbe',
+    renderer: LoopbackProbe,
   },
   {
     tester: ({ type }) => type === 'PIVButton',

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { render, waitFor } from '@testing-library/preact';
+import { rest } from 'msw';
+import { setupServer, SetupServerApi } from 'msw/node';
+import { h } from 'preact';
+import { LoopbackProbeElement } from 'src/types';
+
+import LoopbackProbe from './LoopbackProbe';
+
+const onSubmitHandler = jest.fn();
+jest.mock('../../hooks', () => ({
+  useOnSubmit: () => onSubmitHandler,
+}));
+jest.mock('../../../../util/Logger');
+
+describe('LoopbackProbe', () => {
+  const server: SetupServerApi = setupServer();
+
+  beforeAll(() => {
+    server.listen({
+      onUnhandledRequest: 'error',
+    });
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+    server.resetHandlers();
+  });
+  afterAll(() => {
+    server.close();
+  });
+
+  it.each`
+    step                       | cancelStep
+    ${'device-challenge-poll'} | ${'authenticatorChallenge-cancel'}
+    ${'challenge-poll'}        | ${'currentAuthenticator-cancel'}
+  `('successfully probes ports and sends challenge', async ({ step, cancelStep }) => {
+    server.use(
+      rest.get('http://localhost:2000/probe', async (_, res, ctx) => res(ctx.status(500))),
+      rest.get('http://localhost:6511/probe', async (_, res, ctx) => res(ctx.status(500))),
+      rest.get('http://localhost:6512/probe', async (_, res, ctx) => res(ctx.status(200))),
+      rest.post('http://localhost:6512/challenge', async (_, res, ctx) => res(ctx.status(200))),
+    );
+
+    const props: { uischema: LoopbackProbeElement } = {
+      uischema: {
+        type: 'LoopbackProbe',
+        options: {
+          deviceChallengePayload: {
+            ports: ['2000', '6511', '6512', '6513'],
+            domain: 'http://localhost',
+            challengeRequest: 'mockChallengeRequest',
+            probeTimeoutMillis: 100, // optional
+          },
+          cancelStep,
+          step,
+        },
+      },
+    };
+
+    render(<LoopbackProbe {...props} />);
+
+    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), { timeout: 100 });
+
+    expect(onSubmitHandler).toHaveBeenCalledWith({
+      step,
+    });
+  });
+
+  it.each`
+    step                       | cancelStep
+    ${'device-challenge-poll'} | ${'authenticatorChallenge-cancel'}
+    ${'challenge-poll'}        | ${'currentAuthenticator-cancel'}
+  `('found no ports', async ({ step, cancelStep }) => {
+    server.use(
+      rest.get(/http:\/\/localhost:\d{4}\/probe/, async (_, res, ctx) => res(ctx.status(500))),
+    );
+
+    const props: { uischema: LoopbackProbeElement } = {
+      uischema: {
+        type: 'LoopbackProbe',
+        options: {
+          deviceChallengePayload: {
+            ports: ['2000', '6511', '6512', '6513'],
+            domain: 'http://localhost',
+            challengeRequest: 'mockChallengeRequest',
+            probeTimeoutMillis: 100, // optional
+          },
+          cancelStep,
+          step,
+        },
+      },
+    };
+
+    render(<LoopbackProbe {...props} />);
+
+    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), { timeout: 100 });
+
+    expect(onSubmitHandler).toHaveBeenCalledWith({
+      isActionStep: true,
+      step: cancelStep,
+      params: {
+        reason: 'OV_UNREACHABLE_BY_LOOPBACK',
+        statusCode: null,
+      },
+    });
+  });
+
+  it('successfully probes ports but challenge returns non-503 error status', async () => {
+    server.use(
+      rest.get('http://localhost:2000/probe', async (_, res, ctx) => res(ctx.status(500))),
+      rest.get('http://localhost:6511/probe', async (_, res, ctx) => res(ctx.status(500))),
+      rest.get('http://localhost:6512/probe', async (_, res, ctx) => res(ctx.status(200))),
+      rest.post('http://localhost:6512/challenge', async (_, res, ctx) => res(ctx.status(400))),
+    );
+
+    const props: { uischema: LoopbackProbeElement } = {
+      uischema: {
+        type: 'LoopbackProbe',
+        options: {
+          deviceChallengePayload: {
+            ports: ['2000', '6511', '6512', '6513'],
+            domain: 'http://localhost',
+            challengeRequest: 'mockChallengeRequest',
+            probeTimeoutMillis: 100, // optional
+          },
+          cancelStep: 'authenticatorChallenge-cancel',
+          step: 'device-challenge-poll',
+        },
+      },
+    };
+
+    render(<LoopbackProbe {...props} />);
+
+    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), { timeout: 100 });
+
+    expect(onSubmitHandler).toHaveBeenCalledWith({
+      isActionStep: true,
+      step: 'authenticatorChallenge-cancel',
+      params: {
+        reason: 'OV_RETURNED_ERROR',
+        statusCode: 400,
+      },
+    });
+  });
+
+  it('challenge returns 503 error status but later port succeeds', async () => {
+    server.use(
+      rest.get('http://localhost:2000/probe', async (_, res, ctx) => res(ctx.status(500))),
+      rest.get('http://localhost:6511/probe', async (_, res, ctx) => res(ctx.status(500))),
+      rest.get('http://localhost:6512/probe', async (_, res, ctx) => res(ctx.status(200))),
+      rest.get('http://localhost:6513/probe', async (_, res, ctx) => res(ctx.status(200))),
+      rest.post('http://localhost:6512/challenge', async (_, res, ctx) => res(ctx.status(503))),
+      rest.post('http://localhost:6513/challenge', async (_, res, ctx) => res(ctx.status(200))),
+    );
+
+    const props: { uischema: LoopbackProbeElement } = {
+      uischema: {
+        type: 'LoopbackProbe',
+        options: {
+          deviceChallengePayload: {
+            ports: ['2000', '6511', '6512', '6513'],
+            domain: 'http://localhost',
+            challengeRequest: 'mockChallengeRequest',
+            probeTimeoutMillis: 100, // optional
+          },
+          cancelStep: 'authenticatorChallenge-cancel',
+          step: 'device-challenge-poll',
+        },
+      },
+    };
+
+    render(<LoopbackProbe {...props} />);
+
+    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), { timeout: 100 });
+
+    expect(onSubmitHandler).toHaveBeenCalledWith({
+      step: 'device-challenge-poll',
+    });
+  });
+
+  it('port probe request times out', async () => {
+    server.use(
+      rest.get('http://localhost:2000/probe', async (_, res, ctx) => res(ctx.status(500))),
+      rest.get('http://localhost:6511/probe', async (_, res, ctx) => res(ctx.status(500))),
+      rest.get('http://localhost:6512/probe', async (_, res, ctx) => res(
+        // This is the right port, but it should fail due to timeout
+        // probeTimeoutMillis is set to 100ms
+        ctx.delay(200),
+        ctx.status(200),
+      )),
+      rest.get('http://localhost:6513/probe', async (_, res, ctx) => res(ctx.status(500))),
+    );
+
+    const props: { uischema: LoopbackProbeElement } = {
+      uischema: {
+        type: 'LoopbackProbe',
+        options: {
+          deviceChallengePayload: {
+            ports: ['2000', '6511', '6512', '6513'],
+            domain: 'http://localhost',
+            challengeRequest: 'mockChallengeRequest',
+            probeTimeoutMillis: 100, // optional
+          },
+          cancelStep: 'authenticatorChallenge-cancel',
+          step: 'device-challenge-poll',
+        },
+      },
+    };
+
+    render(<LoopbackProbe {...props} />);
+
+    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), {
+      timeout: 300, // need to wait longer since we are testing request timeout
+    });
+
+    expect(onSubmitHandler).toHaveBeenCalledWith({
+      isActionStep: true,
+      step: 'authenticatorChallenge-cancel',
+      params: {
+        reason: 'OV_UNREACHABLE_BY_LOOPBACK',
+        statusCode: null,
+      },
+    });
+  });
+});

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -82,10 +82,12 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
     }
   };
 
+  /* eslint-disable no-await-in-loop, no-continue */
   useEffect(() => {
     const doLoopback = async () => {
       let foundPort = false;
       // loop over each port
+      // eslint-disable-next-line no-restricted-syntax
       for (const port of ports) {
         try {
           // probe the port
@@ -165,6 +167,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
     doLoopback();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  /* eslint-enable no-await-in-loop, no-continue */
 
   return null;
 };

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -69,8 +69,8 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
   const probeTimeoutMillis: number = typeof deviceChallengePayload.probeTimeoutMillis === 'undefined'
     ? 100 : deviceChallengePayload.probeTimeoutMillis;
   const ports: number[] = deviceChallengePayload.ports || [];
-  const domain: string = deviceChallengePayload.domain;
-  const challengeRequest: string = deviceChallengePayload.challengeRequest;
+  const { domain } = deviceChallengePayload;
+  const { challengeRequest } = deviceChallengePayload;
 
   const cancelHandler = (params?: Record<string, unknown> | undefined) => {
     if (typeof cancelStep !== 'undefined') {
@@ -84,7 +84,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
 
   useEffect(() => {
     const doLoopback = async () => {
-      let foundPort: boolean = false;
+      let foundPort = false;
       // loop over each port
       for (const port of ports) {
         try {
@@ -142,7 +142,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
           // only for unexpected error conditions (e.g. fetch throws an error)
           Logger.error(`Something unexpected happened while we were checking port ${port}`);
         }
-      };
+      }
 
       if (foundPort) {
         // success condition

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -88,8 +88,10 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
   const probeTimeoutMillis: number = typeof deviceChallengePayload.probeTimeoutMillis === 'undefined'
     ? 100 : deviceChallengePayload.probeTimeoutMillis;
   const ports: string[] = deviceChallengePayload.ports || [];
-  const { domain } = deviceChallengePayload;
-  const { challengeRequest } = deviceChallengePayload;
+  const {
+    domain,
+    challengeRequest,
+  } = deviceChallengePayload;
 
   const cancelHandler = (params?: ActionParams) => {
     if (typeof cancelStep !== 'undefined') {

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -87,7 +87,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
 
   const probeTimeoutMillis: number = typeof deviceChallengePayload.probeTimeoutMillis === 'undefined'
     ? 100 : deviceChallengePayload.probeTimeoutMillis;
-  const ports: number[] = deviceChallengePayload.ports || [];
+  const ports: string[] = deviceChallengePayload.ports || [];
   const { domain } = deviceChallengePayload;
   const { challengeRequest } = deviceChallengePayload;
 
@@ -144,13 +144,13 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
             // the wrong OS profile responds to the challenge request
             if (challengeResponse.status !== 503) {
               // when challenge response with other error statuses,
-              // cancel polling and return
+              // cancel polling and return immediately
               cancelHandler({
                 reason: 'OV_RETURNED_ERROR',
                 statusCode: challengeResponse.status,
               });
 
-              break;
+              return;
             }
             // no errors but this is not the port we're looking for
             // continue with next loop iteration

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -10,8 +10,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { FunctionComponent, h } from 'preact';
+import { FunctionComponent } from 'preact';
 import { useEffect } from 'preact/hooks';
+import crossFetch from 'cross-fetch';
 import Logger from 'util/Logger';
 import { useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';
@@ -34,6 +35,7 @@ type RequestOptions = {
 const makeRequest = async ({ url, timeout, method, data }: RequestOptions) => {
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeout);
+  const fetch = global.fetch || crossFetch;
 
   const response = await fetch(url, {
     method,

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -25,7 +25,13 @@ type RequestOptions = {
   data?: string;
 }
 
-const makeRequest = async ({ url, timeout, method = 'GET', data }: RequestOptions) => {
+/**
+ * Temporary request client to be removed once this functionality is added
+ * to auth-js library.
+ * @see https://oktainc.atlassian.net/browse/OKTA-561852
+ * @returns Promise<Response>
+ */
+const makeRequest = async ({ url, timeout, method, data }: RequestOptions) => {
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeout);
 
@@ -40,22 +46,23 @@ const makeRequest = async ({ url, timeout, method = 'GET', data }: RequestOption
   return response;
 }
 
-const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({ uischema }) => {
-  const {
-    options: {
-      ports,
-      domain,
-      challengeRequest,
-    },
-  } = uischema;
+const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = () => {
   const onSubmitHandler = useOnSubmit();
   const context = useWidgetContext();
   const { idxTransaction } = context;
   const relatesTo = idxTransaction?.nextStep?.relatesTo;
+
   // @ts-expect-error probeTimeoutMillis is not on IdxAuthenticator
-  const probeTimeoutMillis = typeof relatesTo?.value.probeTimeoutMillis === 'undefined' ?
+  const probeTimeoutMillis: number = typeof relatesTo?.value.probeTimeoutMillis === 'undefined' ?
     // @ts-expect-error probeTimeoutMillis is not on IdxAuthenticator
     100 : relatesTo?.value.probeTimeoutMillis;
+  // @ts-expect-error ports is not on IdxAuthenticator
+  const ports: number[] = relatesTo?.value.ports || [];
+  // @ts-expect-error domain is not on IdxAuthenticator
+  const domain: string = relatesTo?.value.domain;
+  // @ts-expect-error challengeRequest is not on IdxAuthenticator
+  const challengeRequest: string = relatesTo?.value.challengeRequest;
+
   const cancelStep = idxTransaction?.availableSteps?.find(({ name }) => name === 'authenticatorChallenge-cancel');
   const cancelHandler = (params?: Record<string, unknown> | undefined) => {
     if (typeof cancelStep !== 'undefined') {
@@ -101,7 +108,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({ 
 
               return false;
             }
-            // there's more ports to try continue with next port
+            // there's more ports to try, continue with next port
             return true;
           }
 

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -10,9 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-// Allow this shadow dependency from auth-js because it is temporary
-// eslint-disable-next-line import/no-extraneous-dependencies
-import crossFetch from 'cross-fetch';
+import fetch from 'cross-fetch';
 import { FunctionComponent } from 'preact';
 import { useEffect } from 'preact/hooks';
 
@@ -29,7 +27,7 @@ type RequestOptions = {
 };
 
 /**
- * Temporary request client to be removed once this functionality is added
+ * Temporary request client can be removed if this functionality is added
  * to auth-js library.
  * @see https://oktainc.atlassian.net/browse/OKTA-561852
  * @returns Promise<Response>
@@ -39,7 +37,6 @@ const makeRequest = async ({
 }: RequestOptions) => {
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeout);
-  const fetch = global.fetch || crossFetch;
 
   const response = await fetch(url, {
     method,

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -18,7 +18,7 @@ import { useEffect } from 'preact/hooks';
 
 import Logger from '../../../../util/Logger';
 import { useOnSubmit } from '../../hooks';
-import { LoopbackProbeElement } from '../../types';
+import { ActionParams, LoopbackProbeElement } from '../../types';
 import { isAndroid } from '../../util';
 
 type RequestOptions = {
@@ -72,7 +72,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
   const { domain } = deviceChallengePayload;
   const { challengeRequest } = deviceChallengePayload;
 
-  const cancelHandler = (params?: Record<string, unknown> | undefined) => {
+  const cancelHandler = (params?: ActionParams) => {
     if (typeof cancelStep !== 'undefined') {
       onSubmitHandler({
         isActionStep: true,

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { FunctionComponent, h } from 'preact';
+import { useEffect } from 'preact/hooks';
+import { useWidgetContext } from '../../contexts';
+import { useOnSubmit } from '../../hooks';
+import { LoopbackProbeElement } from '../../types';
+
+type RequestOptions = {
+  url: string;
+  method?: 'GET' | 'POST';
+  data?: string;
+}
+
+// add timeout option: https://dmitripavlutin.com/timeout-fetch-request/
+const makeRequest = async ({ url, method = 'GET', data }: RequestOptions) => {
+  console.warn(`[LoopbackProbe#makeRequest]: Making a ${method} request to ${url}`);
+  try {
+    const response = await fetch(url, {
+      method,
+      ...(typeof data === 'string' ? { body: data } : {}),
+    });
+
+    return response;
+  } catch (e) {
+    throw new Error(`Failed to make a request to ${url}.`);
+  }
+}
+
+const checkPort = async (domain: string, port: number): Promise<number> => {
+  try {
+    // deviceChallenge.domain is where the baseUrl should come from
+    const response = await makeRequest({
+      url: `${domain}:${port}/probe`,
+    });
+
+    if (!response.ok) {
+      throw new Error();
+    }
+  } catch (e) {
+    // TODO: use Logger.error
+    console.warn(`Something unexpected happened while we were checking port ${port}`);
+    throw e;
+  }
+
+  return port;
+}
+
+const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({ uischema }) => {
+  const {
+    options: {
+      ports,
+      domain,
+      challengeRequest,
+    },
+  } = uischema;
+  const onSubmitHandler = useOnSubmit();
+  const context = useWidgetContext();
+  const { idxTransaction } = context;
+  const cancelStep = idxTransaction?.availableSteps?.find(({ name }) => name === 'authenticatorChallenge-cancel');
+  const cancelHandler = (params?: Record<string, unknown> | undefined) => {
+    if (typeof cancelStep !== 'undefined') {
+      onSubmitHandler({
+        isActionStep: true,
+        step: cancelStep?.name,
+        params,
+      });
+    }
+  };
+
+  useEffect(() => {
+    const doProbing = async () => {
+      const promises = ports.map((portNumber) => {
+        return checkPort(domain, portNumber);
+      });
+
+      try {
+        // @ts-expect-error TODO see if we can update to es2021
+        const successPort = await Promise.any(promises);
+        console.warn('success!', successPort);
+        return successPort;
+      } catch (e) {
+        // TODO; use Logger.error
+        console.warn('No available ports. Loopback server failed and polling is cancelled');
+        // call cancel polling method
+        cancelHandler({
+          reason: 'OV_UNREACHABLE_BY_LOOPBACK',
+          statusCode: null,
+        });
+
+        // // @ts-expect-error es2021 issue
+        // if (e instanceof AggregateError) {
+        //   // @ts-expect-error es2021 issue
+        //   console.warn(e.errors);
+        // }
+      }
+    };
+
+    const onPortFound = async (port: number) => {
+      const response = await makeRequest({
+        url: `${domain}:${port}/challenge`,
+        method: 'POST',
+        // todo get actual challengeRequest value
+        data: JSON.stringify({ challengeRequest }),
+      });
+      if (!response.ok) {
+        if (response.status !== 503) {
+          // Windows and MacOS return status code 503 when 
+          // there are multiple profiles on the device and
+          // the wrong OS profile responds to the challenge request
+          cancelHandler({
+            reason: 'OV_RETURNED_ERROR',
+            statusCode: response.status,
+          });
+        }
+      }
+    };
+    const main = async () => {
+      const loopbackServerPort = await doProbing();
+
+      if (loopbackServerPort) {
+        await onPortFound(loopbackServerPort);
+        // trigger another poll
+        onSubmitHandler({
+          step: 'device-challenge-poll',
+        });
+      }
+    };
+
+    main();
+  }, []);
+
+  return null;
+};
+
+export default LoopbackProbe;

--- a/src/v3/src/components/LoopbackProbe/index.ts
+++ b/src/v3/src/components/LoopbackProbe/index.ts
@@ -10,6 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export * from './transformOktaVerifyDeviceChallengePoll';
-export * from './transformOktaVerifyFPLoopbackPoll';
-export * from './transformOktaVerifyFPLaunchAuthenticator';
+import LoopbackProbe from './LoopbackProbe';
+
+export default LoopbackProbe;

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -57,6 +57,7 @@ import {
 } from './googleAuthenticator';
 import {
   transformOktaVerifyDeviceChallengePoll,
+  transformOktaVerifyFPLoopbackPoll,
   transformOktaVerifyFPLaunchAuthenticator,
 } from './oktaVerify';
 import { transformPIVAuthenticator } from './piv';
@@ -179,6 +180,13 @@ const TransformerMap: {
   [IDX_STEP.DEVICE_CHALLENGE_POLL]: {
     [CHALLENGE_METHOD.CUSTOM_URI]: {
       transform: transformOktaVerifyDeviceChallengePoll,
+      buttonConfig: {
+        showDefaultSubmit: false,
+        showDefaultCancel: true,
+      },
+    },
+    [CHALLENGE_METHOD.LOOPBACK]: {
+      transform: transformOktaVerifyFPLoopbackPoll,
       buttonConfig: {
         showDefaultSubmit: false,
         showDefaultCancel: true,

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -57,8 +57,8 @@ import {
 } from './googleAuthenticator';
 import {
   transformOktaVerifyDeviceChallengePoll,
-  transformOktaVerifyFPLoopbackPoll,
   transformOktaVerifyFPLaunchAuthenticator,
+  transformOktaVerifyFPLoopbackPoll,
 } from './oktaVerify';
 import { transformPIVAuthenticator } from './piv';
 import {

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -189,7 +189,7 @@ const TransformerMap: {
       transform: transformOktaVerifyFPLoopbackPoll,
       buttonConfig: {
         showDefaultSubmit: false,
-        showDefaultCancel: true,
+        showDefaultCancel: false,
       },
     },
   },

--- a/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyDeviceChallengePoll.test.ts.snap
+++ b/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyDeviceChallengePoll.test.ts.snap
@@ -1,6 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Transform Okta Verify Device Challenge Poll Tests should transform elements when challengeMethod is CUSTOM_URI 1`] = `
+exports[`Transform Okta Verify Device Challenge Poll Tests where remediation is challenge-poll should transform elements when challengeMethod is CUSTOM_URI 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "customUri.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "customUri.required.content.prompt",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "href": "okta-verify.html",
+          "step": "challenge-poll",
+        },
+        "type": "OpenOktaVerifyFPButton",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "customUri.required.content.download.title",
+        },
+        "type": "Description",
+      },
+      Object {
+        "options": Object {
+          "href": "https://apps.apple.com/us/app/okta-verify/id490179405",
+          "label": "customUri.required.content.download.linkText",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Transform Okta Verify Device Challenge Poll Tests where remediation is device-challenge-poll should transform elements when challengeMethod is CUSTOM_URI 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {

--- a/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyFPLoopbackPoll.test.ts.snap
+++ b/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyFPLoopbackPoll.test.ts.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Transform Okta Verify FP Loopback Poll where remediation is challenge-poll should create Loopback Poll elements for display 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "deviceTrust.sso.redirectText",
+        },
+        "type": "Title",
+      },
+      Object {
+        "type": "Spinner",
+      },
+      Object {
+        "options": Object {
+          "cancelStep": "currentAuthenticator-cancel",
+          "deviceChallengePayload": Object {
+            "challengeRequest": "mockChallengeRequest",
+            "domain": "http://localhost",
+            "ports": Array [
+              "2000",
+              "6511",
+              "6512",
+              "6513",
+            ],
+          },
+          "step": "challenge-poll",
+        },
+        "type": "LoopbackProbe",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "actionParams": Object {
+            "reason": "USER_CANCELED",
+            "statusCode": null,
+          },
+          "isActionStep": true,
+          "label": "goback",
+          "step": "currentAuthenticator-cancel",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Transform Okta Verify FP Loopback Poll where remediation is device-challenge-poll should create Loopback Poll elements for display when step is device-challenge-poll 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "deviceTrust.sso.redirectText",
+        },
+        "type": "Title",
+      },
+      Object {
+        "type": "Spinner",
+      },
+      Object {
+        "options": Object {
+          "cancelStep": "authenticatorChallenge-cancel",
+          "deviceChallengePayload": Object {
+            "challengeRequest": "mockChallengeRequest",
+            "domain": "http://localhost",
+            "ports": Array [
+              "2000",
+              "6511",
+              "6512",
+              "6513",
+            ],
+          },
+          "step": "device-challenge-poll",
+        },
+        "type": "LoopbackProbe",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "actionParams": Object {
+            "reason": "USER_CANCELED",
+            "statusCode": null,
+          },
+          "isActionStep": true,
+          "label": "goback",
+          "step": "authenticatorChallenge-cancel",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/layout/oktaVerify/index.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/index.ts
@@ -11,5 +11,5 @@
  */
 
 export * from './transformOktaVerifyDeviceChallengePoll';
-export * from './transformOktaVerifyFPLoopbackPoll';
 export * from './transformOktaVerifyFPLaunchAuthenticator';
+export * from './transformOktaVerifyFPLoopbackPoll';

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.test.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.test.ts
@@ -80,9 +80,9 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
                   challengeMethod: 'CUSTOM_URI',
                   href: 'okta-verify.html',
                   downloadHref: 'https://apps.apple.com/us/app/okta-verify/id490179405',
-                }
-              }
-            }
+                },
+              },
+            },
           },
         },
       };

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.test.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.test.ts
@@ -26,41 +26,89 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
   const formBag = getStubFormBag();
   const widgetProps: WidgetProps = {};
 
-  beforeEach(() => {
-    formBag.uischema.elements = [];
-    transaction.nextStep = {
-      name: '',
-      relatesTo: {
-        value: {
-          // @ts-expect-error Property 'challengeMethod' does not exist on type 'IdxAuthenticator'.
-          challengeMethod: 'CUSTOM_URI',
-          href: 'okta-verify.html',
-          downloadHref: 'https://apps.apple.com/us/app/okta-verify/id490179405',
+  describe('where remediation is device-challenge-poll', () => {
+    beforeEach(() => {
+      formBag.uischema.elements = [];
+      transaction.nextStep = {
+        name: 'device-challenge-poll',
+        relatesTo: {
+          value: {
+            // @ts-expect-error Property 'challengeMethod' does not exist on type 'IdxAuthenticator'.
+            challengeMethod: 'CUSTOM_URI',
+            href: 'okta-verify.html',
+            downloadHref: 'https://apps.apple.com/us/app/okta-verify/id490179405',
+          },
         },
-      },
-    };
-  });
-
-  it('should transform elements when challengeMethod is CUSTOM_URI', () => {
-    const updatedFormBag = transformOktaVerifyDeviceChallengePoll({
-      transaction,
-      formBag,
-      widgetProps,
+      };
     });
 
-    expect(updatedFormBag).toMatchSnapshot();
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('customUri.title');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe('customUri.required.content.prompt');
-    expect((updatedFormBag.uischema.elements[2] as OpenOktaVerifyFPButtonElement).options.href)
-      .toBe('okta-verify.html');
-    expect((updatedFormBag.uischema.elements[3] as DescriptionElement).options.content)
-      .toBe('customUri.required.content.download.title');
-    expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)
-      .toBe('customUri.required.content.download.linkText');
-    expect((updatedFormBag.uischema.elements[4] as LinkElement).options.href)
-      .toBe('https://apps.apple.com/us/app/okta-verify/id490179405');
+    it('should transform elements when challengeMethod is CUSTOM_URI', () => {
+      const updatedFormBag = transformOktaVerifyDeviceChallengePoll({
+        transaction,
+        formBag,
+        widgetProps,
+      });
+
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('customUri.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('customUri.required.content.prompt');
+      expect((updatedFormBag.uischema.elements[2] as OpenOktaVerifyFPButtonElement).options.href)
+        .toBe('okta-verify.html');
+      expect((updatedFormBag.uischema.elements[3] as DescriptionElement).options.content)
+        .toBe('customUri.required.content.download.title');
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)
+        .toBe('customUri.required.content.download.linkText');
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.href)
+        .toBe('https://apps.apple.com/us/app/okta-verify/id490179405');
+    });
+  });
+
+  describe('where remediation is challenge-poll', () => {
+    beforeEach(() => {
+      formBag.uischema.elements = [];
+      transaction.nextStep = {
+        name: 'challenge-poll',
+        relatesTo: {
+          value: {
+            contextualData: {
+              // @ts-expect-error Property 'challenge' does not exist
+              challenge: {
+                value: {
+                  challengeMethod: 'CUSTOM_URI',
+                  href: 'okta-verify.html',
+                  downloadHref: 'https://apps.apple.com/us/app/okta-verify/id490179405',
+                }
+              }
+            }
+          },
+        },
+      };
+    });
+
+    it('should transform elements when challengeMethod is CUSTOM_URI', () => {
+      const updatedFormBag = transformOktaVerifyDeviceChallengePoll({
+        transaction,
+        formBag,
+        widgetProps,
+      });
+
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('customUri.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+        .toBe('customUri.required.content.prompt');
+      expect((updatedFormBag.uischema.elements[2] as OpenOktaVerifyFPButtonElement).options.href)
+        .toBe('okta-verify.html');
+      expect((updatedFormBag.uischema.elements[3] as DescriptionElement).options.content)
+        .toBe('customUri.required.content.download.title');
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)
+        .toBe('customUri.required.content.download.linkText');
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.href)
+        .toBe('https://apps.apple.com/us/app/okta-verify/id490179405');
+    });
   });
 });

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
@@ -27,8 +27,12 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
   formBag,
 }) => {
   const { nextStep = {} as NextStep } = transaction;
-  const { relatesTo } = nextStep;
   const { uischema } = formBag;
+
+  const deviceChallengePayload = transaction.nextStep?.name === IDX_STEP.DEVICE_CHALLENGE_POLL
+    ? transaction.nextStep?.relatesTo?.value
+    // @ts-expect-error challenge is not defined on contextualData
+    : transaction.nextStep?.relatesTo?.value?.contextualData?.challenge?.value;
 
   uischema.elements.unshift({
     type: 'Title',
@@ -44,9 +48,8 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
   uischema.elements.push({
     type: 'OpenOktaVerifyFPButton',
     options: {
-      step: IDX_STEP.DEVICE_CHALLENGE_POLL,
-      // @ts-expect-error Property 'href' does not exist on type 'IdxAuthenticator'.
-      href: relatesTo?.value.href,
+      step: nextStep.name,
+      href: deviceChallengePayload.href,
     },
   } as OpenOktaVerifyFPButtonElement);
 
@@ -60,8 +63,7 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
     type: 'Link',
     options: {
       label: loc('customUri.required.content.download.linkText', 'login'),
-      // @ts-expect-error Property 'downloadHref' does not exist on type 'IdxAuthenticator'.
-      href: relatesTo?.value.downloadHref,
+      href: deviceChallengePayload.downloadHref
     },
   } as LinkElement);
 

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
@@ -63,7 +63,7 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
     type: 'Link',
     options: {
       label: loc('customUri.required.content.download.linkText', 'login'),
-      href: deviceChallengePayload.downloadHref
+      href: deviceChallengePayload.downloadHref,
     },
   } as LinkElement);
 

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.test.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
+
+import {
+  LinkElement, LoopbackProbeElement, SpinnerElement, TitleElement, WidgetProps,
+} from '../../../types';
+import { transformOktaVerifyFPLoopbackPoll } from './transformOktaVerifyFPLoopbackPoll';
+
+describe('Transform Okta Verify FP Loopback Poll', () => {
+  const transaction = getStubTransactionWithNextStep();
+  const formBag = getStubFormBag();
+  let widgetProps: WidgetProps;
+
+  describe('where remediation is device-challenge-poll', () => {
+    beforeEach(() => {
+      formBag.uischema.elements = [];
+      transaction.nextStep = {
+        name: 'device-challenge-poll',
+        relatesTo: {
+          value: {
+            // @ts-expect-error ports does not exist on IdxAuthenticator
+            ports: ['2000', '6511', '6512', '6513'],
+            domain: 'http://localhost',
+            challengeRequest: 'mockChallengeRequest',
+          },
+        },
+      };
+    });
+
+    it('should create Loopback Poll elements for display when step is device-challenge-poll', () => {
+      const updatedFormBag = transformOktaVerifyFPLoopbackPoll({
+        transaction,
+        formBag,
+        widgetProps,
+      });
+
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).type)
+        .toBe('Title');
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('deviceTrust.sso.redirectText');
+      expect((updatedFormBag.uischema.elements[1] as SpinnerElement).type)
+        .toBe('Spinner');
+      expect((updatedFormBag.uischema.elements[2] as LoopbackProbeElement).type)
+        .toBe('LoopbackProbe');
+      expect((updatedFormBag.uischema.elements[2] as LoopbackProbeElement).options)
+        .toStrictEqual({
+          deviceChallengePayload: {
+            ports: ['2000', '6511', '6512', '6513'],
+            domain: 'http://localhost',
+            challengeRequest: 'mockChallengeRequest',
+          },
+          cancelStep: 'authenticatorChallenge-cancel',
+          step: 'device-challenge-poll',
+        });
+      expect((updatedFormBag.uischema.elements[3] as LinkElement).type)
+        .toBe('Link');
+      expect((updatedFormBag.uischema.elements[3] as LinkElement).options.step)
+        .toBe('authenticatorChallenge-cancel');
+    });
+  });
+
+  describe('where remediation is challenge-poll', () => {
+    beforeEach(() => {
+      formBag.uischema.elements = [];
+      transaction.nextStep = {
+        name: 'challenge-poll',
+        relatesTo: {
+          value: {
+            contextualData: {
+              // @ts-expect-error challenge does not exist on contextualData
+              challenge: {
+                value: {
+                  ports: ['2000', '6511', '6512', '6513'],
+                  domain: 'http://localhost',
+                  challengeRequest: 'mockChallengeRequest',
+                },
+              },
+            },
+          },
+        },
+      };
+    });
+
+    it('should create Loopback Poll elements for display', () => {
+      const updatedFormBag = transformOktaVerifyFPLoopbackPoll({
+        transaction,
+        formBag,
+        widgetProps,
+      });
+
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).type)
+        .toBe('Title');
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('deviceTrust.sso.redirectText');
+      expect((updatedFormBag.uischema.elements[1] as SpinnerElement).type)
+        .toBe('Spinner');
+      expect((updatedFormBag.uischema.elements[2] as LoopbackProbeElement).type)
+        .toBe('LoopbackProbe');
+      expect((updatedFormBag.uischema.elements[2] as LoopbackProbeElement).options)
+        .toStrictEqual({
+          deviceChallengePayload: {
+            ports: ['2000', '6511', '6512', '6513'],
+            domain: 'http://localhost',
+            challengeRequest: 'mockChallengeRequest',
+          },
+          cancelStep: 'currentAuthenticator-cancel',
+          step: 'challenge-poll',
+        });
+      expect((updatedFormBag.uischema.elements[3] as LinkElement).type)
+        .toBe('Link');
+      expect((updatedFormBag.uischema.elements[3] as LinkElement).options.step)
+        .toBe('currentAuthenticator-cancel');
+    });
+  });
+});

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { NextStep } from '@okta/okta-auth-js';
+
+import {
+  IdxStepTransformer,
+  LoopbackProbeElement,
+  SpinnerElement,
+  TitleElement,
+} from '../../../types';
+import { loc } from '../../../util';
+
+export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
+  transaction,
+  formBag,
+}) => {
+  const { nextStep = {} as NextStep } = transaction;
+  const { relatesTo } = nextStep;
+  const { uischema } = formBag;
+
+  uischema.elements.unshift({
+    type: 'Title',
+    options: { content: loc('deviceTrust.sso.redirectText', 'login') },
+  } as TitleElement);
+
+  uischema.elements.push({
+    type: 'Spinner',
+  } as SpinnerElement);
+
+  uischema.elements.unshift({
+    type: 'LoopbackProbe',
+    options: {
+      // @ts-expect-error ports is not defined on value
+      ports: relatesTo?.value.ports,
+      // @ts-expect-error ports is not defined on value
+      domain: relatesTo?.value.domain,
+      // @ts-expect-error ports is not defined on value
+      challengeRequest: relatesTo?.value.challengeRequest,
+    },
+  } as LoopbackProbeElement);
+
+  return formBag;
+};

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
@@ -14,6 +14,7 @@ import { NextStep } from '@okta/okta-auth-js';
 
 import {
   IdxStepTransformer,
+  LinkElement,
   LoopbackProbeElement,
   SpinnerElement,
   TitleElement,
@@ -37,7 +38,7 @@ export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
     type: 'Spinner',
   } as SpinnerElement);
 
-  uischema.elements.unshift({
+  uischema.elements.push({
     type: 'LoopbackProbe',
     options: {
       // @ts-expect-error ports is not defined on value
@@ -48,6 +49,20 @@ export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
       challengeRequest: relatesTo?.value.challengeRequest,
     },
   } as LoopbackProbeElement);
+
+  const cancelStep = transaction.availableSteps?.find(({ name }) => name === 'authenticatorChallenge-cancel');
+  if (typeof cancelStep !== 'undefined') {
+    const cancelLink: LinkElement = {
+      type: 'Link',
+      contentType: 'footer',
+      options: {
+        label: loc('goback', 'login'),
+        isActionStep: true,
+        step: cancelStep.name,
+      },
+    };
+    uischema.elements.push(cancelLink);
+  }
 
   return formBag;
 };

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
@@ -40,14 +40,6 @@ export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
 
   uischema.elements.push({
     type: 'LoopbackProbe',
-    options: {
-      // @ts-expect-error ports is not defined on value
-      ports: relatesTo?.value.ports,
-      // @ts-expect-error ports is not defined on value
-      domain: relatesTo?.value.domain,
-      // @ts-expect-error ports is not defined on value
-      challengeRequest: relatesTo?.value.challengeRequest,
-    },
   } as LoopbackProbeElement);
 
   const cancelStep = transaction.availableSteps?.find(({ name }) => name === 'authenticatorChallenge-cancel');

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
@@ -10,8 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { NextStep } from '@okta/okta-auth-js';
-
 import {
   IdxStepTransformer,
   LinkElement,
@@ -25,8 +23,6 @@ export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
   transaction,
   formBag,
 }) => {
-  const { nextStep = {} as NextStep } = transaction;
-  const { relatesTo } = nextStep;
   const { uischema } = formBag;
 
   uischema.elements.unshift({

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
@@ -35,12 +35,12 @@ export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
     type: 'Spinner',
   } as SpinnerElement);
 
-  const cancelStep = transaction.nextStep?.name === IDX_STEP.DEVICE_CHALLENGE_POLL ?
-    'authenticatorChallenge-cancel' : 'currentAuthenticator-cancel';
-  const deviceChallengePayload = transaction.nextStep?.name === IDX_STEP.DEVICE_CHALLENGE_POLL ?
-    transaction.nextStep?.relatesTo?.value :
+  const cancelStep = transaction.nextStep?.name === IDX_STEP.DEVICE_CHALLENGE_POLL
+    ? 'authenticatorChallenge-cancel' : 'currentAuthenticator-cancel';
+  const deviceChallengePayload = transaction.nextStep?.name === IDX_STEP.DEVICE_CHALLENGE_POLL
+    ? transaction.nextStep?.relatesTo?.value
     // @ts-expect-error challenge is not defined on contextualData
-    transaction.nextStep?.relatesTo?.value?.contextualData?.challenge?.value;
+    : transaction.nextStep?.relatesTo?.value?.contextualData?.challenge?.value;
 
   uischema.elements.push({
     type: 'LoopbackProbe',

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
@@ -59,6 +59,10 @@ export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
         label: loc('goback', 'login'),
         isActionStep: true,
         step: cancelStep.name,
+        actionParams: {
+          reason: 'USER_CANCELED',
+          statusCode: null,
+        },
       },
     };
     uischema.elements.push(cancelLink);

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
@@ -21,9 +21,11 @@ import {
 } from 'src/types';
 
 import { transformOktaVerifyDeviceChallengePoll } from '../layout/oktaVerify/transformOktaVerifyDeviceChallengePoll';
+import { transformOktaVerifyFPLoopbackPoll } from '../layout/oktaVerify/transformOktaVerifyFPLoopbackPoll';
 import { transformOktaVerifyChallengePoll } from './transformOktaVerifyChallengePoll';
 
 jest.mock('../layout/oktaVerify/transformOktaVerifyDeviceChallengePoll');
+jest.mock('../layout/oktaVerify/transformOktaVerifyFPLoopbackPoll');
 
 describe('Transform Okta Verify Challenge Poll Tests', () => {
   const transaction = getStubTransactionWithNextStep();
@@ -167,6 +169,34 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
 
     expect(transformOktaVerifyDeviceChallengePoll).toHaveBeenCalledTimes(1);
     expect(transformOktaVerifyDeviceChallengePoll).toHaveBeenLastCalledWith({
+      transaction,
+      formBag,
+      widgetProps,
+    });
+  });
+
+  it('should call FP loopback poll transformer when selected authenticator method is signed_nonce AND challengeMethod is loopback', () => {
+    transaction.nextStep = {
+      name: '',
+      relatesTo: {
+        value: {
+          methods: [{ type: 'signed_nonce' }],
+          contextualData: {
+            // @ts-expect-error challenge is not on contextualData
+            challenge: {
+              value: {
+                challengeMethod: 'LOOPBACK',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    transformOktaVerifyChallengePoll({ transaction, formBag, widgetProps });
+
+    expect(transformOktaVerifyFPLoopbackPoll).toHaveBeenCalledTimes(1);
+    expect(transformOktaVerifyFPLoopbackPoll).toHaveBeenLastCalledWith({
       transaction,
       formBag,
       widgetProps,

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
@@ -12,6 +12,7 @@
 
 import { NextStep } from '@okta/okta-auth-js';
 
+import { CHALLENGE_METHOD } from '../../constants';
 import PhoneSvg from '../../img/phone-icon.svg';
 import {
   DescriptionElement,
@@ -22,7 +23,6 @@ import {
   SpinnerElement,
   TitleElement,
 } from '../../types';
-import { CHALLENGE_METHOD } from '../../constants';
 import { loc } from '../../util';
 import { transformOktaVerifyDeviceChallengePoll, transformOktaVerifyFPLoopbackPoll } from '../layout/oktaVerify';
 import { getUIElementWithName } from '../utils';

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
@@ -120,7 +120,7 @@ export const transformOktaVerifyChallengePoll: IdxStepTransformer = (options) =>
     }
   } else if (selectedMethod.type === 'signed_nonce') {
     if (relatesTo?.value.type === 'app') {
-      // selectedMethod.type === 'app' reflects a FastPass OV Loopback flow
+      // relatesTo.value.type === 'app' reflects a FastPass OV Loopback flow
       return transformOktaVerifyFPLoopbackPoll(options);
     }
     // selectedMethod.type === 'signed_nonce' reflects a FastPass OV flow

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
@@ -23,7 +23,7 @@ import {
   TitleElement,
 } from '../../types';
 import { loc } from '../../util';
-import { transformOktaVerifyDeviceChallengePoll } from '../layout/oktaVerify';
+import { transformOktaVerifyDeviceChallengePoll, transformOktaVerifyFPLoopbackPoll } from '../layout/oktaVerify';
 import { getUIElementWithName } from '../utils';
 
 export const transformOktaVerifyChallengePoll: IdxStepTransformer = (options) => {
@@ -119,6 +119,10 @@ export const transformOktaVerifyChallengePoll: IdxStepTransformer = (options) =>
       } as SpinnerElement);
     }
   } else if (selectedMethod.type === 'signed_nonce') {
+    if (relatesTo?.value.type === 'app') {
+      // selectedMethod.type === 'app' reflects a FastPass OV Loopback flow
+      return transformOktaVerifyFPLoopbackPoll(options);
+    }
     // selectedMethod.type === 'signed_nonce' reflects a FastPass OV flow
     return transformOktaVerifyDeviceChallengePoll(options);
   }

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
@@ -22,6 +22,7 @@ import {
   SpinnerElement,
   TitleElement,
 } from '../../types';
+import { CHALLENGE_METHOD } from '../../constants';
 import { loc } from '../../util';
 import { transformOktaVerifyDeviceChallengePoll, transformOktaVerifyFPLoopbackPoll } from '../layout/oktaVerify';
 import { getUIElementWithName } from '../utils';
@@ -119,11 +120,12 @@ export const transformOktaVerifyChallengePoll: IdxStepTransformer = (options) =>
       } as SpinnerElement);
     }
   } else if (selectedMethod.type === 'signed_nonce') {
-    if (relatesTo?.value.type === 'app') {
-      // relatesTo.value.type === 'app' reflects a FastPass OV Loopback flow
+    // selectedMethod.type === 'signed_nonce' reflects a FastPass OV flow
+    // @ts-expect-error ts(2339) Property 'challengeMethod' does not exist on type 'IdxAuthenticator'.
+    const challengeMethod = relatesTo?.value?.contextualData?.challenge?.value?.challengeMethod;
+    if (challengeMethod === CHALLENGE_METHOD.LOOPBACK) {
       return transformOktaVerifyFPLoopbackPoll(options);
     }
-    // selectedMethod.type === 'signed_nonce' reflects a FastPass OV flow
     return transformOktaVerifyDeviceChallengePoll(options);
   }
 

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -15,6 +15,7 @@ import {
   IdxMessage,
   IdxTransaction,
   Input,
+  NextStep,
   WebauthnVerificationValues,
 } from '@okta/okta-auth-js';
 import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';
@@ -258,6 +259,16 @@ export interface OpenOktaVerifyFPButtonElement extends UISchemaElement {
 
 export interface LoopbackProbeElement extends UISchemaElement {
   type: 'LoopbackProbe';
+  options: {
+    deviceChallengePayload: {
+      ports: number[];
+      domain: string;
+      challengeRequest: string;
+      probeTimeoutMillis?: number;
+    };
+    step: string;
+    cancelStep: string;
+  };
 }
 
 export interface TitleElement extends UISchemaElement {

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -258,11 +258,6 @@ export interface OpenOktaVerifyFPButtonElement extends UISchemaElement {
 
 export interface LoopbackProbeElement extends UISchemaElement {
   type: 'LoopbackProbe';
-  options: {
-    ports: number[];
-    domain: string;
-    challengeRequest: string;
-  };
 }
 
 export interface TitleElement extends UISchemaElement {

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -15,7 +15,6 @@ import {
   IdxMessage,
   IdxTransaction,
   Input,
-  NextStep,
   WebauthnVerificationValues,
 } from '@okta/okta-auth-js';
 import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -68,7 +68,7 @@ export type InputAttributes = {
 
 // flat params
 export type ActionParams = {
-  [key: string]: string | boolean | number;
+  [key: string]: string | boolean | number | null;
 };
 
 export interface ActionOptions {

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -256,6 +256,15 @@ export interface OpenOktaVerifyFPButtonElement extends UISchemaElement {
   };
 }
 
+export interface LoopbackProbeElement extends UISchemaElement {
+  type: 'LoopbackProbe';
+  options: {
+    ports: number[];
+    domain: string;
+    challengeRequest: string;
+  };
+}
+
 export interface TitleElement extends UISchemaElement {
   type: 'Title';
   options: {

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -260,7 +260,7 @@ export interface LoopbackProbeElement extends UISchemaElement {
   type: 'LoopbackProbe';
   options: {
     deviceChallengePayload: {
-      ports: number[];
+      ports: string[];
       domain: string;
       challengeRequest: string;
       probeTimeoutMillis?: number;

--- a/test/testcafe/framework/page-objects-v1/DeviceCodeActivatePageObject.js
+++ b/test/testcafe/framework/page-objects-v1/DeviceCodeActivatePageObject.js
@@ -74,7 +74,7 @@ export default class DeviceCodeActivatePageObject extends BasePageObject {
   }
 
   isBeaconTerminalPresent() {
-    return this.beacon.find('[data-se="factor-beacon"]').exists;
+    return Selector('[data-se="factor-beacon"]').exists;
   }
 
   isTryAgainButtonPresent() {

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -14,7 +14,6 @@ export default class BasePageObject {
   constructor(t) {
     this.t = t;
     this.url = '';
-    this.beacon = new Selector('.beacon-container');
     this.form = new BaseFormObject(t);
   }
 
@@ -235,7 +234,7 @@ export default class BasePageObject {
   }
 
   getBeaconClass() {
-    return this.beacon.find('[data-se="factor-beacon"]').getAttribute('class');
+    return Selector('[data-se="factor-beacon"]').getAttribute('class');
   }
 
   refresh() {

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -7,13 +7,8 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
   constructor(t) {
     super(t);
     this.t = t;
-    this.beacon = new Selector('.beacon-container');
     this.body = new Selector('.device-challenge-poll');
     this.footer = new Selector('.auth-footer');
-  }
-
-  getBeaconClass() {
-    return this.beacon.find('[data-se="factor-beacon"]').getAttribute('class');
   }
 
   /**

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -39,16 +39,29 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.footer.find('[data-se="sign-in-options"]');
   }
 
+  /**
+   * @deprecated use getCancelLink
+   */
   getFooterCancelPollingLink() {
-    return this.footer.find('[data-se="cancel-authenticator-challenge"]');
+    if (userVariables.v3) {
+      return this.getCancelLink();
+    }
+    return this.form.getLink('Cancel and take me to sign in');
   }
 
   getFooterSwitchAuthenticatorLink() {
     return this.footer.find('[data-se="switchAuthenticator"]');
   }
 
+  /**
+   * @deprecated use getCancelLink
+   */
   getFooterSignOutLink() {
-    return this.footer.find('[data-se="cancel"]');
+    if (userVariables.v3) {
+      return this.getCancelLink();
+    }
+    // return this.footer.find('[data-se="cancel"]');
+    return this.form.getLink('Take me to sign in');
   }
 
   async clickCancelPollingButton() {

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -39,9 +39,6 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.footer.find('[data-se="sign-in-options"]');
   }
 
-  /**
-   * @deprecated use getCancelLink
-   */
   getFooterCancelPollingLink() {
     if (userVariables.v3) {
       return this.getCancelLink();
@@ -53,9 +50,6 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.footer.find('[data-se="switchAuthenticator"]');
   }
 
-  /**
-   * @deprecated use getCancelLink
-   */
   getFooterSignOutLink() {
     if (userVariables.v3) {
       return this.getCancelLink();
@@ -77,7 +71,7 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
   }
 
   getDownloadOktaVerifyLink() {
-    return this.body.find('#download-ov').getAttribute('href');
+    return this.form.getLink('Download here').getAttribute('href');
   }
 
   getPrimaryButtonText() {
@@ -89,7 +83,11 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
   }
 
   async clickCancelAndGoBackLink() {
-    await this.t.click(Selector('a[data-se="cancel-authenticator-challenge"]'));
+    if (userVariables.v3) {
+      await this.t.click(this.getCancelLink());
+    } else {
+      await this.t.click(Selector('a[data-se="cancel-authenticator-challenge"]'));
+    }
   }
 
   async clickUniversalLink() {

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -60,8 +60,14 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     await this.t.click(this.getFooterSwitchAuthenticatorLink());
   }
 
-  getSpinner() {
-    return this.body.find('.spinner');
+  async hasSpinner() {
+    if (userVariables.v3) {
+      return this.form.getSpinner().exists;
+    }
+
+    const display = await this.body.find('.spinner').getStyleProperty('display');
+
+    return display === 'block';
   }
 
   getDownloadOktaVerifyLink() {

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -49,8 +49,7 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     if (userVariables.v3) {
       return this.getCancelLink();
     }
-    // return this.footer.find('[data-se="cancel"]');
-    return this.form.getLink('Take me to sign in');
+    return this.footer.find('[data-se="cancel"]');
   }
 
   async clickCancelPollingButton() {

--- a/test/testcafe/framework/page-objects/DeviceCodeActivatePageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceCodeActivatePageObject.js
@@ -69,7 +69,7 @@ export default class DeviceCodeActivatePageObject extends BasePageObject {
   }
 
   isBeaconTerminalPresent() {
-    return this.beacon.find('[data-se="factor-beacon"]').exists;
+    return Selector('[data-se="factor-beacon"]').exists;
   }
 
   isTryAgainButtonPresent() {

--- a/test/testcafe/framework/page-objects/DeviceEnrollmentTerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceEnrollmentTerminalPageObject.js
@@ -8,7 +8,6 @@ export default class DeviceEnrollmentTerminalPageObject extends BasePageObject {
   constructor(t) {
     super(t);
     this.t = t;
-    this.beacon = new Selector('.beacon-container');
     this.body = new Selector('.device-enrollment-terminal');
     this.footer = new Selector('.auth-footer');
   }
@@ -35,10 +34,6 @@ export default class DeviceEnrollmentTerminalPageObject extends BasePageObject {
 
   getBackLinkText() {
     return this.getBackLink().innerText;
-  }
-
-  getBeaconClass() {
-    return this.beacon.find('[data-se="factor-beacon"]').getAttribute('class');
   }
 
   getHeader() {

--- a/test/testcafe/framework/page-objects/SignInDevicePageObject.js
+++ b/test/testcafe/framework/page-objects/SignInDevicePageObject.js
@@ -6,13 +6,12 @@ export default class SignInDeviceViewPageObject extends BasePageObject {
   constructor(t) {
     super(t);
     this.t = t;
-    this.beacon = new Selector('.beacon-container');
     this.body = new Selector('.launch-authenticator');
     this.footer = new Selector('.auth-footer');
   }
 
-  getBeaconClass() {
-    return this.beacon.find('[data-se="factor-beacon"]').getAttribute('class');
+  getHeader() {
+    return this.body.find('[data-se="o-form-head"]').innerText;
   }
 
   getContentText() {

--- a/test/testcafe/framework/page-objects/TerminalPageObjectV3.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObjectV3.js
@@ -1,14 +1,9 @@
 import { Selector } from 'testcafe';
 import TerminalPageObject from './TerminalPageObject';
 
-const BEACON_SELECTOR = '[data-se="factor-beacon"]';
 const CANCEL_LINK = '[data-se="cancel"]';
 
 export default class TerminalPageObjectV3 extends TerminalPageObject {
-
-  getBeaconClass() {
-    return Selector(BEACON_SELECTOR).getAttribute('class');
-  }
 
   async signoutLinkExists() {
     const cancelElement = await Selector(CANCEL_LINK);

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -214,7 +214,7 @@ export default class BaseFormObject {
 
   getErrorBoxCount() {
     if (userVariables.v3) {
-      return within(this.el).getAllByRole('alert').count;
+      return within(this.el).queryAllByRole('alert').count;
     }
 
     return this.el.find(FORM_INFOBOX_ERROR).count;
@@ -222,7 +222,7 @@ export default class BaseFormObject {
 
   getErrorBoxText() {
     if (userVariables.v3) {
-      return within(this.el).getAllByRole('alert').nth(0).innerText;
+      return within(this.el).queryAllByRole('alert').nth(0).innerText;
     }
 
     return this.el.find(FORM_INFOBOX_ERROR).innerText;

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -352,7 +352,7 @@ test
   .requestHooks(loopbackFallbackLogger, universalLinkWithoutLaunchMock)('SSO Extension fails and falls back to universal link', async t => {
     loopbackFallbackLogger.clear();
     const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
-    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
+    await t.expect(deviceChallengeFalllbackPage.getFormTitle()).eql('Sign In');
     await t.expect(loopbackFallbackLogger.count(
       record => record.response.statusCode === 200 &&
         record.request.url.match(/introspect/)
@@ -360,8 +360,8 @@ test
     deviceChallengeFalllbackPage.clickOktaVerifyButton();
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
-    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign in with Okta FastPass');
-    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
+    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Sign in with Okta FastPass');
+    await t.expect(await deviceChallengePollPageObject.hasSpinner()).eql(true);
     await t.expect(deviceChallengePollPageObject.getPrimaryButtonText()).eql('Open Okta Verify');
     await t.expect(deviceChallengePollPageObject.getFooterLink().exists).eql(false);
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);

--- a/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
@@ -145,7 +145,7 @@ test.requestHooks(logger, mock)('probing and polling APIs are sent and responded
 });
 
 test
-  .meta('v3', false) // Need to add title when this specific type of error is returned (OKTA-TICKET?)
+  .meta('v3', false) // Need to add title when this specific type of error is returned (OKTA-564968)
   .requestHooks(logger, deviceInvalidatedErrorMsg)('add title when device or account is invalidated', async t => {
     mockCalls = 0;
     const deviceChallengePollPageObject = await setup(t);
@@ -154,7 +154,7 @@ test
   });
 
 test
-  .meta('v3', false) // Need to handle this error case correctly (OKTA-TICKET?)
+  .meta('v3', false) // Need to handle this error case correctly (OKTA-564970)
   .requestHooks(logger, nonIdxError)('Non IDX error', async t => {
     mockCalls = 0;
     const deviceChallengePollPageObject = await setup(t);

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -527,7 +527,7 @@ test
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Sign in with Okta FastPass');
 
-    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
+    await t.expect(await deviceChallengePollPageObject.hasSpinner()).eql(true);
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().innerText).eql('Cancel and take me to sign in');
 
     await t.wait(5000); // wait for FASTPASS_FALLBACK_SPINNER_TIMEOUT
@@ -571,7 +571,7 @@ test
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Sign in with Okta FastPass');
-    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
+    await t.expect(await deviceChallengePollPageObject.hasSpinner()).eql(true);
     await t.expect(deviceChallengePollPageObject.getPrimaryButtonText()).eql('Open Okta Verify');
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
     deviceChallengePollPageObject.clickUniversalLink();
@@ -683,13 +683,13 @@ test
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Sign in with Okta FastPass');
 
-    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
+    await t.expect(await deviceChallengePollPageObject.hasSpinner()).eql(true);
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().innerText).eql('Cancel and take me to sign in');
 
 
     await t.expect(deviceChallengePollPageObject.waitForPrimaryButtonAfterSpinner().innerText).eql('Open Okta Verify');
     await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
-    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('none');
+    await t.expect(await deviceChallengePollPageObject.hasSpinner()).eql(false);
 
     deviceChallengePollPageObject.clickAppLink();
     // verify login_hint has been appended to the app link url

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -613,7 +613,7 @@ test
   });
 
 test
-  .meta('v3', false) // Not yet implemented in v3
+  .meta('v3', false) // Not yet implemented in v3 (OKTA-560815)
   .requestHooks(LoginHintCustomURIMock)('expect login_hint in CustomURI when engFastpassMultipleAccounts is on', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
@@ -652,7 +652,7 @@ test
   });
 
 test
-  .meta('v3', false) // Not yet implemented in v3 (OKTA-548963)
+  .meta('v3', false) // Not yet implemented in v3 (OKTA-548963, OKTA-560815)
   .requestHooks(LoginHintUniversalLinkMock)('expect login_hint in UniversalLink with engFastpassMultipleAccounts on', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
@@ -690,7 +690,7 @@ test
   });
 
 test
-  .meta('v3', false) // Not yet implemented in v3 (OKTA-548963)
+  .meta('v3', false) // Not yet implemented in v3 (OKTA-548963, OKTA-560815)
   .requestHooks(LoginHintAppLinkMock)('expect login_hint in AppLink when engFastpassMultipleAccounts is on', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -295,7 +295,6 @@ async function setupLoopbackFallback(t) {
   return deviceChallengeFalllbackPage;
 }
 
-// TODO: sy- remove this comment: this test is passing
 test
   .requestHooks(loopbackSuccessLogger, loopbackSuccessMock)('in loopback server approach, probing and polling requests are sent and responded', async t => {
     const deviceChallengePollPageObject = await setup(t);
@@ -328,7 +327,6 @@ test
     await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
   });
 
-// TODO: sy- remove this comment: this test is passing
 test
   .requestHooks(loopbackUserCancelLogger, loopbackUserCancelLoggerMock)('request body has reason value of true when user clicks cancel and go back link', async t => {
     loopbackPollMockLogger.clear();
@@ -343,7 +341,6 @@ test
     )).eql(1);
   });
 
-// TODO sy-remove this comment: this test is passing
 test
   .requestHooks(loopbackPollMockLogger, loopbackPollFailedMock)('next poll should not start if previous is failed', async t => {
     loopbackPollMockLogger.clear();
@@ -371,7 +368,6 @@ test
     )).eql(2);
   });
 
-// TODO sy- remove this comment: this test is passing
 test
   .requestHooks(loopbackChallengeErrorLogger, loopbackChallengeErrorMock)('in loopback server approach, will cancel polling when challenge errors out', async t => {
     const deviceChallengePollPageObject = await setup(t);
@@ -409,7 +405,6 @@ test
     await t.expect(loopbackSuccessLogger.contains(record => record.request.url.match(/6512|6513/))).eql(false);
   });
 
-// TODO remove this note: this test is passing
 test
   .requestHooks(loopbackChallengeWrongProfileLogger, loopbackChallengeWrongProfileMock)('in loopback server approach, will cancel polling when challenge errors out with non-503 status', async t => {
     const deviceChallengePollPageObject = await setup(t);
@@ -449,7 +444,6 @@ test
     )).eql(1);
   });
 
-// TODO remove this note: this test is passing
 test
   .requestHooks(loopbackSuccessLogger, loopbackSuccessButNotAssignedAppMock)('loopback succeeds but user is not assigned to app, then clicks cancel link', async t => {
     const deviceChallengePollPageObject = await setup(t);
@@ -478,7 +472,6 @@ test
     await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().exists).eql(true);
   });
 
-// TODO sy- remove this comment: this test is passing
 test
   .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)('loopback fails and falls back to custom uri', async t => {
     loopbackFallbackLogger.clear();

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -294,8 +294,8 @@ async function setupLoopbackFallback(t) {
   return deviceChallengeFalllbackPage;
 }
 
+// TODO: sy- remove this comment: this test is passing
 test
-  .meta('v3', false) // Not yet implemented in v3 (OKTA-548961)
   .requestHooks(loopbackSuccessLogger, loopbackSuccessMock)('in loopback server approach, probing and polling requests are sent and responded', async t => {
     const deviceChallengePollPageObject = await setup(t);
     // await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
@@ -310,7 +310,6 @@ test
       record => record.response.statusCode === 500 &&
         record.request.url.match(/2000/)
     )).eql(1);
-    // TODO sy- test failing because we don't try challenge on all ports that respond right now
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
         record.request.method === 'get' &&
@@ -367,11 +366,7 @@ test
       })).eql(1);
   });
 
-// reconsider/rewrite this test on OKTA-390965,
-// currently polling cancellation is triggered as soon as challenge errors out
-// which adds more count to the polling call
 test
-  .meta('v3', false) // Not yet implemented in v3 (OKTA-548961)
   .requestHooks(loopbackPollMockLogger, loopbackPollTimeoutMock).skip('new poll does not starts until last one is ended', async t => {
     loopbackPollMockLogger.clear();
     await setup(t);
@@ -418,8 +413,8 @@ test
     )).eql(1);
   });
 
+// TODO remove this note: this test is passing
 test
-  .meta('v3', false) // Not yet implemented in v3 (OKTA-548961)
   .requestHooks(loopbackChallengeWrongProfileLogger, loopbackChallengeWrongProfileMock)('in loopback server approach, will cancel polling when challenge errors out with non-503 status', async t => {
     const deviceChallengePollPageObject = await setup(t);
     // await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
@@ -462,7 +457,6 @@ test
 test
   .requestHooks(loopbackSuccessLogger, loopbackSuccessButNotAssignedAppMock)('loopback succeeds but user is not assigned to app, then clicks cancel link', async t => {
     const deviceChallengePollPageObject = await setup(t);
-    // await t.debug();
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(true);
 
     await t.expect(loopbackSuccessLogger.count(

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -298,7 +298,7 @@ async function setupLoopbackFallback(t) {
 test
   .requestHooks(loopbackSuccessLogger, loopbackSuccessMock)('in loopback server approach, probing and polling requests are sent and responded', async t => {
     const deviceChallengePollPageObject = await setup(t);
-    // await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
     // await t.expect(deviceChallengePollPageObject.getFooterLink().exists).eql(false);
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(true);
@@ -385,7 +385,7 @@ test
 test
   .requestHooks(loopbackChallengeErrorLogger, loopbackChallengeErrorMock)('in loopback server approach, will cancel polling when challenge errors out', async t => {
     const deviceChallengePollPageObject = await setup(t);
-    // await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
     await t.expect(deviceChallengePollPageObject.getFooterLink().exists).eql(false);
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(true);
@@ -417,7 +417,7 @@ test
 test
   .requestHooks(loopbackChallengeWrongProfileLogger, loopbackChallengeWrongProfileMock)('in loopback server approach, will cancel polling when challenge errors out with non-503 status', async t => {
     const deviceChallengePollPageObject = await setup(t);
-    // await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
     await t.expect(deviceChallengePollPageObject.getFooterLink().exists).eql(false);
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(true);
@@ -506,7 +506,7 @@ test
     )).eql(1);
     deviceChallengeFalllbackPage.clickOktaVerifyButton();
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
-    // await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Click "Open Okta Verify" on the browser prompt');
     await deviceChallengePollPageObject.hasText('Didn’t get a prompt?');
     await deviceChallengePollPageObject.hasText('Open Okta Verify');

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -300,7 +300,6 @@ test
     const deviceChallengePollPageObject = await setup(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
-    // await t.expect(deviceChallengePollPageObject.getFooterLink().exists).eql(false);
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(true);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
@@ -479,12 +478,10 @@ test
     await t.expect(loopbackSuccessLogger.contains(record => record.request.url.match(/6513/))).eql(false);
 
     pollingError = true;
-    // TODO sy- can we remove this? seems unnecessary to check one is not there and the other is
-    // await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
     await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().exists).eql(true);
   });
 
-// TODO sy- remove this comment: this test is passing (with caveat, see TODOs)
+// TODO sy- remove this comment: this test is passing
 test
   .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)('loopback fails and falls back to custom uri', async t => {
     loopbackFallbackLogger.clear();
@@ -513,8 +510,7 @@ test
     await deviceChallengePollPageObject.hasText('Don’t have Okta Verify?');
     await deviceChallengePollPageObject.hasText('Download here');
     await t.expect(deviceChallengePollPageObject.getDownloadOktaVerifyLink()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
-    // TODO: sy-need to check this assertion out in v2 behavior
-    // await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
+    await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().exists).eql(true);
   });
 
 const getPageUrl = ClientFunction(() => window.location.href);

--- a/test/testcafe/spec/SignInDeviceView_spec.js
+++ b/test/testcafe/spec/SignInDeviceView_spec.js
@@ -1,4 +1,4 @@
-import { RequestLogger, RequestMock, Selector, userVariables } from 'testcafe';
+import { RequestLogger, RequestMock, Selector } from 'testcafe';
 import SignInDevicePageObject from '../framework/page-objects/SignInDevicePageObject';
 import smartProbingRequired from '../../../playground/mocks/data/idp/idx/smart-probing-required';
 import launchAuthenticatorOption from '../../../playground/mocks/data/idp/idx/identify-with-device-launch-authenticator';


### PR DESCRIPTION
## Description:

Adds the device-challenge-poll transformer when the method is LOOPBACK.

The LoopbackProbe component contains nearly all of the imperative logic for this transformer.

We also will need to update this implementation once the auth-js library has either an exposed HTTP client or encapsulates the request logic to the localhost server within the library for this application to consume.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-548961](https://oktainc.atlassian.net/browse/OKTA-548961)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



