### PR TITLE
OKTA-557593 : updating field components to only trigger field validat…

### DIFF
--- a/src/v3/src/components/Checkbox/Checkbox.tsx
+++ b/src/v3/src/components/Checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@ import {
 import { h } from 'preact';
 
 import { useWidgetContext } from '../../contexts';
-import { useAutoFocus, useOnChange, useValue } from '../../hooks';
+import { useAutoFocus, useValue } from '../../hooks';
 import {
   ChangeEvent,
   UISchemaElementComponent,
@@ -30,26 +30,18 @@ import { withFormValidationState } from '../hocs';
 
 const Checkbox: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
   uischema,
-  setTouched,
   errors,
-  setErrors,
-  onValidateHandler,
+  handleChange,
+  handleBlur,
   describedByIds,
 }) => {
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
-  const onChangeHandler = useOnChange(uischema);
 
   const { options: { inputMeta: { name } }, focus, required } = uischema;
   const label = getTranslation(uischema.translations!, 'label');
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
   const hasErrors = typeof errors !== 'undefined';
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setTouched?.(true);
-    onChangeHandler(e.currentTarget.checked);
-    onValidateHandler?.(setErrors, e.currentTarget.checked);
-  };
 
   return (
     <FormControl
@@ -66,7 +58,12 @@ const Checkbox: UISchemaElementComponent<UISchemaElementComponentWithValidationP
             id={name}
             name={name}
             inputRef={focusRef}
-            onChange={handleChange}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              handleChange?.(e.currentTarget.checked);
+            }}
+            onBlur={(e: ChangeEvent<HTMLInputElement>) => {
+              handleBlur?.(e?.currentTarget?.checked);
+            }}
             disabled={loading}
             inputProps={{
               'data-se': name,

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -27,7 +27,6 @@ import { useState } from 'preact/hooks';
 import { useWidgetContext } from '../../contexts';
 import {
   useAutoFocus,
-  useOnChange,
   useValue,
 } from '../../hooks';
 import {
@@ -42,15 +41,13 @@ import { withFormValidationState } from '../hocs';
 
 const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
   uischema,
-  setTouched,
   errors,
-  setErrors,
-  onValidateHandler,
+  handleChange,
+  handleBlur,
   describedByIds,
 }) => {
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
-  const onChangeHandler = useOnChange(uischema);
   const { translations = [], focus, required } = uischema;
   const {
     attributes,
@@ -66,15 +63,7 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
   const explainId = explain && `${name}-explain`;
   const ariaDescribedByIds = [describedByIds, hintId, explainId].filter(Boolean).join(' ')
     || undefined;
-
   const [showPassword, setShowPassword] = useState<boolean>(false);
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const changedVal = e.currentTarget.value;
-    setTouched?.(true);
-    onChangeHandler(changedVal);
-    onValidateHandler?.(setErrors, changedVal);
-  };
 
   const handleClickShowPassword = () => {
     setShowPassword(!showPassword);
@@ -108,7 +97,12 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
         name={name}
         error={hasErrors}
         inputRef={focusRef}
-        onChange={handleChange}
+        onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+          handleChange?.(e.currentTarget.value);
+        }}
+        onBlur={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+          handleBlur?.(e?.currentTarget?.value);
+        }}
         type={showPassword ? 'text' : 'password'}
         value={value}
         disabled={loading}

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -21,11 +21,11 @@ import { h } from 'preact';
 import { useWidgetContext } from '../../contexts';
 import {
   useAutoFocus,
-  useOnChange,
   useValue,
 } from '../../hooks';
 import {
-  ChangeEvent, UISchemaElementComponent, UISchemaElementComponentWithValidationProps,
+  ChangeEvent,
+  UISchemaElementComponent, UISchemaElementComponentWithValidationProps,
 } from '../../types';
 import { getTranslation } from '../../util';
 import FieldErrorContainer from '../FieldErrorContainer';
@@ -34,15 +34,13 @@ import { withFormValidationState } from '../hocs';
 const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
   type,
   uischema,
-  setTouched,
   errors,
-  setErrors,
-  onValidateHandler,
+  handleChange,
+  handleBlur,
   describedByIds,
 }) => {
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
-  const onChangeHandler = useOnChange(uischema);
   const { translations = [], focus, required } = uischema;
   const label = getTranslation(translations, 'label');
   const hint = getTranslation(translations, 'hint');
@@ -59,12 +57,6 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
   const explainId = explain && `${name}-explain`;
   const ariaDescribedByIds = [describedByIds, hintId, explainId].filter(Boolean).join(' ')
     || undefined;
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setTouched?.(true);
-    onChangeHandler(e.currentTarget.value);
-    onValidateHandler?.(setErrors, e.currentTarget.value);
-  };
 
   return (
     <Box>
@@ -93,7 +85,12 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
         id={name}
         name={name}
         error={hasErrors}
-        onChange={handleChange}
+        onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+          handleChange?.(e.currentTarget.value);
+        }}
+        onBlur={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+          handleBlur?.(e?.currentTarget?.value);
+        }}
         disabled={loading}
         fullWidth
         inputProps={{

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.test.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.test.tsx
@@ -59,7 +59,12 @@ const mockDataSchemaRef = { current: { phoneNumber: { validate: jest.fn() } } };
 const mockLoading = jest.fn().mockReturnValue(false);
 jest.mock('../../contexts', () => ({
   useWidgetContext: jest.fn().mockImplementation(
-    () => ({ data: mockData, dataSchemaRef: mockDataSchemaRef, loading: mockLoading() }),
+    () => ({
+      data: mockData,
+      dataSchemaRef: mockDataSchemaRef,
+      loading: mockLoading(),
+      widgetProps: {},
+    }),
   ),
 }));
 

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -71,8 +71,8 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
 
   const countries = CountryUtil.getCountries() as Record<string, string>;
   const [phone, setPhone] = useState<string>('');
-  const defaultCountryCode = getDefaultCountryCode(widgetProps);
   // Sets the default country code
+  const defaultCountryCode = getDefaultCountryCode(widgetProps);
   const [phoneCode, setPhoneCode] = useState(`+${CountryUtil.getCallingCodeForCountry(defaultCountryCode)}`);
   const [extension, setExtension] = useState<string>('');
   const [phoneChanged, setPhoneChanged] = useState<boolean>(false);

--- a/src/v3/src/components/Radio/Radio.tsx
+++ b/src/v3/src/components/Radio/Radio.tsx
@@ -21,7 +21,7 @@ import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';
 import { h } from 'preact';
 
 import { useWidgetContext } from '../../contexts';
-import { useAutoFocus, useOnChange, useValue } from '../../hooks';
+import { useAutoFocus, useValue } from '../../hooks';
 import {
   ChangeEvent,
   UISchemaElementComponent,
@@ -33,15 +33,13 @@ import { withFormValidationState } from '../hocs';
 
 const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
   uischema,
-  setTouched,
   errors,
-  setErrors,
-  onValidateHandler,
+  handleChange,
+  handleBlur,
   describedByIds,
 }) => {
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
-  const onChangeHandler = useOnChange(uischema);
   const {
     required,
     translations = [],
@@ -58,12 +56,6 @@ const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProp
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
   const hasErrors = typeof errors !== 'undefined';
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setTouched?.(true);
-    onChangeHandler(e.currentTarget.value);
-    onValidateHandler?.(setErrors, e.currentTarget.value);
-  };
-
   return (
     <FormControl
       component="fieldset"
@@ -77,7 +69,9 @@ const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProp
         data-se={name}
         aria-describedby={describedByIds}
         value={value as string ?? ''}
-        onChange={handleChange}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          handleChange?.(e.currentTarget.value);
+        }}
       >
         {
           (customOptions ?? options)?.map((item: IdxOption, index: number) => (
@@ -87,6 +81,9 @@ const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProp
               value={item.value}
               label={item.label}
               disabled={loading}
+              onBlur={(e: ChangeEvent<HTMLInputElement>) => {
+                handleBlur?.(e?.currentTarget?.value);
+              }}
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...(index === 0 && { inputRef: focusRef } )}
             />

--- a/src/v3/src/components/Select/Select.tsx
+++ b/src/v3/src/components/Select/Select.tsx
@@ -19,7 +19,7 @@ import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';
 import { h } from 'preact';
 
 import { useWidgetContext } from '../../contexts';
-import { useAutoFocus, useOnChange, useValue } from '../../hooks';
+import { useAutoFocus, useValue } from '../../hooks';
 import {
   UISchemaElementComponent,
   UISchemaElementComponentWithValidationProps,
@@ -30,15 +30,13 @@ import { withFormValidationState } from '../hocs';
 
 const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
   uischema,
-  setTouched,
   errors,
-  setErrors,
-  onValidateHandler,
+  handleChange,
+  handleBlur,
   describedByIds,
 }) => {
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
-  const onChangeHandler = useOnChange(uischema);
   const { focus, required, translations = [] } = uischema;
   const label = getTranslation(translations, 'label');
   const {
@@ -52,15 +50,6 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
   const focusRef = useAutoFocus<HTMLSelectElement>(focus);
   const hasErrors = typeof errors !== 'undefined';
 
-  const handleChange = (e: SelectChangeEvent<string>) => {
-    setTouched?.(true);
-    const selectTarget = (
-      e?.target as SelectChangeEvent['target'] & { value: string; name: string; }
-    );
-    onChangeHandler(selectTarget.value);
-    onValidateHandler?.(setErrors, selectTarget.value);
-  };
-
   return (
     <FormControl
       disabled={loading}
@@ -70,7 +59,19 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
       <InputLabel htmlFor={name}>{label}</InputLabel>
       <MuiSelect
         native
-        onChange={handleChange}
+        // onChange={handleChange}
+        onChange={(e: SelectChangeEvent<string>) => {
+          const selectTarget = (
+            e?.target as SelectChangeEvent['target'] & { value: string; name: string; }
+          );
+          handleChange?.(selectTarget.value);
+        }}
+        onBlur={(e: SelectChangeEvent<string>) => {
+          const selectTarget = (
+            e?.target as SelectChangeEvent['target'] & { value: string; name: string; }
+          );
+          handleBlur?.(selectTarget.value);
+        }}
         inputRef={focusRef}
         value={value as string}
         inputProps={{

--- a/src/v3/src/components/Select/Select.tsx
+++ b/src/v3/src/components/Select/Select.tsx
@@ -59,7 +59,6 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
       <InputLabel htmlFor={name}>{label}</InputLabel>
       <MuiSelect
         native
-        // onChange={handleChange}
         onChange={(e: SelectChangeEvent<string>) => {
           const selectTarget = (
             e?.target as SelectChangeEvent['target'] & { value: string; name: string; }

--- a/src/v3/src/components/hocs/withFormValidationState.tsx
+++ b/src/v3/src/components/hocs/withFormValidationState.tsx
@@ -15,7 +15,7 @@ import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
 import { getMessage } from '../../../../v2/ion/i18nTransformer';
-import { useFormFieldValidation } from '../../hooks';
+import { useFormFieldValidation, useOnChange } from '../../hooks';
 import { FieldElement, UISchemaElementComponent } from '../../types';
 import { buildErrorMessageIds } from '../../util';
 import { getDisplayName } from './getDisplayName';
@@ -51,6 +51,17 @@ export const withFormValidationState: WrappedFunctionComponent<
     const [touched, setTouched] = useState<boolean>(false);
     const [errors, setErrors] = useState<string[] | undefined>();
     const onValidateHandler = useFormFieldValidation(uischema);
+    const onChangeHandler = useOnChange(uischema);
+
+    const handleChange = (value: string | number | boolean) => {
+      setTouched?.(true);
+      onChangeHandler(value);
+    };
+
+    const handleBlur = (value: string | number | boolean) => {
+      setTouched?.(true);
+      onValidateHandler?.(setErrors, value);
+    };
 
     // For server side errors, need to reset the touched value
     useEffect(() => {
@@ -65,6 +76,8 @@ export const withFormValidationState: WrappedFunctionComponent<
       errors: fieldErrors,
       setErrors,
       onValidateHandler,
+      handleChange,
+      handleBlur,
       describedByIds: !fieldErrors
         ? ariaDescribedBy
         : ` ${buildErrorMessageIds(fieldErrors, name)} ${ariaDescribedBy || ''} `,

--- a/src/v3/src/types/component.ts
+++ b/src/v3/src/types/component.ts
@@ -33,6 +33,8 @@ export type UISchemaElementComponentWithValidationProps = {
     setErrors?: StateUpdater<string[] | undefined>,
     value?: string | boolean | number,
   ) => void,
+  handleChange?: (value: string | number | boolean) => void;
+  handleBlur?: (value: string | number | boolean) => void;
   describedByIds?: string;
 };
 

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -166,6 +166,7 @@ export type WidgetOptions = {
   helpLinks?: {
     custom?: CustomLink[];
   } & Record<string, string>;
+  defaultCountryCode?: string;
 };
 
 export type IdxMethod =

--- a/src/v3/src/util/settingsUtils.test.ts
+++ b/src/v3/src/util/settingsUtils.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { WidgetProps } from '../types';
-import { getLanguageCode } from './settingsUtils';
+import { getDefaultCountryCode, getLanguageCode } from './settingsUtils';
 
 jest.mock('../../../util/BrowserFeatures', () => ({
   getUserLanguages: jest.fn().mockReturnValue(['en', 'en-US']),
@@ -45,5 +45,21 @@ describe('Settings Utils Tests', () => {
     widgetProps.language = () => ('es');
 
     expect(getLanguageCode(widgetProps)).toBe('es');
+  });
+
+  it('should return "US" as the default country code value when org does not provide a value', () => {
+    expect(getDefaultCountryCode(widgetProps)).toBe('US');
+  });
+
+  it('should return "US" as the default country code when org provided value is invalid', () => {
+    widgetProps.defaultCountryCode = 'ABDC';
+
+    expect(getDefaultCountryCode(widgetProps)).toBe('US');
+  });
+
+  it('should return org provided country code as the default value when code is valid', () => {
+    widgetProps.defaultCountryCode = 'BW';
+
+    expect(getDefaultCountryCode(widgetProps)).toBe('BW');
   });
 });

--- a/src/v3/src/util/settingsUtils.ts
+++ b/src/v3/src/util/settingsUtils.ts
@@ -15,8 +15,9 @@ import union from 'lodash/union';
 import config from '../../../config/config.json';
 import { LanguageCode } from '../../../types';
 import BrowserFeatures from '../../../util/BrowserFeatures';
+import CountryUtil from '../../../util/CountryUtil';
 import Util from '../../../util/Util';
-import { WidgetProps } from '../types';
+import { WidgetOptions, WidgetProps } from '../types';
 
 export const getSupportedLanguages = (widgetProps: WidgetProps): string[] => {
   const { i18n, language, assets: { languages } = {} } = widgetProps;
@@ -94,4 +95,15 @@ export const getBaseUrl = (widgetProps: WidgetProps): string | undefined => {
   const issuerPath = issuer || authParams?.issuer;
   const [parsedBaseUrl] = issuerPath?.split('/oauth2/') ?? [];
   return parsedBaseUrl;
+};
+
+export const getDefaultCountryCode = (widgetProps: Partial<WidgetOptions>): string => {
+  const defaultCountry = 'US';
+  const { defaultCountryCode } = widgetProps;
+  if (typeof defaultCountryCode === 'undefined') {
+    return defaultCountry;
+  }
+  const countries = CountryUtil.getCountries();
+  return Object.keys(countries).includes(defaultCountryCode)
+    ? defaultCountryCode : defaultCountry;
 };

--- a/src/v3/src/util/settingsUtils.ts
+++ b/src/v3/src/util/settingsUtils.ts
@@ -17,7 +17,7 @@ import { LanguageCode } from '../../../types';
 import BrowserFeatures from '../../../util/BrowserFeatures';
 import CountryUtil from '../../../util/CountryUtil';
 import Util from '../../../util/Util';
-import { WidgetOptions, WidgetProps } from '../types';
+import { WidgetProps } from '../types';
 
 export const getSupportedLanguages = (widgetProps: WidgetProps): string[] => {
   const { i18n, language, assets: { languages } = {} } = widgetProps;
@@ -97,7 +97,7 @@ export const getBaseUrl = (widgetProps: WidgetProps): string | undefined => {
   return parsedBaseUrl;
 };
 
-export const getDefaultCountryCode = (widgetProps: Partial<WidgetOptions>): string => {
+export const getDefaultCountryCode = (widgetProps: WidgetProps): string => {
   const defaultCountry = 'US';
   const { defaultCountryCode } = widgetProps;
   if (typeof defaultCountryCode === 'undefined') {

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -298,8 +298,8 @@ test
   .requestHooks(loopbackBiometricsErrorDesktopMock)('show biometrics error for desktop platform in loopback', async t => {
     probeSuccess = false;
     const deviceChallengePollPageObject = await setup(t);
-    await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
+    await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     // in v3 all cancel buttons are the same so skip this assertion
     if (!userVariables.v3) {
       await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -298,8 +298,8 @@ test
   .requestHooks(loopbackBiometricsErrorDesktopMock)('show biometrics error for desktop platform in loopback', async t => {
     probeSuccess = false;
     const deviceChallengePollPageObject = await setup(t);
-    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
     // in v3 all cancel buttons are the same so skip this assertion
     if (!userVariables.v3) {
       await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);


### PR DESCRIPTION
## Description:

The purpose of this PR is to change the frequency at which we trigger field level validation error messages. The ask is to only trigger the validation message onBlur instead of onChange. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-557593](https://oktainc.atlassian.net/browse/OKTA-557593)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



