### PR TITLE
CSP fix for AuthenticatorVerifyOptions

### DIFF
--- a/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
+++ b/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
@@ -36,8 +36,9 @@ const AuthenticatorRow = View.extend({
   `,
   postRender: function() {
     View.prototype.postRender.apply(this, arguments);
-    if (this.model.get('logoUri')) {
-      this.el.querySelector('.custom-app-logo').style.backgroundImage = `url(${this.model.get('logoUri')})`;
+    const logoUri = this.model.get('logoUri');
+    if (logoUri) {
+      this.el.querySelector('.custom-logo').style.backgroundImage = `url(${logoUri})`;
     }
   },
   children: function(){

--- a/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
+++ b/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
@@ -12,15 +12,13 @@
 import { ListView, View, createButton, loc } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
 
-// https://oktainc.atlassian.net/browse/OKTA-554392
 const AuthenticatorRow = View.extend({
   className: 'authenticator-row clearfix',
   template: hbs`
     <div class="authenticator-icon-container">
       {{#if logoUri}}
         <div class="factor-icon authenticator-icon {{iconClassName}} custom-logo" role="img" 
-          aria-label="{{i18n code="oie.auth.logo.aria.label" bundle="login"}}"
-          style="background-image: url('{{logoUri}}')"></div>
+          aria-label="{{i18n code="oie.auth.logo.aria.label" bundle="login"}}"></div>
       {{else}}
         <div class="factor-icon authenticator-icon {{iconClassName}}" role="img" 
           aria-label="{{i18n code="oie.auth.logo.aria.label" bundle="login"}}"></div>
@@ -36,6 +34,12 @@ const AuthenticatorRow = View.extend({
       <div class="authenticator-button" {{#if buttonDataSeAttr}}data-se="{{buttonDataSeAttr}}"{{/if}}></div>
     </div>
   `,
+  postRender: function() {
+    View.prototype.postRender.apply(this, arguments);
+    if (this.model.get('logoUri')) {
+      this.el.querySelector('.custom-app-logo').style.backgroundImage = `url(${this.model.get('logoUri')})`;
+    }
+  },
   children: function(){
     return [[createButton({
       className: 'button select-factor',

--- a/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
@@ -41,6 +41,10 @@ export default class SelectFactorPageObject extends BasePageObject {
     return this.form.getElement(factorIconSelector).nth(index).getAttribute('class');
   }
 
+  getFactorIconBgImageByIndex(index) {
+    return this.form.getElement(factorIconSelector).nth(index).getStyleProperty('background-image');
+  }
+
   async factorCustomLogoExist(index) {
     const elCount = await this.form.getElement(factorCustomLogoSelector).nth(index).find(CUSTOM_LOGO_SELECTOR).count;
     return elCount === 1;

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -240,6 +240,7 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(15)).eql('Custom Push App');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(15)).contains('mfa-custom-app-logo');
   await t.expect(await selectFactorPage.factorCustomLogoExist(15)).eql(true);
+  await t.expect(selectFactorPage.getFactorIconBgImageByIndex(15)).match(/^url\(".*\/img\/logos\/default\.png"\)$/);
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(15)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(15)).eql('custom_app');
 


### PR DESCRIPTION
## Description:
`style-src` CSP error is triggered for `authenticator-verification-select-authenticator` mock in playground. 
(Triggered by Custom Push App authenticator)
https://github.com/okta/okta-signin-widget/blob/master/src/v2/view-builder/components/AuthenticatorVerifyOptions.js#L22
Fix by applying `backgroundImage` style in `postRender`


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-554392](https://oktainc.atlassian.net/browse/OKTA-554392)

### Reviewers:

### Screenshot/Video:
<img width="765" alt="OKTA-554392-bottom" src="https://user-images.githubusercontent.com/72614880/208934628-0f5c71bb-a571-4f8a-a7eb-150fa6e3b736.png">


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=3046f2cebefd82b316f3011c2083ac8b63da6b09&tab=main

