### PR TITLE
OKTA-578544: run e2e-monolith against dockolith 1.6.0

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -99,11 +99,10 @@ test_suites:
       script_name: find-internal-packages
       criteria: MERGE
       queue_name: small
-    # E2E tests using dockerized monolith - optional (for now)
     - name: e2e-monolith
       script_path: ../okta-signin-widget/scripts
       sort_order: '1'
       timeout: '30'
       script_name: e2e-monolith
-      criteria: OPTIONAL
+      criteria: MERGE
       queue_name: ci-queue-prodJenga-Monolith-Build

--- a/scripts/downstream/create-downstream-for-monolith.sh
+++ b/scripts/downstream/create-downstream-for-monolith.sh
@@ -4,14 +4,14 @@ setup_service node v14.18.0
 # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
 setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
 
-# Get monolith build version based on commit sha
+# install dockolith based on upstream branch
+export DOCKOLITH_BRANCH=${upstream_artifact_branch}
 source ./scripts/monolith/install-dockolith.sh
+
+# prepare dockolith
 pushd ./scripts/dockolith > /dev/null
   yarn # install dependencies and build TS
-  mono_build_version=`./scripts/api/get-build-version.sh "${upstream_artifact_sha}"`
 popd > /dev/null
 
-# Update script: MONOLITH_BUILDVERSION in e2e-monolith.sh
-pushd ./scripts > /dev/null
-  sed -i "s/\(MONOLITH_BUILDVERSION\=\).*/\1\"${mono_build_version}\"/g" e2e-monolith.sh
-popd > /dev/null
+# run e2e
+source ./scripts/e2e-monolith.sh

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -x
 
-# Monolith version to test against
-# TODO: auto-select a recent stable version OKTA-561403
-export MONOLITH_BUILDVERSION=2023.01.0-begin-28-g616122a68e33
-
 export WIDGET_HOME="$(readlink -f "$(dirname "$0")/..")"
 export LOCAL_MONOLITH=true
 export CI=true
@@ -12,6 +8,7 @@ export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/junit"
 echo $TEST_SUITE_TYPE > $TEST_SUITE_TYPE_FILE
 echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
 export ORG_OIE_ENABLED=true
+export DOCKOLITH_BRANCH=${DOCKOLITH_BRANCH:-dockolith-1.6.0}
 
 set +e
 source $OKTA_HOME/$REPO/scripts/setup.sh

--- a/scripts/monolith/install-dockolith.sh
+++ b/scripts/monolith/install-dockolith.sh
@@ -5,9 +5,15 @@ if [[ -z ${DOCKOLITH_BRANCH} ]]; then
 fi
 
 pushd ./scripts
-rm -rf dockolith
-echo "Cloning dockolith from branch: ${DOCKOLITH_BRANCH}"
-git clone --depth 1 -b $DOCKOLITH_BRANCH https://github.com/okta/dockolith.git
+  rm -rf dockolith
+  echo "Cloning dockolith from branch: ${DOCKOLITH_BRANCH}"
+  git clone --depth 1 -b $DOCKOLITH_BRANCH https://github.com/okta/dockolith.git
+  
+  # build dockolith target
+  pushd ./dockolith
+  yarn
+  yarn build
+  popd
 popd
 
 # Yarn "add" always modifies package.json https://github.com/yarnpkg/yarn/issues/1743

--- a/scripts/monolith/lib/common-widget-setup.sh
+++ b/scripts/monolith/lib/common-widget-setup.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -xe
 
-# Set MONOLITH_BUILDVERSION before running this script
-# https://artifacts.aue1e.internal/artifactory/integration/test-baselines/
-: "${MONOLITH_BUILDVERSION?:"missing MONOLITH_BUILDVERSION"}"
-
 export WIDGET_HOME=${WIDGET_HOME:-`(readlink -f "$(dirname "$0")/../../..")`}
 export WIDGET_VERSION="${WIDGET_VERSION:-$(cat ${WIDGET_HOME}/package.json | jq '.version' -r)}"
 export SYNTHETIC_WIDGET_VERSION=${SYNTHETIC_WIDGET_VERSION:-${WIDGET_VERSION}-local}

--- a/test/e2e/page-objects/test-app.page.js
+++ b/test/e2e/page-objects/test-app.page.js
@@ -98,12 +98,7 @@ class TestAppPage {
   }
 
   async assertWidget(displayed) {
-    if (displayed) {
-      await waitForLoad(this.widget);
-    }
-    await this.widget.then(el => el.isDisplayed()).then(isDisplayed => {
-      expect(isDisplayed).toBe(displayed);
-    });
+    await this.widget.waitForDisplayed({ reverse: !displayed });
   }
 
   async assertWidgetRemoved() {


### PR DESCRIPTION
## Description:

**CI CHANGE ONLY**
* updates `e2e-monolith` bacon.yml criteria to MERGE
* install dockolith from stable tag (1.6.0) instead of pulling directly from master


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-578544](https://oktainc.atlassian.net/browse/OKTA-578544)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



