### PR TITLE
OKTA-528630 : Preventing authenticator selection list links from making API requests

### DIFF
--- a/src/v3/src/components/AuthCoin/AuthCoin.tsx
+++ b/src/v3/src/components/AuthCoin/AuthCoin.tsx
@@ -69,7 +69,7 @@ const AuthCoin: FunctionComponent<AuthCoinProps> = (props) => {
       className={containerClasses}
       data-se="factor-beacon"
       sx={(theme) => ({
-        '--PrimaryFill': theme.palette.primary.dark,
+        '--PrimaryFill': theme.palette.primary.main,
         '--SecondaryFill': theme.palette.primary.light,
         '--BackgroundFill': theme.palette.grey[50],
       })}

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -21,9 +21,10 @@ import { ClickHandler, LinkElement, UISchemaElementComponent } from '../../types
 const Link: UISchemaElementComponent<{
   uischema: LinkElement
 }> = ({ uischema }) => {
+  const widgetContext = useWidgetContext();
   const {
     loading,
-  } = useWidgetContext();
+  } = widgetContext;
   const {
     focus,
     ariaDescribedBy,
@@ -47,6 +48,11 @@ const Link: UISchemaElementComponent<{
       return;
     }
 
+    if (typeof onClickHandler !== 'undefined') {
+      onClickHandler(widgetContext);
+      return;
+    }
+
     onSubmitHandler({
       params: actionParams,
       isActionStep,
@@ -59,11 +65,10 @@ const Link: UISchemaElementComponent<{
       <LinkMui
         // eslint-disable-next-line no-script-url
         href="javascript:void(0)"
-        onClick={onClickHandler || onClick}
+        onClick={onClick}
         aria-describedby={ariaDescribedBy}
         ref={focusRef}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...(dataSe && { 'data-se': dataSe } )}
+        data-se={dataSe}
       >
         {label}
       </LinkMui>
@@ -73,8 +78,7 @@ const Link: UISchemaElementComponent<{
           href={href}
           ref={focusRef}
           aria-describedby={ariaDescribedBy}
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...(dataSe && { 'data-se': dataSe } )}
+          data-se={dataSe}
         >
           {label}
         </LinkMui>

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -22,7 +22,6 @@ import { omit } from 'lodash';
 import merge from 'lodash/merge';
 import { useCallback } from 'preact/hooks';
 
-import { IDX_STEP } from '../constants';
 import { useWidgetContext } from '../contexts';
 import { ErrorXHR, EventErrorContext, MessageType } from '../types';
 import {
@@ -144,13 +143,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       const transactionHasWarning = (newTransaction.messages || []).some(
         (message) => message.class === MessageType.WARNING.toString(),
       );
-      // TODO: OKTA-521014 below logic only needed because of this bug, remove once fixed
-      const isSwitchAuthenticator = newTransaction.nextStep?.name
-        && [
-          IDX_STEP.SELECT_AUTHENTICATOR_ENROLL,
-          IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE,
-        ].includes(newTransaction.nextStep.name);
-      if (newTransaction.requestDidSucceed === false && !isSwitchAuthenticator) {
+      if (newTransaction.requestDidSucceed === false) {
         events?.afterError?.(
           getEventContext(newTransaction),
           getErrorEventContext(newTransaction.rawIdxState),
@@ -159,9 +152,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       const isClientTransaction = !newTransaction.requestDidSucceed
         || (areTransactionsEqual(currTransaction, newTransaction) && transactionHasWarning);
       setIsClientTransaction(isClientTransaction);
-      if (isClientTransaction
-          && !newTransaction.messages?.length
-          && !isSwitchAuthenticator) {
+      if (isClientTransaction && !newTransaction.messages?.length) {
         setMessage({
           message: loc('oform.errorbanner.title', 'login'),
           class: 'ERROR',

--- a/src/v3/src/transformer/button/transformReturnToAuthenticatorListButton.ts
+++ b/src/v3/src/transformer/button/transformReturnToAuthenticatorListButton.ts
@@ -40,7 +40,7 @@ export const transformReturnToAuthenticatorListButton: TransformStepFnWithOption
     if (typeof widgetContext === 'undefined') {
       return;
     }
-    const { setIdxTransaction } = widgetContext;
+    const { setIdxTransaction, setMessage } = widgetContext;
     const availableSteps = transaction.availableSteps?.filter(
       ({ name }) => name !== IDX_STEP.SELECT_AUTHENTICATOR_ENROLL,
     ) || [];
@@ -51,6 +51,7 @@ export const transformReturnToAuthenticatorListButton: TransformStepFnWithOption
       ({ name }) => name !== IDX_STEP.SELECT_AUTHENTICATOR_ENROLL,
     );
 
+    setMessage(undefined);
     setIdxTransaction({
       ...transaction,
       messages: [],

--- a/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
+++ b/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
@@ -40,7 +40,7 @@ export const transformVerifyWithOtherButton: TransformStepFnWithOptions = ({
     if (typeof widgetContext === 'undefined') {
       return;
     }
-    const { setIdxTransaction } = widgetContext;
+    const { setIdxTransaction, setMessage } = widgetContext;
     const availableSteps = transaction.availableSteps?.filter(
       ({ name }) => name !== IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE,
     ) || [];
@@ -51,6 +51,7 @@ export const transformVerifyWithOtherButton: TransformStepFnWithOptions = ({
       ({ name }) => name !== IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE,
     );
 
+    setMessage(undefined);
     setIdxTransaction({
       ...transaction,
       messages: [],

--- a/src/v3/src/transformer/button/updateTransactionWithNextStep.ts
+++ b/src/v3/src/transformer/button/updateTransactionWithNextStep.ts
@@ -23,7 +23,7 @@ export const updateTransactionWithNextStep = (
   const availableSteps = transaction.availableSteps?.filter(
     ({ name }) => name !== nextStep.name,
   ) || [];
-  const verifyWithOtherRem = transaction.neededToProceed.find(
+  const verifyWithOtherRemediations = transaction.neededToProceed.find(
     ({ name }) => name === nextStep.name,
   ) || {} as IdxRemediation;
   const availableRemediations = transaction.neededToProceed.filter(
@@ -35,7 +35,7 @@ export const updateTransactionWithNextStep = (
     ...transaction,
     messages: [],
     neededToProceed: [
-      verifyWithOtherRem,
+      verifyWithOtherRemediations,
       ...availableRemediations,
     ],
     availableSteps: [

--- a/src/v3/src/transformer/button/updateTransactionWithNextStep.ts
+++ b/src/v3/src/transformer/button/updateTransactionWithNextStep.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxRemediation, IdxTransaction, NextStep } from '@okta/okta-auth-js';
+
+import { IWidgetContext } from '../../types';
+
+export const updateTransactionWithNextStep = (
+  transaction: IdxTransaction,
+  nextStep: NextStep,
+  widgetContext: IWidgetContext,
+): void => {
+  const { setIdxTransaction, setMessage } = widgetContext;
+  const availableSteps = transaction.availableSteps?.filter(
+    ({ name }) => name !== nextStep.name,
+  ) || [];
+  const verifyWithOtherRem = transaction.neededToProceed.find(
+    ({ name }) => name === nextStep.name,
+  ) || {} as IdxRemediation;
+  const availableRemediations = transaction.neededToProceed.filter(
+    ({ name }) => name !== nextStep.name,
+  );
+
+  setMessage(undefined);
+  setIdxTransaction({
+    ...transaction,
+    messages: [],
+    neededToProceed: [
+      verifyWithOtherRem,
+      ...availableRemediations,
+    ],
+    availableSteps: [
+      nextStep,
+      ...availableSteps,
+    ],
+    nextStep,
+  });
+};

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorEnroll.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorEnroll.test.ts.snap
@@ -29,6 +29,7 @@ Object {
       },
       Object {
         "contentType": "subtitle",
+        "noMargin": true,
         "options": Object {
           "content": "oie.setup.required",
         },
@@ -90,6 +91,7 @@ Object {
       },
       Object {
         "contentType": "subtitle",
+        "noMargin": true,
         "options": Object {
           "content": "oie.setup.optional",
         },
@@ -159,6 +161,7 @@ Object {
       },
       Object {
         "contentType": "subtitle",
+        "noMargin": true,
         "options": Object {
           "content": "oie.setup.optional",
         },

--- a/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorVerify.test.ts.snap
+++ b/src/v3/src/transformer/selectAuthenticator/__snapshots__/transformSelectAuthenticatorVerify.test.ts.snap
@@ -22,6 +22,7 @@ Object {
       },
       Object {
         "contentType": "subtitle",
+        "noMargin": true,
         "options": Object {
           "content": "oie.password.reset.verification",
         },
@@ -75,6 +76,7 @@ Object {
       },
       Object {
         "contentType": "subtitle",
+        "noMargin": true,
         "options": Object {
           "content": "oie.password.reset.verification",
         },
@@ -128,6 +130,7 @@ Object {
       },
       Object {
         "contentType": "subtitle",
+        "noMargin": true,
         "options": Object {
           "content": "oie.select.authenticators.verify.subtitle",
         },

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.ts
@@ -65,6 +65,7 @@ export const transformSelectAuthenticatorEnroll: IdxStepTransformer = ({
   const description: DescriptionElement = {
     type: 'Description',
     contentType: 'subtitle',
+    noMargin: true,
     options: {
       content: skipStep ? loc('oie.setup.optional', 'login') : loc('oie.setup.required', 'login'),
     },

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.ts
@@ -75,6 +75,7 @@ export const transformSelectAuthenticatorVerify: IdxStepTransformer = ({
   const informationalTextElement: DescriptionElement = {
     type: 'Description',
     contentType: 'subtitle',
+    noMargin: true,
     options: {
       content: isPwRecovery
         ? loc('oie.password.reset.verification', 'login')

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -359,7 +359,7 @@ export interface LinkElement extends UISchemaElement {
     label: string;
     href?: string;
     dataSe?: string;
-    onClick?: () => unknown;
+    onClick?: (widgetContext?: IWidgetContext) => unknown;
   };
 }
 

--- a/src/v3/test/e2e/tests/theming.ts
+++ b/src/v3/test/e2e/tests/theming.ts
@@ -36,7 +36,7 @@ test('Theme configuration applies correctly', async (t) => {
 
   await t
     .expect(phoneAuthCoin.find('.siwFillPrimary').getStyleProperty('fill'))
-    .eql('rgb(202, 0, 228)');
+    .eql('rgb(62, 0, 70)');
   await t
     .expect(phoneAuthCoin.find('.siwFillSecondary').getStyleProperty('fill'))
     .eql('rgb(241, 131, 255)');

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -1,5 +1,658 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`authenticator-enroll-phone-sms Send correct payload when back to authenticators list 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-version="0.0.0"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-2"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader MuiBox-root emotion-3"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-4"
+          />
+        </div>
+        <div
+          class="MuiBox-root emotion-5"
+        >
+          <div
+            class="identifier-container MuiBox-root emotion-6"
+          >
+            <div
+              class="identifierContainer MuiBox-root emotion-7"
+            >
+              <span
+                class="userIconContainer MuiBox-root emotion-8"
+              >
+                <svg
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-9"
+                  fill="none"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                  <title>
+                    User
+                  </title>
+                </svg>
+              </span>
+              <span
+                class="identifier identifierSpan MuiBox-root emotion-8"
+                data-se="identifier"
+              >
+                tester13@test.com
+              </span>
+            </div>
+          </div>
+          <form
+            class="o-form"
+            data-se="o-form"
+            novalidate=""
+            style="max-width: 100%; word-break: break-word;"
+          >
+            <div
+              class="MuiBox-root emotion-11"
+            >
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
+                  class="MuiBox-root emotion-13"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    data-se="o-form-head"
+                    id="select-authenticator-enroll_Title_Set_up_security_methods_aut2h3fft10VeLDPD1d7_1"
+                  >
+                    Set up security methods
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_aut2h3fft10VeLDPD1d7_2"
+                  >
+                    Security methods help protect your account by ensuring only you have access.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-8"
+              >
+                <div
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="select-authenticator-enroll_Description_Set_up_required_aut2h3fft10VeLDPD1d7_3"
+                  >
+                    Set up required
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <ul
+                  class="MuiList-root MuiList-padding emotion-22"
+                >
+                  <li
+                    class="MuiListItem-root MuiListItem-padding emotion-23"
+                  >
+                    <button
+                      aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_aut2h3fft10VeLDPD1d7_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_aut2h3fft10VeLDPD1d7_2 select-authenticator-enroll_Description_Set_up_required_aut2h3fft10VeLDPD1d7_3 google_otp_0-description google_otp_0-ctaLabel"
+                      aria-labelledby="google_otp_0-label"
+                      class="authenticator-row authButton MuiBox-root emotion-24"
+                      data-se="authenticator-button"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        class="authenticator-icon-container MuiBox-root emotion-8"
+                        data-se="authenticator-icon"
+                      >
+                        <div
+                          class="iconContainer mfa-google-auth authenticator-icon MuiBox-root emotion-26"
+                          data-se="factor-beacon"
+                        >
+                          <svg
+                            aria-labelledby="google_otp_0"
+                            fill="none"
+                            height="48"
+                            role="img"
+                            viewBox="0 0 48 48"
+                            width="48"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <title
+                              id="google_otp_0"
+                            >
+                              Google Authenticator
+                            </title>
+                            <path
+                              class="siwFillBg"
+                              clip-rule="evenodd"
+                              d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                              fill="#F5F5F6"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
+                              fill="#616161"
+                            />
+                            <path
+                              d="M24 34.182c-5.623 0-10.181-4.557-10.181-10.181 0-5.624 4.558-10.182 10.182-10.182 2.81 0 5.355 1.14 7.2 2.982l4.114-4.114A15.952 15.952 0 0 0 24 8C15.163 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001 4.42 0 8.419-1.79 11.316-4.685l-4.114-4.114A10.164 10.164 0 0 1 24 34.182Z"
+                              fill="#9E9E9E"
+                            />
+                            <path
+                              d="M34.183 24H29.09a5.09 5.09 0 1 0-8.76 3.528l-.004.004 6.304 6.304.001.001c4.348-1.16 7.55-5.124 7.55-9.836Z"
+                              fill="#424242"
+                            />
+                            <path
+                              d="M40 24h-5.82c0 4.713-3.204 8.676-7.549 9.837l4.493 4.493C36.385 35.71 40 30.277 40 24Z"
+                              fill="#616161"
+                            />
+                            <path
+                              d="M24 39.818c-8.806 0-15.948-7.114-15.999-15.909L8 24.001c0 8.837 7.164 16 16 16 8.838 0 16.001-7.163 16.001-16L40 23.909c-.05 8.795-7.194 15.91-16 15.91Z"
+                              fill="#212121"
+                              fill-opacity=".1"
+                            />
+                            <path
+                              d="m26.634 33.837.141.142c4.273-1.207 7.408-5.134 7.408-9.797v-.181c0 4.712-3.204 8.675-7.55 9.836Z"
+                              fill="#fff"
+                              fill-opacity=".05"
+                            />
+                            <path
+                              d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
+                              fill="#9E9E9E"
+                            />
+                            <path
+                              d="M37.092 22.546H24a1.454 1.454 0 1 0 0 2.908h13.09a1.454 1.454 0 0 0 .002-2.908Z"
+                              fill="#BDBDBD"
+                              opacity=".5"
+                            />
+                            <path
+                              d="M10.909 25.091a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181ZM24 12a1.09 1.09 0 1 0 0-2.182A1.09 1.09 0 0 0 24 12Zm0 26.182a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Zm-9.272-22.348a1.09 1.09 0 1 0 0-2.182 1.09 1.09 0 0 0 0 2.182Zm0 18.53a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
+                              fill="#BDBDBD"
+                            />
+                            <path
+                              d="M33.274 34.364a1.09 1.09 0 1 0 0-2.181 1.09 1.09 0 0 0 0 2.181Z"
+                              fill="#757575"
+                            />
+                            <path
+                              d="M24 22.728h13.091c.773 0 1.404.603 1.45 1.364 0-.03.005-.06.005-.091 0-.804-.651-1.455-1.455-1.455h-13.09a1.454 1.454 0 0 0-1.45 1.546 1.451 1.451 0 0 1 1.45-1.364Z"
+                              fill="#fff"
+                              fill-opacity=".2"
+                            />
+                            <path
+                              d="M38.54 24.09a1.456 1.456 0 0 1-1.449 1.365h-13.09a1.452 1.452 0 0 1-1.45-1.364 1.454 1.454 0 0 0 1.45 1.545h13.09a1.454 1.454 0 0 0 1.45-1.545Z"
+                              fill="#212121"
+                              fill-opacity=".2"
+                            />
+                            <path
+                              d="M24 14c2.811 0 5.357 1.14 7.2 2.983l4.204-4.206-.09-.092L31.2 16.8a10.154 10.154 0 0 0-7.2-2.982c-5.623 0-10.181 4.557-10.181 10.181l.001.092C13.87 18.509 18.408 14 24 14Z"
+                              fill="#212121"
+                              fill-opacity=".1"
+                            />
+                            <path
+                              d="M24 40.001c8.838 0 16.001-7.163 16.001-16S32.838 8 24.001 8 8 15.164 8 24c0 8.838 7.164 16.001 16 16.001Z"
+                              fill="url(#paint0_radial_5_581)"
+                            />
+                            <defs>
+                              <radialgradient
+                                cx="0"
+                                cy="0"
+                                gradientTransform="translate(12.692 12.656) scale(31.946)"
+                                gradientUnits="userSpaceOnUse"
+                                id="paint0_radial_5_581"
+                                r="1"
+                              >
+                                <stop
+                                  stop-color="#fff"
+                                  stop-opacity=".1"
+                                />
+                                <stop
+                                  offset="1"
+                                  stop-color="#fff"
+                                  stop-opacity="0"
+                                />
+                              </radialgradient>
+                            </defs>
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        class="authenticator-description infoSection MuiBox-root emotion-8"
+                      >
+                        <h3
+                          class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-28"
+                          data-se="authenticator-button-label"
+                          id="google_otp_0-label"
+                        >
+                          Google Authenticator
+                        </h3>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-29"
+                          data-se="authenticator-button-description"
+                          id="google_otp_0-description"
+                        >
+                          Enter a temporary code generated from the Google Authenticator app.
+                        </p>
+                        <div
+                          class="cta-button authenticator-button actionName MuiBox-root emotion-8"
+                          data-se="google_otp"
+                        >
+                          <span
+                            class="button select-factor link-button MuiBox-root emotion-31"
+                            data-se="cta-button-label"
+                            id="google_otp_0-ctaLabel"
+                          >
+                            Set up
+                          </span>
+                          <svg
+                            aria-labelledby="google_otp_0-arrow-right"
+                            fill="currentColor"
+                            height="11"
+                            role="img"
+                            viewBox="0 0 14 11"
+                            width="14"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <title
+                              id="google_otp_0-arrow-right"
+                            >
+                              Set up
+                            </title>
+                            <path
+                              d="M0 6.5H8V10.5L13.8158 5.8842C13.8734 5.83728 13.9198 5.77855 13.9517 5.71217C13.9835 5.64579 14 5.5734 14 5.5001C14 5.42681 13.9835 5.35441 13.9517 5.28803C13.9198 5.22165 13.8734 5.16292 13.8158 5.116L8 0.5V4.5H0V6.5Z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                  <li
+                    class="MuiListItem-root MuiListItem-padding emotion-23"
+                  >
+                    <button
+                      aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_aut2h3fft10VeLDPD1d7_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_aut2h3fft10VeLDPD1d7_2 select-authenticator-enroll_Description_Set_up_required_aut2h3fft10VeLDPD1d7_3 okta_verify_1-description okta_verify_1-ctaLabel"
+                      aria-labelledby="okta_verify_1-label"
+                      class="authenticator-row authButton MuiBox-root emotion-24"
+                      data-se="authenticator-button"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        class="authenticator-icon-container MuiBox-root emotion-8"
+                        data-se="authenticator-icon"
+                      >
+                        <div
+                          class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-26"
+                          data-se="factor-beacon"
+                        >
+                          <svg
+                            aria-labelledby="okta_verify_1"
+                            fill="none"
+                            height="48"
+                            role="img"
+                            viewBox="0 0 48 48"
+                            width="48"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <title
+                              id="okta_verify_1"
+                            >
+                              Okta Verify
+                            </title>
+                            <circle
+                              class="siwFillBg"
+                              cx="24"
+                              cy="24"
+                              fill="#F5F5F6"
+                              r="24"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M32.872 22.853a8.947 8.947 0 1 1-2.288-4.91L24 24.498l-3.205-3.19c-.482-.48-1.322-.48-1.804 0a1.26 1.26 0 0 0-.374.898c0 .34.133.659.374.898l4.107 4.09c.24.239.561.371.902.371.336 0 .664-.136.902-.372L38.636 13.52a18.089 18.089 0 0 0-1.634-1.967A17.947 17.947 0 0 0 24 6C14.059 6 6 14.059 6 24s8.059 18 18 18 18-8.059 18-18c0-2.972-.722-5.775-1.998-8.245l-7.13 7.098Z"
+                              fill="#00297A"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        class="authenticator-description infoSection MuiBox-root emotion-8"
+                      >
+                        <h3
+                          class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-28"
+                          data-se="authenticator-button-label"
+                          id="okta_verify_1-label"
+                        >
+                          Okta Verify
+                        </h3>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-29"
+                          data-se="authenticator-button-description"
+                          id="okta_verify_1-description"
+                        >
+                          Okta Verify is an authenticator app, installed on your phone, used to prove your identity
+                        </p>
+                        <div
+                          class="cta-button authenticator-button actionName MuiBox-root emotion-8"
+                          data-se="okta_verify"
+                        >
+                          <span
+                            class="button select-factor link-button MuiBox-root emotion-31"
+                            data-se="cta-button-label"
+                            id="okta_verify_1-ctaLabel"
+                          >
+                            Set up
+                          </span>
+                          <svg
+                            aria-labelledby="okta_verify_1-arrow-right"
+                            fill="currentColor"
+                            height="11"
+                            role="img"
+                            viewBox="0 0 14 11"
+                            width="14"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <title
+                              id="okta_verify_1-arrow-right"
+                            >
+                              Set up
+                            </title>
+                            <path
+                              d="M0 6.5H8V10.5L13.8158 5.8842C13.8734 5.83728 13.9198 5.77855 13.9517 5.71217C13.9835 5.64579 14 5.5734 14 5.5001C14 5.42681 13.9835 5.35441 13.9517 5.28803C13.9198 5.22165 13.8734 5.16292 13.8158 5.116L8 0.5V4.5H0V6.5Z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                  <li
+                    class="MuiListItem-root MuiListItem-padding emotion-23"
+                  >
+                    <button
+                      aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_aut2h3fft10VeLDPD1d7_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_aut2h3fft10VeLDPD1d7_2 select-authenticator-enroll_Description_Set_up_required_aut2h3fft10VeLDPD1d7_3 phone_number_2-description phone_number_2-ctaLabel"
+                      aria-labelledby="phone_number_2-label"
+                      class="authenticator-row authButton MuiBox-root emotion-24"
+                      data-se="authenticator-button"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        class="authenticator-icon-container MuiBox-root emotion-8"
+                        data-se="authenticator-icon"
+                      >
+                        <div
+                          class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-26"
+                          data-se="factor-beacon"
+                        >
+                          <svg
+                            aria-labelledby="phone_number_2"
+                            fill="none"
+                            height="48"
+                            role="img"
+                            viewBox="0 0 48 48"
+                            width="48"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <title
+                              id="phone_number_2"
+                            >
+                              Voice Call Authentication
+                            </title>
+                            <circle
+                              class="siwFillBg"
+                              cx="24"
+                              cy="24"
+                              fill="#F5F5F6"
+                              r="24"
+                            />
+                            <path
+                              class="siwFillPrimary"
+                              d="M21.5 37h-9a2.6 2.6 0 0 1-2.5-2.682V14.682A2.6 2.6 0 0 1 12.5 12h9a2.6 2.6 0 0 1 2.5 2.682v19.636A2.6 2.6 0 0 1 21.5 37Zm-9-24a1.6 1.6 0 0 0-1.5 1.682v19.636A1.6 1.6 0 0 0 12.5 36h9a1.6 1.6 0 0 0 1.5-1.682V14.682A1.6 1.6 0 0 0 21.5 13h-9Z"
+                              fill="#00297A"
+                            />
+                            <path
+                              class="siwFillPrimary"
+                              d="M19 34h-4v1h4v-1Zm-1-19a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
+                              fill="#00297A"
+                            />
+                            <path
+                              class="siwFillSecondary"
+                              d="M34.606 34.606 33.9 33.9a13.998 13.998 0 0 0 0-19.8l.707-.707a15 15 0 0 1 0 21.212l-.001.001Z"
+                              fill="#A7B5EC"
+                            />
+                            <path
+                              class="siwFillSecondary"
+                              d="m31.071 31.071-.707-.707a9 9 0 0 0 0-12.728l.707-.707a10 10 0 0 1 0 14.142Zm-3.535-3.536-.707-.707a4 4 0 0 0 0-5.656l.707-.707a5 5 0 0 1 0 7.07Z"
+                              fill="#A7B5EC"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        class="authenticator-description infoSection MuiBox-root emotion-8"
+                      >
+                        <h3
+                          class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-28"
+                          data-se="authenticator-button-label"
+                          id="phone_number_2-label"
+                        >
+                          Phone
+                        </h3>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-29"
+                          data-se="authenticator-button-description"
+                          id="phone_number_2-description"
+                        >
+                          Verify with a code sent to your phone
+                        </p>
+                        <div
+                          class="cta-button authenticator-button actionName MuiBox-root emotion-8"
+                          data-se="phone_number"
+                        >
+                          <span
+                            class="button select-factor link-button MuiBox-root emotion-31"
+                            data-se="cta-button-label"
+                            id="phone_number_2-ctaLabel"
+                          >
+                            Set up
+                          </span>
+                          <svg
+                            aria-labelledby="phone_number_2-arrow-right"
+                            fill="currentColor"
+                            height="11"
+                            role="img"
+                            viewBox="0 0 14 11"
+                            width="14"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <title
+                              id="phone_number_2-arrow-right"
+                            >
+                              Set up
+                            </title>
+                            <path
+                              d="M0 6.5H8V10.5L13.8158 5.8842C13.8734 5.83728 13.9198 5.77855 13.9517 5.71217C13.9835 5.64579 14 5.5734 14 5.5001C14 5.42681 13.9835 5.35441 13.9517 5.28803C13.9198 5.22165 13.8734 5.16292 13.8158 5.116L8 0.5V4.5H0V6.5Z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                  <li
+                    class="MuiListItem-root MuiListItem-padding emotion-23"
+                  >
+                    <button
+                      aria-describedby="select-authenticator-enroll_Title_Set_up_security_methods_aut2h3fft10VeLDPD1d7_1 select-authenticator-enroll_Description_Security_methods_help_protect_your_account_by_ensuring_only_you_have_access_aut2h3fft10VeLDPD1d7_2 select-authenticator-enroll_Description_Set_up_required_aut2h3fft10VeLDPD1d7_3 webauthn_3-description webauthn_3-ctaLabel"
+                      aria-labelledby="webauthn_3-label"
+                      class="authenticator-row authButton MuiBox-root emotion-24"
+                      data-se="authenticator-button"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        class="authenticator-icon-container MuiBox-root emotion-8"
+                        data-se="authenticator-icon"
+                      >
+                        <div
+                          class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-26"
+                          data-se="factor-beacon"
+                        >
+                          <svg
+                            aria-labelledby="webauthn_3"
+                            fill="none"
+                            height="48"
+                            role="img"
+                            viewBox="0 0 48 48"
+                            width="48"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <title
+                              id="webauthn_3"
+                            >
+                              Security Key or Biometric Authenticator
+                            </title>
+                            <path
+                              class="siwFillBg"
+                              clip-rule="evenodd"
+                              d="M24 48c13.255 0 24-10.745 24-24S37.255 0 24 0 0 10.745 0 24s10.745 24 24 24Z"
+                              fill="#F5F5F6"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              class="siwFillPrimary"
+                              d="M24 17V9h-9v8h-3v15.5a2.5 2.5 0 0 0 2.5 2.5h6.34a8.58 8.58 0 0 1-.38-1H14.5a1.5 1.5 0 0 1-1.5-1.5V18h13v3.84a8.58 8.58 0 0 1 1-.38V17h-3Zm-8 0v-7h7v7h-7Z"
+                              fill="#00297A"
+                            />
+                            <path
+                              class="siwFillPrimary"
+                              d="M19.5 25a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
+                              fill="#00297A"
+                            />
+                            <path
+                              class="siwFillSecondary"
+                              d="M30 40a9 9 0 1 1 9-9 9.01 9.01 0 0 1-9 9Zm0-17a8 8 0 1 0 8 8 8.009 8.009 0 0 0-8-8Z"
+                              fill="#A7B5EC"
+                            />
+                            <path
+                              class="siwFillSecondary"
+                              d="M32.084 36.019a.472.472 0 0 1-.319-.112.501.501 0 0 1-.159-.532c.43-1.389 1.274-4.787-.119-6.352a1.962 1.962 0 0 0-1.946-.6 1.93 1.93 0 0 0-1.387 2.354c.007.024.666 2.823-.966 4.55a.5.5 0 1 1-.727-.685c1.24-1.314.728-3.6.723-3.622a2.933 2.933 0 0 1 2.106-3.566 2.977 2.977 0 0 1 2.944.906c1.67 1.875.922 5.386.328 7.312a.5.5 0 0 1-.478.347Z"
+                              fill="#A7B5EC"
+                            />
+                            <path
+                              class="siwFillSecondary"
+                              d="M28.63 37.25a.5.5 0 0 1-.359-.849c2.235-2.3 1.345-5.782 1.336-5.817a.5.5 0 0 1 .966-.259c.045.165 1.052 4.067-1.586 6.774a.5.5 0 0 1-.358.151Z"
+                              fill="#A7B5EC"
+                            />
+                            <path
+                              class="siwFillSecondary"
+                              d="M34.88 35.2a.5.5 0 0 1-.488-.612c.493-2.2.716-5.235-1.03-7.2a4.508 4.508 0 0 0-4.455-1.357 4.416 4.416 0 0 0-2.72 2.069 4.2 4.2 0 0 0-.468 3.2 3.1 3.1 0 0 1-.355 2.347.5.5 0 1 1-.728-.685 2.37 2.37 0 0 0 .11-1.434 5.174 5.174 0 0 1 .577-3.939 5.42 5.42 0 0 1 3.333-2.518 5.524 5.524 0 0 1 5.453 1.66c1.628 1.832 2.051 4.551 1.257 8.082a.5.5 0 0 1-.487.387Z"
+                              fill="#A7B5EC"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        class="authenticator-description infoSection MuiBox-root emotion-8"
+                      >
+                        <h3
+                          class="MuiTypography-root MuiTypography-h3 authenticator-label emotion-28"
+                          data-se="authenticator-button-label"
+                          id="webauthn_3-label"
+                        >
+                          Security Key or Biometric Authenticator
+                        </h3>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph authenticator-description--text emotion-29"
+                          data-se="authenticator-button-description"
+                          id="webauthn_3-description"
+                        >
+                          Use a security key or a biometric authenticator to sign in
+                        </p>
+                        <div
+                          class="cta-button authenticator-button actionName MuiBox-root emotion-8"
+                          data-se="webauthn"
+                        >
+                          <span
+                            class="button select-factor link-button MuiBox-root emotion-31"
+                            data-se="cta-button-label"
+                            id="webauthn_3-ctaLabel"
+                          >
+                            Set up
+                          </span>
+                          <svg
+                            aria-labelledby="webauthn_3-arrow-right"
+                            fill="currentColor"
+                            height="11"
+                            role="img"
+                            viewBox="0 0 14 11"
+                            width="14"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <title
+                              id="webauthn_3-arrow-right"
+                            >
+                              Set up
+                            </title>
+                            <path
+                              d="M0 6.5H8V10.5L13.8158 5.8842C13.8734 5.83728 13.9198 5.77855 13.9517 5.71217C13.9835 5.64579 14 5.5734 14 5.5001C14 5.42681 13.9835 5.35441 13.9517 5.28803C13.9198 5.22165 13.8734 5.16292 13.8158 5.116L8 0.5V4.5H0V6.5Z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                  data-se="cancel"
+                  href="javascript:void(0)"
+                >
+                  Back to sign in
+                </a>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
 exports[`authenticator-enroll-phone-sms should render form 1`] = `
 <div>
   <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-12"
+                class="MuiBox-root emotion-8"
               >
                 <div
                   class="MuiBox-root emotion-13"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-12"
+                class="MuiBox-root emotion-8"
               >
                 <div
                   class="MuiBox-root emotion-13"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-12"
+                class="MuiBox-root emotion-8"
               >
                 <div
                   class="MuiBox-root emotion-13"

--- a/src/v3/test/integration/authenticator-enroll-phone-sms.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-phone-sms.test.tsx
@@ -50,13 +50,15 @@ describe('authenticator-enroll-phone-sms', () => {
 
     it('when back to authenticators list', async () => {
       const {
-        authClient, user, findByText,
+        authClient, container, user, findByText,
       } = await setup({ mockResponse });
 
       await user.click(await findByText(/Return to authenticator list/));
-      expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      expect(authClient.options.httpRequestClient).not.toHaveBeenCalledWith(
         ...createAuthJsPayloadArgs('POST', 'idp/idx/credential/enroll'),
       );
+      await findByText(/Set up security methods/);
+      expect(container).toMatchSnapshot();
     });
   });
 });

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, RequestLogger, ClientFunction, userVariables } from 'testcafe';
+import { RequestMock, RequestLogger, ClientFunction } from 'testcafe';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import ChallengePhonePageObject from '../framework/page-objects/ChallengePhonePageObject';
 import { checkConsoleMessages, renderWidget, oktaDashboardContent } from '../framework/shared';
@@ -170,7 +170,7 @@ test
     const pageTitle = challengePhonePageObject.getFormTitle();
     const pageSubtitle = challengePhonePageObject.getFormSubtitle();
     const primaryButtonText = challengePhonePageObject.getSaveButtonLabel();
-    const secondaryButtonText = challengePhonePageObject.getSecondaryLinkText('Receive a voice call instead')
+    const secondaryButtonText = challengePhonePageObject.getSecondaryLinkText('Receive a voice call instead');
     await t.expect(pageTitle).contains('Verify with your phone');
     await t.expect(pageSubtitle).contains('Send a code via SMS to');
     await t.expect(pageSubtitle).contains('+1 XXX-XXX-2342');

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -217,7 +217,7 @@ test.requestHooks(mockEnrollAuthenticatorPassword)('should navigate to password 
   await t.expect(enrollPasswordPage.confirmPasswordFieldExists()).eql(true);
 });
 
-test.meta('v3', false).requestHooks(requestLogger, mockEnrollAuthenticatorPassword)('select password challenge page and hit switch authenticator and re-select password', async t => {
+test.requestHooks(requestLogger, mockEnrollAuthenticatorPassword)('select password challenge page and hit switch authenticator and re-select password', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Set up security methods');
 

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -300,7 +300,7 @@ test.requestHooks(mockChallengePassword)('should navigate to password challenge 
   await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with your password');
 });
 
-test.meta('v3', false).requestHooks(requestLogger, mockChallengePassword)('select password challenge page and hit switch authenticator and re-select password', async t => {
+test.requestHooks(requestLogger, mockChallengePassword)('select password challenge page and hit switch authenticator and re-select password', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   await t.expect(selectFactorPage.getIdentifier()).eql('testUser@okta.com');


### PR DESCRIPTION
## Description:
The purpose of this PR is to prevent the switch authenticator list links from making an API request. The reason for this is because the backend cannot handle requests to this endpoint without providing a payload. Prior to this change a 400 bad request error was thrown anytime a user clicks these links. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-528630](https://oktainc.atlassian.net/browse/OKTA-528630)

### Reviewers:

### Screenshot/Video:
**Return to authenticator list link functionality**


https://user-images.githubusercontent.com/97472729/215846921-c4ae9376-d777-4e7b-b71e-67f94671ad85.mov



**Verify with other link functionality**

https://user-images.githubusercontent.com/97472729/215845316-97ffb761-5716-4f0c-afb3-bd45e8fe0283.mov



### Downstream Monolith Build:



