### PR TITLE
CSP fix for BaseOktaVerifyChallengeView

### DIFF
--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -1,4 +1,4 @@
-import { $ } from '@okta/courage';
+import { $, View } from '@okta/courage';
 import { BaseFormWithPolling } from '../internals';
 import Logger from 'util/Logger';
 import {
@@ -170,10 +170,19 @@ const Body = BaseFormWithPolling.extend({
 
   doCustomURI() {
     this.ulDom && this.ulDom.remove();
-    // https://oktainc.atlassian.net/browse/OKTA-554464
-    this.ulDom = this.add(`
-      <iframe src="${this.customURI}" id="custom-uri-container" style="display:none;"></iframe>
-    `).last();
+
+    const IframeView = View.extend({
+      tagName: 'iframe',
+      id: 'custom-uri-container',
+      attributes: {
+        src: this.customURI,
+      },
+      initialize() {
+        this.el.style.display = 'none';
+      }
+    });
+
+    this.ulDom = this.add(IframeView).last();
   },
 
   stopProbing() {

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -20,6 +20,10 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.body.find('[data-se="o-form-head"]').innerText;
   }
 
+  getIframe() {
+    return this.body.find('iframe');
+  }
+
   getIframeAttributes() {
     return Selector('#custom-uri-container').attributes;
   }

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -571,15 +571,15 @@ test
 test
   .requestHooks(customURILogger, customURIMock)('in custom URI approach, Okta Verify iframe should be single and hidden', async t => {
     const deviceChallengePollPageObject = await setup(t);
-    await t.wait(100); // opening the page in iframe takes just a moment
     let iframe = await deviceChallengePollPageObject.getIframe();
+    await t.expect(iframe.exists).ok({ timeout: 100 });
     let attributes = await deviceChallengePollPageObject.getIframeAttributes();
     await t.expect(attributes.src).contains('okta-verify.html');
     await t.expect(iframe.visible).eql(false);
 
     await deviceChallengePollPageObject.clickLaunchOktaVerifyLink();
-    await t.wait(100); // opening the page in iframe takes just a moment
     iframe = await deviceChallengePollPageObject.getIframe();
+    await t.expect(iframe.exists).ok({ timeout: 100 });
     attributes = await deviceChallengePollPageObject.getIframeAttributes();
     await t.expect(attributes.src).contains('okta-verify.html');
     await t.expect(iframe.visible).eql(false);

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -568,6 +568,24 @@ test
     )).eql(2);
   });
 
+  test
+    .requestHooks(customURILogger, customURIMock)('in custom URI approach, Okta Verify iframe should be single and hidden', async t => {
+      const deviceChallengePollPageObject = await setup(t);
+      await t.wait(100); // opening the page in iframe takes just a moment
+      let iframe = await deviceChallengePollPageObject.getIframe();
+      let attributes = await deviceChallengePollPageObject.getIframeAttributes();
+      await t.expect(attributes.src).contains('okta-verify.html');
+      await t.expect(iframe.visible).eql(false);
+
+      await deviceChallengePollPageObject.clickLaunchOktaVerifyLink();
+      await t.wait(100); // opening the page in iframe takes just a moment
+      iframe = await deviceChallengePollPageObject.getIframe();
+      attributes = await deviceChallengePollPageObject.getIframeAttributes();
+      await t.expect(attributes.src).contains('okta-verify.html');
+      await t.expect(iframe.visible).eql(false);
+      await t.expect(deviceChallengePollPageObject.getIframe().count).eql(1);
+    });
+
 test
   .requestHooks(loopbackFallbackLogger, universalLinkWithoutLaunchMock)('SSO Extension fails and falls back to universal link', async t => {
     loopbackFallbackLogger.clear();

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -568,23 +568,23 @@ test
     )).eql(2);
   });
 
-  test
-    .requestHooks(customURILogger, customURIMock)('in custom URI approach, Okta Verify iframe should be single and hidden', async t => {
-      const deviceChallengePollPageObject = await setup(t);
-      await t.wait(100); // opening the page in iframe takes just a moment
-      let iframe = await deviceChallengePollPageObject.getIframe();
-      let attributes = await deviceChallengePollPageObject.getIframeAttributes();
-      await t.expect(attributes.src).contains('okta-verify.html');
-      await t.expect(iframe.visible).eql(false);
+test
+  .requestHooks(customURILogger, customURIMock)('in custom URI approach, Okta Verify iframe should be single and hidden', async t => {
+    const deviceChallengePollPageObject = await setup(t);
+    await t.wait(100); // opening the page in iframe takes just a moment
+    let iframe = await deviceChallengePollPageObject.getIframe();
+    let attributes = await deviceChallengePollPageObject.getIframeAttributes();
+    await t.expect(attributes.src).contains('okta-verify.html');
+    await t.expect(iframe.visible).eql(false);
 
-      await deviceChallengePollPageObject.clickLaunchOktaVerifyLink();
-      await t.wait(100); // opening the page in iframe takes just a moment
-      iframe = await deviceChallengePollPageObject.getIframe();
-      attributes = await deviceChallengePollPageObject.getIframeAttributes();
-      await t.expect(attributes.src).contains('okta-verify.html');
-      await t.expect(iframe.visible).eql(false);
-      await t.expect(deviceChallengePollPageObject.getIframe().count).eql(1);
-    });
+    await deviceChallengePollPageObject.clickLaunchOktaVerifyLink();
+    await t.wait(100); // opening the page in iframe takes just a moment
+    iframe = await deviceChallengePollPageObject.getIframe();
+    attributes = await deviceChallengePollPageObject.getIframeAttributes();
+    await t.expect(attributes.src).contains('okta-verify.html');
+    await t.expect(iframe.visible).eql(false);
+    await t.expect(deviceChallengePollPageObject.getIframe().count).eql(1);
+  });
 
 test
   .requestHooks(loopbackFallbackLogger, universalLinkWithoutLaunchMock)('SSO Extension fails and falls back to universal link', async t => {


### PR DESCRIPTION
## Description:
`style-src` CSP error is triggered for `windowAuthnCustomUri` mocks grroup in playground. 
https://github.com/okta/okta-signin-widget/blob/master/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js#L174
Fix by using `View` class for building iframe and hiding it in `initialize`


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-554464](https://oktainc.atlassian.net/browse/OKTA-554464)

### Reviewers:

### Screenshot/Video:

https://user-images.githubusercontent.com/72614880/208949232-3256763c-3d80-420e-8957-1143242e3e68.mov




### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=742c22ca47bd0a12d3a0434f925683c6bac4abe9&tab=main

