### PR TITLE
V3 parity spec for IDX Session Expired flow

### DIFF
--- a/test/testcafe/spec/IdxSessionExpired_spec.js
+++ b/test/testcafe/spec/IdxSessionExpired_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock } from 'testcafe';
+import { RequestMock, userVariables } from 'testcafe';
 import { checkConsoleMessages, renderWidget as rerenderWidget } from '../framework/shared';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import xhrWellKnownResponse from '../../../playground/mocks/data/oauth2/well-known-openid-configuration.json';
@@ -32,11 +32,13 @@ const interactionCodeFlowBaseMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrSessionExpired, 401);
 
-fixture('IDX Session Expired');
+fixture('IDX Session Expired')
+  .meta('v3', true);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
   await identityPage.navigateToPage();
+  await t.expect(identityPage.formExists()).eql(true);
   await checkConsoleMessages({
     controller: 'primary-auth',
     formName: 'identify',
@@ -70,11 +72,14 @@ test.requestHooks(sessionExpiresDuringPasswordChallenge)('reloads into fresh sta
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('credentials.passcode', 'test');
-  await identityPage.clickNextButton();
+  await identityPage.clickVerifyButton();
 
   await t.expect(identityPage.getGlobalErrors()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
   await t.expect(identityPage.getSignoutLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
-  await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  // OKTA-551654 - Doesn't work in v3. userId isn't present on session expired screen
+  if (!userVariables.v3) {
+    await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  }
 
   await identityPage.refresh();
 
@@ -90,11 +95,14 @@ test.requestHooks(sessionExpiresBackToSignIn)('back to sign loads identify after
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('credentials.passcode', 'test');
-  await identityPage.clickNextButton();
+  await identityPage.clickVerifyButton();
 
   await t.expect(identityPage.getGlobalErrors()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
   await t.expect(identityPage.getSignoutLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
-  await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  // OKTA-551654 - Doesn't work in v3. userId isn't present on session expired screen
+  if (!userVariables.v3) {
+    await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  }
 
   await identityPage.clickSignOutLink();
 
@@ -110,11 +118,14 @@ test.requestHooks(interactionCodeFlowBaseMock)('Int. Code Flow: reloads into fre
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('credentials.passcode', 'test');
-  await identityPage.clickNextButton();
+  await identityPage.clickVerifyButton();
 
   await t.expect(identityPage.getGlobalErrors()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
   await t.expect(identityPage.getSignoutLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
-  await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  // OKTA-551654 - Doesn't work in v3. userId isn't present on session expired screen
+  if (!userVariables.v3) {
+    await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  }
 
   await identityPage.refresh();
   identityPage = await setupInteractionCodeFlow(t);
@@ -131,11 +142,14 @@ test.requestHooks(interactionCodeFlowBaseMock)('Int. Code Flow: back to sign loa
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('credentials.passcode', 'test');
-  await identityPage.clickNextButton();
+  await identityPage.clickVerifyButton();
 
   await t.expect(identityPage.getGlobalErrors()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
   await t.expect(identityPage.getSignoutLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
-  await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  // OKTA-551654 - Doesn't work in v3. userId isn't present on session expired screen
+  if (!userVariables.v3) {
+    await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  }
 
   await identityPage.clickSignOutLink();
 


### PR DESCRIPTION
## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



