### PR TITLE
OKTA-557948 : Fastpass apple SSO custom biometrics error

### DIFF
--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -64,12 +64,7 @@ const InfoBox: UISchemaElementComponent<{
       >
         {title && <AlertTitle>{title}</AlertTitle>}
         {message}
-        {bullets?.length > 0
-        && (
-        <Box>
-          <List uischema={bulletList} />
-        </Box>
-        )}
+        {bullets?.length > 0 && <List uischema={bulletList} />}
       </Alert>
     </Box>
   );

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -58,7 +58,7 @@ const InfoBox: UISchemaElementComponent<{
       >
         { title && <AlertTitle>{title}</AlertTitle> }
         { message }
-        { listOptions && <List uischema={ {type: 'List', options: listOptions } } /> }
+        { listOptions && <List uischema={{ type: 'List', options: listOptions }} /> }
       </Alert>
     </Box>
   );

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -20,7 +20,6 @@ import { h } from 'preact';
 import { useWidgetContext } from '../../contexts';
 import {
   InfoboxElement,
-  ListElement,
   MessageType,
   MessageTypeVariant,
   UISchemaElementComponent,
@@ -40,14 +39,9 @@ const InfoBox: UISchemaElementComponent<{
       title,
       class: messageClass,
       dataSe,
-      bullets = [],
+      listOptions,
     },
   } = uischema;
-
-  const bulletList: ListElement = {
-    type: 'List',
-    options: { items: bullets },
-  };
 
   return loading ? null : (
     <Box
@@ -58,14 +52,13 @@ const InfoBox: UISchemaElementComponent<{
       <Alert
         severity={MessageTypeVariant[messageClass as MessageType] ?? MessageTypeVariant.INFO}
         variant="infobox"
-        title={title}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...({ 'data-se': dataSe })}
         className={`infobox-${messageClass.toLowerCase()}`}
       >
         { title && <AlertTitle>{title}</AlertTitle> }
         { message }
-        { bullets?.length > 0 && <List uischema={bulletList} /> }
+        { listOptions && <List uischema={ {type: 'List', options: listOptions } } /> }
       </Alert>
     </Box>
   );

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -10,8 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { AlertTitle } from '@mui/material';
-import { Alert, Box } from '@okta/odyssey-react-mui';
+import {
+  Alert,
+  AlertTitle,
+  Box,
+} from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 
 import { useWidgetContext } from '../../contexts';
