### PR TITLE
Revert "Fixes `feature.rememberMe` in OIE widget (#3002)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 
 ```html
 <!-- Latest CDN production Javascript and CSS -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.1.3/js/okta-sign-in.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.2.1/js/okta-sign-in.min.js" type="text/javascript"></script>
 
-<link href="https://global.oktacdn.com/okta-signin-widget/7.1.3/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/7.2.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 **NOTE:** The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](https://github.com/okta/okta-signin-widget/releases). We recommend using the latest widget version.
@@ -267,13 +267,13 @@ When using one of the bundles without the polyfill included, you may want to con
 
 ```html
 <!-- Polyfill for older browsers -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.1.3/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.2.1/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
 
 <!-- Widget bundle for Okta Identity Engine -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.1.3/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.2.1/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
 
 <!-- CSS for widget -->
-<link href="https://global.oktacdn.com/okta-signin-widget/7.1.3/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/7.2.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -9,13 +9,13 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 
 ```html
 <!-- Polyfill for older browsers -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.1.3/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.2.1/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
 
 <!-- Widget bundle for Okta Identity Engine -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.1.3/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.2.1/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
 
 <!-- CSS for widget -->
-<link href="https://global.oktacdn.com/okta-signin-widget/7.1.3/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/7.2.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 **NOTE:** The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](https://github.com/okta/okta-signin-widget/releases). We recommend using the latest widget version.

--- a/src/v2/client/updateAppState.ts
+++ b/src/v2/client/updateAppState.ts
@@ -1,13 +1,45 @@
 import { IdxResponse } from "@okta/okta-auth-js";
+import CookieUtil from '../../util/CookieUtil';
 import AppState from '../models/AppState';
 import sessionStorageHelper from './sessionStorageHelper';
 import { interactionCodeFlow } from './interactionCodeFlow';
 import { FORMS } from "../ion/RemediationConstants";
 import transformIdxResponse from '../ion/transformIdxResponse';
 
+function hasAuthenticationSucceeded(idxResponse: IdxResponse) {
+  // Check whether authentication has succeeded. This is done by checking the server response
+  // and seeing if either the 'success' or 'successWithInteractionCode' objects are present.
+  return idxResponse?.rawIdxState?.success || idxResponse?.rawIdxState?.successWithInteractionCode;
+}
+
+/**
+  * When "Remember My Username" is enabled, we save the identifier in a cookie
+  * so that the next time the user visits the SIW, the identifier field can be 
+  * pre-filled with this value.
+  */
+function updateIdentifierCookie(appState: AppState, idxResponse: IdxResponse) {
+  const settings = appState.settings;
+  if (settings.get('features.rememberMe')) {
+    // Update the cookie with the identifier
+    const user = idxResponse?.context?.user;
+    const { identifier } = user?.value || {};
+    if (identifier) {
+      CookieUtil.setUsernameCookie(identifier);
+    }
+  } else {
+    // We remove the cookie explicitly if this feature is disabled.
+    CookieUtil.removeUsernameCookie();
+  }    
+}
 
 export async function updateAppState(appState: AppState, idxResponse: IdxResponse): Promise<void> {
   const settings = appState.settings;
+
+  // Only update the cookie when the user has successfully authenticated themselves 
+  // to avoid incorrect/unnecessary updates.
+  if (hasAuthenticationSucceeded(idxResponse) && settings.get('features.rememberMyUsernameOnOIE')) {
+      updateIdentifierCookie(appState, idxResponse);
+  }
 
   const lastResponse = appState.get('idx');
   const useInteractionCodeFlow = settings.get('oauth2Enabled');

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -21,7 +21,6 @@ import { EventErrorContext } from 'types/events';
 import { CONFIGURED_FLOW } from '../client/constants';
 import { ConfigError } from 'util/Errors';
 import { updateAppState } from 'v2/client';
-import CookieUtil from '../../util/CookieUtil';
 
 export interface ContextData {
   controller: string;
@@ -238,16 +237,6 @@ export default Controller.extend({
 
     // Run hook: transform the user name (a.k.a identifier)
     const values = this.transformIdentifier(formName, model);
-
-    // widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
-    if (this.options.settings.get('features.rememberMe') && this.options.settings.get('features.rememberMyUsernameOnOIE')) {
-      if (values.identifier) {
-        CookieUtil.setUsernameCookie(values.identifier);
-      }
-    }
-    else {
-      CookieUtil.removeUsernameCookie();
-    }
 
     // Error out when this is not a remediation form. Unexpected Exception.
     if (!this.options.appState.hasRemediationObject(formName)) {


### PR DESCRIPTION
This reverts commit 01444a4eaa2b8aeee02896bdcb92a9938b7c5822.

## Description:



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-565937](https://oktainc.atlassian.net/browse/OKTA-565937)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&author=aaron.granick%40okta.com&branch=d16t-okta-signin-widget-6854d73-63bef77e&lastCommit=true&page=1&pageSize=6&sha=f9ad3cb358dd6e5ca687e178d29c115d018e4e3a&tab=main

