### PR TITLE
OKTA-575557 context for profile enrollment with password

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/src/v2/ion/ViewClassNamesFactory.js
+++ b/src/v2/ion/ViewClassNamesFactory.js
@@ -11,6 +11,7 @@ const FORMNAME_CLASSNAME_MAPPINGS = {
   },
   [FORMS.ENROLL_PROFILE]: {
     [FORMS.ENROLL_PROFILE]: 'registration',
+    [AUTHENTICATOR_KEY.PASSWORD]: 'registration',
   },
   [FORMS.CHALLENGE_AUTHENTICATOR]: {
     [AUTHENTICATOR_KEY.EMAIL]: 'mfa-verify-passcode',

--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -1,4 +1,4 @@
-import { $ } from '@okta/courage';
+import { $, View } from '@okta/courage';
 import { BaseFormWithPolling } from '../internals';
 import Logger from 'util/Logger';
 import {
@@ -170,10 +170,19 @@ const Body = BaseFormWithPolling.extend({
 
   doCustomURI() {
     this.ulDom && this.ulDom.remove();
-    // https://oktainc.atlassian.net/browse/OKTA-554464
-    this.ulDom = this.add(`
-      <iframe src="${this.customURI}" id="custom-uri-container" style="display:none;"></iframe>
-    `).last();
+
+    const IframeView = View.extend({
+      tagName: 'iframe',
+      id: 'custom-uri-container',
+      attributes: {
+        src: this.customURI,
+      },
+      initialize() {
+        this.el.style.display = 'none';
+      }
+    });
+
+    this.ulDom = this.add(IframeView).last();
   },
 
   stopProbing() {

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -20,6 +20,10 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.body.find('[data-se="o-form-head"]').innerText;
   }
 
+  getIframe() {
+    return this.body.find('iframe');
+  }
+
   getIframeAttributes() {
     return Selector('#custom-uri-container').attributes;
   }

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -569,6 +569,24 @@ test
   });
 
 test
+  .requestHooks(customURILogger, customURIMock)('in custom URI approach, Okta Verify iframe should be single and hidden', async t => {
+    const deviceChallengePollPageObject = await setup(t);
+    let iframe = await deviceChallengePollPageObject.getIframe();
+    await t.expect(iframe.exists).ok({ timeout: 100 });
+    let attributes = await deviceChallengePollPageObject.getIframeAttributes();
+    await t.expect(attributes.src).contains('okta-verify.html');
+    await t.expect(iframe.visible).eql(false);
+
+    await deviceChallengePollPageObject.clickLaunchOktaVerifyLink();
+    iframe = await deviceChallengePollPageObject.getIframe();
+    await t.expect(iframe.exists).ok({ timeout: 100 });
+    attributes = await deviceChallengePollPageObject.getIframeAttributes();
+    await t.expect(attributes.src).contains('okta-verify.html');
+    await t.expect(iframe.visible).eql(false);
+    await t.expect(deviceChallengePollPageObject.getIframe().count).eql(1);
+  });
+
+test
   .requestHooks(loopbackFallbackLogger, universalLinkWithoutLaunchMock)('SSO Extension fails and falls back to universal link', async t => {
     loopbackFallbackLogger.clear();
     const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);


### PR DESCRIPTION
- Releng: Revving up to version(s) 7.4.0 for artifact(s) okta-signin-widget
- CSP fix for BaseOktaVerifyChallengeView (#2994)
- fix: set context.controller to "registration" on "enroll-profile" when identify with password is enabled

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-575557](https://oktainc.atlassian.net/browse/OKTA-575557)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