@@ -43,9 +46,7 @@ const InfoBox: UISchemaElementComponent<{
 
   const bulletList: ListElement = {
     type: 'List',
-    options: {
-      items: bullets,
-    },
+    options: { items: bullets },
   };
 
   return loading ? null : (
@@ -62,9 +63,9 @@ const InfoBox: UISchemaElementComponent<{
         {...({ 'data-se': dataSe })}
         className={`infobox-${messageClass.toLowerCase()}`}
       >
-        {title && <AlertTitle>{title}</AlertTitle>}
-        {message}
-        {bullets?.length > 0 && <List uischema={bulletList} />}
+        { title && <AlertTitle>{title}</AlertTitle> }
+        { message }
+        { bullets?.length > 0 && <List uischema={bulletList} /> }
       </Alert>
     </Box>
   );

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -10,16 +10,19 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { AlertTitle } from '@mui/material';
 import { Alert, Box } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 
 import { useWidgetContext } from '../../contexts';
 import {
   InfoboxElement,
+  ListElement,
   MessageType,
   MessageTypeVariant,
   UISchemaElementComponent,
 } from '../../types';
+import List from '../List';
 
 const InfoBox: UISchemaElementComponent<{
   uischema: InfoboxElement
@@ -34,8 +37,16 @@ const InfoBox: UISchemaElementComponent<{
       title,
       class: messageClass,
       dataSe,
+      bullets = [],
     },
   } = uischema;
+
+  const bulletList: ListElement = {
+    type: 'List',
+    options: {
+      items: bullets,
+    },
+  };
 
   return loading ? null : (
     <Box
@@ -51,7 +62,14 @@ const InfoBox: UISchemaElementComponent<{
         {...({ 'data-se': dataSe })}
         className={`infobox-${messageClass.toLowerCase()}`}
       >
+        {title && <AlertTitle>{title}</AlertTitle>}
         {message}
+        {bullets?.length > 0
+        && (
+        <Box>
+          <List uischema={bulletList} />
+        </Box>
+        )}
       </Alert>
     </Box>
   );

--- a/src/v3/src/constants/idxConstants.ts
+++ b/src/v3/src/constants/idxConstants.ts
@@ -114,6 +114,8 @@ export const TERMINAL_KEY: Record<string, string> = {
 };
 
 export const OV_UV_ENABLE_BIOMETRIC_SERVER_KEY = 'oie.authenticator.oktaverify.method.totp.verify.enable.biometrics';
+export const OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP = 'oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.desktop';
+export const OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE = 'oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.mobile';
 
 export const EMAIL_AUTHENTICATOR_TERMINAL_KEYS = [
   TERMINAL_KEY.EMAIL_LINK_CANT_BE_PROCESSED,

--- a/src/v3/src/transformer/layout/recovery/transformRequestActivation.ts
+++ b/src/v3/src/transformer/layout/recovery/transformRequestActivation.ts
@@ -41,7 +41,6 @@ export const transformRequestActivation: IdxStepTransformer = ({ formBag, transa
   const expiredMessage: InfoboxElement = {
     type: 'InfoBox',
     options: {
-      contentType: 'string',
       class: 'ERROR',
       message: loc('idx.expired.activation.token', 'login'),
       dataSe: 'callout',

--- a/src/v3/src/transformer/messages/transform.test.ts
+++ b/src/v3/src/transformer/messages/transform.test.ts
@@ -52,7 +52,6 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
     const updatedFormBag = transformMessages({ transaction, widgetProps, step: '' })(formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.contentType).toBe('string');
     expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.class)
       .toBe('ERROR');
     expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.message)
@@ -72,7 +71,6 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
     const updatedFormBag = transformMessages({ transaction, widgetProps, step: '' })(formBag);
 
     expect(updatedFormBag.uischema.elements.length).toBe(1);
-    expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.contentType).toBe('string');
     expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.class)
       .toBe('ERROR');
     expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.message)

--- a/src/v3/src/transformer/messages/transform.ts
+++ b/src/v3/src/transformer/messages/transform.ts
@@ -68,7 +68,6 @@ const transformCustomMessages = (formBag: FormBag, messages: IdxMessage[]): Form
   formattedMessages.forEach((message) => messageElements.push({
     type: 'InfoBox',
     options: {
-      contentType: 'string',
       class: message.class ?? 'INFO',
       message: message.message,
       title: message.title && loc(message.title, 'login'),
@@ -107,7 +106,6 @@ export const transformMessages: TransformStepFnWithOptions = ({ transaction }) =
     messageElements.push({
       type: 'InfoBox',
       options: {
-        contentType: 'string',
         class: messageClass,
         message: message.message,
         dataSe: 'callout',

--- a/src/v3/src/transformer/terminal/__snapshots__/transformTerminalMessages.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformTerminalMessages.test.ts.snap
@@ -44,7 +44,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "dataSe": "callout",
           "message": "oie.tooManyRequests",
         },
@@ -73,7 +72,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "dataSe": "callout",
           "message": "idx.operation.cancelled.on.other.device",
         },
@@ -109,7 +107,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "dataSe": "callout",
           "message": "idx.session.expired",
         },
@@ -138,7 +135,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "dataSe": "callout",
           "message": "idx.return.link.expired",
         },
@@ -167,7 +163,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "message": "oform.error.unexpected",
         },
         "type": "InfoBox",
@@ -195,7 +190,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "dataSe": "callout",
           "message": "Test error message",
         },

--- a/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
@@ -12,7 +12,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "dataSe": "callout",
           "message": "oform.error.unexpected",
         },
@@ -36,7 +35,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "dataSe": "callout",
           "message": "oie.configuration.error",
         },
@@ -60,7 +58,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "dataSe": "callout",
           "message": "oie.feature.disabled",
         },
@@ -84,7 +81,6 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "contentType": "string",
           "dataSe": "callout",
           "message": "oie.invalid.recovery.token",
         },

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.ts
@@ -52,7 +52,6 @@ const appendMessageElements = (uischema: UISchemaLayout, messages: IdxMessage[])
         options: {
           message: message.message,
           class: messageClass,
-          contentType: 'string',
           dataSe: 'callout',
         },
       };
@@ -86,7 +85,7 @@ const appendBiometricsErrorBox = (
       class: 'ERROR',
       contentType: 'string',
       dataSe: 'callout',
-      bullets: bulletPoints,
+      listOptions: { items: bulletPoints },
     },
   } as InfoboxElement);
 };
@@ -100,7 +99,6 @@ export const transformTerminalMessages: TerminalKeyTransformer = (transaction, f
       options: {
         message: loc('oform.error.unexpected', 'login'),
         class: 'ERROR',
-        contentType: 'string',
       },
     } as InfoboxElement);
     return formBag;

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.ts
@@ -12,7 +12,11 @@
 
 import { IdxMessage } from '@okta/okta-auth-js';
 
