### PR TITLE
Fix CSP violation for page swap animation in v1

### DIFF
--- a/src/util/Animations.js
+++ b/src/util/Animations.js
@@ -83,10 +83,12 @@ fn.swapPages = function(options) {
   $parent.append($newRoot);
 
   $parent.addClass('animation-container-overflow');
-  $newRoot.animate({ left: '0px', top: '0px', opacity: 1 }, SWAP_PAGE_TIME, function() {
+  const newRootAnimations = { left: '0px', top: '0px', opacity: 1 };
+  $newRoot.animate(newRootAnimations, SWAP_PAGE_TIME, function() {
     $parent.removeClass('animation-container-overflow');
     $newRoot.removeClass(directionClassName);
-    $newRoot.removeAttr('style');
+    const clearStyles = Object.keys(newRootAnimations).reduce((styles, attr) => ({ ...styles, [attr]: '' }), {});
+    $newRoot.css(clearStyles);
     success.call(ctx);
     deferred.resolve();
   });

--- a/src/util/Animations.js
+++ b/src/util/Animations.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint max-statements: [2, 15] */
+/* eslint max-statements: [2, 16] */
 
 import Q from 'q';
 import Enums from './Enums';

--- a/test/unit/legacy-tests.js
+++ b/test/unit/legacy-tests.js
@@ -3,6 +3,7 @@
 // - events are missing properties such as "origin" that are bound to the source window
 // - ???
 module.exports = [
+  'Animations_spec.js',
   'AdminConsentRequired_spec.js',
   'DeviceCodeActivate_spec.js',
   'DeviceCodeActivateTerminal_spec.js',

--- a/test/unit/spec/v1/Animations_spec.js
+++ b/test/unit/spec/v1/Animations_spec.js
@@ -58,33 +58,35 @@ function mockAnimations() {
 };
 
 
-Expect.describe('Animations.swapPages', function() {
-  itp('should remove styles from new form on animation complete', function() {
-    const mock = mockAnimations();
-    // Open PrimaryAuth page
-    return setup().then(function(test) {
-      // Trigger transition to ForgotPassword page
-      test.form.helpFooter().click();
-      test.form.forgotPasswordLink().click();
-      expect(test.router.navigate).toHaveBeenCalledWith('signin/forgot-password', { trigger: true });
-      // Wait for animation is completed, but success callback is not called
-      return mock.waitForAnimationComplete(test).then(function(test) {
-        // Check that styles were cleared for old and new pages
-        const oldForm = test.form.$('.primary-auth').get(0);
-        const newForm = test.form.$('.forgot-password').get(0);
-        expect(getComputedStyle(oldForm).position).not.toBe('absolute');
-        expect(getComputedStyle(oldForm).opacity).toBe('0');
-        expect(getComputedStyle(newForm).position).not.toBe('absolute');
-        expect(getComputedStyle(newForm).opacity).toBe('1');
-        expect(getComputedStyle(newForm).left).toBe('auto');
-        expect(getComputedStyle(newForm).top).toBe('auto');
+Expect.describe('Animations', function() {
+  describe('swapPages', function() {
+    itp('should remove styles from new form on animation complete', function() {
+      const mock = mockAnimations();
+      // Open PrimaryAuth page
+      return setup().then(function(test) {
+        // Trigger transition to ForgotPassword page
+        test.form.helpFooter().click();
+        test.form.forgotPasswordLink().click();
+        expect(test.router.navigate).toHaveBeenCalledWith('signin/forgot-password', { trigger: true });
+        // Wait for animation is completed, but success callback is not called
+        return mock.waitForAnimationComplete(test).then(function(test) {
+          // Check that styles were cleared for old and new pages
+          const oldForm = test.form.$('.primary-auth').get(0);
+          const newForm = test.form.$('.forgot-password').get(0);
+          expect(getComputedStyle(oldForm).position).withContext('old form position').toBe('static');
+          expect(getComputedStyle(oldForm).opacity).withContext('old form opacity').toBe('0');
+          expect(getComputedStyle(newForm).position).withContext('new form position').toBe('static');
+          expect(getComputedStyle(newForm).opacity).withContext('new form opacity').toBe('1');
+          expect(getComputedStyle(newForm).left).withContext('new form left').toBe('auto');
+          expect(getComputedStyle(newForm).top).withContext('new form top').toBe('auto');
 
-        // Run a success callback manually
-        mock.afterAnimation();
-        return Expect.waitForForgotPassword(test).then(function(test) {
-          // Old page should be removed from DOM
-          const $oldForm = test.form.$('.primary-auth');
-          expect($oldForm.length).toBe(0);
+          // Run a success callback manually
+          mock.afterAnimation();
+          return Expect.waitForForgotPassword(test).then(function(test) {
+            // Old page should be removed from DOM
+            const $oldForm = test.form.$('.primary-auth');
+            expect($oldForm.length).withContext('$oldForm.length').toBe(0);
+          });
         });
       });
     });

--- a/test/unit/spec/v1/Animations_spec.js
+++ b/test/unit/spec/v1/Animations_spec.js
@@ -55,7 +55,7 @@ function mockAnimations() {
     return originalSwapPages.apply(this, arguments);
   });
   return ret;
-};
+}
 
 
 Expect.describe('Animations', function() {
@@ -86,6 +86,7 @@ Expect.describe('Animations', function() {
             // Old page should be removed from DOM
             const $oldForm = test.form.$('.primary-auth');
             expect($oldForm.length).withContext('$oldForm.length').toBe(0);
+            Util.stopRouter();
           });
         });
       });

--- a/test/unit/spec/v1/Animations_spec.js
+++ b/test/unit/spec/v1/Animations_spec.js
@@ -1,0 +1,92 @@
+/* eslint max-params: [2, 13], max-len: [2, 160] */
+import { _ } from '@okta/courage';
+import getAuthClient from 'helpers/getAuthClient';
+import Router from 'v1/LoginRouter';
+import $sandbox from 'sandbox';
+import Expect from 'helpers/util/Expect';
+import Util from 'helpers/mocks/Util';
+import PrimaryAuthForm from 'helpers/dom/PrimaryAuthForm';
+import Animations from 'util/Animations';
+const itp = Expect.itp;
+
+
+function setup(settings) {
+  settings || (settings = {});
+  const baseUrl = 'https://foo.com';
+  const authClient = getAuthClient({
+    authParams: { issuer: baseUrl }
+  });
+  const router = new Router(
+    _.extend(
+      {
+        el: $sandbox,
+        baseUrl: baseUrl,
+        authClient: authClient,
+        'features.router': true,
+      },
+      settings
+    )
+  );
+  Util.registerRouter(router);
+  Util.mockRouterNavigate(router, true);
+
+  const test = {
+    router: router,
+    form: new PrimaryAuthForm($sandbox),
+    ac: authClient,
+  };
+
+  return Expect.waitForPrimaryAuth(test);
+}
+
+function mockAnimations() {
+  const ret = {
+    afterAnimation: null,
+    waitForAnimationComplete: function(cb) {
+      return Expect.wait(() => !!ret.afterAnimation, cb);
+    }
+  };
+  const originalSwapPages = Animations.swapPages;
+  spyOn(Animations, 'swapPages').and.callFake(function(opts) {
+    const origSuccess = opts.success;
+    spyOn(opts, 'success').and.callFake(function() {
+      ret.afterAnimation = () => origSuccess.apply(this, arguments);
+    });
+    return originalSwapPages.apply(this, arguments);
+  });
+  return ret;
+};
+
+
+Expect.describe('Animations.swapPages', function() {
+  itp('should remove styles from new form on animation complete', function() {
+    const mock = mockAnimations();
+    // Open PrimaryAuth page
+    return setup().then(function(test) {
+      // Trigger transition to ForgotPassword page
+      test.form.helpFooter().click();
+      test.form.forgotPasswordLink().click();
+      expect(test.router.navigate).toHaveBeenCalledWith('signin/forgot-password', { trigger: true });
+      // Wait for animation is completed, but success callback is not called
+      return mock.waitForAnimationComplete(test).then(function(test) {
+        // Check that styles were cleared for old and new pages
+        const oldForm = test.form.$('.primary-auth').get(0);
+        const newForm = test.form.$('.forgot-password').get(0);
+        expect(getComputedStyle(oldForm).position).not.toBe('absolute');
+        expect(getComputedStyle(oldForm).opacity).toBe('0');
+        expect(getComputedStyle(newForm).position).not.toBe('absolute');
+        expect(getComputedStyle(newForm).opacity).toBe('1');
+        expect(getComputedStyle(newForm).left).toBe('auto');
+        expect(getComputedStyle(newForm).top).toBe('auto');
+
+        // Run a success callback manually
+        mock.afterAnimation();
+        return Expect.waitForForgotPassword(test).then(function(test) {
+          // Old page should be removed from DOM
+          const $oldForm = test.form.$('.primary-auth');
+          expect($oldForm.length).toBe(0);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description:

Animation in v1 router causes CSP violation (only in Safari) by this line
https://github.com/okta/okta-signin-widget/blob/6dcb41ef2a6726bc93217f3928b288e37c4b221c/src/util/Animations.js#L89

Fixed by clearing style attributes with `$.css()` method.
Added unit test for `Animations.swapPages` with Karma

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-569917](https://oktainc.atlassian.net/browse/OKTA-569917)

### Reviewers:

### Screenshot/Video:

Before:

https://user-images.githubusercontent.com/72614880/215806600-cdf21443-6f5c-457d-be0e-2642b9695919.mov

After:

https://user-images.githubusercontent.com/72614880/215806667-f2f6243e-20f1-428b-8e83-d79cfd66fe16.mov


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=f57f952a3548d4a594494e053fa502de6a6f3fc4&tab=main
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=98ed8e88dbb07b976690c8114f2e42345488b2e9&tab=main
