### PR TITLE
Revert "Enabling widget flows on IE11 (#2990)"

### DIFF
--- a/test/e2e/features/widget-flows.feature
+++ b/test/e2e/features/widget-flows.feature
@@ -1,3 +1,5 @@
+# https://oktainc.atlassian.net/browse/OKTA-545127
+@skip(browserName=/internet.*explorer/)
 Feature: Widget Flows
 
   Background:


### PR DESCRIPTION
This reverts commit 8b230de7ef9dd3c2046b9b738afdfe630258e2d7.

## Description:
`e2e-saucelabs` suite has been flaky on master and feature branches since this suite was enabled on IE11


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



