### PR TITLE
remove engFastpassMultipleAccounts flag from outside usage

### DIFF
--- a/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
+++ b/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
@@ -31,7 +31,7 @@ export default View.extend({
       icon: 'okta-verify-authenticator',
       title: loc('oktaVerify.button', 'login'),
       click() {
-        if (this.settings.get('features.engFastpassMultipleAccounts') && this.model.get('identifier')) {
+        if (this.model.get('identifier')) {
           this.options.settings.set('identifier', encodeURIComponent(this.model.get('identifier')));
         }
 

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -417,10 +417,10 @@ test
   });
 
 test
-  .requestHooks(loginHintAppLinkMock)('expect login_hint in AppLink when engFastpassMultipleAccounts is on', async t => {
+  .requestHooks(loginHintAppLinkMock)('expect login_hint in AppLink in all cases', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
-      features: { engFastpassMultipleAccounts: true },
+      features: { },
     });
 
     const username = 'john.smith@okta.com';

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -417,7 +417,7 @@ test
   });
 
 test
-  .requestHooks(loginHintAppLinkMock)('expect login_hint in AppLink in all cases', async t => {
+  .requestHooks(loginHintAppLinkMock)('expect login_hint in AppLink', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
       features: { },

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -593,10 +593,10 @@ test
   });
 
 test
-  .requestHooks(LoginHintCustomURIMock)('expect login_hint in CustomURI when engFastpassMultipleAccounts is on', async t => {
+  .requestHooks(LoginHintCustomURIMock)('expect login_hint in CustomURI in all cases', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
-      features: { engFastpassMultipleAccounts: true },
+      features: { },
     });
 
     // enter username as login_hint on the SIW page
@@ -612,29 +612,10 @@ test
   });
 
 test
-  .requestHooks(LoginHintCustomURIMock)('expect login_hint not in CustomURI when engFastpassMultipleAccounts is off', async t => {
+  .requestHooks(LoginHintUniversalLinkMock)('expect login_hint in UniversalLink in all cases', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
-      features: { engFastpassMultipleAccounts: false },
-    });
-
-    // enter username as login_hint on the SIW page
-    const username = 'john.smith@okta.com';
-    await identityPage.fillIdentifierField(username);
-    identityPage.clickOktaVerifyButton();
-    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
-    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Click "Open Okta Verify" on the browser prompt');
-
-    // verify login_hint is not appended to the customURI url in the iframe
-    const attributes = await deviceChallengePollPageObject.getIframeAttributes();
-    await t.expect(attributes.src).notContains(encodeURIComponent(username));
-  });
-
-test
-  .requestHooks(LoginHintUniversalLinkMock)('expect login_hint in UniversalLink with engFastpassMultipleAccounts on', async t => {
-    const identityPage = await setupLoopbackFallback(t);
-    await renderWidget({
-      features: { engFastpassMultipleAccounts: true },
+      features: { },
     });
 
     const username = 'john.smith@okta.com';
@@ -649,28 +630,10 @@ test
   });
 
 test
-  .requestHooks(LoginHintUniversalLinkMock)('expect login_hint not in UniversalLink engFastpassMultipleAccounts off', async t => {
+  .requestHooks(LoginHintAppLinkMock)('expect login_hint in AppLink in all cases', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
-      features: { engFastpassMultipleAccounts: false },
-    });
-
-    const username = 'john.smith@okta.com';
-    await identityPage.fillIdentifierField(username);
-    identityPage.clickOktaVerifyButton();
-    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
-    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign in with Okta FastPass');
-
-    deviceChallengePollPageObject.clickUniversalLink();
-    // verify login_hint is not appended to the universal link url
-    await t.expect(getPageUrl()).notContains(encodeURIComponent(username));
-  });
-
-test
-  .requestHooks(LoginHintAppLinkMock)('expect login_hint in AppLink when engFastpassMultipleAccounts is on', async t => {
-    const identityPage = await setupLoopbackFallback(t);
-    await renderWidget({
-      features: { engFastpassMultipleAccounts: true },
+      features: { },
     });
 
     const username = 'john.smith@okta.com';
@@ -690,23 +653,4 @@ test
     deviceChallengePollPageObject.clickAppLink();
     // verify login_hint has been appended to the app link url
     await t.expect(getPageUrl()).contains('login_hint='+encodeURIComponent(username));
-  });
-
-test
-  .requestHooks(LoginHintAppLinkMock)('expect login_hint not in AppLink when engFastpassMultipleAccounts is off', async t => {
-    const identityPage = await setupLoopbackFallback(t);
-    await renderWidget({
-      features: { engFastpassMultipleAccounts: false },
-    });
-
-    const username = 'john.smith@okta.com';
-    await identityPage.fillIdentifierField(username);
-    identityPage.clickOktaVerifyButton();
-    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
-    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign in with Okta FastPass');
-
-    deviceChallengePollPageObject.clickAppLink();
-    await t.wait(100); // opening the link takes just a moment
-    // verify login_hint is not appended to the app link url
-    await t.expect(getPageUrl()).notContains(encodeURIComponent(username));
   });

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -593,7 +593,7 @@ test
   });
 
 test
-  .requestHooks(LoginHintCustomURIMock)('expect login_hint in CustomURI in all cases', async t => {
+  .requestHooks(LoginHintCustomURIMock)('expect login_hint in CustomURI', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
       features: { },
@@ -612,7 +612,7 @@ test
   });
 
 test
-  .requestHooks(LoginHintUniversalLinkMock)('expect login_hint in UniversalLink in all cases', async t => {
+  .requestHooks(LoginHintUniversalLinkMock)('expect login_hint in UniversalLink', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
       features: { },
@@ -630,7 +630,7 @@ test
   });
 
 test
-  .requestHooks(LoginHintAppLinkMock)('expect login_hint in AppLink in all cases', async t => {
+  .requestHooks(LoginHintAppLinkMock)('expect login_hint in AppLink', async t => {
     const identityPage = await setupLoopbackFallback(t);
     await renderWidget({
       features: { },


### PR DESCRIPTION
## Description:



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-481591](https://oktainc.atlassian.net/browse/OKTA-481591) OIE SKU FF Reduction: ENG_FASTPASS_MULTIPLE_ACCOUNTS

Nutshell: remove the flag ENG_FASTPASS_MULTIPLE_ACCOUNTS as it is fully enabled by the OIE LGA SKU

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:

okta-core

