### PR TITLE
OKTA-556721 : Prevent screen reader from reading password requirement status title

### DIFF
--- a/.testcaferc-parity.js
+++ b/.testcaferc-parity.js
@@ -13,5 +13,6 @@ module.exports = {
   userVariables: {
     v3: true,
   },
+  // OKTA-575629 Remove this when v3 parity test flakiness is resolved
   assertionTimeout: 10000,
 };

--- a/.testcaferc-parity.js
+++ b/.testcaferc-parity.js
@@ -14,5 +14,5 @@ module.exports = {
     v3: true,
   },
   // OKTA-575629 Remove this when v3 parity test flakiness is resolved
-  assertionTimeout: 10000,
+  assertionTimeout: 20000,
 };

--- a/.testcaferc-parity.js
+++ b/.testcaferc-parity.js
@@ -13,5 +13,5 @@ module.exports = {
   userVariables: {
     v3: true,
   },
-  pageLoadTimeout: 10000,
+  assertionTimeout: 10000,
 };

--- a/.testcaferc-parity.js
+++ b/.testcaferc-parity.js
@@ -13,4 +13,5 @@ module.exports = {
   userVariables: {
     v3: true,
   },
+  pageLoadTimeout: 10000,
 };

--- a/src/v3/src/components/PasswordRequirements/Icon.tsx
+++ b/src/v3/src/components/PasswordRequirements/Icon.tsx
@@ -38,6 +38,7 @@ const Icon: FunctionComponent<PasswordRequirementIconProps> = (
       display="flex"
     >
       <OdyIcon
+        // test
         aria-hidden
         titleAccess={status}
         name={statusToIconProps[status].name}

--- a/src/v3/src/components/PasswordRequirements/Icon.tsx
+++ b/src/v3/src/components/PasswordRequirements/Icon.tsx
@@ -38,7 +38,6 @@ const Icon: FunctionComponent<PasswordRequirementIconProps> = (
       display="flex"
     >
       <OdyIcon
-        // test
         aria-hidden
         titleAccess={status}
         name={statusToIconProps[status].name}

--- a/src/v3/src/components/PasswordRequirements/Icon.tsx
+++ b/src/v3/src/components/PasswordRequirements/Icon.tsx
@@ -38,7 +38,7 @@ const Icon: FunctionComponent<PasswordRequirementIconProps> = (
       display="flex"
     >
       <OdyIcon
-        // TODO: OKTA-556721 - Create and use loc string here for requirement status
+        aria-hidden
         titleAccess={status}
         name={statusToIconProps[status].name}
         color={statusToIconProps[status].color}

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -197,7 +197,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -240,7 +240,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -284,7 +284,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -328,7 +328,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -372,7 +372,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -416,7 +416,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -614,7 +614,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-77"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -195,7 +196,8 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
+                              aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -238,6 +240,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -281,6 +284,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -324,6 +328,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -367,6 +372,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -410,6 +416,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -607,6 +614,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-77"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -274,7 +274,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-39"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -274,6 +274,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-39"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -196,7 +196,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -240,7 +240,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -284,7 +284,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -328,7 +328,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -514,7 +514,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -195,6 +196,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -238,6 +240,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -281,6 +284,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -324,6 +328,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -509,6 +514,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -196,7 +196,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -240,7 +240,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -284,7 +284,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -328,7 +328,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -514,7 +514,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -195,6 +196,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -238,6 +240,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -281,6 +284,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -324,6 +328,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -509,6 +514,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -167,6 +167,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -210,6 +211,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -253,6 +255,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -296,6 +299,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -339,6 +343,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -382,6 +387,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -425,6 +431,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -468,6 +475,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -653,6 +661,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-87"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -167,7 +167,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -211,7 +211,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -255,7 +255,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -299,7 +299,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -343,7 +343,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -387,7 +387,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -431,7 +431,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -475,7 +475,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -661,7 +661,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-87"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -195,6 +196,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -238,6 +240,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -281,6 +284,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -324,6 +328,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -367,6 +372,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -410,6 +416,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -595,6 +602,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-77"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -196,7 +196,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -240,7 +240,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -284,7 +284,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -328,7 +328,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -372,7 +372,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -416,7 +416,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -602,7 +602,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-77"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -196,7 +196,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -240,7 +240,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -284,7 +284,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -328,7 +328,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -514,7 +514,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"
@@ -733,7 +733,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -777,7 +777,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -821,7 +821,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -865,7 +865,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -909,7 +909,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -1095,7 +1095,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                            aria-hidden="true"
+                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -195,6 +196,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -238,6 +240,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -281,6 +284,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -324,6 +328,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -509,6 +514,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"
@@ -727,6 +733,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -770,6 +777,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -813,6 +821,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -856,6 +865,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -899,6 +909,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -1084,6 +1095,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
+                            aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"

--- a/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
+++ b/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
@@ -69,7 +69,7 @@ export default class EnrollPasswordPageObject extends BasePageObject {
     const expectedTitleValue = expectComplete ? 'complete' : 'incomplete';
     const passwordMatchWrapper = this.form.getElement('[data-se="password-authenticator--matches');
 
-    return within(passwordMatchWrapper).queryByRole('img', { name: expectedTitleValue }).exists;
+    return within(passwordMatchWrapper).findByTitle(expectedTitleValue).exists;
   }
 
   // This will be used by any password page that has requirements on it.

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -298,7 +298,6 @@ test
   .requestHooks(loopbackBiometricsErrorDesktopMock)('show biometrics error for desktop platform in loopback', async t => {
     probeSuccess = false;
     const deviceChallengePollPageObject = await setup(t);
-    await t.expect(deviceChallengePollPageObject.formExists()).eql(true);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
     // in v3 all cancel buttons are the same so skip this assertion

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -298,6 +298,7 @@ test
   .requestHooks(loopbackBiometricsErrorDesktopMock)('show biometrics error for desktop platform in loopback', async t => {
     probeSuccess = false;
     const deviceChallengePollPageObject = await setup(t);
+    await t.expect(deviceChallengePollPageObject.formExists()).eql(true);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
     // in v3 all cancel buttons are the same so skip this assertion


### PR DESCRIPTION
## Description:

This PR prevents screen readers from reading out the password requirements icon status titles.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-556721](https://oktainc.atlassian.net/browse/OKTA-556721)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



