### PR TITLE
Adds `cspNonce` to widget config

### DIFF
--- a/src/v3/.eslintrc.js
+++ b/src/v3/.eslintrc.js
@@ -129,6 +129,20 @@ module.exports = {
           json: 'always',
         }],
 
+        // prevent inline styles which cause CSP violations
+        'react/forbid-component-props': ['error', {
+          forbid: [{
+            propName: 'style',
+            message: 'Inline styles cause CSP issues',
+          }],
+        }],
+        'react/forbid-dom-props': ['error', {
+          forbid: [{
+            propName: 'style',
+            message: 'Inline styles cause CSP issues',
+          }],
+        }],
+
         // use @typescript-eslint/no-unused-vars
         'no-unused-vars': 'off',
 

--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -100,6 +100,7 @@ export default {
           ...rule,
           use: rule.use.reduce((acc, loader) => {
             acc.push(
+              // force MiniCssExtractPlugin.loader for watch mode and static builds
               /style-loader/.test(loader) ? MiniCssExtractPlugin.loader : loader
             );
             return acc;

--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -190,7 +190,7 @@ export default {
       devServer: {
         headers: {
           'Content-Security-Policy': mergeContentSecurityPolicies(
-            "style-src 'self' 'nonce-playground'; object-src 'self'; script-src 'self' 'unsafe-eval'",
+            "style-src 'self'; object-src 'self'; script-src 'self' 'unsafe-eval' 'nonce-playground'",
             playgroundConfig.devServer.headers['Content-Security-Policy'] || '',
           ),
         },

--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -101,7 +101,7 @@ export default {
           use: rule.use.reduce((acc, loader) => {
             acc.push(
               // force MiniCssExtractPlugin.loader for watch mode and static builds
-              /style-loader/.test(loader) ? MiniCssExtractPlugin.loader : loader
+              /style-loader/.test(loader) ? MiniCssExtractPlugin.loader : loader,
             );
             return acc;
           }, []),

--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -189,7 +189,7 @@ export default {
       devServer: {
         headers: {
           'Content-Security-Policy': mergeContentSecurityPolicies(
-            "object-src 'self'; script-src 'self' 'unsafe-eval'",
+            "style-src 'self' 'nonce-playground'; object-src 'self'; script-src 'self' 'unsafe-eval'",
             playgroundConfig.devServer.headers['Content-Security-Policy'] || '',
           ),
         },

--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -190,6 +190,7 @@ export default {
       devServer: {
         headers: {
           'Content-Security-Policy': mergeContentSecurityPolicies(
+            // 'nonce-playground' for script-src can be removed in OKTA-517096
             "style-src 'self'; object-src 'self'; script-src 'self' 'unsafe-eval' 'nonce-playground'",
             playgroundConfig.devServer.headers['Content-Security-Policy'] || '',
           ),

--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -48,11 +48,6 @@ export default {
       chunk.name === 'bundle' ? 'okta-sign-in.next.js' : '[name].next.js'
     );
 
-    // remove MiniCssExtractPlugin
-    config.plugins = config.plugins.filter(
-      (plugin) => !(plugin instanceof MiniCssExtractPlugin),
-    );
-
     config.plugins.push(new DefinePlugin({
       // for OktaSignIn.__version, AuthContainer[data-version]
       VERSION: JSON.stringify(`okta-signin-widget-${version}`),
@@ -105,7 +100,7 @@ export default {
           ...rule,
           use: rule.use.reduce((acc, loader) => {
             acc.push(
-              loader !== MiniCssExtractPlugin.loader ? loader : 'style-loader',
+              /style-loader/.test(loader) ? MiniCssExtractPlugin.loader : loader
             );
             return acc;
           }, []),

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import classNames from 'classnames';
 import { FunctionComponent, h } from 'preact';
 import { useCallback, useEffect } from 'preact/hooks';
 
@@ -22,10 +23,12 @@ import {
 import { getValidationMessages } from '../../util';
 import InfoSection from '../InfoSection/InfoSection';
 import Layout from './Layout';
+import style from './style.css';
 
 const Form: FunctionComponent<{
   uischema: UISchemaLayout;
 }> = ({ uischema }) => {
+  const classes = classNames('o-form', style.siwForm);
   const {
     data,
     idxTransaction: currTransaction,
@@ -92,9 +95,8 @@ const Form: FunctionComponent<{
     <form
       noValidate
       onSubmit={handleSubmit}
-      className="o-form" // FIXME update page objects using .o-form selectors
+      className={classes} // FIXME update page objects using .o-form selectors
       data-se="o-form"
-      style={{ maxWidth: '100%', wordBreak: 'break-word' }}
     >
       <InfoSection message={message} />
       <Layout uischema={uischema} />

--- a/src/v3/src/components/Form/style.css
+++ b/src/v3/src/components/Form/style.css
@@ -1,0 +1,4 @@
+.siwForm {
+  max-inline-size: 100%;
+  word-break: break-word;
+}

--- a/src/v3/src/components/HiddenInput/HiddenInput.tsx
+++ b/src/v3/src/components/HiddenInput/HiddenInput.tsx
@@ -10,23 +10,26 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import classNames from 'classnames';
 import { h } from 'preact';
 
 import {
   HiddenInputElement,
   UISchemaElementComponent,
 } from '../../types';
+import style from './style.css';
 
 const InputText: UISchemaElementComponent<{ uischema: HiddenInputElement }> = ({
   uischema,
 }) => {
   const { name, value } = uischema.options;
+  // Can't use hidden types otherwise browser plugins (i.e. Password Managers) will ignore
+  const classes = classNames(style.hidden);
 
   return (
     <input
       type="text"
-      // Can't use hidden types otherwise browser plugins (i.e. Password Managers) will ignore
-      style={{ display: 'none' }}
+      className={classes}
       id={name}
       name={name}
       value={value}

--- a/src/v3/src/components/HiddenInput/style.css
+++ b/src/v3/src/components/HiddenInput/style.css
@@ -1,0 +1,3 @@
+.hidden {
+  display: none;
+}

--- a/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
+++ b/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import classNames from 'classnames';
 import { FunctionComponent, h } from 'preact';
 import React from 'preact/compat';
 import { useState } from 'preact/hooks';
@@ -27,19 +28,21 @@ import {
   getBaseUrl, getTranslation, isAndroid, setUrlQueryParams,
 } from '../../util';
 import Button from '../Button';
+import style from './style.css';
 
 type IFrameProps = {
   src: string;
 };
-const IFrame: FunctionComponent<IFrameProps> = ({ src }) => (
-  // eslint-disable-next-line jsx-a11y/iframe-has-title
-  <iframe
-    src={src}
-    style={{
-      display: 'none',
-    }}
-  />
-);
+const IFrame: FunctionComponent<IFrameProps> = ({ src }) => {
+  const classes = classNames(style.hidden);
+  return (
+    // eslint-disable-next-line jsx-a11y/iframe-has-title
+    <iframe
+      src={src}
+      className={classes}
+    />
+  );
+};
 
 const OpenOktaVerifyFPButton: UISchemaElementComponent<{
   uischema: OpenOktaVerifyFPButtonElement

--- a/src/v3/src/components/OpenOktaVerifyFPButton/style.css
+++ b/src/v3/src/components/OpenOktaVerifyFPButton/style.css
@@ -1,0 +1,3 @@
+.hidden {
+  display: none;
+}

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -75,6 +75,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     authClient,
     brandColors,
     brandName,
+    cspNonce,
     events,
     muiThemeOverrides,
     logo,
@@ -304,9 +305,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     >
       {/* Note: we need to keep both themeproviders (MUI/ODS) until ODS exports all MUI components */}
       <MuiThemeProvider theme={brandedTheme}>
-        {/* the style is to allow the widget to inherit the parent's bg color */}
-        <ScopedCssBaseline sx={{ backgroundColor: 'inherit' }}>
-          <OdysseyCacheProvider>
+        <OdysseyCacheProvider nonce={cspNonce}>
+          {/* the style is to allow the widget to inherit the parent's bg color */}
+          <ScopedCssBaseline sx={{ backgroundColor: 'inherit' }}>
             <OdysseyMuiThemeProvider theme={brandedTheme}>
               <AuthContainer>
                 <AuthHeader
@@ -325,8 +326,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
                 </AuthContent>
               </AuthContainer>
             </OdysseyMuiThemeProvider>
-          </OdysseyCacheProvider>
-        </ScopedCssBaseline>
+          </ScopedCssBaseline>
+        </OdysseyCacheProvider>
       </MuiThemeProvider>
     </WidgetContextProvider>
   );

--- a/src/v3/src/template.html
+++ b/src/v3/src/template.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="apple-touch-icon" href="/static/icons/apple-touch-icon.png">
     <script type="text/javascript" nonce="playground">
+      // this script block can be removed after OKTA-517096
       window.cspNonce = 'playground';
     </script>
     <% preact.headEnd %>

--- a/src/v3/src/template.html
+++ b/src/v3/src/template.html
@@ -5,6 +5,9 @@
     <title>Okta Sign-in Widget v3 Playground</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="apple-touch-icon" href="/static/icons/apple-touch-icon.png">
+    <script type="text/javascript" nonce="playground">
+      window.cspNonce = 'playground';
+    </script>
     <% preact.headEnd %>
   </head>
   <body>

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -123,6 +123,7 @@ export type WidgetOptions = {
   recoveryToken?: string;
 
   el?: string;
+  cspNonce?: string;
   baseUrl?: string;
   brandName?: string;
   brandColors?: BrandColors;

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -205,10 +204,9 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -384,10 +382,9 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-email-verification-data should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -109,10 +109,9 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1698,10 +1697,9 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -3287,10 +3285,9 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -171,10 +171,9 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -452,10 +451,9 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -740,10 +738,9 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1011,10 +1008,9 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -419,9 +418,9 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                 class="MuiBox-root emotion-9"
               >
                 <input
+                  class="hidden"
                   id="generated"
                   name="username"
-                  style="display: none;"
                   type="text"
                 />
               </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"
@@ -762,10 +761,9 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -109,10 +109,9 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-enroll-security-question-error custom question should sho
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -507,10 +506,9 @@ exports[`authenticator-enroll-security-question-error predefined question should
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1025,10 +1023,9 @@ exports[`authenticator-enroll-security-question-error predefined question should
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1543,10 +1540,9 @@ exports[`authenticator-enroll-security-question-error predefined question should
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-enroll-security-question custom question fails client sid
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -507,10 +506,9 @@ exports[`authenticator-enroll-security-question custom question renders correct 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -870,10 +868,9 @@ exports[`authenticator-enroll-security-question predefined question renders corr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1343,10 +1340,9 @@ exports[`authenticator-enroll-security-question predefined question should rende
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -101,10 +101,9 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -126,9 +125,9 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                 class="MuiBox-root emotion-9"
               >
                 <input
+                  class="hidden"
                   id="generated"
                   name="username"
-                  style="display: none;"
                   type="text"
                 />
               </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -341,9 +340,9 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 class="MuiBox-root emotion-9"
               >
                 <input
+                  class="hidden"
                   id="generated"
                   name="username"
-                  style="display: none;"
                   type="text"
                 />
               </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-expired-password should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -341,9 +340,9 @@ exports[`authenticator-expired-password should render form 1`] = `
                 class="MuiBox-root emotion-9"
               >
                 <input
+                  class="hidden"
                   id="generated"
                   name="username"
-                  style="display: none;"
                   type="text"
                 />
               </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -473,9 +472,9 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 class="MuiBox-root emotion-9"
               >
                 <input
+                  class="hidden"
                   id="generated"
                   name="username"
-                  style="display: none;"
                   type="text"
                 />
               </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -317,10 +316,9 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -608,10 +606,9 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -940,10 +937,9 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
           class="MuiBox-root emotion-6"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-7"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -419,9 +418,9 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                 class="MuiBox-root emotion-9"
               >
                 <input
+                  class="hidden"
                   id="username"
                   name="username"
-                  style="display: none;"
                   type="text"
                 />
               </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-reset-password should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -341,9 +340,9 @@ exports[`authenticator-reset-password should render form 1`] = `
                 class="MuiBox-root emotion-9"
               >
                 <input
+                  class="hidden"
                   id="generated"
                   name="username"
-                  style="display: none;"
                   type="text"
                 />
               </div>
@@ -650,10 +649,9 @@ exports[`authenticator-reset-password should render form with custom brand name 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -892,9 +890,9 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 class="MuiBox-root emotion-9"
               >
                 <input
+                  class="hidden"
                   id="generated"
                   name="username"
-                  style="display: none;"
                   type="text"
                 />
               </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -109,10 +109,9 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`Email authenticator verification when email magic link = false Tests sh
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`Email authenticator verification when email magic link = undefined rend
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -275,10 +274,9 @@ exports[`Email authenticator verification when email magic link = undefined rend
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -495,10 +493,9 @@ exports[`Email authenticator verification when email magic link = undefined rend
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -703,10 +700,9 @@ exports[`Email authenticator verification when email magic link = undefined rend
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -967,10 +963,9 @@ exports[`Email authenticator verification when email magic link = undefined rend
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1202,10 +1197,9 @@ exports[`Email authenticator verification when email magic link = undefined rend
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -1368,10 +1362,9 @@ exports[`Email authenticator verification when email magic link = undefined shou
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -171,10 +171,9 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -288,10 +287,9 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -109,10 +109,9 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`authenticator-verification-security-question renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -119,10 +119,9 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -453,10 +452,9 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -780,10 +778,9 @@ exports[`authenticator-verification-webauthn should render form with required us
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -101,10 +101,9 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -109,10 +109,9 @@ exports[`byol loading custom language should load custom language with "language
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1698,10 +1697,9 @@ exports[`byol loading custom language should load custom language with assets.ba
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -3287,10 +3285,9 @@ exports[`byol loading default language should not load custom language when the 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -4876,10 +4873,9 @@ exports[`byol loading default language should not load custom language with "lan
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`email-challenge-consent should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -1859,10 +1858,9 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`enroll-profile-new should render form 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`enroll-profile-update-required-field fails client side validation with 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"
@@ -326,10 +325,9 @@ exports[`enroll-profile-update-required-field should render form with one requir
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`enroll-profile-update fails client side validation with empty required 
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"
@@ -298,10 +297,9 @@ exports[`enroll-profile-update should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"

--- a/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`error-400-unauthorized-client should render form 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`error-account-creation should render form 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"

--- a/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`error-feature-not-enabled should render form 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`error-recovery-token-invalid should render form 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`error-session-expired should render form 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -301,10 +300,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -594,10 +592,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -822,10 +819,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1061,10 +1057,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1334,10 +1329,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1540,10 +1534,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1746,10 +1739,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -2039,10 +2031,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -3525,10 +3516,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -3764,10 +3754,9 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -119,10 +119,9 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`identify-recovery renders form 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`identify-with-password Client-side field change validation tests fails 
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -332,10 +331,9 @@ exports[`identify-with-password Client-side field change validation tests should
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -638,10 +636,9 @@ exports[`identify-with-password Client-side field change validation tests should
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -944,10 +941,9 @@ exports[`identify-with-password renders form with focus 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"
@@ -1193,10 +1189,9 @@ exports[`identify-with-password renders form without focus 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -95,10 +95,9 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -1581,10 +1580,9 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`request-activation-email renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -63,10 +63,9 @@ exports[`terminal-return-email-error should render form 1`] = `
           class="MuiBox-root emotion-6"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-7"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`terminal-return-email renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -99,10 +99,9 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -99,10 +99,9 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -62,10 +62,9 @@ exports[`unlock-account-success renders form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-11"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -26,10 +26,9 @@ exports[`user-unlock-account renders form 1`] = `
           class="MuiBox-root emotion-5"
         >
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -119,10 +119,9 @@ exports[`webauthn-enroll should render form 1`] = `
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -324,10 +323,9 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"
@@ -536,10 +534,9 @@ exports[`webauthn-enroll should render form with user verification and edge brow
             </div>
           </div>
           <form
-            class="o-form"
+            class="o-form siwForm"
             data-se="o-form"
             novalidate=""
-            style="max-width: 100%; word-break: break-word;"
           >
             <div
               class="MuiBox-root emotion-12"

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -84,7 +84,10 @@ module.exports = {
     headers: {
       // Allow google domains for testing recaptcha
       // eslint-disable-next-line max-len
-      'Content-Security-Policy': `script-src http://${HOST}:${DEV_SERVER_PORT} https://www.google.com https://www.gstatic.com`
+      'Content-Security-Policy': [
+        `script-src http://${HOST}:${DEV_SERVER_PORT} https://www.google.com https://www.gstatic.com`,
+        `style-src http://${HOST}:${DEV_SERVER_PORT} 'nonce-playground'`,
+      ].join('; '),
     },
     compress: true,
     port: DEV_SERVER_PORT,


### PR DESCRIPTION
## Description:

Allow a `cspNonce` to be passed to the widget config so it can be used by the MUI cache provider when CSP enforcement is desired.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-552075](https://oktainc.atlassian.net/browse/OKTA-552075)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