-import { TERMINAL_KEY } from '../../constants';
+import {
+  OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP,
+  OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE,
+  TERMINAL_KEY,
+} from '../../constants';
 import {
   DescriptionElement,
   InfoboxElement,
@@ -57,10 +61,39 @@ const appendMessageElements = (uischema: UISchemaLayout, messages: IdxMessage[])
   });
 };
 
+const appendBiometricsErrorBox = (
+  uischema: UISchemaLayout,
+  isBiometricsRequiredDesktop = false,
+) => {
+  const bulletPoints = [
+    loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point1', 'login'),
+    loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point2', 'login'),
+    loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point3', 'login'),
+  ];
+
+  // Add an additional bullet point for desktop devices
+  if (isBiometricsRequiredDesktop) {
+    bulletPoints.push(
+      loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point4', 'login'),
+    );
+  }
+
+  uischema.elements.push({
+    type: 'InfoBox',
+    options: {
+      message: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.description', 'login'),
+      title: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.title', 'login'),
+      class: 'ERROR',
+      contentType: 'string',
+      dataSe: 'callout',
+      bullets: bulletPoints,
+    },
+  } as InfoboxElement);
+};
+
 export const transformTerminalMessages: TerminalKeyTransformer = (transaction, formBag) => {
   const { messages } = transaction;
   const { uischema } = formBag;
-
   if (transaction.error) {
     uischema.elements.push({
       type: 'InfoBox',
@@ -98,6 +131,12 @@ export const transformTerminalMessages: TerminalKeyTransformer = (transaction, f
     displayedMessages[0].message = loc(TERMINAL_KEY.SESSION_EXPIRED, 'login');
   } else if (containsMessageKey(TERMINAL_KEY.IDX_RETURN_LINK_OTP_ONLY, messages)) {
     return transformEmailMagicLinkOTPOnly(transaction, formBag);
+  } else if (containsMessageKey(OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE, messages)) {
+    appendBiometricsErrorBox(uischema);
+    return formBag;
+  } else if (containsMessageKey(OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP, messages)) {
+    appendBiometricsErrorBox(uischema, true);
+    return formBag;
   }
 
   appendMessageElements(uischema, messages);

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
@@ -74,7 +74,6 @@ export const transformUnhandledErrors: ErrorTransformer = (widgetProps, error) =
     options: {
       message: getErrorMessage(error, widgetProps),
       class: 'ERROR',
-      contentType: 'string',
       dataSe: 'callout',
     },
   } as InfoboxElement];

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -397,10 +397,9 @@ export interface InfoboxElement extends UISchemaElement {
   options: {
     message: string;
     class: string;
-    contentType: string;
     title?: string;
     dataSe?: string;
-    bullets?: string[];
+    listOptions?: ListElement['options'];
   }
 }
 

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -400,6 +400,7 @@ export interface InfoboxElement extends UISchemaElement {
     contentType: string;
     title?: string;
     dataSe?: string;
+    bullets?: string[];
   }
 }
 

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -139,6 +139,11 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                     <div
                       class="MuiAlert-message emotion-18"
                     >
+                      <div
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root emotion-19"
+                      >
+                        Update Okta Verify
+                      </div>
                       The device used to set up Okta Verify does not meet your organization’s security requirements because it is not FIPS compliant. Contact your administrator for help.
                     </div>
                   </div>
@@ -151,10 +156,10 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <div
-                    class="MuiBox-root emotion-21"
+                    class="MuiBox-root emotion-22"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-22"
+                      class="MuiTypography-root MuiTypography-h4 emotion-23"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_3_1"
                     >
@@ -166,7 +171,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <div
-                    class="MuiBox-root emotion-24"
+                    class="MuiBox-root emotion-25"
                   >
                     <ol
                       class="ods-WBGspT ods-OWSpcm ods-vhS2n4 ods-6fHBGU ods-1RXKSO ods-pMtclx ods-Xtd4sS ods-M9dxDe"
@@ -193,11 +198,11 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <div
-                    class="qrContainer MuiBox-root emotion-26"
+                    class="qrContainer MuiBox-root emotion-27"
                   >
                     <img
                       alt="QR code"
-                      class="qrImg MuiBox-root emotion-27"
+                      class="qrImg MuiBox-root emotion-28"
                       src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAe1BMVEX+/v4AAAD///90dHS9vb3Ozs6ZmZmJiYkeHh6dnZ1bW1tQUFBgYGDq6ur5+fnz8/OSkpJ9fX3ExMRqamrU1NRERES3t7cwMDClpaXb29vk5OSsrKzY2NgPDw/t7e1vb28mJiY+Pj55eXkXFxdKSko5OTlUVFQrKyuFhYX3xPd8AAAGcklEQVR4nO2d2XraMBBGicIW9kDCYiCQlBLe/wnbxjPKx4hBsiwToP+5I5Y0PtBqt1yrAQAAAAAAAAAAAAAAADiPiad4CcliFhGcbx7jmLzk4cxiEppjSDnqsTE30+KKZvMQS53utxGco085nqJjNiMMH6OjwdAFhn5gCMNi3JrhrhXIaO0zfKSUPZ/hbBQac5bAsBXcrWj7DBeUsO4z7AXH5C+rnGFoDq8hd3amPsNOcEwYnssLQzcHDK/e0Dc0CzHMCTf0xkxqONAwqmE7h0UaeRk1a8jXNUPjjZnQ0AzkF8+8K4bfP4CWcyZ+EtdQy/lwUcOuZmiL0g1FQhjCEIYwhGGE4b21FvV+9o/+nD6v990v3t+0Fv/WDFdFe203Z1i45w1DGMIQhj5DZ/R0b4am/zQ/4olFFnTBTnHfqqGdxXDmHghb5O0bKiGGMIQhDGEYaLgLNpTDwWszfO+eZPcYamjy4WGW8XBw+O4bH54O+TdoBYZndmRxDq9hTy2ydtrwwrP63hxewwl9Hmn/MW927QmGtgQYujlgeC7v/2M40psJQWFDtbUI308zSWC4bofyUNDwb59GWQMOj7lOYFicAobEze/cgyEMYQhDxXDiLzbYkOBHOJr02ZlNbEbH1DoR5wxf6rH0pSHt+B39ps9d3uFLGaa0xcksomMuihuWfwbJv897K3Jc9rmn8vgN5U6FWwOGMLx+rt4wuNqKr0tnbtbQqjJBXWoWDYXBcWlmIBO8yfZQY7vSYihFfgeVCbKUfRpRmMlkguLPPXkZi5jOdH9Mn0btl16lYdKeNwxhCEMYVm/YF21tXyaYpjdsiM5EUkNnzvtVFP5auE/TdHIQvHnYznnLnBs5W55izluuW5iuiNpVCtcNg9ctHMNneTNVrMzAEIYwhGE6Q66HDz7DfeHWQltWdldIZc4PMeAtZZi95MixpWPY3kyO6DVki794OUYbrlrDLRVpzzmar74yrqYchL/FEoZyE5pu6KDvEVaKdAwdxpRR3WYVY6iaRxiGFn3GME8whiEMYXhfhinrUl8Ivl91hVStSzvxhqYxzXnR2sPe6DStVaChGSzzEEteIR23jouyxq06peQrbEh/aI0jDL19mqU2jnX6NJqhXMd35+rlbyn7NOq/tBBDb7907ik1wtBJIQ1lv7QMMIQhDGvXZChwDLUq1RlbnDFUUA3jq1DX8DAYHjFwDIenGdgOCKdwDNezL35lWhEz4pcwNMPTRUYZqpChO6uv4nQemJmWgxO0jg2/f9xV/K94CUMbS06jW2oU46AZxuz2giEMYQjDyxl69wg/RRvKIY9uyAnZ8CC7AmVai2HfAx2GXxso19/sYbpcFA90679fv7CT96phnu51t6XP7R39RRQZp+jFl1I7NcKe/PHpNVRxbuInUHve1nBWwvDyPi4whCEMy99gPI6hgJsRu0d4F21Yok419adImtTPMP35Mkem4IXP9jz/PP+kPzxSBv/TQbbhoZiNiBnh0u+Z8Z8j7MCTzP5ukpzVT7pH2Evw2ZcOS/r1F96UCVZmYHgGGOrA8JvrMIyvS8MNy6yQsuGs1wmjJ98zM1zkZF1KsBW3uaaiezzh28zyHOO9KJonVD8px54NW3nK/bKEYYpzMQjZxKp9GmcjmTPGt7dZok9T4dkm34Z0QfZL5dkmcp4mCTA8kQOGMIRh1YZ6K+E3LNpaOKcoifVDZzdVCsP4s6AL9Gm8VLJuUcKQv+f7NeSiYAhDGMLwlgyTrpBWaLhpjMNwnit6P+Q8U4L68DoNwwfVWswUK6TVGobehG4YbwZDGMLwrgzVGlE1jKhL4+vUBO9GeONW7eP5iI+pcj8m87WHFtmixpyiVMV7Zjxf+IVPhqz+/RZuzJ85vxSGMIThfRhqVai4cK2GAW/SURRl8/GzhmXmvBmxz1t/htQ5eoo5+G6ijKE/R3lDvqCu41/rygwMYQjDOP4jwwT7aZiFaP7U1kLdX+oYpmgtZr1AJnJPlGPYzRN27AamVb4FasUP00w7eYpn2hvFZBvF0LTyHB1tUB1iWBzv2Zd2uKr1aTryn4e2jp9kX1uVhjKm9r4n3fBH9ybCEIYwLG1Y+nmLiFMFeTZxL0We6cKHVpfGzCZOm5GM+JmZbKSk0I48Mg3KIXf8mjrldBYM6C5HEc/MJHjnizeBHrP8BQAAAAAAAAAAAAAAAACCP5IF57xc3OReAAAAAElFTkSuQmCC"
                     />
                   </div>
@@ -208,7 +213,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                   <button
                     aria-describedby="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_3_1"
                     aria-label="Setup without scanning a QR code."
-                    class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-29"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
                     tabindex="0"
                     type="button"
                   >
@@ -220,7 +225,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                   data-se="switchAuthenticator"
                   href="javascript:void(0)"
                 >
@@ -231,7 +236,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                   data-se="cancel"
                   href="javascript:void(0)"
                 >

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -115,7 +115,6 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-15"
                     data-se="callout"
                     role="alert"
-                    title="Update Okta Verify"
                   >
                     <div
                       class="MuiAlert-icon emotion-16"

--- a/test/testcafe/spec/ChallengeOktaVerifySSOExtensionView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifySSOExtensionView_spec.js
@@ -103,11 +103,11 @@ test
     await t.expect(getStateHandleFromSessionStorage()).eql(null);
   });
 
