### PR TITLE
V3 parity spec for enroll phone authenticator data view

### DIFF
--- a/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
@@ -4,7 +4,8 @@ import { userVariables } from 'testcafe';
 const PASSCODE_FIELD_NAME = 'credentials.passcode';
 const PHONE_NUMBER_SELECTOR = '.phone-authenticator-enroll__phone';
 const PHONE_NUMBER_EXTENSION_SELECTOR = '.phone-authenticator-enroll__phone-ext';
-const phoneFieldName = 'authenticator\\.phoneNumber';
+const PHONE_FIELD_NAME = 'authenticator\\.phoneNumber';
+const PHONE_CODE_FIELD_NAME = "phoneCode";
 const RESEND_VIEW_SELECTOR = '.phone-authenticator-enroll--warning';
 
 export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
@@ -17,18 +18,12 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
     return this.form.selectRadioButtonOptionByValue('authenticator\\.methodType', methodType);
   }
 
-  extensionIsHidden() {
+  async extensionIsHidden() {
     if (userVariables.v3) {
-      return !this.form.fieldByLabelExists('Extension');
+      const exists = await this.form.fieldByLabelExists('Extension');
+      return !exists;
     }
     return this.form.getElement(PHONE_NUMBER_EXTENSION_SELECTOR).hasClass('hide');
-  }
-
-  extensionText() {
-    if (userVariables.v3) {
-      return this.form.getElement('label[for="phoneExtension"]').innerText;
-    }
-    return this.form.getElement(PHONE_NUMBER_EXTENSION_SELECTOR).innerText;
   }
 
   countryCodeText() {
@@ -44,7 +39,10 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
   }
 
   hasPhoneNumberError() {
-    return this.form.hasTextBoxErrorMessage(phoneFieldName);
+    if (userVariables.v3) {
+      return this.form.hasTextBoxErrorMessage(PHONE_FIELD_NAME);    
+    }
+    return this.form.hasTextBoxErrorMessage(PHONE_CODE_FIELD_NAME);
   }
 
   clickSaveButton(name) {
@@ -59,7 +57,7 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
   }
 
   fillPhoneNumber(value) {
-    return this.form.setTextBoxValue(phoneFieldName, value);
+    return this.form.setTextBoxValue(PHONE_FIELD_NAME, value);
   }
 
   phoneNumberFieldIsSmall() {
@@ -111,4 +109,9 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
     const isHidden = await this.form.getElement(RESEND_VIEW_SELECTOR).hasClass('hide')
     return !isHidden;
   }
+
+  formFieldExistsByLabel(label) {
+    return this.form.fieldByLabelExists(label);
+  }
+
 }

--- a/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
@@ -18,18 +18,39 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
   }
 
   extensionIsHidden() {
+    if (userVariables.v3) {
+      return !this.form.fieldByLabelExists('Extension');
+    }
     return this.form.getElement(PHONE_NUMBER_EXTENSION_SELECTOR).hasClass('hide');
   }
+
+  extensionText() {
+    if (userVariables.v3) {
+      return this.form.getElement('label[for="phoneExtension"]').innerText;
+    }
+    return this.form.getElement(PHONE_NUMBER_EXTENSION_SELECTOR).innerText;
+  }
+
+  countryCodeText() {
+    if (userVariables.v3) {
+      return this.form.getElement('[data-se="authenticator.phoneNumber"]').parent('div').innerText;
+    }
+    return this.form.getElement('.phone-authenticator-enroll__phone-code').innerText;
+  }
+
 
   getElement(selector) {
     return this.form.getElement(selector);
   }
 
   hasPhoneNumberError() {
-    return this.form.hasTextBoxError(phoneFieldName);
+    return this.form.hasTextBoxErrorMessage(phoneFieldName);
   }
 
-  clickSaveButton() {
+  clickSaveButton(name) {
+    if (userVariables.v3) {
+      return this.form.clickSaveButton(name);
+    }
     return this.form.clickSaveButton();
   }
 
@@ -42,6 +63,9 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
   }
 
   phoneNumberFieldIsSmall() {
+    if (userVariables.v3) {
+      return this.form.elementExist('[inputmode="tel"]');
+    }
     return this.form.getElement(PHONE_NUMBER_SELECTOR)
       .hasClass('phone-authenticator-enroll__phone--small');
   }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -32,7 +32,7 @@ export default class BaseFormObject {
   }
 
   fieldByLabelExists(label, options = undefined) {
-    return within(this.el).getByLabelText(new RegExp(label), options).exists;
+    return within(this.el).queryByLabelText(new RegExp(label), options).exists;
   }
 
   getElement(selector) {

--- a/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
@@ -48,7 +48,7 @@ test.requestHooks(mock)('default sms mode', async t => {
   await t.expect(enrollPhonePage.getSaveButtonLabel()).eql('Receive a code via SMS');
 
   // Extension field is hidden
-  await t.expect(await enrollPhonePage.extensionIsHidden()).eql(false);
+  await t.expect(await enrollPhonePage.extensionIsHidden()).eql(true);
 
   await t.expect(await enrollPhonePage.signoutLinkExists()).ok();
 
@@ -65,8 +65,7 @@ test.requestHooks(mock)('voice mode click and extension will get shown', async t
 
   // Extension field is shown
   await t.expect(await enrollPhonePage.extensionIsHidden()).eql(false);
-  const extensionText = await enrollPhonePage.extensionText();
-  await t.expect(extensionText.trim()).eql('Extension');
+  await t.expect(await enrollPhonePage.formFieldExistsByLabel('Extension')).eql(true);
 
   // Default country code US
   const countryCodeText = await enrollPhonePage.countryCodeText();


### PR DESCRIPTION
## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-509015](https://oktainc.atlassian.net/browse/OKTA-509015)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



