### PR TITLE
Support dockerized monolith E2E tests with okta-hosted login page

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,10 @@
       ],
       "autoAttachChildProcesses": true,
       "console": "integratedTerminal",
-      "cwd": "${workspaceRoot}/test/e2e"
+      "cwd": "${workspaceRoot}/test/e2e",
+      "env": {
+        "DEBUG": "1"
+      }
     },
     {
       "type": "node",
@@ -67,7 +70,10 @@
       ],
       "autoAttachChildProcesses": true,
       "console": "integratedTerminal",
-      "cwd": "${workspaceRoot}/test/e2e"
+      "cwd": "${workspaceRoot}/test/e2e",
+      "env": {
+        "DEBUG": "1"
+      }
     }
 
   ]

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 # Monolith version to test against
-export MONOLITH_BUILDVERSION=2022.10.1-begin-254-gaefef87dfc4e
+export MONOLITH_BUILDVERSION=2022.11.1-begin-468-g4ac0323d4b2b
 
 export LOCAL_MONOLITH=true
 export CI=true

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 # Monolith version to test against
-export MONOLITH_BUILDVERSION=2022.11.1-begin-468-g4ac0323d4b2b
+export MONOLITH_BUILDVERSION=2022.12.0-begin-507-ga84e4b4b9e67
 
 export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"
 export LOCAL_MONOLITH=true

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -17,6 +17,14 @@ source $OKTA_HOME/$REPO/scripts/setup.sh
 set -e
 cd $OKTA_HOME/$REPO
 
+create_log_group "Build Widget"
+  # Build
+  if ! yarn build:release; then
+    echo "build failed! Exiting..."
+    exit ${TEST_FAILURE}
+  fi
+finish_log_group $?
+
 # Start monolith
 create_log_group "Start Monolith"
 source ./scripts/monolith/install-dockolith.sh
@@ -31,14 +39,6 @@ echo "${DOCKER_HOST_CONTAINER_IP} ${TEST_ORG_SUBDOMAIN}.okta1.com" >> /etc/hosts
 cat /etc/hosts
 source ./scripts/monolith/create-testenv.sh
 export ORG_OIE_ENABLED=true
-finish_log_group $?
-
-# Build Widget
-create_log_group "Build Widget"
-if ! yarn build:release; then
-  echo "build failed! Exiting..."
-  exit ${TEST_FAILURE}
-fi
 finish_log_group $?
 
 # Setup E2E environment

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -36,6 +36,7 @@ create_log_group "Create Test Org"
 # Add widget test host to /etc/hosts
 export TEST_ORG_SUBDOMAIN="siw-test-1"
 echo "${DOCKER_HOST_CONTAINER_IP} ${TEST_ORG_SUBDOMAIN}.okta1.com" >> /etc/hosts
+echo "${DOCKER_HOST_CONTAINER_IP} ${TEST_ORG_SUBDOMAIN}-admin.okta1.com" >> /etc/hosts
 cat /etc/hosts
 source ./scripts/monolith/create-testenv.sh
 export ORG_OIE_ENABLED=true

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -2,7 +2,7 @@
 
 # Monolith version to test against
 # TODO: auto-select a recent stable version OKTA-561403
-export MONOLITH_BUILDVERSION=2023.01.0-begin-73-gf922f1d6a9f3
+export MONOLITH_BUILDVERSION=2023.01.0-begin-28-g616122a68e33
 
 export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"
 export LOCAL_MONOLITH=true

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -2,7 +2,7 @@
 
 # Monolith version to test against
 # TODO: auto-select a recent stable version OKTA-561403
-export MONOLITH_BUILDVERSION=2022.12.2-begin-263-gf27ee20e1cf5
+export MONOLITH_BUILDVERSION=2022.12.3-begin-75-ge12fe65f6ab9
 
 export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"
 export LOCAL_MONOLITH=true

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -2,7 +2,7 @@
 
 # Monolith version to test against
 # TODO: auto-select a recent stable version OKTA-561403
