### PR TITLE
Fix flakiness in LoopbackProbe unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- START GITHUB ONLY -->
+
 [<img src="https://aws1.discourse-cdn.com/standard14/uploads/oktadev/original/1X/0c6402653dfb70edc661d4976a43a46f33e5e919.png" align="right" width="256px"/>](https://devforum.okta.com/)
 [![Support](https://img.shields.io/badge/support-developer%20forum-blue.svg)](https://devforum.okta.com)
 [![Build Status](https://travis-ci.org/okta/okta-signin-widget.svg?branch=master)](https://travis-ci.org/okta/okta-signin-widget)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <!-- START GITHUB ONLY -->
-
 [<img src="https://aws1.discourse-cdn.com/standard14/uploads/oktadev/original/1X/0c6402653dfb70edc661d4976a43a46f33e5e919.png" align="right" width="256px"/>](https://devforum.okta.com/)
 [![Support](https://img.shields.io/badge/support-developer%20forum-blue.svg)](https://devforum.okta.com)
 [![Build Status](https://travis-ci.org/okta/okta-signin-widget.svg?branch=master)](https://travis-ci.org/okta/okta-signin-widget)

--- a/src/v3/.eslintrc.js
+++ b/src/v3/.eslintrc.js
@@ -129,13 +129,6 @@ module.exports = {
           json: 'always',
         }],
 
-        // prevent inline styles which cause CSP violations
-        'react/forbid-component-props': ['error', {
-          forbid: [{
-            propName: 'style',
-            message: 'Inline styles cause CSP issues',
-          }],
-        }],
         'react/forbid-dom-props': ['error', {
           forbid: [{
             propName: 'style',
@@ -166,9 +159,12 @@ module.exports = {
         'class-methods-use-this': 'off',
 
         'react/forbid-component-props': [
-          2,
+          'error',
           {
             forbid: [
+              // prevent inline styles which cause CSP violations
+              { propName: 'style', message: 'Inline styles cause CSP issues' },
+              // ensure RTL friendly properties
               { propName: 'margin', message: 'Use "marginBlock" and "marginInline" instead.' },
               { propName: 'marginTop', message: 'Use "marginBlockStart" instead.' },
               { propName: 'marginBottom', message: 'Use "marginBlockEnd" instead.' },

--- a/src/v3/src/components/AuthCoin/AuthCoin.test.tsx
+++ b/src/v3/src/components/AuthCoin/AuthCoin.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { render } from '@testing-library/preact';
+import { cleanup, render } from '@testing-library/preact';
 import { h } from 'preact';
 import { AuthCoinProps } from 'src/types';
 
@@ -23,6 +23,10 @@ describe('AuthCoin tests', () => {
     props = {
       authenticatorKey: 'custom_otp',
     };
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should display Branded AuthCoin and disallow style customization', async () => {

--- a/src/v3/src/components/AuthHeader/AuthHeader.test.tsx
+++ b/src/v3/src/components/AuthHeader/AuthHeader.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { render } from '@testing-library/preact';
+import { cleanup, render } from '@testing-library/preact';
 import { h } from 'preact';
 
 import AuthHeader, { AuthHeaderProps } from './AuthHeader';
@@ -24,6 +24,10 @@ describe('AuthHeader tests', () => {
       logoText: 'Mock Logo',
       brandName: 'Mock Company',
     };
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should display brand logo only', async () => {

--- a/src/v3/src/components/IdentifierContainer/IdentifierContainer.test.tsx
+++ b/src/v3/src/components/IdentifierContainer/IdentifierContainer.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { IdxTransaction } from '@okta/okta-auth-js';
-import { render } from '@testing-library/preact';
+import { cleanup, render } from '@testing-library/preact';
 import { h } from 'preact';
 import { IDX_STEP } from 'src/constants';
 import { getStubTransaction } from 'src/mocks/utils/utils';
@@ -32,6 +32,10 @@ describe('IdentifierContainer Tests', () => {
   beforeEach(() => {
     transaction = getStubTransaction();
     mockProps = {};
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should not display identifier container if transaction is null', async () => {

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { render, waitFor } from '@testing-library/preact';
+import { cleanup, render, waitFor } from '@testing-library/preact';
 import { rest } from 'msw';
 import { setupServer, SetupServerApi } from 'msw/node';
 import { h } from 'preact';
@@ -45,6 +45,7 @@ describe('LoopbackProbe', () => {
     });
   });
   afterEach(() => {
+    cleanup();
     jest.clearAllMocks();
     server.resetHandlers();
   });

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -243,8 +243,8 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    // 400ms covers 2 probe requests at 100ms max each plus 1 delayed request at 200ms
-    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
+    // 500ms covers 3 probe requests at 100ms max each plus 1 delayed request at 200ms
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 500 });
 
     expect(proceedStub).toHaveBeenCalledWith({
       actions: [{

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -84,7 +84,8 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
+    // 300ms covers 3 probe requests at 100ms max each
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
 
     expect(proceedStub).toHaveBeenCalledWith({
       step,
@@ -119,6 +120,7 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
+    // 100ms covers 1 probe request at 100ms max
     await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
 
     expect(proceedStub).toHaveBeenCalledWith({
@@ -159,7 +161,8 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
+    // 300ms covers 3 probe requests at 100ms max each
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
 
     expect(proceedStub).toHaveBeenCalledWith({
       actions: [{
@@ -202,7 +205,8 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 100 });
+    // 400ms covers 4 probe requests at 100ms max each
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 400 });
 
     expect(proceedStub).toHaveBeenCalledWith({
       step: 'device-challenge-poll',
@@ -241,9 +245,8 @@ describe('LoopbackProbe', () => {
 
     render(<LoopbackProbe {...props} />);
 
-    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), {
-      timeout: 300, // need to wait longer since we are testing request timeout
-    });
+    // 400ms covers 2 probe requests at 100ms max each plus 1 delayed request at 200ms
+    await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
 
     expect(proceedStub).toHaveBeenCalledWith({
       actions: [{

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -53,7 +53,6 @@ describe('LoopbackProbe', () => {
     server.close();
   });
 
-  // TODO: FIXME OKTA-575814 - intermittently fails on bacon
   it.each`
     step                       | cancelStep
     ${'device-challenge-poll'} | ${'authenticatorChallenge-cancel'}
@@ -176,7 +175,6 @@ describe('LoopbackProbe', () => {
     });
   });
 
-  // TODO: FIXME OKTA-575814 - intermittently fails on bacon
   it('challenge returns 503 error status but later port succeeds', async () => {
     server.use(
       rest.get('http://localhost:2000/probe', async (_, res, ctx) => res(ctx.status(500))),

--- a/src/v3/src/components/PIVButton/PIVButton.test.tsx
+++ b/src/v3/src/components/PIVButton/PIVButton.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { IdxTransaction } from '@okta/okta-auth-js';
-import { render, waitFor } from '@testing-library/preact';
+import { cleanup, render, waitFor } from '@testing-library/preact';
 import { h } from 'preact';
 import { getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 
@@ -48,6 +48,10 @@ describe('PIVButton Tests', () => {
         translations: [{ name: 'label', value: 'Verify', i18nKey: 'some.key' }],
       },
     };
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should render PIV retry button w/o spinner when an error message exists in transaction', async () => {

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.test.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.test.tsx
@@ -11,6 +11,7 @@
  */
 
 import {
+  cleanup,
   render,
   RenderResult,
   waitFor,
@@ -75,6 +76,10 @@ describe('PhoneAuthenticator tests', () => {
   beforeEach(() => {
     mockHandleFunction = jest.fn();
     mockLoading.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should format phoneNumber correctly when field is changed for SMS methodType', async () => {

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
@@ -12,7 +12,9 @@
 
 import '@testing-library/jest-dom';
 
-import { cleanup, fireEvent, render, within } from '@testing-library/preact';
+import {
+  cleanup, fireEvent, render, within,
+} from '@testing-library/preact';
 import { h } from 'preact';
 import { act } from 'preact/test-utils';
 

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
@@ -12,7 +12,7 @@
 
 import '@testing-library/jest-dom';
 
-import { fireEvent, render, within } from '@testing-library/preact';
+import { cleanup, fireEvent, render, within } from '@testing-library/preact';
 import { h } from 'preact';
 import { act } from 'preact/test-utils';
 
@@ -39,6 +39,10 @@ jest.mock('../../contexts', () => ({
 describe('ReminderPrompt', () => {
   beforeEach(() => {
     mockSubmitHook.mockRestore();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should show prompt with working link after default timeout passes', async () => {

--- a/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
+++ b/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
@@ -10,7 +10,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+import {
+  cleanup, fireEvent, render, waitFor,
+} from '@testing-library/preact';
 import { h } from 'preact';
 import {
   MessageType,

--- a/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
+++ b/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { fireEvent, render, waitFor } from '@testing-library/preact';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
 import { h } from 'preact';
 import {
   MessageType,
@@ -56,6 +56,10 @@ describe('WebAuthNControlSubmitControl Tests', () => {
         },
       } as WebAuthNButtonElement,
     };
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should render webauthn verify button and handle click', async () => {


### PR DESCRIPTION
## Description:

We now wait a bit longer for an assertion for `proceed` in `LoopbackProbe.test.tsx` using this forumla:

`probeTimeoutMillis` x number of probes expected + any network timeout delays expected

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-575814](https://oktainc.atlassian.net/browse/OKTA-575814)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



