### PR TITLE
Handles non-IDX error responses

### DIFF
--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -31,6 +31,7 @@ jest.mock('../../../src/contexts', () => ({
         stateHandle: 'fake-state-handle',
       },
     },
+    setIdxTransaction: jest.fn(),
   }),
 }));
 jest.mock('../../../../util/Logger');
@@ -84,10 +85,7 @@ describe('LoopbackProbe', () => {
     await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
 
     expect(proceedStub).toHaveBeenCalledWith({
-      actions: [{
-        name: step,
-        params: undefined,
-      }],
+      step,
       stateHandle: 'fake-state-handle',
     });
   });
@@ -204,10 +202,7 @@ describe('LoopbackProbe', () => {
     await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
 
     expect(proceedStub).toHaveBeenCalledWith({
-      actions: [{
-        name: 'device-challenge-poll',
-        params: undefined,
-      }],
+      step: 'device-challenge-poll',
       stateHandle: 'fake-state-handle',
     });
   });

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -19,7 +19,7 @@ import { LoopbackProbeElement } from 'src/types';
 import LoopbackProbe from './LoopbackProbe';
 
 const proceedStub = jest.fn();
-jest.mock('../../../src/contexts', () => ({
+jest.mock('../../contexts', () => ({
   useWidgetContext: () => ({
     authClient: {
       idx: {

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -18,9 +18,20 @@ import { LoopbackProbeElement } from 'src/types';
 
 import LoopbackProbe from './LoopbackProbe';
 
-const onSubmitHandler = jest.fn();
-jest.mock('../../hooks', () => ({
-  useOnSubmit: () => onSubmitHandler,
+const proceedStub = jest.fn();
+jest.mock('../../../src/contexts', () => ({
+  useWidgetContext: () => ({
+    authClient: {
+      idx: {
+        proceed: proceedStub,
+      },
+    },
+    idxTransaction: {
+      context: {
+        stateHandle: 'fake-state-handle',
+      },
+    },
+  }),
 }));
 jest.mock('../../../../util/Logger');
 
@@ -70,10 +81,14 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), { timeout: 100 });
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
 
-    expect(onSubmitHandler).toHaveBeenCalledWith({
-      step,
+    expect(proceedStub).toHaveBeenCalledWith({
+      actions: [{
+        name: step,
+        params: undefined,
+      }],
+      stateHandle: 'fake-state-handle',
     });
   });
 
@@ -104,15 +119,17 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), { timeout: 100 });
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
 
-    expect(onSubmitHandler).toHaveBeenCalledWith({
-      isActionStep: true,
-      step: cancelStep,
-      params: {
-        reason: 'OV_UNREACHABLE_BY_LOOPBACK',
-        statusCode: null,
-      },
+    expect(proceedStub).toHaveBeenCalledWith({
+      actions: [{
+        name: cancelStep,
+        params: {
+          reason: 'OV_UNREACHABLE_BY_LOOPBACK',
+          statusCode: null,
+        },
+      }],
+      stateHandle: 'fake-state-handle',
     });
   });
 
@@ -142,15 +159,17 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), { timeout: 100 });
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
 
-    expect(onSubmitHandler).toHaveBeenCalledWith({
-      isActionStep: true,
-      step: 'authenticatorChallenge-cancel',
-      params: {
-        reason: 'OV_RETURNED_ERROR',
-        statusCode: 400,
-      },
+    expect(proceedStub).toHaveBeenCalledWith({
+      actions: [{
+        name: 'authenticatorChallenge-cancel',
+        params: {
+          reason: 'OV_RETURNED_ERROR',
+          statusCode: 400,
+        },
+      }],
+      stateHandle: 'fake-state-handle',
     });
   });
 
@@ -182,10 +201,14 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), { timeout: 100 });
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
 
-    expect(onSubmitHandler).toHaveBeenCalledWith({
-      step: 'device-challenge-poll',
+    expect(proceedStub).toHaveBeenCalledWith({
+      actions: [{
+        name: 'device-challenge-poll',
+        params: undefined,
+      }],
+      stateHandle: 'fake-state-handle',
     });
   });
 
@@ -220,17 +243,19 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    await waitFor(() => expect(onSubmitHandler).toHaveBeenCalledTimes(1), {
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), {
       timeout: 300, // need to wait longer since we are testing request timeout
     });
 
-    expect(onSubmitHandler).toHaveBeenCalledWith({
-      isActionStep: true,
-      step: 'authenticatorChallenge-cancel',
-      params: {
-        reason: 'OV_UNREACHABLE_BY_LOOPBACK',
-        statusCode: null,
-      },
+    expect(proceedStub).toHaveBeenCalledWith({
+      actions: [{
+        name: 'authenticatorChallenge-cancel',
+        params: {
+          reason: 'OV_UNREACHABLE_BY_LOOPBACK',
+          statusCode: null,
+        },
+      }],
+      stateHandle: 'fake-state-handle',
     });
   });
 });

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -10,12 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { IdxActionParams } from '@okta/okta-auth-js';
 import fetch from 'cross-fetch';
 import { FunctionComponent } from 'preact';
 import { useEffect } from 'preact/hooks';
 
 import Logger from '../../../../util/Logger';
-import { useOnSubmit } from '../../hooks';
+import { useWidgetContext } from '../../contexts';
 import { ActionParams, LoopbackProbeElement } from '../../types';
 import { isAndroid } from '../../util';
 
@@ -83,7 +84,8 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
     },
   },
 }) => {
-  const onSubmitHandler = useOnSubmit();
+  const widgetContext = useWidgetContext();
+  const { authClient, idxTransaction } = widgetContext;
 
   const probeTimeoutMillis: number = typeof deviceChallengePayload.probeTimeoutMillis === 'undefined'
     ? 100 : deviceChallengePayload.probeTimeoutMillis;
@@ -93,13 +95,22 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
     challengeRequest,
   } = deviceChallengePayload;
 