-export MONOLITH_BUILDVERSION=2022.12.0-begin-507-ga84e4b4b9e67
+export MONOLITH_BUILDVERSION=2022.11.2-begin-157-g8096959870a8
 
 export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"
 export LOCAL_MONOLITH=true

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
 
 # Monolith version to test against
+# TODO: auto-select a recent stable version OKTA-561403
 export MONOLITH_BUILDVERSION=2022.12.0-begin-507-ga84e4b4b9e67
 
 export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -2,7 +2,7 @@
 
 # Monolith version to test against
 # TODO: auto-select a recent stable version OKTA-561403
-export MONOLITH_BUILDVERSION=2022.12.2-begin-259-gdeb54c572369
+export MONOLITH_BUILDVERSION=2022.12.2-begin-263-gf27ee20e1cf5
 
 export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"
 export LOCAL_MONOLITH=true

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -2,7 +2,7 @@
 
 # Monolith version to test against
 # TODO: auto-select a recent stable version OKTA-561403
-export MONOLITH_BUILDVERSION=2022.11.2-begin-157-g8096959870a8
+export MONOLITH_BUILDVERSION=2022.12.2-begin-259-gdeb54c572369
 
 export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"
 export LOCAL_MONOLITH=true

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -3,6 +3,7 @@
 # Monolith version to test against
 export MONOLITH_BUILDVERSION=2022.11.1-begin-468-g4ac0323d4b2b
 
+export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"
 export LOCAL_MONOLITH=true
 export CI=true
 export TEST_SUITE_TYPE="junit"

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -2,7 +2,7 @@
 
 # Monolith version to test against
 # TODO: auto-select a recent stable version OKTA-561403
-export MONOLITH_BUILDVERSION=2022.12.3-begin-75-ge12fe65f6ab9
+export MONOLITH_BUILDVERSION=2023.01.0-begin-73-gf922f1d6a9f3
 
 export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"
 export LOCAL_MONOLITH=true

--- a/scripts/monolith/deploy-widget.sh
+++ b/scripts/monolith/deploy-widget.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-export WIDGET_HOME="$(readlink -f "$(dirname "$BASH_SOURCE")/../..")"
+export WIDGET_HOME="$(readlink -f "$(dirname "$0")/../..")"
 source ${WIDGET_HOME}/scripts/monolith/lib/common-widget-setup.sh
 
 setup_logging_api

--- a/scripts/monolith/deploy-widget.sh
+++ b/scripts/monolith/deploy-widget.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+
+export WIDGET_HOME="$(readlink -f "$(dirname "$BASH_SOURCE")/../..")"
+source ${WIDGET_HOME}/scripts/monolith/lib/common-widget-setup.sh
+
+setup_logging_api
+export_cloud_config
+
+#Set the spring config profiles. this determines which config files are loaded
+# http://localhost:8100/okta/ci,ci_test_shared_credentials
+# web credentials for CCS in bootstrap-ci.properties
+export MONOLITH_PROFILES_ACTIVE="ci_test_shared_credentials,ci"
+
+# Stop monolith if it is running
+common::widget::stop_webapp
+
+# Local widget will be deployed before startup
+common::widget::start_webapp

--- a/scripts/monolith/deploy-widget.sh
+++ b/scripts/monolith/deploy-widget.sh
@@ -9,7 +9,7 @@ export_cloud_config
 #Set the spring config profiles. this determines which config files are loaded
 # http://localhost:8100/okta/ci,ci_test_shared_credentials
 # web credentials for CCS in bootstrap-ci.properties
-export MONOLITH_PROFILES_ACTIVE="ci_test_shared_credentials,ci"
+export MONOLITH_PROFILES_ACTIVE="ci_test_shared_credentials,ci,widget"
 
 # Stop monolith if it is running
 common::widget::stop_webapp

--- a/scripts/monolith/install-dockolith.sh
+++ b/scripts/monolith/install-dockolith.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -xe
 
-# REMOVE ME
-DOCKOLITH_BRANCH=ag-OKTA-536775-support-content-injection
-
 if [[ -z ${DOCKOLITH_BRANCH} ]]; then
   export DOCKOLITH_BRANCH=master
 fi

--- a/scripts/monolith/install-dockolith.sh
+++ b/scripts/monolith/install-dockolith.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -xe
 
+# REMOVE ME
+DOCKOLITH_BRANCH=ag-OKTA-536775-support-content-injection
+
 if [[ -z ${DOCKOLITH_BRANCH} ]]; then
   export DOCKOLITH_BRANCH=master
 fi

--- a/scripts/monolith/lib/common-widget-setup.sh
+++ b/scripts/monolith/lib/common-widget-setup.sh
@@ -4,7 +4,7 @@
 # https://artifacts.aue1e.internal/artifactory/integration/test-baselines/
 : "${MONOLITH_BUILDVERSION?:"missing MONOLITH_BUILDVERSION"}"
 
-export WIDGET_HOME=${WIDGET_HOME:-`(readlink -f "$(dirname "$BASH_SOURCE")/../../..")`}
+export WIDGET_HOME=${WIDGET_HOME:-`(readlink -f "$(dirname "$0")/../../..")`}
 export WIDGET_VERSION="${WIDGET_VERSION:-$(cat ${WIDGET_HOME}/package.json | jq '.version' -r)}"
 export SYNTHETIC_WIDGET_VERSION=${SYNTHETIC_WIDGET_VERSION:-${WIDGET_VERSION}-local}
 export DOCKOLITH_HOME="${DOCKOLITH_HOME:-${WIDGET_HOME}/scripts/dockolith}"

