### PR TITLE
Handle no-support for getTransports and getClientExtensionResults on some browsers.

### DIFF
--- a/src/util/webauthn.js
+++ b/src/util/webauthn.js
@@ -52,9 +52,17 @@ function getAssertion(challenge, allowList) {
   return adaptToOkta(promise);
 }
 
+function processWebAuthnResponse(inputFunction) {
+  if (typeof inputFunction === 'undefined' || inputFunction() === undefined || inputFunction() === null) {
+    return null;
+  }
+  return JSON.stringify(inputFunction());
+}
+
 export default {
   makeCredential: makeCredential,
   getAssertion: getAssertion,
+  processWebAuthnResponse: processWebAuthnResponse,
   isAvailable: function() {
     return Object.prototype.hasOwnProperty.call(window, 'msCredentials');
   },

--- a/src/util/webauthn.js
+++ b/src/util/webauthn.js
@@ -52,11 +52,15 @@ function getAssertion(challenge, allowList) {
   return adaptToOkta(promise);
 }
 
-function processWebAuthnResponse(inputFunction) {
-  if (typeof inputFunction === 'undefined' || inputFunction() === undefined || inputFunction() === null) {
+function processWebAuthnResponse(inputFunction, context) {
+  if (typeof inputFunction === 'undefined') {
     return null;
   }
-  return JSON.stringify(inputFunction());
+  const responseValue = inputFunction.apply(context);
+  if (responseValue === undefined || responseValue === null) {
+    return null;
+  }
+  return JSON.stringify(responseValue);
 }
 
 export default {

--- a/src/v1/controllers/EnrollWebauthnController.js
+++ b/src/v1/controllers/EnrollWebauthnController.js
@@ -100,9 +100,11 @@ export default FormController.extend({
                 attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
                 clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),
                 // example data: ["nfc", "usb"]
-                transports: webauthn.processWebAuthnResponse(newCredential.response.getTransports),
+                transports: webauthn.processWebAuthnResponse(newCredential.response.getTransports,
+                  newCredential.response),
                 // example data: {"credProps":{"rk":true}}
-                clientExtensions: webauthn.processWebAuthnResponse(newCredential.getClientExtensionResults)
+                clientExtensions: webauthn.processWebAuthnResponse(newCredential.getClientExtensionResults,
+                  newCredential)
               });
             })
             .catch(function(error) {

--- a/src/v1/controllers/EnrollWebauthnController.js
+++ b/src/v1/controllers/EnrollWebauthnController.js
@@ -34,13 +34,6 @@ function getExcludeCredentials(credentials) {
   return excludeCredentials;
 }
 
-function processResponseValue(inputValue) {
-  if (inputValue === undefined || inputValue === null) {
-    return null;
-  }
-  return JSON.stringify(inputValue);
-}
-
 export default FormController.extend({
   className: 'enroll-webauthn',
   Model: {
@@ -107,9 +100,9 @@ export default FormController.extend({
                 attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
                 clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),
                 // example data: ["nfc", "usb"]
-                transports: processResponseValue(newCredential.response.getTransports()),
+                transports: webauthn.processWebAuthnResponse(newCredential.response.getTransports),
                 // example data: {"credProps":{"rk":true}}
-                clientExtensions: processResponseValue(newCredential.getClientExtensionResults())
+                clientExtensions: webauthn.processWebAuthnResponse(newCredential.getClientExtensionResults)
               });
             })
             .catch(function(error) {

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
@@ -85,9 +85,9 @@ const Body = BaseForm.extend({
             clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),
             attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
             // example data: ["nfc", "usb"]
-            transports: webauthn.processWebAuthnResponse(newCredential.response.getTransports),
+            transports: webauthn.processWebAuthnResponse(newCredential.response.getTransports, newCredential.response),
             // example data: {"credProps":{"rk":true}}
-            clientExtensions: webauthn.processWebAuthnResponse(newCredential.getClientExtensionResults)
+            clientExtensions: webauthn.processWebAuthnResponse(newCredential.getClientExtensionResults, newCredential)
           }
         });
         this.saveForm(this.model);

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
@@ -19,13 +19,6 @@ function getExcludeCredentials(authenticatorEnrollments = []) {
   return credentials;
 }
 
-function processResponseValue(inputValue) {
-  if (inputValue === undefined || inputValue === null) {
-    return null;
-  }
-  return JSON.stringify(inputValue);
-}
-
 const Body = BaseForm.extend({
   title() {
     return loc('oie.enroll.webauthn.title', 'login');
@@ -92,9 +85,9 @@ const Body = BaseForm.extend({
             clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),
             attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
             // example data: ["nfc", "usb"]
-            transports: processResponseValue(newCredential.response.getTransports()),
+            transports: webauthn.processWebAuthnResponse(newCredential.response.getTransports),
             // example data: {"credProps":{"rk":true}}
-            clientExtensions: processResponseValue(newCredential.getClientExtensionResults())
+            clientExtensions: webauthn.processWebAuthnResponse(newCredential.getClientExtensionResults)
           }
         });
         this.saveForm(this.model);

--- a/test/unit/spec/v1/EnrollWebauthn_spec.js
+++ b/test/unit/spec/v1/EnrollWebauthn_spec.js
@@ -130,8 +130,7 @@ Expect.describe('EnrollWebauthn', function() {
     spyOn(navigator.credentials, 'create').and.callFake(function() {
       const deferred = Q.defer();
       const localTransports = transports;
-      // eslint-disable-next-line no-use-before-define
-      const localClientExtensions = localClientExtensions;
+      const localClientExtensions = clientExtensions;
 
       const authenticatorResponse = {
         response: {
@@ -442,72 +441,133 @@ Expect.describe('EnrollWebauthn', function() {
         });
     });
 
-    itp.each([[true, false], [true, true], [false, true], [false, false]])('calls navigator.credentials.create on getTransports/getClientExtensions non-supported browser',
-      function(mockGetTransports, mockGetClientExtensions) {
-        mockWebauthnNonSupportResponse(true, mockGetTransports, mockGetClientExtensions);
-        return setup()
-          .then(function(test) {
-            Util.resetAjaxRequests();
-            test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
-            test.form.submit();
-            return Expect.waitForSpyCall(test.successSpy, test);
-          })
-          .then(function(test) {
-            expect(navigator.credentials.create).toHaveBeenCalledWith({
-              publicKey: {
-                rp: {
-                  name: 'acme',
-                },
-                user: {
-                  id: CryptoUtil.strToBin('00u1212qZXXap6Cts0g4'),
-                  name: 'test.user@okta.com',
-                  displayName: 'Test User',
-                },
-                pubKeyCredParams: [
-                  {
-                    type: 'public-key',
-                    alg: -7,
-                  },
-                ],
-                challenge: CryptoUtil.strToBin('G7bIvwrJJ33WCEp6GGSH'),
-                authenticatorSelection: {
-                  authenticatorAttachment: 'cross-platform',
-                  requireResidentKey: false,
-                  userVerification: 'preferred',
-                },
-                u2fParams: {
-                  appid: 'https://test.okta.com',
-                },
-                excludeCredentials: [
-                  {
-                    type: 'public-key',
-                    id: CryptoUtil.strToBin(
-                      'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'
-                    ),
-                  },
-                ],
+    itp('calls navigator.credentials.create on getClientExtensions non-supported browser', function() {
+      mockWebauthnNonSupportResponse(true, true, false);
+      return setup()
+        .then(function(test) {
+          Util.resetAjaxRequests();
+          test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
+          test.form.submit();
+          return Expect.waitForSpyCall(test.successSpy, test);
+        })
+        .then(function(test) {
+          expect(navigator.credentials.create).toHaveBeenCalledWith({
+            publicKey: {
+              rp: {
+                name: 'acme',
               },
-              signal: jasmine.any(Object),
-            });
-            expect(Util.numAjaxRequests()).toBe(2);
-            const dataObject = {
-              attestation: testAttestationObject,
-              clientData: testClientData,
-              stateToken: 'testStateToken',
-            };
-            if (mockGetTransports) {
-              dataObject.clientExtensions = JSON.stringify(clientExtensions);
-            }
-            if (mockGetClientExtensions) {
-              dataObject.transports = JSON.stringify(transports);
-            }
+              user: {
+                id: CryptoUtil.strToBin('00u1212qZXXap6Cts0g4'),
+                name: 'test.user@okta.com',
+                displayName: 'Test User',
+              },
+              pubKeyCredParams: [
+                {
+                  type: 'public-key',
+                  alg: -7,
+                },
+              ],
+              challenge: CryptoUtil.strToBin('G7bIvwrJJ33WCEp6GGSH'),
+              authenticatorSelection: {
+                authenticatorAttachment: 'cross-platform',
+                requireResidentKey: false,
+                userVerification: 'preferred',
+              },
+              u2fParams: {
+                appid: 'https://test.okta.com',
+              },
+              excludeCredentials: [
+                {
+                  type: 'public-key',
+                  id: CryptoUtil.strToBin(
+                    'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'
+                  ),
+                },
+              ],
+            },
+            signal: jasmine.any(Object),
+          });
+          expect(Util.numAjaxRequests()).toBe(2);
+          const dataObject = {
+            attestation: testAttestationObject,
+            clientData: testClientData,
+            stateToken: 'testStateToken',
+            clientExtensions: JSON.stringify(clientExtensions),
+            transports: null
+          };
+
+          dataObject.
+
             Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://test.okta.com/api/v1/authn/factors/fuf52dhWPdJAbqiUU0g4/lifecycle/activate',
               data: dataObject
             });
-            expect(test.router.controller.model.webauthnAbortController).toBe(null);
+          expect(test.router.controller.model.webauthnAbortController).toBe(null);
+        });
+    });
+
+    itp('calls navigator.credentials.create on getClientExtensions non-supported browser', function() {
+      mockWebauthnNonSupportResponse(true, false, true);
+      return setup()
+        .then(function(test) {
+          Util.resetAjaxRequests();
+          test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
+          test.form.submit();
+          return Expect.waitForSpyCall(test.successSpy, test);
+        })
+        .then(function(test) {
+          expect(navigator.credentials.create).toHaveBeenCalledWith({
+            publicKey: {
+              rp: {
+                name: 'acme',
+              },
+              user: {
+                id: CryptoUtil.strToBin('00u1212qZXXap6Cts0g4'),
+                name: 'test.user@okta.com',
+                displayName: 'Test User',
+              },
+              pubKeyCredParams: [
+                {
+                  type: 'public-key',
+                  alg: -7,
+                },
+              ],
+              challenge: CryptoUtil.strToBin('G7bIvwrJJ33WCEp6GGSH'),
+              authenticatorSelection: {
+                authenticatorAttachment: 'cross-platform',
+                requireResidentKey: false,
+                userVerification: 'preferred',
+              },
+              u2fParams: {
+                appid: 'https://test.okta.com',
+              },
+              excludeCredentials: [
+                {
+                  type: 'public-key',
+                  id: CryptoUtil.strToBin(
+                    'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'
+                  ),
+                },
+              ],
+            },
+            signal: jasmine.any(Object),
           });
-      });
+          expect(Util.numAjaxRequests()).toBe(2);
+          const dataObject = {
+            attestation: testAttestationObject,
+            clientData: testClientData,
+            stateToken: 'testStateToken',
+            transports: JSON.stringify(transports),
+            clientExtensions: null
+          };
+
+          Expect.isJsonPost(Util.getAjaxRequest(1), {
+            url: 'https://test.okta.com/api/v1/authn/factors/fuf52dhWPdJAbqiUU0g4/lifecycle/activate',
+            data: dataObject
+          });
+          expect(test.router.controller.model.webauthnAbortController).toBe(null);
+        });
+    });
 
     itp('shows error when navigator.credentials.create failed', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);

--- a/test/unit/spec/v1/EnrollWebauthn_spec.js
+++ b/test/unit/spec/v1/EnrollWebauthn_spec.js
@@ -124,7 +124,7 @@ Expect.describe('EnrollWebauthn', function() {
     });
   }
 
-  function mockWebauthnNonSupportResponse(resolvePromise, mockGetTransports, mockGetClientExtensions) {
+  function mockWebauthnNonSupportResponse(mockGetTransports, mockGetClientExtensions) {
     mockWebauthn();
     spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
     spyOn(navigator.credentials, 'create').and.callFake(function() {
@@ -146,9 +146,7 @@ Expect.describe('EnrollWebauthn', function() {
         authenticatorResponse.getClientExtensionResults = function() { return localClientExtensions; };
       }
 
-      if (resolvePromise) {
-        deferred.resolve(authenticatorResponse);
-      }
+      deferred.resolve(authenticatorResponse);
       return deferred.promise;
     });
   }
@@ -442,7 +440,7 @@ Expect.describe('EnrollWebauthn', function() {
     });
 
     itp('calls navigator.credentials.create on getTransports non-supported browser', function() {
-      mockWebauthnNonSupportResponse(true, false, true);
+      mockWebauthnNonSupportResponse(false, true);
       return setup()
         .then(function(test) {
           Util.resetAjaxRequests();
@@ -505,7 +503,7 @@ Expect.describe('EnrollWebauthn', function() {
     });
 
     itp('calls navigator.credentials.create on getClientExtensions non-supported browser', function() {
-      mockWebauthnNonSupportResponse(true, true, false);
+      mockWebauthnNonSupportResponse(true, false);
       return setup()
         .then(function(test) {
           Util.resetAjaxRequests();

--- a/test/unit/spec/v1/EnrollWebauthn_spec.js
+++ b/test/unit/spec/v1/EnrollWebauthn_spec.js
@@ -441,8 +441,8 @@ Expect.describe('EnrollWebauthn', function() {
         });
     });
 
-    itp('calls navigator.credentials.create on getClientExtensions non-supported browser', function() {
-      mockWebauthnNonSupportResponse(true, true, false);
+    itp('calls navigator.credentials.create on getTransports non-supported browser', function() {
+      mockWebauthnNonSupportResponse(true, false, true);
       return setup()
         .then(function(test) {
           Util.resetAjaxRequests();
@@ -496,18 +496,16 @@ Expect.describe('EnrollWebauthn', function() {
             transports: null
           };
 
-          dataObject.
-
-            Expect.isJsonPost(Util.getAjaxRequest(1), {
-              url: 'https://test.okta.com/api/v1/authn/factors/fuf52dhWPdJAbqiUU0g4/lifecycle/activate',
-              data: dataObject
-            });
+          Expect.isJsonPost(Util.getAjaxRequest(1), {
+            url: 'https://test.okta.com/api/v1/authn/factors/fuf52dhWPdJAbqiUU0g4/lifecycle/activate',
+            data: dataObject
+          });
           expect(test.router.controller.model.webauthnAbortController).toBe(null);
         });
     });
 
     itp('calls navigator.credentials.create on getClientExtensions non-supported browser', function() {
-      mockWebauthnNonSupportResponse(true, false, true);
+      mockWebauthnNonSupportResponse(true, true, false);
       return setup()
         .then(function(test) {
           Util.resetAjaxRequests();

--- a/test/unit/spec/v1/EnrollWebauthn_spec.js
+++ b/test/unit/spec/v1/EnrollWebauthn_spec.js
@@ -124,6 +124,36 @@ Expect.describe('EnrollWebauthn', function() {
     });
   }
 
+  function mockWebauthnNonSupportResponse(resolvePromise, mockGetTransports, mockGetClientExtensions) {
+    mockWebauthn();
+    spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
+    spyOn(navigator.credentials, 'create').and.callFake(function() {
+      const deferred = Q.defer();
+      const localTransports = transports;
+      // eslint-disable-next-line no-use-before-define
+      const localClientExtensions = localClientExtensions;
+
+      const authenticatorResponse = {
+        response: {
+          attestationObject: CryptoUtil.strToBin(testAttestationObject),
+          clientDataJSON: CryptoUtil.strToBin(testClientData),
+        }
+      };
+
+      if (mockGetTransports) {
+        authenticatorResponse.response.getTransports = function() { return localTransports; };
+      }
+      if (mockGetClientExtensions) {
+        authenticatorResponse.getClientExtensionResults = function() { return localClientExtensions; };
+      }
+
+      if (resolvePromise) {
+        deferred.resolve(authenticatorResponse);
+      }
+      return deferred.promise;
+    });
+  }
+
   Expect.describe('Header & Footer', function() {
     itp('displays the correct factorBeacon', function() {
       return setup().then(function(test) {
@@ -411,6 +441,73 @@ Expect.describe('EnrollWebauthn', function() {
           expect(test.router.controller.model.webauthnAbortController).toBe(null);
         });
     });
+
+    itp.each([[true, false], [true, true], [false, true], [false, false]])('calls navigator.credentials.create on getTransports/getClientExtensions non-supported browser',
+      function(mockGetTransports, mockGetClientExtensions) {
+        mockWebauthnNonSupportResponse(true, mockGetTransports, mockGetClientExtensions);
+        return setup()
+          .then(function(test) {
+            Util.resetAjaxRequests();
+            test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
+            test.form.submit();
+            return Expect.waitForSpyCall(test.successSpy, test);
+          })
+          .then(function(test) {
+            expect(navigator.credentials.create).toHaveBeenCalledWith({
+              publicKey: {
+                rp: {
+                  name: 'acme',
+                },
+                user: {
+                  id: CryptoUtil.strToBin('00u1212qZXXap6Cts0g4'),
+                  name: 'test.user@okta.com',
+                  displayName: 'Test User',
+                },
+                pubKeyCredParams: [
+                  {
+                    type: 'public-key',
+                    alg: -7,
+                  },
+                ],
+                challenge: CryptoUtil.strToBin('G7bIvwrJJ33WCEp6GGSH'),
+                authenticatorSelection: {
+                  authenticatorAttachment: 'cross-platform',
+                  requireResidentKey: false,
+                  userVerification: 'preferred',
+                },
+                u2fParams: {
+                  appid: 'https://test.okta.com',
+                },
+                excludeCredentials: [
+                  {
+                    type: 'public-key',
+                    id: CryptoUtil.strToBin(
+                      'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt'
+                    ),
+                  },
+                ],
+              },
+              signal: jasmine.any(Object),
+            });
+            expect(Util.numAjaxRequests()).toBe(2);
+            const dataObject = {
+              attestation: testAttestationObject,
+              clientData: testClientData,
+              stateToken: 'testStateToken',
+            };
+            if (mockGetTransports) {
+              dataObject.clientExtensions = JSON.stringify(clientExtensions);
+            }
+            if (mockGetClientExtensions) {
+              dataObject.transports = JSON.stringify(transports);
+            }
+            Expect.isJsonPost(Util.getAjaxRequest(1), {
+              url: 'https://test.okta.com/api/v1/authn/factors/fuf52dhWPdJAbqiUU0g4/lifecycle/activate',
+              data: dataObject
+            });
+            expect(test.router.controller.model.webauthnAbortController).toBe(null);
+          });
+      });
 
     itp('shows error when navigator.credentials.create failed', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -263,7 +263,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
       .catch(done.fail);
   });
 
-  it.each([[true, false], [true, true], [false, true], [false, false]])('calls navigator.credentials.create on getTransports/getClientExtensions non-supported browser', function(mockGetTransports,
+  it.each([[true, false], [false, true], [false, false]])('calls navigator.credentials.create on getTransports/getClientExtensions non-supported browser', function(mockGetTransports,
     mockGetClientExtensions, done) {
 
     const newCredential = {


### PR DESCRIPTION
## Description:

- > As part of this https://github.com/okta/okta-signin-widget/pull/2914, we added support to send additional info to backend after webauthn enrollment.
- > But this caused regression due to non-support of these APIs on few browsers 
    https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/getClientExtensionResults
    https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getTransports
- > Fix is to check whether these APIs are supported before calling them.


## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-571393](https://oktainc.atlassian.net/browse/OKTA-571393)

### Reviewers:
@okta/enterpriseauth-team 

### Screenshot/Video:

## OIE Videos

CHROME

https://user-images.githubusercontent.com/100623681/215632873-946d3363-31c1-4118-b59a-42b510f23ffd.mov

FIREFOX

https://user-images.githubusercontent.com/100623681/215632912-39673ccc-6abe-4196-a94c-a0ac5821172b.mov

## V1 VIDEOS

CHROME

https://user-images.githubusercontent.com/100623681/215634393-f11aee4d-89a1-4939-8e5e-7f43dd61c086.mov

FIREFOX

https://user-images.githubusercontent.com/100623681/215634445-2033b14c-b692-4cf5-8373-332ec2e55711.mov



### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=0d5d23a48544ba2ea4ddb8a8cc64026294362bb1&tab=main


