### PR TITLE
OKTA-551378: add CSP nonce option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ See the [Usage Guide](#usage-guide) for more information on how to get started u
     - [features.hideSignOutLinkInMFA](#featureshidesignoutlinkinmfa)
     - [features.rememberMe](#featuresrememberme)
     - [features.autoFocus](#featuresautofocus)
+  - [cspNonce](#cspNonce)
 - [Events](#events)
   - [ready](#ready)
   - [afterError](#aftererror)
@@ -1353,6 +1354,14 @@ Pre-fills the identifier field with the previously used username.
 
 Defaults to `true`.
 Automatically focuses the first input field of any form when displayed. 
+
+### cspNonce
+
+The widget injects secure inline script/style blocks at runtime for customization purpose, but those blocks may violate CSP rules that set in the hosted web page.
+
+`cspNonce` allows set [nonce](https://content-security-policy.com/nonce/) value from `Content-Security-Policy` header to the injected blocks, so script/style from those blocks can still be executable.
+
+**Note:** [nonce](https://content-security-policy.com/nonce/) directive was added to CSP level2, you may still see CSP errors in browser console if it's used in unsupported browsers. 
 
 ## Events
 

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -172,6 +172,9 @@ const local: Record<string, ModelProperty> = {
   //Colors
   'colors.brand': 'string',
 
+  //cspNonce
+  'cspNonce': 'string',
+
   //Descriptions
   brandName: 'string',
 

--- a/src/util/ColorsUtil.js
+++ b/src/util/ColorsUtil.js
@@ -41,13 +41,16 @@ fn.lighten = function(hex, lum) {
   return newHex;
 };
 
-fn.addStyle = function(colors) {
+fn.addStyle = function(colors, cspNonce) {
   const css = template(colors);
   const main = document.getElementById(Enums.WIDGET_CONTAINER_ID);
   const style = document.createElement('style');
 
   style.id = Enums.WIDGET_CONFIG_COLORS_ID;
   style.type = 'text/css';
+  if (cspNonce) {
+    style.nonce = cspNonce;
+  }
   style.appendChild(document.createTextNode(css));
 
   main.appendChild(style);

--- a/src/v1/BaseLoginRouter.js
+++ b/src/v1/BaseLoginRouter.js
@@ -188,8 +188,9 @@ export default Router.extend({
       const colors = {
         brand: this.settings.get('colors.brand'),
       };
+      const cspNonce = this.settings.get('cspNonce');
 
-      ColorsUtil.addStyle(colors);
+      ColorsUtil.addStyle(colors, cspNonce);
     }
 
     const oldController = this.controller;

--- a/src/v2/BaseLoginRouter.ts
+++ b/src/v2/BaseLoginRouter.ts
@@ -183,8 +183,9 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
       const colors = {
         brand: this.settings.get('colors.brand'),
       };
+      const cspNonce = this.settings.get('cspNonce');
 
-      ColorsUtil.addStyle(colors);
+      ColorsUtil.addStyle(colors, cspNonce);
     }
 
     // Show before initial render

--- a/test/app/src/config.ts
+++ b/test/app/src/config.ts
@@ -28,7 +28,7 @@ export function getIssuerOrigin(issuer: string): string {
   return issuer?.split('/oauth2/')[0];
 }
 
-export function getBaseUrl(options: WidgetOptions): string {
+export function getBaseUrl(options: WidgetOptions = {}): string {
   const baseUrl = options.baseUrl;
   if (baseUrl) {
     return baseUrl;
@@ -39,7 +39,7 @@ export function getBaseUrl(options: WidgetOptions): string {
   }
 }
 
-export function getIssuer(options: WidgetOptions): string {
+export function getIssuer(options: WidgetOptions = {}): string {
   return options.issuer || options.authParams?.issuer;
 }
 

--- a/test/app/src/configForm.ts
+++ b/test/app/src/configForm.ts
@@ -96,7 +96,7 @@ export function getConfigFromForm(): Config {
 }
 
 export function updateFormFromConfig(config: Config): void {
-  const { bundle, useBundledWidget, widgetOptions } = config;
+  const { bundle, useBundledWidget, widgetOptions = {} } = config;
   const { useMinBundle, usePolyfill } = config;
 
   // Widget options

--- a/test/app/webpack.config.js
+++ b/test/app/webpack.config.js
@@ -10,11 +10,10 @@ const DEV_SERVER_PORT = 3000;
 const { DIST_ESM, BUNDLE, USE_MIN, USE_POLYFILL, TARGET } = process.env;
 
 // CSP settings
-const scriptSrc = `script-src http://localhost:${DEV_SERVER_PORT} https://global.oktacdn.com`;
-const styleSrc = `style-src http://localhost:${DEV_SERVER_PORT} https://unpkg.com`;
+const scriptSrc = `script-src http://localhost:${DEV_SERVER_PORT} https://global.oktacdn.com 'nonce-e2e'`;
+const styleSrc = `style-src http://localhost:${DEV_SERVER_PORT} https://unpkg.com 'nonce-e2e'`;
 
-// TODO: remove this rule: OKTA-551378
-const styleSrcElem = `style-src-elem http://localhost:${DEV_SERVER_PORT} https://unpkg.com 'unsafe-inline'`;
+const styleSrcElem = `style-src-elem http://localhost:${DEV_SERVER_PORT} https://unpkg.com 'nonce-e2e'`;
 const csp = `${scriptSrc}; ${styleSrc}; ${styleSrcElem}`;
 
 const webpackConfig = {

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -15,7 +15,7 @@ Feature: Widget Customization and Basic operations
       Then widget is removed from the page
 
     Scenario: User can customize the widget
-      When widget config is updated with colors and i18n
+      When widget config is updated with colors and i18n with CSP nonce
       Then widget background shows the updated color
       And widget displays customized title
 

--- a/test/e2e/features/csp.feature
+++ b/test/e2e/features/csp.feature
@@ -12,9 +12,3 @@ Feature: CSP
       When user triggers CSP failure in the test app: style-attr
       Then user sees the CSP error on the page
         | inline blocked due to CSP rule style-src-attr |
-
-    # TODO: implement this test OKTA-551378
-    # Scenario: User triggers CSP error: style-elem
-    #   When user triggers CSP failure in the test app: style-elem
-    #   Then user sees the CSP error on the page
-    #     | inline blocked due to CSP rule style-src-elem |

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "scripts": {
     "test": "node ./runner.js",
-    "test:lang": "node ./runner.langtests.js"
+    "test:lang": "node ./runner.langtests.js",
+    "test:cucumber": "wdio run cucumber.wdio.conf.ts",
+    "test:spec": "wdio run wdio.conf.js"
   },
   "dependencies": {
     "@okta/okta-sdk-nodejs": "^6.5.0",

--- a/test/e2e/specs/csp-issues.e2e.js
+++ b/test/e2e/specs/csp-issues.e2e.js
@@ -1,0 +1,40 @@
+import TestAppPage from '../page-objects/test-app.page';
+import { waitForLoad } from '../util/waitUtil';
+
+const {
+  WIDGET_TEST_SERVER,
+  WIDGET_SPA_CLIENT_ID,
+} = process.env;
+
+describe('CSP existing issues', () => {
+  let config;
+  beforeEach(async () => {
+    await TestAppPage.open();
+    config = {
+      baseUrl: WIDGET_TEST_SERVER,
+      clientId: WIDGET_SPA_CLIENT_ID,
+      redirectUri: 'http://localhost:3000/done',
+      useClassicEngine: true,
+      authParams: {
+        pkce: false,
+        scopes: ['openid', 'email', 'profile']
+      }
+    };
+  });
+
+  afterEach(async () => {
+    await TestAppPage.ssoLogout();
+  });
+
+  it('causes CSP error when change brand color', async () => {
+    config.colors = {
+      brand: '#008000'
+    };
+
+    await TestAppPage.setConfig(config);
+    await TestAppPage.startWithRenderEl.click();
+    await waitForLoad(TestAppPage.widget);
+    await TestAppPage.assertCSPError('inline blocked due to CSP rule style-src-elem');
+  });
+
+});

--- a/test/e2e/steps/given.ts
+++ b/test/e2e/steps/given.ts
@@ -189,13 +189,14 @@ Given(
 );
 
 Given(
-  /^widget config is updated with colors and i18n$/,
+  /^widget config is updated with colors and i18n with CSP nonce$/,
   async function() {
     const config = {
       ...interactionCodeFlowconfig,
       colors: {
         brand: '#008000'
       },
+      cspNonce: 'e2e', // nonce is set in webpack.config,
       i18n: {
         en: {
           'primaryauth.title': 'Sign In to Acme'

--- a/test/unit/spec/ColorsUtil_spec.js
+++ b/test/unit/spec/ColorsUtil_spec.js
@@ -32,6 +32,29 @@ describe('ColorsUtil', function() {
 
       ColorsUtil.addStyle(colors);
       expect($(`#${Enums.WIDGET_CONFIG_COLORS_ID}`)).toBeDefined();
+      expect($(`#${Enums.WIDGET_CONFIG_COLORS_ID}`).prop('nonce')).toEqual('');
+      expect(normalize($(`#${Enums.WIDGET_CONFIG_COLORS_ID}`).text())).toBe(normalize(expectedStyle));
+    });
+
+    it('applys cspNonce to style tag', function() {
+      const colors = {
+        brand: '#008000',
+      };
+      const cspNonce = 'random';
+      const expectedStyle = `
+          #okta-sign-in.auth-container .button-primary,
+          #okta-sign-in.auth-container .button-primary:active,
+          #okta-sign-in.auth-container .button-primary:focus { background: #008000; }
+          #okta-sign-in.auth-container .button-primary:hover { background: #008600; }
+          #okta-sign-in.auth-container .button.button-primary.link-button-disabled {
+            background: #008000;
+            opacity: 0.5;
+          }
+        `;
+
+      ColorsUtil.addStyle(colors, cspNonce);
+      expect($(`#${Enums.WIDGET_CONFIG_COLORS_ID}`)).toBeDefined();
+      expect($(`#${Enums.WIDGET_CONFIG_COLORS_ID}`).prop('nonce')).toEqual('random');
       expect(normalize($(`#${Enums.WIDGET_CONFIG_COLORS_ID}`).text())).toBe(normalize(expectedStyle));
     });
   });

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -33,7 +33,7 @@ const headers = {};
 if (!process.env.DISABLE_CSP) {
   // Allow google domains for testing recaptcha
   const scriptSrc = `script-src http://${HOST}:${DEV_SERVER_PORT} https://www.google.com https://www.gstatic.com`;
-  const styleSrc =  `style-src http://${HOST}:${DEV_SERVER_PORT}`;
+  const styleSrc =  `style-src http://${HOST}:${DEV_SERVER_PORT} 'nonce-playground'`;
   const csp = `${scriptSrc}; ${styleSrc};`;
   headers['Content-Security-Policy'] = csp;
 }


### PR DESCRIPTION
## Description:

Adds cspNonce widget option to enable execution of certain script/style injection logic

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-551378](https://oktainc.atlassian.net/browse/OKTA-551378)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=3&pageSize=6&sha=0085c5c85f83e9a5d5ac453be18f6b894941f6e7&tab=main