--- a/scripts/monolith/lib/common-widget-setup.sh
+++ b/scripts/monolith/lib/common-widget-setup.sh
@@ -43,8 +43,9 @@ function common::widget::start_webapp() {
 function common::widget::deploy_widget() {
   local -r monolith_container_id="$1"
 
-  # Write synthetic version to a tmp file named "override.properties"
-  local -r local_conf_file=${DOCKOLITH_TMP}/override.properties
+  # Write synthetic version to a tmp file named "application-widet.properties"
+  # This will be loaded with the "widget" CCS profile
+  local -r local_conf_file=${DOCKOLITH_TMP}/application-widget.properties
   mkdir -p ${DOCKOLITH_TMP}
   echo "ui.widget.version=${SYNTHETIC_WIDGET_VERSION}" > ${local_conf_file}
 

--- a/scripts/monolith/lib/common-widget-setup.sh
+++ b/scripts/monolith/lib/common-widget-setup.sh
@@ -30,6 +30,7 @@ function common::widget::start_webapp() {
     local -r service_name="Monolith"
     local -r prepare_container_callback="common::widget::deploy_widget"
 
+    export DOCKER_HOST_CONTAINER_IP="FUBAR"
     echo "DOCKER_HOST_CONTAINER_IP before: ${DOCKER_HOST_CONTAINER_IP}"
     if ! (start_image "${image_name}" "${compose_env_file}" "${compose_path}" "${service_name}" ${prepare_container_callback}); then
         echo "webapp startup failed!"

--- a/scripts/monolith/lib/common-widget-setup.sh
+++ b/scripts/monolith/lib/common-widget-setup.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -xe
+
+# Set MONOLITH_BUILDVERSION before running this script
+# https://artifacts.aue1e.internal/artifactory/integration/test-baselines/
+: "${MONOLITH_BUILDVERSION?:"missing MONOLITH_BUILDVERSION"}"
+
+export WIDGET_HOME=${WIDGET_HOME:-`(readlink -f "$(dirname "$BASH_SOURCE")/../../..")`}
+export WIDGET_VERSION="${WIDGET_VERSION:-$(cat ${WIDGET_HOME}/package.json | jq '.version' -r)}"
+export SYNTHETIC_WIDGET_VERSION=${SYNTHETIC_WIDGET_VERSION:-${WIDGET_VERSION}-local}
+export DOCKOLITH_HOME="${DOCKOLITH_HOME:-${WIDGET_HOME}/scripts/dockolith}"
+
+# Dockolith should be installed before running this script
+# Run `./scripts/monolith/install-dockolith.sh` to install latest dockolith version
+source ${DOCKOLITH_HOME}/scripts/lib/dockolith/setup-dockolith.sh
+
+function common::widget::stop_webapp() {
+  local -r compose_path="${OKTA_CORE_HOME}/scripts/docker-ci/composefiles/monolith"
+  local -r compose_env_file=".env"
+
+  pushd ${compose_path}
+      # Stop monolith if it is running
+      docker-compose --env-file "${compose_env_file}" down
+  popd
+}
+
+function common::widget::start_webapp() {
+    local -r image_name="monolith"
+    local -r compose_env_file=".env"
+    local -r compose_path="${OKTA_CORE_HOME}/scripts/docker-ci/composefiles/monolith"
+    local -r service_name="Monolith"
+    local -r prepare_container_callback="common::widget::deploy_widget"
+    if ! (start_image "${image_name}" "${compose_env_file}" "${compose_path}" "${service_name}" ${prepare_container_callback}); then
+        echo "webapp startup failed!"
+        move_logs_tmp_api
+        log_extra_dir_as_zip ${TMP_LOGS_LOCATION} run_logs.zip
+        exit ${BUILD_FAILURE}
+    fi
+}
+
+# Deploys the locally build widget to docker monolith image
+# Uses a synthetic version number: current package version with "-local" suffix
+function common::widget::deploy_widget() {
+  local -r monolith_container_id="$1"
+
+  # Write synthetic version to a tmp file named "override.properties"
+  local -r local_conf_file=${DOCKOLITH_TMP}/override.properties
+  mkdir -p ${DOCKOLITH_TMP}
+  echo "ui.widget.version=${SYNTHETIC_WIDGET_VERSION}" > ${local_conf_file}
+
+  local -r local_assets_dir="${WIDGET_HOME}/dist/dist/"
+  local -r remote_assets_dir="/usr/local/tomcat/webapps/ROOT/js/sdk/okta-signin-widget/${SYNTHETIC_WIDGET_VERSION}"
+
+  # Copy over local widget assets to remote directory (containing synthetic version)
+  docker cp ${local_assets_dir} ${monolith_container_id}:${remote_assets_dir}
+
+  # Copy override.properties (setting the synthetic version)
+  local -r remote_conf_dir="/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/"
+  docker cp ${local_conf_file} ${monolith_container_id}:${remote_conf_dir}
+}

--- a/scripts/monolith/lib/common-widget-setup.sh
+++ b/scripts/monolith/lib/common-widget-setup.sh
@@ -29,12 +29,15 @@ function common::widget::start_webapp() {
     local -r compose_path="${OKTA_CORE_HOME}/scripts/docker-ci/composefiles/monolith"
     local -r service_name="Monolith"
     local -r prepare_container_callback="common::widget::deploy_widget"
+
+    echo "DOCKER_HOST_CONTAINER_IP before: ${DOCKER_HOST_CONTAINER_IP}"
     if ! (start_image "${image_name}" "${compose_env_file}" "${compose_path}" "${service_name}" ${prepare_container_callback}); then
         echo "webapp startup failed!"
         move_logs_tmp_api
         log_extra_dir_as_zip ${TMP_LOGS_LOCATION} run_logs.zip
         exit ${BUILD_FAILURE}
     fi
+    echo "DOCKER_HOST_CONTAINER_IP after: ${DOCKER_HOST_CONTAINER_IP}"
 }
 
 # Deploys the locally build widget to docker monolith image

--- a/scripts/monolith/lib/common-widget-setup.sh
+++ b/scripts/monolith/lib/common-widget-setup.sh
@@ -30,15 +30,12 @@ function common::widget::start_webapp() {
     local -r service_name="Monolith"
     local -r prepare_container_callback="common::widget::deploy_widget"
 
-    export DOCKER_HOST_CONTAINER_IP="FUBAR"
-    echo "DOCKER_HOST_CONTAINER_IP before: ${DOCKER_HOST_CONTAINER_IP}"
     if ! (start_image "${image_name}" "${compose_env_file}" "${compose_path}" "${service_name}" ${prepare_container_callback}); then
         echo "webapp startup failed!"
         move_logs_tmp_api
         log_extra_dir_as_zip ${TMP_LOGS_LOCATION} run_logs.zip
         exit ${BUILD_FAILURE}
     fi
-    echo "DOCKER_HOST_CONTAINER_IP after: ${DOCKER_HOST_CONTAINER_IP}"
 }
 
 # Deploys the locally build widget to docker monolith image

--- a/scripts/monolith/start.sh
+++ b/scripts/monolith/start.sh
@@ -1,13 +1,48 @@
 #!/bin/bash -xe
 
-# Dockolith should be installed before running this script
+create_log_group "Setup"
 
-if [[ -z "${CI}" ]]; then
-  echo "This script only runs on CI, for now"
-  exit 1
-fi
+  export WIDGET_HOME="$(readlink -f "$(dirname "$BASH_SOURCE")/../..")"
+  source ${WIDGET_HOME}/scripts/monolith/lib/common-widget-setup.sh
 
-pushd ./scripts/dockolith
-source ./scripts/docker-monolith.sh
-echo $DOCKER_HOST_CONTAINER_IP
-popd
+  if [ -z "${DOCKOLITH_CI}" ]; then # Local
+    # remove all running containers and networks before running
+    source ${DOCKOLITH_HOME}/scripts/smoke-docker.sh
+
+    # clear all tmp files
+    rm -rf ${DOCKOLITH_TMP}
+  fi
+
+  dockolith::setup;
+finish_log_group $?
+
+create_log_group "Start Tomcat"
+  common::widget::start_webapp;
+finish_log_group $?
+
+create_log_group "Verify Webapp"
+
+  update_hosts_entry $DOCKER_HOST_CONTAINER_IP cdn.okta1.com
+  update_hosts_entry $DOCKER_HOST_CONTAINER_IP rain.okta1.com
+  update_hosts_entry $DOCKER_HOST_CONTAINER_IP backdoorentry.okta1.com
+
+  cat http://backdoorentry.okta1.com:1802
+
+finish_log_group $?
+
+create_log_group "Bootstrap"
+
+  export METRIC_TO_LOG=bootstrap_db
+  if ! log_metric_wrapper dockolith::bootstrap;
+  then
+      echo "bootstrap failed!"
+      move_logs_tmp_api
+      log_extra_dir_as_zip ${TMP_LOGS_LOCATION} run_logs.zip
+      exit ${BUILD_FAILURE}
+  fi
+
+finish_log_group $?
+
+move_logs_tmp_api
+log_extra_dir_as_zip ${TMP_LOGS_LOCATION} run_logs.zip
+#exit $SUCCESS

--- a/scripts/monolith/start.sh
+++ b/scripts/monolith/start.sh
@@ -2,7 +2,7 @@
 
 create_log_group "Setup"
 
-  export WIDGET_HOME="$(readlink -f "$(dirname "$BASH_SOURCE")/../..")"
+  export WIDGET_HOME="$(readlink -f "$(dirname "$0")/../..")"
   source ${WIDGET_HOME}/scripts/monolith/lib/common-widget-setup.sh
 
   if [ -z "${DOCKOLITH_CI}" ]; then # Local

--- a/scripts/monolith/start.sh
+++ b/scripts/monolith/start.sh
@@ -1,49 +1,33 @@
 #!/bin/bash -xe
 
 export WIDGET_HOME=${WIDGET_HOME:-`(readlink -f "$(dirname "$0")/../..")`}
+source ${WIDGET_HOME}/scripts/monolith/lib/common-widget-setup.sh
 
-create_log_group "Setup"
+if [ -z "${DOCKOLITH_CI}" ]; then # Local
+  # remove all running containers and networks before running
+  source ${DOCKOLITH_HOME}/scripts/smoke-docker.sh
 
-  source ${WIDGET_HOME}/scripts/monolith/lib/common-widget-setup.sh
+  # clear all tmp files
+  rm -rf ${DOCKOLITH_TMP}
+fi
 
-  if [ -z "${DOCKOLITH_CI}" ]; then # Local
-    # remove all running containers and networks before running
-    source ${DOCKOLITH_HOME}/scripts/smoke-docker.sh
+dockolith::setup;
 
-    # clear all tmp files
-    rm -rf ${DOCKOLITH_TMP}
-  fi
+echo "start DOCKER_HOST_CONTAINER_IP before: ${DOCKER_HOST_CONTAINER_IP}"
+common::widget::start_webapp;
+echo "start DOCKER_HOST_CONTAINER_IP after: ${DOCKER_HOST_CONTAINER_IP}"
 
-  dockolith::setup;
-finish_log_group $?
+update_hosts_entry $DOCKER_HOST_CONTAINER_IP cdn.okta1.com
+update_hosts_entry $DOCKER_HOST_CONTAINER_IP rain.okta1.com
+update_hosts_entry $DOCKER_HOST_CONTAINER_IP backdoorentry.okta1.com
 
-create_log_group "Start Tomcat"
-  common::widget::start_webapp;
-finish_log_group $?
+cat http://backdoorentry.okta1.com:1802
 
-create_log_group "Verify Webapp"
-
-  update_hosts_entry $DOCKER_HOST_CONTAINER_IP cdn.okta1.com
-  update_hosts_entry $DOCKER_HOST_CONTAINER_IP rain.okta1.com
-  update_hosts_entry $DOCKER_HOST_CONTAINER_IP backdoorentry.okta1.com
-
-  cat http://backdoorentry.okta1.com:1802
-
-finish_log_group $?
-
-create_log_group "Bootstrap"
-
-  export METRIC_TO_LOG=bootstrap_db
-  if ! log_metric_wrapper dockolith::bootstrap;
-  then
-      echo "bootstrap failed!"
-      move_logs_tmp_api
-      log_extra_dir_as_zip ${TMP_LOGS_LOCATION} run_logs.zip
-      exit ${BUILD_FAILURE}
-  fi
-
-finish_log_group $?
-
-move_logs_tmp_api
-log_extra_dir_as_zip ${TMP_LOGS_LOCATION} run_logs.zip
-#exit $SUCCESS
+export METRIC_TO_LOG=bootstrap_db
+if ! log_metric_wrapper dockolith::bootstrap;
+then
+    echo "bootstrap failed!"
+    move_logs_tmp_api
+    log_extra_dir_as_zip ${TMP_LOGS_LOCATION} run_logs.zip
+    exit ${BUILD_FAILURE}
+fi

--- a/scripts/monolith/start.sh
+++ b/scripts/monolith/start.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -xe
 
+export WIDGET_HOME=${WIDGET_HOME:-`(readlink -f "$(dirname "$0")/../..")`}
+
 create_log_group "Setup"
 
-  export WIDGET_HOME="$(readlink -f "$(dirname "$0")/../..")"
   source ${WIDGET_HOME}/scripts/monolith/lib/common-widget-setup.sh
 
   if [ -z "${DOCKOLITH_CI}" ]; then # Local

--- a/scripts/monolith/start.sh
+++ b/scripts/monolith/start.sh
@@ -13,6 +13,12 @@ fi
 
 dockolith::setup;
 
+#Set the spring config profiles. this determines which config files are loaded
+# http://localhost:8100/okta/ci,ci_test_shared_credentials
+# web credentials for CCS in bootstrap-ci.properties
+# special "widget" profile is used to load locally built widget version
+export MONOLITH_PROFILES_ACTIVE="ci_test_shared_credentials,ci,widget"
+
 common::widget::start_webapp;
 
 export DOCKER_HOST_CONTAINER_IP=$(docker inspect --format='{{.NetworkSettings.Networks.monolith_network.IPAddress}}' mono_dockerhost)

--- a/scripts/monolith/start.sh
+++ b/scripts/monolith/start.sh
@@ -13,17 +13,14 @@ fi
 
 dockolith::setup;
 
-echo "start DOCKER_HOST_CONTAINER_IP before: ${DOCKER_HOST_CONTAINER_IP}"
 common::widget::start_webapp;
-echo "start DOCKER_HOST_CONTAINER_IP after: ${DOCKER_HOST_CONTAINER_IP}"
 
 export DOCKER_HOST_CONTAINER_IP=$(docker inspect --format='{{.NetworkSettings.Networks.monolith_network.IPAddress}}' mono_dockerhost)
-
 update_hosts_entry $DOCKER_HOST_CONTAINER_IP cdn.okta1.com
 update_hosts_entry $DOCKER_HOST_CONTAINER_IP rain.okta1.com
 update_hosts_entry $DOCKER_HOST_CONTAINER_IP backdoorentry.okta1.com
 
-cat http://backdoorentry.okta1.com:1802
+curl http://backdoorentry.okta1.com:1802
 
 export METRIC_TO_LOG=bootstrap_db
 if ! log_metric_wrapper dockolith::bootstrap;

--- a/scripts/monolith/start.sh
+++ b/scripts/monolith/start.sh
@@ -17,6 +17,8 @@ echo "start DOCKER_HOST_CONTAINER_IP before: ${DOCKER_HOST_CONTAINER_IP}"
 common::widget::start_webapp;
 echo "start DOCKER_HOST_CONTAINER_IP after: ${DOCKER_HOST_CONTAINER_IP}"
 
+export DOCKER_HOST_CONTAINER_IP=$(docker inspect --format='{{.NetworkSettings.Networks.monolith_network.IPAddress}}' mono_dockerhost)
+
 update_hosts_entry $DOCKER_HOST_CONTAINER_IP cdn.okta1.com
 update_hosts_entry $DOCKER_HOST_CONTAINER_IP rain.okta1.com
 update_hosts_entry $DOCKER_HOST_CONTAINER_IP backdoorentry.okta1.com

--- a/test/e2e/features/self-service-registration.feature
+++ b/test/e2e/features/self-service-registration.feature
@@ -19,6 +19,8 @@ Feature: Self Service Registration
       And user skips enrollment of optional authenticators
       Then user sees the tokens on the page
 
+    # https://oktainc.atlassian.net/browse/OKTA-561398
+    @skip(okta:monolith=true)
     Scenario: User signs up with email and password and optional phone authenticator
       Given user opens the login page
       When user clicks the signup link

--- a/test/e2e/steps/after.ts
+++ b/test/e2e/steps/after.ts
@@ -11,13 +11,13 @@
  */
 
 
-import { After } from '@cucumber/cucumber';
+import { After, AfterStep } from '@cucumber/cucumber';
 import ActionContext from '../support/context';
 import deleteUserAndCredentials from '../support/management-api/deleteUserAndCredentials';
 import TestAppPage from '../page-objects/test-app.page';
 
 // eslint-disable-next-line no-unused-vars
-After(async function (this: ActionContext) {
+AfterStep(async function (this: ActionContext) {
   this.saveScreenshot('after');
 });
 

--- a/test/e2e/steps/after.ts
+++ b/test/e2e/steps/after.ts
@@ -18,7 +18,7 @@ import TestAppPage from '../page-objects/test-app.page';
 
 // eslint-disable-next-line no-unused-vars
 AfterStep(async function (this: ActionContext) {
-  this.saveScreenshot('after');
+  this.saveScreenshot('afterStep');
 });
 
 After(deleteUserAndCredentials);

--- a/test/e2e/support/monolith/create-testenv.ts
+++ b/test/e2e/support/monolith/create-testenv.ts
@@ -10,7 +10,8 @@ import {
   setPolicyForApp,
   disableStepUpForPasswordRecovery,
   getCatchAllRule,
-  getDefaultAuthorizationServer
+  getDefaultAuthorizationServer,
+  enableEmbeddedLogin
 } from '@okta/dockolith';
 import { writeFileSync } from 'fs';
 import path from 'path';
@@ -30,8 +31,7 @@ async function bootstrap() {
       'OKTA_MFA_POLICY'
     ],
     disableFFs: [
-      'REQUIRE_PKCE_FOR_OIDC_APPS',
-      'DISPLAY_EMBEDDED_LOGIN_SUPPORT'
+      'REQUIRE_PKCE_FOR_OIDC_APPS'
     ],
     users: [
       {
@@ -98,6 +98,9 @@ async function bootstrap() {
   for (const option of options.disableFFs) {
     await disableFeatureFlag(config, orgId, option);
   }
+
+  console.error('Enabling embedded login');
+  await enableEmbeddedLogin(config);
 
   // Enable interaction_code grant on the default authorization server
   console.error('Enabling interaction_code grant on the default authorization server');

--- a/test/e2e/support/screenshots.ts
+++ b/test/e2e/support/screenshots.ts
@@ -5,8 +5,9 @@ import fs from 'fs';
 
 
 export async function saveScreenshot(fileName?: string) {
+  const timeStamp = Date.now();
   fileName = fileName || 'shot';
-  fileName = `${fileName}.png`;
+  fileName = `${timeStamp}-${fileName}.png`;
   fileName = fileName.replace(/[^a-z0-9.-]/gi, '-'); // sanitize filename
   const { TMP_LOGS_LOCATION } = process.env;
   const baseDir = TMP_LOGS_LOCATION || path.resolve(__dirname, '../../../build2');

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -8,6 +8,18 @@ const browserOptions = {
     args: []
 };
 
+// Default timeout for all waitFor* commands.
+let waitforTimeout = 10000;
+
+// Default jasmine timeout
+let defaultTimeoutInterval = 60000;
+
+// Increase timeouts when debugging
+if (process.env.DEBUG) {
+  waitforTimeout = waitforTimeout * 100;
+  defaultTimeoutInterval = defaultTimeoutInterval * 100
+}
+
 if (process.env.CHROMIUM_BINARY) {
   browserOptions.binary = process.env.CHROMIUM_BINARY;
 }
@@ -130,7 +142,7 @@ const conf = {
     baseUrl: 'http://localhost:3000',
     //
     // Default timeout for all waitFor* commands.
-    waitforTimeout: 10000,
+    waitforTimeout,
     //
     // Default timeout in milliseconds for request
     // if browser driver or grid doesn't send response
@@ -186,7 +198,7 @@ const conf = {
     //
     // Options to be passed to Jasmine.
     jasmineOpts: {
-        defaultTimeoutInterval: 60000
+        defaultTimeoutInterval
     },
 }
 


### PR DESCRIPTION
## Description:

- Inject locally built widget into dockerized monolith container
- Update create test env script to adjust for product changes

Depends on dockolith update: https://github.com/okta/dockolith/pull/12

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-536775](https://oktainc.atlassian.net/browse/OKTA-536775)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



