### PR TITLE
OKTA-560815 : Add support for engFastpassMultipleAccounts

### DIFF
--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -22,7 +22,7 @@ import {
   LaunchAuthenticatorButtonElement,
   UISchemaElementComponent,
 } from '../../types';
-import { setUrlQueryParams, getTranslation, isAndroid } from '../../util';
+import { getTranslation, isAndroid, setUrlQueryParams } from '../../util';
 import { OktaVerifyIcon } from '../Icon';
 
 const LaunchAuthenticatorButton: UISchemaElementComponent<{
@@ -53,7 +53,7 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
       setUserIdentifier(data.identifier as string);
     }
     if (deviceChallengeUrl) {
-      const loginHintQueryParam = userIdentifier ? {login_hint: userIdentifier} : undefined;
+      const loginHintQueryParam = userIdentifier ? { login_hint: userIdentifier } : undefined;
       if (isAndroid() && challengeMethod !== CHALLENGE_METHOD.APP_LINK) {
         Util.redirectWithFormGet(setUrlQueryParams(deviceChallengeUrl, loginHintQueryParam));
       } else {

--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -22,7 +22,7 @@ import {
   LaunchAuthenticatorButtonElement,
   UISchemaElementComponent,
 } from '../../types';
-import { appendLoginHint, getTranslation, isAndroid } from '../../util';
+import { setUrlQueryParams, getTranslation, isAndroid } from '../../util';
 import { OktaVerifyIcon } from '../Icon';
 
 const LaunchAuthenticatorButton: UISchemaElementComponent<{
@@ -50,13 +50,14 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
   const handleClick: ClickHandler = async () => {
     if (features?.engFastpassMultipleAccounts && data.identifier) {
       // set userIdentifier in widget context to the current Username input field data
-      setUserIdentifier(encodeURIComponent(data.identifier as string));
+      setUserIdentifier(data.identifier as string);
     }
     if (deviceChallengeUrl) {
+      const loginHintQueryParam = userIdentifier ? {login_hint: userIdentifier} : undefined;
       if (isAndroid() && challengeMethod !== CHALLENGE_METHOD.APP_LINK) {
-        Util.redirectWithFormGet(appendLoginHint(deviceChallengeUrl, userIdentifier));
+        Util.redirectWithFormGet(setUrlQueryParams(deviceChallengeUrl, loginHintQueryParam));
       } else {
-        window.location.assign(appendLoginHint(deviceChallengeUrl, userIdentifier));
+        window.location.assign(setUrlQueryParams(deviceChallengeUrl, loginHintQueryParam));
       }
     }
     onSubmitHandler({

--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -22,7 +22,9 @@ import {
   LaunchAuthenticatorButtonElement,
   UISchemaElementComponent,
 } from '../../types';
-import { getTranslation, isAndroid, setUrlQueryParams } from '../../util';
+import {
+  getBaseUrl, getTranslation, isAndroid, setUrlQueryParams,
+} from '../../util';
 import { OktaVerifyIcon } from '../Icon';
 
 const LaunchAuthenticatorButton: UISchemaElementComponent<{
@@ -44,6 +46,7 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
     loginHint,
     setloginHint,
     data,
+    widgetProps,
   } = useWidgetContext();
 
   const handleClick: ClickHandler = async () => {
@@ -53,10 +56,11 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
     }
     if (deviceChallengeUrl) {
       const loginHintQueryParam = loginHint ? { login_hint: loginHint } : undefined;
+      const urlObj = new URL(deviceChallengeUrl, getBaseUrl(widgetProps));
       if (isAndroid() && challengeMethod !== CHALLENGE_METHOD.APP_LINK) {
-        Util.redirectWithFormGet(setUrlQueryParams(deviceChallengeUrl, loginHintQueryParam));
+        Util.redirectWithFormGet(setUrlQueryParams(urlObj, loginHintQueryParam));
       } else {
-        window.location.assign(setUrlQueryParams(deviceChallengeUrl, loginHintQueryParam));
+        window.location.assign(setUrlQueryParams(urlObj, loginHintQueryParam));
       }
     }
     onSubmitHandler({

--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -41,22 +41,22 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
 
   const focusRef = useAutoFocus<HTMLButtonElement>(focus);
   const {
-    loginHint,
-    setLoginHint,
+    userIdentifier,
+    setUserIdentifier,
     data,
     widgetProps: { features },
   } = useWidgetContext();
 
   const handleClick: ClickHandler = async () => {
     if (features?.engFastpassMultipleAccounts && data.identifier) {
-      // set loginHint to the current Username input field data
-      setLoginHint(encodeURIComponent(data.identifier as string));
+      // set userIdentifier in widget context to the current Username input field data
+      setUserIdentifier(encodeURIComponent(data.identifier as string));
     }
     if (deviceChallengeUrl) {
       if (isAndroid() && challengeMethod !== CHALLENGE_METHOD.APP_LINK) {
-        Util.redirectWithFormGet(appendLoginHint(deviceChallengeUrl, loginHint));
+        Util.redirectWithFormGet(appendLoginHint(deviceChallengeUrl, userIdentifier));
       } else {
-        window.location.assign(appendLoginHint(deviceChallengeUrl, loginHint));
+        window.location.assign(appendLoginHint(deviceChallengeUrl, userIdentifier));
       }
     }
     onSubmitHandler({

--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -15,13 +15,14 @@ import { h } from 'preact';
 
 import Util from '../../../../util/Util';
 import { CHALLENGE_METHOD } from '../../constants';
+import { useWidgetContext } from '../../contexts';
 import { useAutoFocus, useOnSubmit } from '../../hooks';
 import {
   ClickHandler,
   LaunchAuthenticatorButtonElement,
   UISchemaElementComponent,
 } from '../../types';
-import { getTranslation, isAndroid } from '../../util';
+import { appendLoginHint, getTranslation, isAndroid } from '../../util';
 import { OktaVerifyIcon } from '../Icon';
 
 const LaunchAuthenticatorButton: UISchemaElementComponent<{
@@ -39,13 +40,23 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
   } = uischema;
 
   const focusRef = useAutoFocus<HTMLButtonElement>(focus);
+  const {
+    loginHint,
+    setLoginHint,
+    data,
+    widgetProps: { features },
+  } = useWidgetContext();
 
   const handleClick: ClickHandler = async () => {
+    if (features?.engFastpassMultipleAccounts && data.identifier) {
+      // set loginHint to the current Username input field data
+      setLoginHint(encodeURIComponent(data.identifier as string));
+    }
     if (deviceChallengeUrl) {
       if (isAndroid() && challengeMethod !== CHALLENGE_METHOD.APP_LINK) {
-        Util.redirectWithFormGet(deviceChallengeUrl);
+        Util.redirectWithFormGet(appendLoginHint(deviceChallengeUrl, loginHint));
       } else {
-        window.location.assign(deviceChallengeUrl);
+        window.location.assign(appendLoginHint(deviceChallengeUrl, loginHint));
       }
     }
     onSubmitHandler({

--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -41,19 +41,18 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
 
   const focusRef = useAutoFocus<HTMLButtonElement>(focus);
   const {
-    userIdentifier,
-    setUserIdentifier,
+    loginHint,
+    setloginHint,
     data,
-    widgetProps: { features },
   } = useWidgetContext();
 
   const handleClick: ClickHandler = async () => {
-    if (features?.engFastpassMultipleAccounts && data.identifier) {
-      // set userIdentifier in widget context to the current Username input field data
-      setUserIdentifier(data.identifier as string);
+    if (data.identifier) {
+      // set loginHint in widget context to the current Username input field data
+      setloginHint(data.identifier as string);
     }
     if (deviceChallengeUrl) {
-      const loginHintQueryParam = userIdentifier ? { login_hint: userIdentifier } : undefined;
+      const loginHintQueryParam = loginHint ? { login_hint: loginHint } : undefined;
       if (isAndroid() && challengeMethod !== CHALLENGE_METHOD.APP_LINK) {
         Util.redirectWithFormGet(setUrlQueryParams(deviceChallengeUrl, loginHintQueryParam));
       } else {

--- a/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
+++ b/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
@@ -23,7 +23,7 @@ import {
   OpenOktaVerifyFPButtonElement,
   UISchemaElementComponent,
 } from '../../types';
-import { setUrlQueryParams, getTranslation, isAndroid } from '../../util';
+import { getTranslation, isAndroid, setUrlQueryParams } from '../../util';
 import Button from '../Button';
 
 type IFrameProps = {
@@ -55,7 +55,7 @@ const OpenOktaVerifyFPButton: UISchemaElementComponent<{
   const [key, setKey] = useState<number>(0);
   const label = getTranslation(translations, 'label');
   const { userIdentifier } = useWidgetContext();
-  const loginHintQueryParam = userIdentifier ? {login_hint: userIdentifier} : undefined;
+  const loginHintQueryParam = userIdentifier ? { login_hint: userIdentifier } : undefined;
   const deviceChallengeUrl = setUrlQueryParams(href as string, loginHintQueryParam);
 
   const buttonUiSchema: ButtonElement = {

--- a/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
+++ b/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
@@ -54,8 +54,8 @@ const OpenOktaVerifyFPButton: UISchemaElementComponent<{
   } = uischema;
   const [key, setKey] = useState<number>(0);
   const label = getTranslation(translations, 'label');
-  const { loginHint } = useWidgetContext();
-  const deviceChallengeUrl = appendLoginHint(href, loginHint);
+  const { userIdentifier } = useWidgetContext();
+  const deviceChallengeUrl = appendLoginHint(href, userIdentifier);
 
   const buttonUiSchema: ButtonElement = {
     type: 'Button',

--- a/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
+++ b/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
@@ -54,8 +54,8 @@ const OpenOktaVerifyFPButton: UISchemaElementComponent<{
   } = uischema;
   const [key, setKey] = useState<number>(0);
   const label = getTranslation(translations, 'label');
-  const { userIdentifier } = useWidgetContext();
-  const loginHintQueryParam = userIdentifier ? { login_hint: userIdentifier } : undefined;
+  const { loginHint } = useWidgetContext();
+  const loginHintQueryParam = loginHint ? { login_hint: loginHint } : undefined;
   const deviceChallengeUrl = setUrlQueryParams(href as string, loginHintQueryParam);
 
   const buttonUiSchema: ButtonElement = {

--- a/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
+++ b/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
@@ -23,7 +23,7 @@ import {
   OpenOktaVerifyFPButtonElement,
   UISchemaElementComponent,
 } from '../../types';
-import { appendLoginHint, getTranslation, isAndroid } from '../../util';
+import { setUrlQueryParams, getTranslation, isAndroid } from '../../util';
 import Button from '../Button';
 
 type IFrameProps = {
@@ -55,7 +55,8 @@ const OpenOktaVerifyFPButton: UISchemaElementComponent<{
   const [key, setKey] = useState<number>(0);
   const label = getTranslation(translations, 'label');
   const { userIdentifier } = useWidgetContext();
-  const deviceChallengeUrl = appendLoginHint(href, userIdentifier);
+  const loginHintQueryParam = userIdentifier ? {login_hint: userIdentifier} : undefined;
+  const deviceChallengeUrl = setUrlQueryParams(href as string, loginHintQueryParam);
 
   const buttonUiSchema: ButtonElement = {
     type: 'Button',

--- a/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
+++ b/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
@@ -16,13 +16,14 @@ import { useState } from 'preact/hooks';
 
 import Util from '../../../../util/Util';
 import { CHALLENGE_METHOD } from '../../constants';
+import { useWidgetContext } from '../../contexts';
 import {
   ButtonElement,
   ButtonType,
   OpenOktaVerifyFPButtonElement,
   UISchemaElementComponent,
 } from '../../types';
-import { getTranslation, isAndroid } from '../../util';
+import { appendLoginHint, getTranslation, isAndroid } from '../../util';
 import Button from '../Button';
 
 type IFrameProps = {
@@ -53,6 +54,8 @@ const OpenOktaVerifyFPButton: UISchemaElementComponent<{
   } = uischema;
   const [key, setKey] = useState<number>(0);
   const label = getTranslation(translations, 'label');
+  const { loginHint } = useWidgetContext();
+  const deviceChallengeUrl = appendLoginHint(href, loginHint);
 
   const buttonUiSchema: ButtonElement = {
     type: 'Button',
@@ -70,9 +73,9 @@ const OpenOktaVerifyFPButton: UISchemaElementComponent<{
         const isCustomUriMethod = challengeMethod === CHALLENGE_METHOD.CUSTOM_URI;
         if ((isAppLinkMethod || isUniversalLinkMethod) && href) {
           if (isAndroid() && isUniversalLinkMethod) {
-            Util.redirectWithFormGet(href);
+            Util.redirectWithFormGet(deviceChallengeUrl);
           } else {
-            window.location.assign(href);
+            window.location.assign(deviceChallengeUrl);
           }
         }
 
@@ -90,7 +93,7 @@ const OpenOktaVerifyFPButton: UISchemaElementComponent<{
       {(href && challengeMethod === CHALLENGE_METHOD.CUSTOM_URI) && (
       <IFrame
         key={key}
-        src={href}
+        src={deviceChallengeUrl}
       />
       )}
     </React.Fragment>

--- a/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
+++ b/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
@@ -23,7 +23,9 @@ import {
   OpenOktaVerifyFPButtonElement,
   UISchemaElementComponent,
 } from '../../types';
-import { getTranslation, isAndroid, setUrlQueryParams } from '../../util';
+import {
+  getBaseUrl, getTranslation, isAndroid, setUrlQueryParams,
+} from '../../util';
 import Button from '../Button';
 
 type IFrameProps = {
@@ -54,9 +56,10 @@ const OpenOktaVerifyFPButton: UISchemaElementComponent<{
   } = uischema;
   const [key, setKey] = useState<number>(0);
   const label = getTranslation(translations, 'label');
-  const { loginHint } = useWidgetContext();
+  const { loginHint, widgetProps } = useWidgetContext();
+  const urlObj = new URL(href as string, getBaseUrl(widgetProps));
   const loginHintQueryParam = loginHint ? { login_hint: loginHint } : undefined;
-  const deviceChallengeUrl = setUrlQueryParams(href as string, loginHintQueryParam);
+  const deviceChallengeUrl = setUrlQueryParams(urlObj, loginHintQueryParam);
 
   const buttonUiSchema: ButtonElement = {
     type: 'Button',

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -31,9 +31,9 @@ import {
   useRef,
   useState,
 } from 'preact/hooks';
-import { IDX_STEP } from '../../constants';
 
 import Bundles from '../../../../util/Bundles';
+import { IDX_STEP } from '../../constants';
 import { WidgetContextProvider } from '../../contexts';
 import { usePolling } from '../../hooks';
 import { transformIdxTransaction } from '../../transformer';

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -96,7 +96,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [widgetRendered, setWidgetRendered] = useState<boolean>(false);
   const brandedTheme = mapMuiThemeFromBrand(brandColors);
-  const [userIdentifier, setUserIdentifier] = useState<string | undefined>(undefined);
+  const [userIdentifier, setUserIdentifier] = useState<string | null>(null);
 
   useEffect(() => {
     // If we need to load a language (or apply custom i18n overrides), do

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -149,6 +149,11 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       return createForm();
     }
 
+    // clear the loginHint value when returning to the identify flow
+    if (idxTransaction?.nextStep?.name === IDX_STEP.IDENTIFY) {
+      setloginHint(null);
+    }
+
     if ([IdxStatus.TERMINAL, IdxStatus.SUCCESS].includes(idxTransaction.status)
         || !idxTransaction.nextStep) {
       return transformTerminalTransaction(idxTransaction, widgetProps, bootstrap);
@@ -246,10 +251,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   }, [pollingTransaction]); // only watch on pollingTransaction changes
 
   useEffect(() => {
-    // clear the loginHint value when returning to the identify flow
-    if (idxTransaction?.nextStep?.name === IDX_STEP.IDENTIFY) {
-      setloginHint(null);
-    }
     if (isClientTransaction) {
       return;
     }

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -31,6 +31,7 @@ import {
   useRef,
   useState,
 } from 'preact/hooks';
+import { IDX_STEP } from '../../constants';
 
 import Bundles from '../../../../util/Bundles';
 import { WidgetContextProvider } from '../../contexts';
@@ -96,7 +97,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [widgetRendered, setWidgetRendered] = useState<boolean>(false);
   const brandedTheme = mapMuiThemeFromBrand(brandColors);
-  const [userIdentifier, setUserIdentifier] = useState<string | null>(null);
+  const [loginHint, setloginHint] = useState<string | null>(null);
 
   useEffect(() => {
     // If we need to load a language (or apply custom i18n overrides), do
@@ -245,6 +246,10 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   }, [pollingTransaction]); // only watch on pollingTransaction changes
 
   useEffect(() => {
+    // clear the loginHint value when returning to the identify flow
+    if (idxTransaction?.nextStep?.name === IDX_STEP.IDENTIFY) {
+      setloginHint(null);
+    }
     if (isClientTransaction) {
       return;
     }
@@ -283,8 +288,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       loading,
       setLoading,
       setWidgetRendered,
-      userIdentifier,
-      setUserIdentifier,
+      loginHint,
+      setloginHint,
     }}
     >
       {/* Note: we need to keep both themeproviders (MUI/ODS) until ODS exports all MUI components */}

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -96,7 +96,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [widgetRendered, setWidgetRendered] = useState<boolean>(false);
   const brandedTheme = mapMuiThemeFromBrand(brandColors);
-  const [loginHint, setLoginHint] = useState<string | undefined>(undefined);
+  const [userIdentifier, setUserIdentifier] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     // If we need to load a language (or apply custom i18n overrides), do
@@ -283,8 +283,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       loading,
       setLoading,
       setWidgetRendered,
-      loginHint,
-      setLoginHint,
+      userIdentifier,
+      setUserIdentifier,
     }}
     >
       {/* Note: we need to keep both themeproviders (MUI/ODS) until ODS exports all MUI components */}

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -96,6 +96,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [widgetRendered, setWidgetRendered] = useState<boolean>(false);
   const brandedTheme = mapMuiThemeFromBrand(brandColors);
+  const [loginHint, setLoginHint] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     // If we need to load a language (or apply custom i18n overrides), do
@@ -282,6 +283,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       loading,
       setLoading,
       setWidgetRendered,
+      loginHint,
+      setLoginHint,
     }}
     >
       {/* Note: we need to keep both themeproviders (MUI/ODS) until ODS exports all MUI components */}

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -52,9 +52,10 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setAuthApiError,
     setIdxTransaction,
     setIsClientTransaction,
+    setLoading,
     setMessage,
     setStepToRender,
-    setLoading,
+    setUserIdentifier,
     widgetProps: { events },
   } = useWidgetContext();
 
@@ -167,6 +168,10 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
           class: 'ERROR',
           i18n: { key: 'oform.errorbanner.title' },
         } as IdxMessage);
+      }
+      // clear the userIdentifier value when returning to the identify flow
+      if(newTransaction.nextStep?.name === IDX_STEP.IDENTIFY) {
+        setUserIdentifier(null);
       }
       setStepToRender(stepToRender);
     } catch (error) {

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -170,7 +170,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
         } as IdxMessage);
       }
       // clear the userIdentifier value when returning to the identify flow
-      if(newTransaction.nextStep?.name === IDX_STEP.IDENTIFY) {
+      if (newTransaction.nextStep?.name === IDX_STEP.IDENTIFY) {
         setUserIdentifier(null);
       }
       setStepToRender(stepToRender);
@@ -190,5 +190,6 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setLoading,
     setMessage,
     setStepToRender,
+    setUserIdentifier,
   ]);
 };

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -55,7 +55,6 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setLoading,
     setMessage,
     setStepToRender,
-    setUserIdentifier,
     widgetProps: { events },
   } = useWidgetContext();
 
@@ -169,10 +168,6 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
           i18n: { key: 'oform.errorbanner.title' },
         } as IdxMessage);
       }
-      // clear the userIdentifier value when returning to the identify flow
-      if (newTransaction.nextStep?.name === IDX_STEP.IDENTIFY) {
-        setUserIdentifier(null);
-      }
       setStepToRender(stepToRender);
     } catch (error) {
       handleError(currTransaction, error);
@@ -190,6 +185,5 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setLoading,
     setMessage,
     setStepToRender,
-    setUserIdentifier,
   ]);
 };

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -42,8 +42,8 @@ export type IWidgetContext = {
   loading: boolean;
   setLoading: StateUpdater<boolean>;
   setWidgetRendered: StateUpdater<boolean>;
-  loginHint?: string;
-  setLoginHint: StateUpdater<string | undefined>;
+  userIdentifier?: string;
+  setUserIdentifier: StateUpdater<string | undefined>;
 };
 
 // Stepper context

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -42,8 +42,8 @@ export type IWidgetContext = {
   loading: boolean;
   setLoading: StateUpdater<boolean>;
   setWidgetRendered: StateUpdater<boolean>;
-  userIdentifier?: string | null;
-  setUserIdentifier: StateUpdater<string | null>;
+  loginHint?: string | null;
+  setloginHint: StateUpdater<string | null>;
 };
 
 // Stepper context

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -42,6 +42,8 @@ export type IWidgetContext = {
   loading: boolean;
   setLoading: StateUpdater<boolean>;
   setWidgetRendered: StateUpdater<boolean>;
+  loginHint?: string;
+  setLoginHint: StateUpdater<string | undefined>;
 };
 
 // Stepper context

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -42,8 +42,8 @@ export type IWidgetContext = {
   loading: boolean;
   setLoading: StateUpdater<boolean>;
   setWidgetRendered: StateUpdater<boolean>;
-  userIdentifier?: string;
-  setUserIdentifier: StateUpdater<string | undefined>;
+  userIdentifier?: string | null;
+  setUserIdentifier: StateUpdater<string | null>;
 };
 
 // Stepper context

--- a/src/v3/src/util/appendLoginHint.ts
+++ b/src/v3/src/util/appendLoginHint.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export const appendLoginHint = (deviceChallengeUrl = '', loginHint = ''): string => {
+  if (deviceChallengeUrl && loginHint) {
+    return `${deviceChallengeUrl}&login_hint=${loginHint}`;
+  }
+  return deviceChallengeUrl;
+};

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+export * from './appendLoginHint';
 export * from './browserUtils';
 export * from './buildErrorMessageIds';
 export * from './clipboard';

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export * from './appendLoginHint';
+export * from './setUrlQueryParams';
 export * from './browserUtils';
 export * from './buildErrorMessageIds';
 export * from './clipboard';

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export * from './setUrlQueryParams';
 export * from './browserUtils';
 export * from './buildErrorMessageIds';
 export * from './clipboard';
@@ -36,6 +35,7 @@ export * from './passwordUtils';
 export * from './removeFieldLevelMessages';
 export * from './resetMessagesToInputs';
 export * from './settingsUtils';
+export * from './setUrlQueryParams';
 export * from './shouldShowCancelLink';
 export * from './toNestedObject';
 export * from './webauthnUtils';

--- a/src/v3/src/util/setUrlQueryParams.ts
+++ b/src/v3/src/util/setUrlQueryParams.ts
@@ -10,9 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export const appendLoginHint = (deviceChallengeUrl = '', loginHint = ''): string => {
-  if (deviceChallengeUrl && loginHint) {
-    return `${deviceChallengeUrl}&login_hint=${loginHint}`;
-  }
-  return deviceChallengeUrl;
-};
+export const setUrlQueryParams = (
+  url: URL | string,
+  params: Record<string, string> = {}
+) => url + '?' + new URLSearchParams(params).toString();

--- a/src/v3/src/util/setUrlQueryParams.ts
+++ b/src/v3/src/util/setUrlQueryParams.ts
@@ -10,7 +10,16 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { getBaseUrl } from "../util";
+import { useWidgetContext } from '../contexts';
+
 export const setUrlQueryParams = (
   url: URL | string,
   params: Record<string, string> = {},
-) => url + '?' + new URLSearchParams(params).toString();
+) => {
+  const { widgetProps } = useWidgetContext();
+  const u = new URL(url, getBaseUrl(widgetProps));
+  Object.entries(params)
+    .forEach(([k, v]) => u.searchParams.set(k, v))
+  return u.toString();
+}

--- a/src/v3/src/util/setUrlQueryParams.ts
+++ b/src/v3/src/util/setUrlQueryParams.ts
@@ -12,5 +12,5 @@
 
 export const setUrlQueryParams = (
   url: URL | string,
-  params: Record<string, string> = {}
+  params: Record<string, string> = {},
 ) => url + '?' + new URLSearchParams(params).toString();

--- a/src/v3/src/util/setUrlQueryParams.ts
+++ b/src/v3/src/util/setUrlQueryParams.ts
@@ -10,16 +10,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { getBaseUrl } from "../util";
-import { useWidgetContext } from '../contexts';
-
 export const setUrlQueryParams = (
   url: URL | string,
   params: Record<string, string> = {},
 ) => {
-  const { widgetProps } = useWidgetContext();
-  const u = new URL(url, getBaseUrl(widgetProps));
+  const u = new URL(url);
   Object.entries(params)
-    .forEach(([k, v]) => u.searchParams.set(k, v))
+    .forEach(([k, v]) => u.searchParams.set(k, v));
   return u.toString();
-}
+};

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -603,7 +603,6 @@ test
   });
 
 test
-  .meta('v3', false) // Not yet implemented in v3 (OKTA-560815)
   .requestHooks(LoginHintCustomURIMock)('expect login_hint in CustomURI when engFastpassMultipleAccounts is on', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
@@ -642,7 +641,6 @@ test
   });
 
 test
-  .meta('v3', false) // Not yet implemented in v3 (OKTA-560815)
   .requestHooks(LoginHintUniversalLinkMock)('expect login_hint in UniversalLink with engFastpassMultipleAccounts on', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
@@ -679,7 +677,6 @@ test
   });
 
 test
-  .meta('v3', false) // Not yet implemented in v3 (OKTA-560815)
   .requestHooks(LoginHintAppLinkMock)('expect login_hint in AppLink when engFastpassMultipleAccounts is on', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
@@ -693,8 +690,9 @@ test
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Sign in with Okta FastPass');
 
     await t.expect(await deviceChallengePollPageObject.hasSpinner()).eql(true);
-    await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().innerText).eql('Cancel and take me to sign in');
+    await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(true);
 
+    await t.wait(5000); // wait for FASTPASS_FALLBACK_SPINNER_TIMEOUT
 
     await t.expect(deviceChallengePollPageObject.waitForPrimaryButtonAfterSpinner().innerText).eql('Open Okta Verify');
     await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -603,7 +603,7 @@ test
   });
 
 test
-  .requestHooks(LoginHintCustomURIMock)('expect login_hint in CustomURI when engFastpassMultipleAccounts is on', async t => {
+  .requestHooks(LoginHintCustomURIMock)('expect login_hint in CustomURI in all cases', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
       features: { engFastpassMultipleAccounts: true },
@@ -622,26 +622,7 @@ test
   });
 
 test
-  .requestHooks(LoginHintCustomURIMock)('expect login_hint not in CustomURI when engFastpassMultipleAccounts is off', async t => {
-    const identityPage = await setupLoopbackFallback(t);
-    await renderWidget({
-      features: { engFastpassMultipleAccounts: false },
-    });
-
-    // enter username as login_hint on the SIW page
-    const username = 'john.smith@okta.com';
-    await identityPage.fillIdentifierField(username);
-    identityPage.clickOktaVerifyButton();
-    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
-    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Click "Open Okta Verify" on the browser prompt');
-
-    // verify login_hint is not appended to the customURI url in the iframe
-    const attributes = await deviceChallengePollPageObject.getIframeAttributes();
-    await t.expect(attributes.src).notContains(encodeURIComponent(username));
-  });
-
-test
-  .requestHooks(LoginHintUniversalLinkMock)('expect login_hint in UniversalLink with engFastpassMultipleAccounts on', async t => {
+  .requestHooks(LoginHintUniversalLinkMock)('expect login_hint in UniversalLink in all cases', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
       features: { engFastpassMultipleAccounts: true },
@@ -659,25 +640,7 @@ test
   });
 
 test
-  .requestHooks(LoginHintUniversalLinkMock)('expect login_hint not in UniversalLink engFastpassMultipleAccounts off', async t => {
-    const identityPage = await setupLoopbackFallback(t);
-    await renderWidget({
-      features: { engFastpassMultipleAccounts: false },
-    });
-
-    const username = 'john.smith@okta.com';
-    await identityPage.fillIdentifierField(username);
-    identityPage.clickOktaVerifyButton();
-    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
-    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Sign in with Okta FastPass');
-
-    deviceChallengePollPageObject.clickLaunchOktaVerifyButton();
-    // verify login_hint is not appended to the universal link url
-    await t.expect(getPageUrl()).notContains(encodeURIComponent(username));
-  });
-
-test
-  .requestHooks(LoginHintAppLinkMock)('expect login_hint in AppLink when engFastpassMultipleAccounts is on', async t => {
+  .requestHooks(LoginHintAppLinkMock)('expect login_hint in AppLink in all cases', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
       features: { engFastpassMultipleAccounts: true },
@@ -701,23 +664,4 @@ test
     deviceChallengePollPageObject.clickLaunchOktaVerifyButton();
     // verify login_hint has been appended to the app link url
     await t.expect(getPageUrl()).contains('login_hint='+encodeURIComponent(username));
-  });
-
-test
-  .requestHooks(LoginHintAppLinkMock)('expect login_hint not in AppLink when engFastpassMultipleAccounts is off', async t => {
-    const identityPage = await setupLoopbackFallback(t);
-    await renderWidget({
-      features: { engFastpassMultipleAccounts: false },
-    });
-
-    const username = 'john.smith@okta.com';
-    await identityPage.fillIdentifierField(username);
-    identityPage.clickOktaVerifyButton();
-    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
-    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Sign in with Okta FastPass');
-
-    deviceChallengePollPageObject.clickLaunchOktaVerifyButton();
-    await t.wait(100); // opening the link takes just a moment
-    // verify login_hint is not appended to the app link url
-    await t.expect(getPageUrl()).notContains(encodeURIComponent(username));
   });


### PR DESCRIPTION
## Description:

This PR implements the OVFP behavior for when the engFastpassMultipleAccounts widget feature is enabled.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-560815](https://oktainc.atlassian.net/browse/OKTA-560815)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