+  const submitHandler = (stepName: string, params?: ActionParams) => {
+    const payload: IdxActionParams = {
+      actions: [{
+        name: stepName,
+        params,
+      }],
+    };
+    if (typeof idxTransaction?.context.stateHandle !== 'undefined') {
+      payload.stateHandle = idxTransaction.context.stateHandle;
+    }
+    authClient?.idx.proceed(payload);
+  };
+
   const cancelHandler = (params?: ActionParams) => {
     if (typeof cancelStep !== 'undefined') {
-      onSubmitHandler({
-        isActionStep: true,
-        step: cancelStep,
-        params,
-      });
+      submitHandler(cancelStep, params);
     }
   };
 
@@ -171,9 +182,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
         // success condition
         // once the OV challenge succeeds, triggers another polling right away without waiting
         // for the next ongoing polling to be triggered to make the authentication flow go faster
-        onSubmitHandler({
-          step,
-        });
+        submitHandler(step);
       } else {
         // no more ports to probe: cancel polling and return
         Logger.error('No available ports. Loopback server failed and polling is cancelled.');

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -16,6 +16,7 @@ import {
   IdxActionParams,
   IdxMessage,
   IdxTransaction,
+  OAuthError,
   RawIdxResponse,
 } from '@okta/okta-auth-js';
 import { omit } from 'lodash';
@@ -49,7 +50,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     data,
     idxTransaction: currTransaction,
     dataSchemaRef,
-    setAuthApiError,
+    setResponseError,
     setIdxTransaction,
     setIsClientTransaction,
     setLoading,
@@ -85,12 +86,12 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       // TODO: handle error based on types
       // AuthApiError is one of the potential error that can be thrown here
       // We will want to expose development stage errors from auth-js and file jiras against it
-      setAuthApiError(error as AuthApiError);
+      setResponseError(error as (AuthApiError | OAuthError));
       console.error(error);
       // error event
       events?.afterError?.(
         transaction ? getEventContext(transaction) : {},
-        getErrorEventContext(error as AuthApiError),
+        getErrorEventContext(error as (AuthApiError | OAuthError)),
       );
       return null;
     };
