### PR TITLE
Fix CSP for DeviceFingerprinting

### DIFF
--- a/src/v1/util/DeviceFingerprint.js
+++ b/src/v1/util/DeviceFingerprint.js
@@ -84,7 +84,6 @@ export default {
 
     // Attach listener
     window.addEventListener('message', onMessageReceivedFromOkta, false);
-    // https://oktainc.atlassian.net/browse/OKTA-555211
     // Create and Load devicefingerprint page inside the iframe
     $iframe = $('<iframe>', {
       css: {

--- a/src/v1/util/DeviceFingerprint.js
+++ b/src/v1/util/DeviceFingerprint.js
@@ -87,7 +87,9 @@ export default {
     // https://oktainc.atlassian.net/browse/OKTA-555211
     // Create and Load devicefingerprint page inside the iframe
     $iframe = $('<iframe>', {
-      style: 'display: none;',
+      css: {
+        display: 'none'
+      },
       src: oktaDomainUrl + '/auth/services/devicefingerprint',
     });
     element.append($iframe);

--- a/src/v2/view-builder/utils/DeviceFingerprinting.js
+++ b/src/v2/view-builder/utils/DeviceFingerprinting.js
@@ -89,7 +89,6 @@ export default {
 
       // Attach listener
       window.addEventListener('message', onMessageReceivedFromOkta, false);
-      // https://oktainc.atlassian.net/browse/OKTA-553082
       // Create and Load devicefingerprint page inside the iframe
       $iframe = $('<iframe>', {
         css: {

--- a/src/v2/view-builder/utils/DeviceFingerprinting.js
+++ b/src/v2/view-builder/utils/DeviceFingerprinting.js
@@ -92,7 +92,9 @@ export default {
       // https://oktainc.atlassian.net/browse/OKTA-553082
       // Create and Load devicefingerprint page inside the iframe
       $iframe = $('<iframe>', {
-        style: 'display: none;',
+        css: {
+          display: 'none'
+        },
         src: fingerprintData.oktaDomainUrl + '/auth/services/devicefingerprint',
       });
       fingerprintData.element.append($iframe);

--- a/test/unit/spec/v2/view-builder/utils/DeviceFingerprinting_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/DeviceFingerprinting_spec.js
@@ -34,6 +34,18 @@ describe('DeviceFingerprinting', () => {
     jest.spyOn(DeviceFingerprinting, 'isMessageFromCorrectSource').mockReturnValue(true);
   }
 
+  it('creates hidden iframe during fingerprint generation', async () => {
+    mockIFrameMessages(true);
+    bypassMessageSourceCheck();
+    const fingerprintPromise = DeviceFingerprinting.generateDeviceFingerprint(testContext.fingerprintData);
+    let $iFrame = $sandbox.find('iframe');
+    expect($iFrame.length).toBe(1);
+    expect($iFrame.is(":hidden")).toBe(true);
+    await fingerprintPromise;
+    $iFrame = $sandbox.find('iframe');
+    expect($iFrame.length).toBe(0);
+  });
+
   it('returns a fingerprint if the communication with the iframe is successful', async () => {
     mockIFrameMessages(true);
     bypassMessageSourceCheck();

--- a/test/unit/spec/v2/view-builder/utils/DeviceFingerprinting_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/DeviceFingerprinting_spec.js
@@ -41,6 +41,7 @@ describe('DeviceFingerprinting', () => {
     let $iFrame = $sandbox.find('iframe');
     expect($iFrame.length).toBe(1);
     expect($iFrame.is(":hidden")).toBe(true);
+    expect($iFrame.attr('src')).toBe('/auth/services/devicefingerprint');
     await fingerprintPromise;
     $iFrame = $sandbox.find('iframe');
     expect($iFrame.length).toBe(0);

--- a/test/unit/spec/v2/view-builder/utils/DeviceFingerprinting_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/DeviceFingerprinting_spec.js
@@ -40,7 +40,7 @@ describe('DeviceFingerprinting', () => {
     const fingerprintPromise = DeviceFingerprinting.generateDeviceFingerprint(testContext.fingerprintData);
     let $iFrame = $sandbox.find('iframe');
     expect($iFrame.length).toBe(1);
-    expect($iFrame.is(":hidden")).toBe(true);
+    expect($iFrame.is(':hidden')).toBe(true);
     expect($iFrame.attr('src')).toBe('/auth/services/devicefingerprint');
     await fingerprintPromise;
     $iFrame = $sandbox.find('iframe');


### PR DESCRIPTION
## Description:

`style-src` CSP error is triggered for `identify` mock in playground. To enable code path, set `deviceFingerprinthing: true` in .widgetrc.js

https://github.com/okta/okta-signin-widget/blob/master/src/v2/view-builder/utils/DeviceFingerprinting.js#L94

Fixed by using `css` property for iframe creation with `$()` instead of `style`

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-555211](https://oktainc.atlassian.net/browse/OKTA-555211)

### Reviewers:

### Screenshot/Video:


https://user-images.githubusercontent.com/72614880/208947112-21ba5951-9927-48c7-a4f0-8699286bcdca.mov


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=5f3916e43a63859ddad74f6898dc5b10b83b306b&tab=main