-// TODO: OKTA-557948 Implement custom biometrics error and enable this test
-test.meta('v3', false)
+test.meta('v3', true)
   .requestHooks(credentialSSOExtensionBiometricsErrorMobileMock)('show biometrics error for mobile platform in credential SSO Extension', async t => {
     const ssoExtensionPage = new BasePageObject(t);
     await ssoExtensionPage.navigateToPage();
+    await ssoExtensionPage.formExists();
 
     const errorText = ssoExtensionPage.getErrorBoxText();
     await t.expect(errorText).contains('Biometrics needed for Okta Verify');
@@ -119,11 +119,11 @@ test.meta('v3', false)
     await t.expect(errorText).notContains('Your device\'s biometric sensors are accessible');
   });
 
-// TODO: OKTA-557948 Implement custom biometrics error and enable this test
-test.meta('v3', false)
+test.meta('v3', true)
   .requestHooks(credentialSSOExtensionBiometricsErrorDesktopMock)('show biometrics error for desktop platform in credential SSO Extension', async t => {
     const ssoExtensionPage = new BasePageObject(t);
     await ssoExtensionPage.navigateToPage();
+    await ssoExtensionPage.formExists();
 
     const errorText = ssoExtensionPage.getErrorBoxText();
     await t.expect(errorText).contains('Biometrics needed for Okta Verify');

--- a/test/testcafe/spec/ChallengeOktaVerifySSOExtensionView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifySSOExtensionView_spec.js
@@ -103,7 +103,7 @@ test
     await t.expect(getStateHandleFromSessionStorage()).eql(null);
   });
 
-test.meta('v3', true)
+test
   .requestHooks(credentialSSOExtensionBiometricsErrorMobileMock)('show biometrics error for mobile platform in credential SSO Extension', async t => {
     const ssoExtensionPage = new BasePageObject(t);
     await ssoExtensionPage.navigateToPage();
@@ -119,7 +119,7 @@ test.meta('v3', true)
     await t.expect(errorText).notContains('Your device\'s biometric sensors are accessible');
   });
 
-test.meta('v3', true)
+test
   .requestHooks(credentialSSOExtensionBiometricsErrorDesktopMock)('show biometrics error for desktop platform in credential SSO Extension', async t => {
     const ssoExtensionPage = new BasePageObject(t);
     await ssoExtensionPage.navigateToPage();


### PR DESCRIPTION
## Description:

This PR adds the custom biometrics error with bullet points for fastpass apple SSO extension.  This custom error matches parity with v2.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-557948](https://oktainc.atlassian.net/browse/OKTA-557948)

### Reviewers:

### Screenshot/Video:

![image](https://user-images.githubusercontent.com/107433508/212817773-ea93b19d-0a34-4809-b8b0-49ac7758b73d.png)

### Downstream Monolith Build:



