### PR TITLE
Treat IDX response with no remediations key the same as one with an empty set

### DIFF
--- a/src/v2/models/AppState.ts
+++ b/src/v2/models/AppState.ts
@@ -150,13 +150,16 @@ export default class AppState extends Model {
     }
 
     // didn't expect `remediations` is empty. See `setIonResponse`.
-    const currentViewState = this.get('remediations').filter(r => r.name === currentFormName)[0];
+    //const currentViewState = this.get('remediations').filter(r => r.name === currentFormName)[0];
+    const currentViewState = this.get('remediations') ? this.get('remediations').filter(r => r.name === currentFormName)[0] : null;
 
     if (!currentViewState) {
       Logger.error('Panic!!');
       Logger.error(`\tCannot find view state for form ${currentFormName}.`);
-      const allFormNames = this.get('remediations').map(r => r.name);
-      Logger.error(`\tAll available form names: ${allFormNames}`);
+      if (this.get('remediations')) {
+        const allFormNames = this.get('remediations').map(r => r.name);
+        Logger.error(`\tAll available form names: ${allFormNames}`);
+      }
     }
 
     return currentViewState;


### PR DESCRIPTION
## Description:
fix[widget]: Fixes undefined error

Fixes issue with widget throwing an `undefined` error when back to sign-in from the unlock account screen is selected and the `/interact` call returns an IDX response with no `remediations` key. Currently the logic assumes this key will be present and tries to `filter` off of the entries. This causes and `undefined` exception.

Resolves: # JIRA-OKTA-577885



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-577885](https://oktainc.atlassian.net/browse/OKTA-577885)

### Reviewers:

### Screenshot/Video:

Before fix:
![before_fix](https://user-images.githubusercontent.com/75505052/219292449-c122ede3-2ed4-438c-a779-d214e609121d.jpg)

After fix (logs error to console, but does filter remediations if not present ):
![after_fix](https://user-images.githubusercontent.com/75505052/219292895-224aed7f-633a-4a39-ab3b-c9af0744f1b8.jpg)



### Downstream Monolith Build:



