### PR TITLE
OKTA-580462 - Stretched widget fix

### DIFF
--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -42,7 +42,12 @@ const mergeContentSecurityPolicies = (...policies) => {
 };
 
 export default {
-  webpack(config, env) {
+  webpack(config, env, helpers) {
+    const { plugin } = helpers.getPluginsByName(config, 'MiniCssExtractPlugin')[0];
+    // sets the name of the css bundle
+    plugin.options.filename = 'okta-sign-in.next.css';
+    delete plugin.options.chunkFilename;
+
     config.output.libraryTarget = 'umd';
     config.output.filename = ({ chunk }) => (
       chunk.name === 'bundle' ? 'okta-sign-in.next.js' : '[name].next.js'


### PR DESCRIPTION
## Description:

This PR is part of the fix for the widget stretching the full length of the screen and restoring css styling in production builds.

NOTE:  File path to the `okta-sign-in.next.css` css bundle will need to be added in monolith before this fix will be complete.  

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-580462](https://oktainc.atlassian.net/browse/OKTA-580462)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



