### PR TITLE
Use core-js/stable in polyfill to fix legacy browser support issue

### DIFF
--- a/polyfill/index.js
+++ b/polyfill/index.js
@@ -1,26 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 // core features
-require('core-js/features/object/set-prototype-of');
-require('core-js/features/object/assign');
-require('core-js/features/object/keys');
-require('core-js/features/object/values');
-require('core-js/features/object/from-entries');
-require('core-js/features/object/entries');
-require('core-js/features/object/iterate-entries');
-require('core-js/features/object/iterate-keys');
-require('core-js/features/object/iterate-values');
-require('core-js/features/symbol/iterator');
-require('core-js/es/promise');
-require('core-js/es/typed-array/uint8-array');
-require('core-js/features/array/from');
-require('core-js/features/array/includes');
-require('core-js/features/array/find');
-require('core-js/features/array/find-index');
-require('core-js/features/string/includes');
-require('core-js/features/string/starts-with');
-require('core-js/features/string/ends-with');
-require('core-js/web/url');
+require('core-js/stable');
 
 // crypto is eeded for PKCE
 require('fast-text-encoding'); // TextEncoder

--- a/scripts/buildtools/commands/verify-package.js
+++ b/scripts/buildtools/commands/verify-package.js
@@ -15,8 +15,8 @@ const EXPECTED_BUNDLE_SIZES = {
   'okta-sign-in.no-polyfill.min.js': 1.6 * MB,
   'okta-sign-in.oie.js': 2.4 * MB,
   'okta-sign-in.oie.min.js': 1.2 * MB,
-  'okta-sign-in.polyfill.js': 468 * KB,
-  'okta-sign-in.polyfill.min.js': 99 * KB,
+  'okta-sign-in.polyfill.js': 880 * KB,
+  'okta-sign-in.polyfill.min.js': 180 * KB,
 };
 
 exports.command = 'verify-package';


### PR DESCRIPTION
## Description:

With this change`okta-sign-in.min.js` and `okta-sign-in.polyfill.min.js` will have around 80k size increase.

Bundles size (before change):
```
 12K    okta-plugin-a11y.js
 24K    okta-plugin-a11y.js.map
2.4M    okta-sign-in.classic.js
3.5M    okta-sign-in.classic.js.map
1.1M    okta-sign-in.classic.min.js
3.2M    okta-sign-in.classic.min.js.map
3.2M    okta-sign-in.js
4.5M    okta-sign-in.js.map
1.6M    okta-sign-in.min.js
4.7M    okta-sign-in.min.js.map
1.6M    okta-sign-in.no-polyfill.min.js
4.1M    okta-sign-in.no-polyfill.min.js.map
2.4M    okta-sign-in.oie.js
3.5M    okta-sign-in.oie.js.map
1.3M    okta-sign-in.oie.min.js
3.2M    okta-sign-in.oie.min.js.map
476K    okta-sign-in.polyfill.js
404K    okta-sign-in.polyfill.js.map
100K    okta-sign-in.polyfill.min.js
492K    okta-sign-in.polyfill.min.js.map
```

Bundles size (after change)
```
 12K    okta-plugin-a11y.js
 24K    okta-plugin-a11y.js.map
2.4M    okta-sign-in.classic.js
3.5M    okta-sign-in.classic.js.map
1.1M    okta-sign-in.classic.min.js
3.2M    okta-sign-in.classic.min.js.map
3.2M    okta-sign-in.js
4.5M    okta-sign-in.js.map
1.7M    okta-sign-in.min.js
5.0M    okta-sign-in.min.js.map
1.6M    okta-sign-in.no-polyfill.min.js
4.1M    okta-sign-in.no-polyfill.min.js.map
2.4M    okta-sign-in.oie.js
3.5M    okta-sign-in.oie.js.map
1.3M    okta-sign-in.oie.min.js
3.2M    okta-sign-in.oie.min.js.map
880K    okta-sign-in.polyfill.js
748K    okta-sign-in.polyfill.js.map
180K    okta-sign-in.polyfill.min.js
896K    okta-sign-in.polyfill.min.js.map
```

Original V7 change: https://github.com/okta/okta-signin-widget/commit/9978f8991d3efc3d7f125b312aa0f6fd6d71de3f#diff-bbedaae078e817722e9544235ec39baad394a386024fe6cf0a2ce34d074ddd4cL1


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-559547](https://oktainc.atlassian.net/browse/OKTA-559547)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



