### PR TITLE
fix: defaultCountryCode now respected in gen2

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,10 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    // 'authenticator-enroll-data-phone',
-    'authenticator-enroll-ov-via-sms',
-    
-    //'identify',
+    'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,10 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    'identify',
+    // 'authenticator-enroll-data-phone',
+    'authenticator-enroll-ov-via-sms',
+    
+    //'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',

--- a/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
@@ -88,7 +88,7 @@ export default BaseAuthenticatorView.extend({
       {
         country: {
           // Set default country to "US"
-          'value': 'US',
+          'value': this.settings.get('defaultCountryCode'),
           'type': 'string',
         },
       },

--- a/src/v2/view-builder/views/phone/EnrollAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/EnrollAuthenticatorDataPhoneView.js
@@ -136,8 +136,7 @@ export default BaseAuthenticatorView.extend({
     const local = Object.assign(
       {
         country: {
-          // Set default country to "US"
-          'value': 'US',
+          'value': this.settings.get('defaultCountryCode'),
           'type': 'string',
         },
         extension: {

--- a/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
@@ -5,6 +5,7 @@ const PHONE_NUMBER_SELECTOR = '.phone-authenticator-enroll__phone';
 const PHONE_NUMBER_EXTENSION_SELECTOR = '.phone-authenticator-enroll__phone-ext';
 const phoneFieldName = 'authenticator\\.phoneNumber';
 const RESEND_VIEW_SELECTOR = '.phone-authenticator-enroll--warning';
+const PHONE_NUMBER_COUNTRY_CODE = '.phone-authenticator-enroll__phone-code';
 
 export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
 
@@ -34,6 +35,10 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
 
   waitForError() {
     return this.form.waitForErrorBox();
+  }
+
+  getCountryCodeValue() {
+    return this.form.getElement(PHONE_NUMBER_COUNTRY_CODE).innerText;
   }
 
   fillPhoneNumber(value) {

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -87,7 +87,6 @@ test
 test
   .requestHooks()('shows the correct content in iOS ODA terminal view when Okta Verify is not installed in Universal Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
-    await checkA11y(t);
     await rerenderWidget({
       'proxyIdxResponse': {
         'deviceEnrollment': {
@@ -102,6 +101,7 @@ test
         }
       }
     });
+    await checkA11y(t);
     await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Download Okta Verify');
     await t.expect(deviceEnrollmentTerminalPage.getBeaconClass()).contains('mfa-okta-verify');
     const content = deviceEnrollmentTerminalPage.getContentText();
@@ -122,7 +122,6 @@ test
 test
   .requestHooks()('shows the correct content in iOS MDM terminal view when Okta Verify is not set up in Universal Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
-    await checkA11y(t);
     await rerenderWidget({
       'proxyIdxResponse': {
         'deviceEnrollment': {
@@ -137,6 +136,7 @@ test
         }
       }
     });
+    await checkA11y(t);
     await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required');
     const content = deviceEnrollmentTerminalPage.getContentText();
     await t.expect(content).contains('To access this app, your device needs to meet your organization');
@@ -152,7 +152,6 @@ test
 test
   .requestHooks()('shows the correct content in Android ODA terminal view', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
-    await checkA11y(t);
     await rerenderWidget({
       'proxyIdxResponse': {
         'deviceEnrollment': {
@@ -169,6 +168,7 @@ test
         }
       }
     });
+    await checkA11y(t);
     await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required to use Okta FastPass');
     await t.expect(deviceEnrollmentTerminalPage.getBeaconClass()).contains('mfa-okta-verify');
     const content = deviceEnrollmentTerminalPage.getContentText();
@@ -197,7 +197,6 @@ test
 test
   .requestHooks()('shows the correct content in Android ODA terminal view when Okta Verify is not installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
-    await checkA11y(t);
     await rerenderWidget({
       'proxyIdxResponse': {
         'deviceEnrollment': {
@@ -214,6 +213,7 @@ test
         }
       }
     });
+    await checkA11y(t);
     // switch to the next page when OV account is not setup
     await deviceEnrollmentTerminalPage.clickWithoutOVAccount();
     await deviceEnrollmentTerminalPage.clickNextButton();
@@ -233,7 +233,6 @@ test
 test
   .requestHooks()('shows the correct content in Android ODA terminal view when Okta Verify is installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
-    await checkA11y(t);
     await rerenderWidget({
       'proxyIdxResponse': {
         'deviceEnrollment': {
@@ -250,6 +249,7 @@ test
         }
       }
     });
+    await checkA11y(t);
     // go back then switch to the next page when OV account is setup
     await deviceEnrollmentTerminalPage.clickWithOVAccount();
     await deviceEnrollmentTerminalPage.clickNextButton();
@@ -267,7 +267,6 @@ test
 test
   .requestHooks()('shows the correct content in ANDROID MDM terminal view when Okta Verify is not installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
-    await checkA11y(t);
     await rerenderWidget({
       'proxyIdxResponse': {
         'deviceEnrollment': {
@@ -283,6 +282,7 @@ test
         }
       }
     });
+    await checkA11y(t);
     await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required');
     const content = deviceEnrollmentTerminalPage.getContentText();
     await t.expect(content).contains('To access this app, your device needs to meet your organization');

--- a/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
@@ -2,7 +2,7 @@ import { RequestMock } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import EnrollPhonePageObject from '../framework/page-objects/EnrollPhonePageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
-import { checkConsoleMessages, rerenderWidget } from '../framework/shared';
+import { checkConsoleMessages, renderWidget as rerenderWidget } from '../framework/shared';
 import xhrAuthenticatorEnrollDataPhone from '../../../playground/mocks/data/idp/idx/authenticator-enroll-data-phone';
 import xhrAuthenticatorEnrollDataPhoneVoice from '../../../playground/mocks/data/idp/idx/authenticator-enroll-data-phone-voice';
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';

--- a/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
@@ -2,7 +2,7 @@ import { RequestMock } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import EnrollPhonePageObject from '../framework/page-objects/EnrollPhonePageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, rerenderWidget } from '../framework/shared';
 import xhrAuthenticatorEnrollDataPhone from '../../../playground/mocks/data/idp/idx/authenticator-enroll-data-phone';
 import xhrAuthenticatorEnrollDataPhoneVoice from '../../../playground/mocks/data/idp/idx/authenticator-enroll-data-phone-voice';
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
@@ -67,7 +67,7 @@ test.requestHooks(mock)('voice mode click and extension will get shown', async t
   await t.expect(extensionText.trim()).eql('Extension');
 
   // Default country code US
-  const countryCodeText = await enrollPhonePage.getElement('.phone-authenticator-enroll__phone-code').innerText;
+  const countryCodeText = await enrollPhonePage.getCountryCodeValue();
   await t.expect(countryCodeText.trim()).eql('+1');
 
   // Phone Number input field is rendered small
@@ -138,4 +138,21 @@ test.requestHooks(voiceOnlyOptionMock)('should succeed when values are filled wh
   const pageUrl = await successPage.getPageUrl();
   await t.expect(pageUrl)
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+});
+
+test.requestHooks(mock)('respects settings.defaultCountryCode', async t => {
+  const enrollPhonePage = await setup(t);
+  await checkA11y(t);
+
+  // Default country code US (+1)
+  const defaultCountryCodeText = await enrollPhonePage.getCountryCodeValue();
+  await t.expect(defaultCountryCodeText.trim()).eql('+1');
+
+  await rerenderWidget({
+    defaultCountryCode: 'GB'  // United Kingdom
+  });
+
+  // United Kingdom (+44)
+  const gbCountryCodeText = await enrollPhonePage.getCountryCodeValue();
+  await t.expect(gbCountryCodeText.trim()).eql('+44');
 });

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -5,7 +5,7 @@ import SwitchOVEnrollChannelPageObject from '../framework/page-objects/SwitchOVE
 import EnrollOVViaEmailPageObject from '../framework/page-objects/EnrollOVViaEmailPageObject';
 import EnrollOVViaSMSPageObject from '../framework/page-objects/EnrollOVViaSMSPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
-import { checkConsoleMessages, rerenderWidget } from '../framework/shared';
+import { checkConsoleMessages, renderWidget as rerenderWidget } from '../framework/shared';
 import xhrAuthenticatorEnrollOktaVerifyQr from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-qr';
 import xhrAuthenticatorEnrollOktaVerifyViaEmail from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-via-email';
 import xhrAuthenticatorEnrollOktaVerifyEmail from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-email';

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -343,13 +343,13 @@ test.requestHooks(logger, enrollViaSmsMocks)('should be able enroll via sms', as
 });
 
 test.requestHooks(logger, enrollViaSmsMocks)('respects settings.defaultCountryCode', async t => {
-  // drive to SMS page (click next)
   const enrollOktaVerifyPage = await setup(t);
   await checkA11y(t);
+
+  // drive to SMS page (click next)
   await enrollOktaVerifyPage.clickSwitchChannel();
   const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await switchChannelPageObject.clickNextButton();
-
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
 
   // Default country code US (+1)
@@ -359,6 +359,9 @@ test.requestHooks(logger, enrollViaSmsMocks)('respects settings.defaultCountryCo
   await rerenderWidget({
     defaultCountryCode: 'GB'  // United Kingdom
   });
+  // drive to SMS page (click next) - required again after rerender
+  await enrollOktaVerifyPage.clickSwitchChannel();
+  await switchChannelPageObject.clickNextButton();
 
   // United Kingdom (+44)
   const gbCountryCodeText = await enrollViaSMSPageObject.getCountryLabel();

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -342,6 +342,28 @@ test.requestHooks(logger, enrollViaSmsMocks)('should be able enroll via sms', as
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
 
+test.requestHooks(logger, enrollViaSmsMocks)('respects settings.defaultCountryCode', async t => {
+  // drive to SMS page (click next)
+  const enrollOktaVerifyPage = await setup(t);
+  await checkA11y(t);
+  await enrollOktaVerifyPage.clickSwitchChannel();
+  await switchChannelPageObject.clickNextButton();
+
+  const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
+
+  // Default country code US (+1)
+  const defaultCountryCodeText = await enrollViaSMSPageObject.getCountryLabel();
+  await t.expect(defaultCountryCodeText.trim()).eql('+1');
+
+  await rerenderWidget({
+    defaultCountryCode: 'GB'  // United Kingdom
+  });
+
+  // United Kingdom (+44)
+  const gbCountryCodeText = await enrollViaSMSPageObject.getCountryLabel();
+  await t.expect(gbCountryCodeText.trim()).eql('+44');
+});
+
 test.requestHooks(resendSmsMocks)('after timeout should be able see and click send again link when enrolling via sms', async t => {
   const enrollOktaVerifyPage = await setup(t);
   await checkA11y(t);

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -5,7 +5,7 @@ import SwitchOVEnrollChannelPageObject from '../framework/page-objects/SwitchOVE
 import EnrollOVViaEmailPageObject from '../framework/page-objects/EnrollOVViaEmailPageObject';
 import EnrollOVViaSMSPageObject from '../framework/page-objects/EnrollOVViaSMSPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, rerenderWidget } from '../framework/shared';
 import xhrAuthenticatorEnrollOktaVerifyQr from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-qr';
 import xhrAuthenticatorEnrollOktaVerifyViaEmail from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-via-email';
 import xhrAuthenticatorEnrollOktaVerifyEmail from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-email';
@@ -347,6 +347,7 @@ test.requestHooks(logger, enrollViaSmsMocks)('respects settings.defaultCountryCo
   const enrollOktaVerifyPage = await setup(t);
   await checkA11y(t);
   await enrollOktaVerifyPage.clickSwitchChannel();
+  const switchChannelPageObject = new SwitchOVEnrollChannelPageObject(t);
   await switchChannelPageObject.clickNextButton();
 
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);


### PR DESCRIPTION
## Description:
Views that prompt for a phone number in gen2 did not respect the `defaultCountryCode` setting


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:
- [OKTA-559180](https://oktainc.atlassian.net/browse/OKTA-559180)

### Reviewers:

### Screenshot/Video:
![Screen Shot 2023-02-22 at 14 25 41](https://user-images.githubusercontent.com/90656038/220737483-97040225-53ce-483c-8eea-e0c0847c7114.png)
![Screen Shot 2023-02-22 at 14 26 35](https://user-images.githubusercontent.com/90656038/220737679-2ba11d29-2bdd-420a-902e-224826b69622.png)


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=1154682476622600cb51b42be22c98f402cfde7e&tab=main


