### PR TITLE
CSP fix for HeaderBeacon

### DIFF
--- a/src/v2/view-builder/components/HeaderBeacon.js
+++ b/src/v2/view-builder/components/HeaderBeacon.js
@@ -12,7 +12,6 @@
 import { View } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
 
-// https://oktainc.atlassian.net/browse/OKTA-554417
 export default View.extend({
 
   template: hbs`
@@ -22,8 +21,7 @@ export default View.extend({
       </div>
       {{#if logoUri}}
       <div class="bg-helper auth-beacon auth-beacon-factor custom-app-logo" data-se="factor-beacon" role="img" 
-        aria-label="{{i18n code="oie.auth.logo.aria.label" bundle="login"}}"
-        style="background-image: url('{{logoUri}}')">
+        aria-label="{{i18n code="oie.auth.logo.aria.label" bundle="login"}}">
       {{else}}
       <div class="bg-helper auth-beacon auth-beacon-factor {{className}}" data-se="factor-beacon">
       {{/if}}
@@ -32,6 +30,13 @@ export default View.extend({
     </div >
   `,
 
+  postRender: function() {
+    View.prototype.postRender.apply(this, arguments);
+    const data = this.getTemplateData();
+    if (data.logoUri) {
+      this.el.querySelector('.custom-app-logo').style.backgroundImage = `url(${data.logoUri})`;
+    }
+  },
   getTemplateData: function() {
     const appState = this.options?.appState;
     return { className: this.getBeaconClassName() || '',

--- a/test/testcafe/framework/page-objects/ChallengeCustomAppPushPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeCustomAppPushPageObject.js
@@ -72,4 +72,8 @@ export default class ChallengeCustomAppPushPageObject extends ChallengeFactorPag
     return this.beacon.find(FACTOR_BEACON).getAttribute('class');
   }
 
+  getBeaconBgImage() {
+    return this.beacon.find(FACTOR_BEACON).getStyleProperty('background-image');
+  }
+
 }

--- a/test/testcafe/spec/ChallengeCustomAppPush_spec.js
+++ b/test/testcafe/spec/ChallengeCustomAppPush_spec.js
@@ -133,10 +133,12 @@ test
     const a11ySpan = challengeCustomAppPushPageObject.getA11ySpan();
     const checkboxLabel = challengeCustomAppPushPageObject.getAutoChallengeCheckboxLabel();
     const logoClass = challengeCustomAppPushPageObject.getBeaconClass();
+    const logoBgImage = challengeCustomAppPushPageObject.getBeaconBgImage();
     await t.expect(pushBtn.textContent).contains('Push notification sent');
     await t.expect(a11ySpan.textContent).contains('Push notification sent');
     await t.expect(pushBtn.hasClass('link-button-disabled')).ok();
     await t.expect(logoClass).contains('custom-app-logo');
+    await t.expect(logoBgImage).match(/^url\(".*\/img\/icons\/mfa\/customPushLogo\.svg"\)$/);
     await t.expect(pageTitle).contains('Verify with Custom Push Authenticator');
     await t.expect(checkboxLabel.hasClass('checked')).ok();
     await t.expect(checkboxLabel.textContent).eql('Send push automatically');
@@ -166,10 +168,12 @@ test
     const pushBtn = challengeCustomAppPushPageObject.getPushButton();
     const a11ySpan = challengeCustomAppPushPageObject.getA11ySpan();
     const logoClass = challengeCustomAppPushPageObject.getBeaconClass();
+    const logoBgImage = challengeCustomAppPushPageObject.getBeaconBgImage();
     await t.expect(pushBtn.textContent).contains('Push notification sent');
     await t.expect(a11ySpan.textContent).contains('Push notification sent');
     await t.expect(pushBtn.hasClass('link-button-disabled')).ok();
     await t.expect(logoClass).contains('custom-app-logo');
+    await t.expect(logoBgImage).match(/^url\(".*\/img\/icons\/mfa\/customPushLogo\.svg"\)$/);
     await t.expect(pageTitle).contains('Verify with Custom Push');
 
     // Verify links
@@ -196,10 +200,12 @@ test
     const pushBtn = challengeCustomAppPushPageObject.getPushButton();
     const a11ySpan = challengeCustomAppPushPageObject.getA11ySpan();
     const logoClass = challengeCustomAppPushPageObject.getBeaconClass();
+    const logoBgImage = challengeCustomAppPushPageObject.getBeaconBgImage();
     await t.expect(pushBtn.textContent).contains('Push notification sent');
     await t.expect(a11ySpan.textContent).contains('Push notification sent');
     await t.expect(pushBtn.hasClass('link-button-disabled')).ok();
     await t.expect(logoClass).contains('custom-app-logo');
+    await t.expect(logoBgImage).match(/^url\(".*\/img\/icons\/mfa\/customPushLogo\.svg"\)$/);
     await t.expect(logoClass).notContains('mfa-custom-app');
     await t.expect(pageTitle).contains('Verify with Custom Push');
     await t.expect(await challengeCustomAppPushPageObject.autoChallengeInputExists()).notOk();


### PR DESCRIPTION
## Description:
`style-src` CSP error is triggered for `authenticator-verification-custom-app-push` mock in playground.
https://github.com/okta/okta-signin-widget/blob/master/src/v2/view-builder/components/HeaderBeacon.js#L25
Fix by applying `backgroundImage` style in `postRender`


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-554417](https://oktainc.atlassian.net/browse/OKTA-554417)

### Reviewers:

### Screenshot/Video:
<img width="717" alt="OKTA-554417" src="https://user-images.githubusercontent.com/72614880/208935263-c95cc8a3-7914-423b-ad25-ebc1fdb7fda0.png">


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=016c5ccbc6036a31ad7acc66b751a02ebbbcb319&tab=main