@@ -179,7 +180,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     currTransaction,
     dataSchemaRef,
     events,
-    setAuthApiError,
+    setResponseError,
     setIdxTransaction,
     setIsClientTransaction,
     setLoading,

--- a/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Unhandled Error Transformer Tests should add Infobox with unexpected error message when error is not provided 1`] = `
+exports[`Unhandled Error Transformer Tests When AuthApiError is returned should add Infobox with unexpected error message when error is not provided 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -23,7 +23,53 @@ Object {
 }
 `;
 
-exports[`Unhandled Error Transformer Tests should add info box when oie configuration error 1`] = `
+exports[`Unhandled Error Transformer Tests When AuthApiError is returned should add infobox with custom message from server 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "dataSe": "callout",
+          "message": "Custom error message",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Unhandled Error Transformer Tests When OAuthError is returned should add Infobox with unexpected error message when error is not provided 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "dataSe": "callout",
+          "message": "oform.error.unexpected",
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Unhandled Error Transformer Tests When OAuthError is returned should add info box when oie configuration error 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -46,7 +92,7 @@ Object {
 }
 `;
 
-exports[`Unhandled Error Transformer Tests should add info box when oie is not enabled error 1`] = `
+exports[`Unhandled Error Transformer Tests When OAuthError is returned should add info box when oie is not enabled error 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -69,7 +115,7 @@ Object {
 }
 `;
 
-exports[`Unhandled Error Transformer Tests should add info box when response is invalid recovery token error 1`] = `
+exports[`Unhandled Error Transformer Tests When OAuthError is returned should add info box when response is invalid recovery token error 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.ts
@@ -93,7 +93,7 @@ const appendBiometricsErrorBox = (
 };
 
 export const transformTerminalMessages: TerminalKeyTransformer = (transaction, formBag) => {
-  const { messages } = transaction;
+  const { messages, requestDidSucceed } = transaction;
   const { uischema } = formBag;
   if (transaction.error) {
     uischema.elements.push({
@@ -107,6 +107,15 @@ export const transformTerminalMessages: TerminalKeyTransformer = (transaction, f
   }
 
   if (!messages?.length) {
+    if (requestDidSucceed === false) {
+      uischema.elements.push({
+        type: 'InfoBox',
+        options: {
+          message: loc('error.unsupported.response', 'login'),
+          class: 'ERROR',
+        },
+      } as InfoboxElement);
+    }
     return formBag;
   }
 

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
@@ -10,85 +10,131 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { AuthApiError } from '@okta/okta-auth-js';
+import { AuthApiError, OAuthError } from '@okta/okta-auth-js';
 import { InfoboxElement, WidgetProps } from 'src/types';
 
 import { transformUnhandledErrors } from './transformUnhandledErrors';
 
 describe('Unhandled Error Transformer Tests', () => {
-  let apiError: AuthApiError;
-  let widgetProps: WidgetProps;
+  describe('When AuthApiError is returned', () => {
+    let apiError: AuthApiError;
+    let widgetProps: WidgetProps;
 
-  beforeEach(() => {
-    widgetProps = {};
-    apiError = {
-      name: '',
-      message: '',
-      errorSummary: '',
-      errorCode: '',
-    };
+    beforeEach(() => {
+      widgetProps = {};
+      apiError = {
+        name: 'AuthApiError',
+        message: '',
+        errorSummary: '',
+        errorCode: '',
+      };
+    });
+
+    it('should add Infobox with unexpected error message when error is not provided', () => {
+      const formBag = transformUnhandledErrors(widgetProps);
+
+      expect(formBag).toMatchSnapshot();
+      expect(formBag.uischema.elements.length).toBe(1);
+      const el = formBag.uischema.elements[0] as InfoboxElement;
+      expect(el.type).toBe('InfoBox');
+      expect(el.options?.message).toBe('oform.error.unexpected');
+      expect(el.options?.class).toBe('ERROR');
+    });
+
+    it('should add infobox with custom message from server', () => {
+      const mockErrorMessage = 'Custom error message';
+      apiError = {
+        ...apiError,
+        errorCode: 'some_error_key',
+        errorSummary: mockErrorMessage,
+      };
+      const formBag = transformUnhandledErrors(widgetProps, apiError);
+
+      expect(formBag).toMatchSnapshot();
+      expect(formBag.uischema.elements.length).toBe(1);
+      const el = formBag.uischema.elements[0] as InfoboxElement;
+      expect(el.type).toBe('InfoBox');
+      expect(el.options?.message).toBe(mockErrorMessage);
+      expect(el.options?.class).toBe('ERROR');
+    });
   });
 
-  it('should add Infobox with unexpected error message when error is not provided', () => {
-    const formBag = transformUnhandledErrors(widgetProps);
+  describe('When OAuthError is returned', () => {
+    let apiError: OAuthError;
+    let widgetProps: WidgetProps;
 
-    expect(formBag).toMatchSnapshot();
-    expect(formBag.uischema.elements.length).toBe(1);
-    const el = formBag.uischema.elements[0] as InfoboxElement;
-    expect(el.type).toBe('InfoBox');
-    expect(el.options?.message).toBe('oform.error.unexpected');
-    expect(el.options?.class).toBe('ERROR');
-  });
+    beforeEach(() => {
+      widgetProps = {};
+      apiError = {
+        name: 'OAuthError',
+        message: '',
+        errorCode: '',
+        errorSummary: '',
+        error: '',
+        error_description: '',
+      };
+    });
 
-  it('should add info box when response is invalid recovery token error', () => {
-    const mockErrorMessage = 'The recovery token is invalid';
-    apiError = {
-      ...apiError,
-      errorCode: 'invalid_request',
-      errorSummary: mockErrorMessage,
-    };
-    const formBag = transformUnhandledErrors(widgetProps, apiError);
+    it('should add Infobox with unexpected error message when error is not provided', () => {
+      const formBag = transformUnhandledErrors(widgetProps);
 
-    expect(formBag).toMatchSnapshot();
-    expect(formBag.uischema.elements.length).toBe(1);
-    expect(formBag.uischema.elements[0].type).toBe('InfoBox');
-    expect((formBag.uischema.elements[0] as InfoboxElement).options?.message).toBe('oie.invalid.recovery.token');
-    expect((
-      formBag.uischema.elements[0] as InfoboxElement
-    ).options?.class).toBe('ERROR');
-  });
+      expect(formBag).toMatchSnapshot();
+      expect(formBag.uischema.elements.length).toBe(1);
+      const el = formBag.uischema.elements[0] as InfoboxElement;
+      expect(el.type).toBe('InfoBox');
+      expect(el.options?.message).toBe('oform.error.unexpected');
+      expect(el.options?.class).toBe('ERROR');
+    });
 
-  it('should add info box when oie is not enabled error', () => {
-    const mockErrorMessage = 'Another mocked error message';
-    apiError = {
-      ...apiError,
-      errorCode: 'access_denied',
-      errorSummary: mockErrorMessage,
-    };
-    const formBag = transformUnhandledErrors(widgetProps, apiError);
+    it('should add info box when response is invalid recovery token error', () => {
+      const mockErrorMessage = 'The recovery token is invalid';
+      apiError = {
+        ...apiError,
+        error: 'invalid_request',
+        error_description: mockErrorMessage,
+      };
+      const formBag = transformUnhandledErrors(widgetProps, apiError);
 
-    expect(formBag).toMatchSnapshot();
-    expect(formBag.uischema.elements.length).toBe(1);
-    const el = formBag.uischema.elements[0] as InfoboxElement;
-    expect(el.type).toBe('InfoBox');
-    expect(el.options?.message).toBe('oie.feature.disabled');
-    expect(el.options?.class).toBe('ERROR');
-  });
+      expect(formBag).toMatchSnapshot();
+      expect(formBag.uischema.elements.length).toBe(1);
+      expect(formBag.uischema.elements[0].type).toBe('InfoBox');
+      expect((formBag.uischema.elements[0] as InfoboxElement).options?.message).toBe('oie.invalid.recovery.token');
+      expect((
+        formBag.uischema.elements[0] as InfoboxElement
+      ).options?.class).toBe('ERROR');
+    });
 
-  it('should add info box when oie configuration error', () => {
-    const mockErrorMessage = 'Yet another mocked error message';
-    apiError = {
-      ...apiError,
-      errorCode: 'some_error_key',
-      errorSummary: mockErrorMessage,
-    };
-    const formBag = transformUnhandledErrors(widgetProps, apiError);
+    it('should add info box when oie is not enabled error', () => {
+      const mockErrorMessage = 'A mocked error message';
+      apiError = {
+        ...apiError,
+        error: 'access_denied',
+        error_description: mockErrorMessage,
+      };
+      const formBag = transformUnhandledErrors(widgetProps, apiError);
 
-    expect(formBag).toMatchSnapshot();
-    expect(formBag.uischema.elements.length).toBe(1);
-    const el = formBag.uischema.elements[0] as InfoboxElement;
-    expect(el.type).toBe('InfoBox');
-    expect(el.options?.message).toBe('oie.configuration.error');
-    expect(el.options?.class).toBe('ERROR');
+      expect(formBag).toMatchSnapshot();
+      expect(formBag.uischema.elements.length).toBe(1);
+      const el = formBag.uischema.elements[0] as InfoboxElement;
+      expect(el.type).toBe('InfoBox');
+      expect(el.options?.message).toBe('oie.feature.disabled');
+      expect(el.options?.class).toBe('ERROR');
+    });
+
+    it('should add info box when oie configuration error', () => {
+      apiError = {
+        ...apiError,
+        error: 'unauthorized_client',
+        error_description: 'The client is not authorized to use the provided grant type. Configured grant types: [refresh_token, implicit, authorization_code].'
+      };
+      const formBag = transformUnhandledErrors(widgetProps, apiError);
+
+      expect(formBag).toMatchSnapshot();
+      expect(formBag.uischema.elements.length).toBe(1);
+      const el = formBag.uischema.elements[0] as InfoboxElement;
+      expect(el.type).toBe('InfoBox');
+      expect(el.options?.message).toBe('oie.configuration.error');
+      expect(el.options?.class).toBe('ERROR');
+    });
   });
 });

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
@@ -125,7 +125,7 @@ describe('Unhandled Error Transformer Tests', () => {
       apiError = {
         ...apiError,
         error: 'unauthorized_client',
-        error_description: 'The client is not authorized to use the provided grant type. Configured grant types: [refresh_token, implicit, authorization_code].'
+        error_description: 'The client is not authorized to use the provided grant type. Configured grant types: [refresh_token, implicit, authorization_code].',
       };
       const formBag = transformUnhandledErrors(widgetProps, apiError);
 

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
@@ -27,7 +27,10 @@ type ErrorTester<T extends (AuthApiError | OAuthError)> = {
   message: (err?: T) => string,
 };
 
-const getErrorMessage = (error?: (AuthApiError | OAuthError), widgetProps?: WidgetProps) : string => {
+const getErrorMessage = (
+  error?: (AuthApiError | OAuthError),
+  widgetProps?: WidgetProps,
+) : string => {
   const authApiErrorChecks: ErrorTester<AuthApiError>[] = [
     // error message comes from server response
     {
@@ -71,16 +74,18 @@ const getErrorMessage = (error?: (AuthApiError | OAuthError), widgetProps?: Widg
   let message: string | undefined;
   switch (error?.name) {
     case 'AuthApiError':
-      const authApiError = error as AuthApiError;
-      message = authApiErrorChecks.find(({ tester }) => tester(authApiError))?.message(authApiError);
+      message = authApiErrorChecks
+        .find(({ tester }) => tester(error as AuthApiError))?.message(error as AuthApiError);
       break;
     case 'OAuthError':
-      const oauthError = error as OAuthError;
-      message = oauthErrorChecks.find(({ tester }) => tester(oauthError))?.message(oauthError);
+      message = oauthErrorChecks
+        .find(({ tester }) => tester(error as OAuthError))?.message(error as OAuthError);
       break;
+    default:
+      // intentionally fall through
   }
   // default fall back for unknown errors
-  return message ? message : loc('oform.error.unexpected');
+  return message || loc('oform.error.unexpected');
 };
 
 export const transformUnhandledErrors: ErrorTransformer = (widgetProps, error) => {

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
@@ -52,6 +52,10 @@ const getErrorMessage = (error?: AuthApiError, widgetProps?: WidgetProps) : stri
       message: () => loc('oie.feature.disabled', 'login'),
     },
     {
+      tester: (err?: AuthApiError) => err?.errorCode && err?.errorSummary,
+      message: (err?: AuthApiError) => err?.errorSummary,
+    },
+    {
       tester: (err?: AuthApiError) => err?.errorCode && !!err?.errorSummary,
       message: () => loc('oie.configuration.error', 'login'),
     },

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
@@ -56,7 +56,7 @@ const getErrorMessage = (error?: AuthApiError, widgetProps?: WidgetProps) : stri
       message: (err?: AuthApiError) => err?.errorSummary,
     },
     {
-      tester: (err?: AuthApiError) => err?.errorCode && !!err?.errorSummary,
+      tester: (err?: AuthApiError) => err?.errorCode && !err?.errorSummary,
       message: () => loc('oie.configuration.error', 'login'),
     },
     // default fall back for unknown errors

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -14,6 +14,7 @@ import {
   AuthApiError,
   IdxMessage,
   IdxTransaction,
+  OAuthError,
   OktaAuth,
 } from '@okta/okta-auth-js';
 import { MutableRef, StateUpdater } from 'preact/hooks';
@@ -31,7 +32,7 @@ export type IWidgetContext = {
   onSuccessCallback?: (data: Record<string, unknown>) => void;
   onErrorCallback?: (data: Record<string, unknown>) => void;
   idxTransaction: IdxTransaction | undefined;
-  setAuthApiError: StateUpdater<AuthApiError | null>;
+  setResponseError: StateUpdater<AuthApiError | OAuthError | null>;
   setIdxTransaction: StateUpdater<IdxTransaction | undefined>;
   setIsClientTransaction: StateUpdater<boolean>;
   stepToRender: string | undefined;

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -328,6 +328,14 @@ export interface ReminderElement extends UISchemaElement {
 export interface ListElement extends UISchemaElement {
   type: 'List';
   options: {
+    /**
+     * Items to render in the list.
+     *
+     * **NOTE**: Only string and UISchemaElement with type
+     * 'Button', 'Description', or 'TextWithHtml'
+     * are supported. Other UISchemaElement types will
+     * not render and print a warning to the console.
+     */
     items: (string | UISchemaLayout)[],
     type?: 'unordered' | 'ordered' | 'description';
     description?: string;

--- a/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
@@ -121,6 +121,7 @@ fixture('Device Challenge Polling View with Polling Failure').meta('v3', true);
 async function setup(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
   await deviceChallengePollPage.navigateToPage();
+  await t.expect(deviceChallengePollPage.formExists()).eql(true);
   return deviceChallengePollPage;
 }
 
@@ -139,7 +140,7 @@ test.requestHooks(logger, mock)('probing and polling APIs are sent and responded
       record.request.url.match(/challenge/) &&
       record.request.body.match(/challengeRequest":"eyJraWQiOiI1/)
   )).eql(1);
-  await t.expect(deviceChallengePollPageObject.form.getErrorBoxText()).eql('You do not have permission to perform the requested action');
+  await t.expect(deviceChallengePollPageObject.getErrorBoxText()).eql('You do not have permission to perform the requested action');
   await t.expect(await deviceChallengePollPageObject.hasSpinner()).eql(false);
   await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().exists).eql(true);
 });
@@ -158,6 +159,6 @@ test
   .requestHooks(logger, nonIdxError)('Non IDX error', async t => {
     mockCalls = 0;
     const deviceChallengePollPageObject = await setup(t);
-    await t.expect(deviceChallengePollPageObject.form.getErrorBoxText()).eql(
+    await t.expect(deviceChallengePollPageObject.getErrorBoxText()).eql(
       'There was an unsupported response from server.');
   });

--- a/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
@@ -7,26 +7,9 @@ import { Constants } from '../framework/shared';
 
 const logger = RequestLogger(/introspect|probe|challenge/, { logRequestBody: true, stringifyRequestBody: true });
 
-let mockCalls = 0;
-const mock = RequestMock()
+const baseMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/introspect/)
   .respond(identifyWithDeviceProbingLoopback)
-  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
-  .respond((req, res) => {
-    if (mockCalls === 0) {
-      res.statusCode = '200';
-      res.headers['content-type'] = 'application/json';
-      res.setBody(identifyWithDeviceProbingLoopback);
-      mockCalls++;
-      return;
-    }
-    return new Promise((resolve) => setTimeout(function() {
-      res.statusCode = '403';
-      res.headers['content-type'] = 'application/json';
-      res.setBody(error);
-      resolve(res);
-    }, Constants.TESTCAFE_DEFAULT_AJAX_WAIT + 2000));
-  })
   .onRequestTo(/2000\/probe/)
   .respond(null, 200, { 
     'access-control-allow-origin': '*',
@@ -44,76 +27,41 @@ const mock = RequestMock()
     'access-control-allow-methods': 'POST, OPTIONS'
   });
 
-const deviceInvalidatedErrorMsg = RequestMock()
-  .onRequestTo(/\/idp\/idx\/introspect/)
-  .respond(identifyWithDeviceProbingLoopback)
+const initialPoll = RequestMock()
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(identifyWithDeviceProbingLoopback);
+
+const noPermissionErrorPoll = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond((req, res) => {
-    if (mockCalls === 0) {
-      res.statusCode = '200';
-      res.headers['content-type'] = 'application/json';
-      res.setBody(identifyWithDeviceProbingLoopback);
-      mockCalls++;
-      return;
-    }
     return new Promise((resolve) => setTimeout(function() {
-      res.statusCode = '400';
+      res.statusCode = '403';
       res.headers['content-type'] = 'application/json';
-      res.setBody(errorDeviceInvalid);
+      res.setBody(error);
       resolve(res);
     }, Constants.TESTCAFE_DEFAULT_AJAX_WAIT + 2000));
-  })
-  .onRequestTo(/2000\/probe/)
-  .respond(null, 200, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
-  })
-  .onRequestTo(/6511|6512|6513\/probe/)
-  .respond(null, 200, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
-  })
-  .onRequestTo(/2000\/challenge/)
-  .respond(null, 200, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
-    'access-control-allow-methods': 'POST, OPTIONS'
   });
 
-const nonIdxError = RequestMock()
-  .onRequestTo(/\/idp\/idx\/introspect/)
-  .respond(identifyWithDeviceProbingLoopback)
+const nonIdxErrorPoll = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond((req, res) => {
-    if (mockCalls === 0) {
-      res.statusCode = '200';
-      res.headers['content-type'] = 'application/json';
-      res.setBody(identifyWithDeviceProbingLoopback);
-      mockCalls++;
-      return;
-    }
     return new Promise((resolve) => setTimeout(function() {
       res.statusCode = '400';
       res.headers['content-type'] = 'application/json';
       res.setBody({});
       resolve(res);
     }, Constants.TESTCAFE_DEFAULT_AJAX_WAIT + 2000));
-  })
-  .onRequestTo(/2000\/probe/)
-  .respond(null, 200, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
-  })
-  .onRequestTo(/6511|6512|6513\/probe/)
-  .respond(null, 200, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
-  })
-  .onRequestTo(/2000\/challenge/)
-  .respond(null, 200, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
-    'access-control-allow-methods': 'POST, OPTIONS'
+  });
+
+const deviceInvalidatedErroPoll = RequestMock()
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond((req, res) => {
+    return new Promise((resolve) => setTimeout(function() {
+      res.statusCode = '400';
+      res.headers['content-type'] = 'application/json';
+      res.setBody(errorDeviceInvalid);
+      resolve(res);
+    }, Constants.TESTCAFE_DEFAULT_AJAX_WAIT + 2000));
   });
 
 fixture('Device Challenge Polling View with Polling Failure').meta('v3', true);
@@ -125,10 +73,13 @@ async function setup(t) {
   return deviceChallengePollPage;
 }
 
-test.requestHooks(logger, mock)('probing and polling APIs are sent and responded', async t => {
-  mockCalls = 0;
+test.requestHooks(logger, baseMock, initialPoll)('probing and polling APIs are sent and responded', async t => {
   const deviceChallengePollPageObject = await setup(t);
   await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
+
+  await t.removeRequestHooks(initialPoll);
+  await t.addRequestHooks(noPermissionErrorPoll);
+
   await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(true);
   await t.expect(logger.count(
     record => record.response.statusCode === 200 &&
@@ -146,19 +97,26 @@ test.requestHooks(logger, mock)('probing and polling APIs are sent and responded
 });
 
 test
-  .requestHooks(logger, deviceInvalidatedErrorMsg)('add title when device or account is invalidated', async t => {
-    mockCalls = 0;
+  .requestHooks(logger, baseMock, initialPoll)('add title when device or account is invalidated', async t => {
     const deviceChallengePollPageObject = await setup(t);
-    await t.expect(deviceChallengePollPageObject.formExists()).eql(true);
+    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
+
+    await t.removeRequestHooks(initialPoll);
+    await t.addRequestHooks(deviceInvalidatedErroPoll);
+
     await t.expect(deviceChallengePollPageObject.getErrorBoxText()).contains('Couldn’t verify your identity');
     await t.expect(deviceChallengePollPageObject.getErrorBoxText()).contains(
       'Your device or account was invalidated. If this is unexpected, contact your administrator for help.');
   });
 
 test
-  .requestHooks(logger, nonIdxError)('Non IDX error', async t => {
-    mockCalls = 0;
+  .requestHooks(logger, baseMock, initialPoll)('Non IDX error', async t => {
     const deviceChallengePollPageObject = await setup(t);
+    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
+
+    await t.removeRequestHooks(initialPoll);
+    await t.addRequestHooks(nonIdxErrorPoll);
+
     await t.expect(deviceChallengePollPageObject.getErrorBoxText()).eql(
       'There was an unsupported response from server.');
   });

--- a/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
@@ -155,7 +155,6 @@ test
   });
 
 test
-  .meta('v3', false) // Need to handle this error case correctly (OKTA-564970)
   .requestHooks(logger, nonIdxError)('Non IDX error', async t => {
     mockCalls = 0;
     const deviceChallengePollPageObject = await setup(t);


### PR DESCRIPTION
## Description:

This PR updates the gen3 widget to handle non-ion/non-IDX error responses from the server, particularly when the JSON response is `{}` with a non-success HTTP code.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-564970](https://oktainc.atlassian.net/browse/OKTA-564970)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



