### PR TITLE
OKTA-549614 : Hide redundant Authenticator button icon text

### DIFF
--- a/src/v3/src/components/AuthCoin/AuthCoin.test.tsx
+++ b/src/v3/src/components/AuthCoin/AuthCoin.test.tsx
@@ -36,21 +36,21 @@ describe('AuthCoin tests', () => {
 
     const { container, findByRole } = render(<AuthCoin {...props} />);
 
-    expect(await findByRole('img')).toBeDefined();
+    expect(await findByRole('img', { hidden: true })).toBeDefined();
     expect(container).toMatchSnapshot();
   });
 
   it('should display standard theme Non-Branded AuthCoin without style customization', async () => {
     const { container, findByRole } = render(<AuthCoin {...props} />);
 
-    expect(await findByRole('img')).toBeDefined();
+    expect(await findByRole('img', { hidden: true })).toBeDefined();
     expect(container).toMatchSnapshot();
   });
 
   it('should display Non-Branded AuthCoin with style customizations', async () => {
     const { container, findByRole } = render(<AuthCoin {...props} />);
 
-    expect(await findByRole('img')).toBeDefined();
+    expect(await findByRole('img', { hidden: true })).toBeDefined();
     expect(container).toMatchSnapshot();
   });
 
@@ -63,7 +63,7 @@ describe('AuthCoin tests', () => {
 
     const { container, findByRole } = render(<AuthCoin {...props} />);
 
-    expect(await findByRole('img')).toBeDefined();
+    expect(await findByRole('img', { hidden: true })).toBeDefined();
     expect(container).toMatchSnapshot();
   });
 
@@ -76,7 +76,7 @@ describe('AuthCoin tests', () => {
 
     const { container, findByRole } = render(<AuthCoin {...props} />);
 
-    expect(await findByRole('img')).toBeDefined();
+    expect(await findByRole('img', { hidden: true })).toBeDefined();
     expect(container).toMatchSnapshot();
   });
 
@@ -88,7 +88,7 @@ describe('AuthCoin tests', () => {
     const { queryByRole, container } = render(<AuthCoin {...props} />);
 
     expect(container.childElementCount).toBe(0);
-    expect(await queryByRole('img')).not.toBeInTheDocument();
+    expect(await queryByRole('img', { hidden: true })).not.toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/v3/src/components/AuthCoin/AuthCoin.tsx
+++ b/src/v3/src/components/AuthCoin/AuthCoin.tsx
@@ -68,6 +68,7 @@ const AuthCoin: FunctionComponent<AuthCoinProps> = (props) => {
     <Box
       className={containerClasses}
       data-se="factor-beacon"
+      aria-hidden
       sx={(theme) => ({
         '--PrimaryFill': theme.palette.primary.main,
         '--SecondaryFill': theme.palette.primary.light,

--- a/src/v3/src/components/AuthCoin/__snapshots__/AuthCoin.test.tsx.snap
+++ b/src/v3/src/components/AuthCoin/__snapshots__/AuthCoin.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`AuthCoin tests should display Branded AuthCoin and disallow style customization 1`] = `
 <div>
   <div
+    aria-hidden="true"
     class="iconContainer mfa-duo MuiBox-root emotion-0"
     data-se="factor-beacon"
   >
@@ -41,6 +42,7 @@ exports[`AuthCoin tests should display Branded AuthCoin and disallow style custo
 exports[`AuthCoin tests should display Non-Branded AuthCoin with style customizations 1`] = `
 <div>
   <div
+    aria-hidden="true"
     class="iconContainer mfa-hotp MuiBox-root emotion-0"
     data-se="factor-beacon"
   >
@@ -88,6 +90,7 @@ exports[`AuthCoin tests should display Non-Branded AuthCoin with style customiza
 exports[`AuthCoin tests should display branded AuthCoin when image URL is provided and AuthenticatorKey requires a branded Type 1`] = `
 <div>
   <div
+    aria-hidden="true"
     class="iconContainer mfa-duo MuiBox-root emotion-0"
     data-se="factor-beacon"
   >
@@ -126,6 +129,7 @@ exports[`AuthCoin tests should display branded AuthCoin when image URL is provid
 exports[`AuthCoin tests should display custom image in place of standard Non-Branded AuthCoin when image URL is provided 1`] = `
 <div>
   <div
+    aria-hidden="true"
     class="iconContainer mfa-hotp MuiBox-root emotion-0"
     data-se="factor-beacon"
   >
@@ -141,6 +145,7 @@ exports[`AuthCoin tests should display custom image in place of standard Non-Bra
 exports[`AuthCoin tests should display standard theme Non-Branded AuthCoin without style customization 1`] = `
 <div>
   <div
+    aria-hidden="true"
     class="iconContainer mfa-hotp MuiBox-root emotion-0"
     data-se="factor-beacon"
   >

--- a/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
+++ b/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
@@ -127,7 +127,6 @@ const AuthenticatorButton: UISchemaElementComponent<{
         <Box
           className="authenticator-icon-container"
           data-se="authenticator-icon"
-          aria-hidden
         >
           <AuthCoin
             authenticatorKey={authenticationKey}

--- a/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
+++ b/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
@@ -127,6 +127,7 @@ const AuthenticatorButton: UISchemaElementComponent<{
         <Box
           className="authenticator-icon-container"
           data-se="authenticator-icon"
+          aria-hidden
         >
           <AuthCoin
             authenticatorKey={authenticationKey}

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1612,6 +1613,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -3201,6 +3203,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-google-auth authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -304,6 +305,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-google-auth authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -592,6 +594,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-google-auth authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -863,6 +866,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-google-auth authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -133,11 +133,11 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-google-auth authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -309,11 +309,11 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -409,11 +409,11 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -523,11 +523,11 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -680,6 +680,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -308,6 +309,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -407,6 +409,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -520,6 +523,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -431,6 +431,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -950,6 +951,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1470,6 +1472,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -431,6 +432,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -794,6 +796,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1268,6 +1271,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -133,11 +133,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-password authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -237,11 +237,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -351,11 +351,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -236,6 +237,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -349,6 +351,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -133,11 +133,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-password authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -237,11 +237,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -351,11 +351,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -475,11 +475,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-security-question authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -579,11 +579,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -679,11 +679,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-google-auth authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -855,11 +855,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-onprem authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -959,11 +959,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-rsa authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -1057,11 +1057,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-duo authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -1157,11 +1157,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-custom-factor authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -1266,11 +1266,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-hotp authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -1375,11 +1375,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-symantec authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >
@@ -1481,11 +1481,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-yubikey authenticator-icon MuiBox-root emotion-26"
                           data-se="factor-beacon"
                         >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -236,6 +237,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -349,6 +351,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -472,6 +475,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -575,6 +579,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -674,6 +679,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -849,6 +855,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -952,6 +959,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1049,6 +1057,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1148,6 +1157,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1256,6 +1266,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1364,6 +1375,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1469,6 +1481,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-yubikey authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -699,6 +700,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-expired-password should present field level error message
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -688,6 +689,7 @@ exports[`authenticator-expired-password should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -852,6 +853,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -896,6 +896,7 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer smart-card-icon authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-reset-password should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -604,6 +605,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -151,11 +152,11 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-5"
                           data-se="factor-beacon"
                         >
@@ -251,11 +252,11 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-5"
                           data-se="factor-beacon"
                         >
@@ -351,11 +352,11 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-5"
                           data-se="factor-beacon"
                         >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
@@ -250,6 +251,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
@@ -349,6 +351,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -151,11 +152,11 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-5"
                           data-se="factor-beacon"
                         >
@@ -251,11 +252,11 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-5"
                           data-se="factor-beacon"
                         >
@@ -351,11 +352,11 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-5"
                           data-se="factor-beacon"
                         >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
@@ -250,6 +251,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >
@@ -349,6 +351,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-9"
                         data-se="authenticator-icon"
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -205,6 +206,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -431,6 +433,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -645,6 +648,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -915,6 +919,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1322,6 +1327,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-google-auth authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -325,6 +326,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -216,6 +217,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -214,6 +215,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -330,6 +332,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -426,6 +429,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -539,6 +543,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -652,6 +657,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -748,6 +754,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -847,6 +854,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1015,6 +1023,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1111,6 +1120,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1201,6 +1211,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1293,6 +1304,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1394,6 +1406,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1495,6 +1508,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1593,6 +1607,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
@@ -1691,6 +1706,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -118,11 +118,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-password authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -215,11 +215,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-webauthn authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -332,11 +332,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-email authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -429,11 +429,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -543,11 +543,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -657,11 +657,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-security-question authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -754,11 +754,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-verify authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -854,11 +854,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-google-auth authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -1023,11 +1023,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-onprem authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -1120,11 +1120,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-rsa authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -1211,11 +1211,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-duo authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -1304,11 +1304,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-custom-factor authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -1406,11 +1406,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-hotp authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -1508,11 +1508,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-symantec authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -1607,11 +1607,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-yubikey authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >
@@ -1706,11 +1706,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-8"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-custom-app-logo authenticator-icon MuiBox-root emotion-23"
                           data-se="factor-beacon"
                         >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-webauthn authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -357,6 +358,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-webauthn authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -684,6 +686,7 @@ exports[`authenticator-verification-webauthn should render form with required us
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-webauthn authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-yubikey authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`byol loading custom language should load custom language with "language
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1612,6 +1613,7 @@ exports[`byol loading custom language should load custom language with assets.ba
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -3201,6 +3203,7 @@ exports[`byol loading default language should not load custom language when the 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -4790,6 +4793,7 @@ exports[`byol loading default language should not load custom language with "lan
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-phone authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`email-challenge-consent should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -229,6 +230,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -518,6 +520,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -742,6 +745,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -979,6 +983,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1252,6 +1257,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1458,6 +1464,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1664,6 +1671,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1953,6 +1961,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -3435,6 +3444,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -3672,6 +3682,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-webauthn authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`oda-enrollment-android-applink should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -238,6 +239,7 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -465,6 +467,7 @@ exports[`oda-enrollment-android-applink should render view when "Yes, I already 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`oda-enrollment-android-loopback should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`oda-enrollment-ios should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -1505,6 +1506,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-verify authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`terminal-return-email-error should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`terminal-return-email renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -23,6 +23,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`user-unlock-account renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-11"
                         data-se="authenticator-icon"
                       >
@@ -193,6 +194,7 @@ exports[`user-unlock-account renders form 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-11"
                         data-se="authenticator-icon"
                       >

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -97,11 +97,11 @@ exports[`user-unlock-account renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-11"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-email authenticator-icon MuiBox-root emotion-20"
                           data-se="factor-beacon"
                         >
@@ -194,11 +194,11 @@ exports[`user-unlock-account renders form 1`] = `
                       type="button"
                     >
                       <div
-                        aria-hidden="true"
                         class="authenticator-icon-container MuiBox-root emotion-11"
                         data-se="authenticator-icon"
                       >
                         <div
+                          aria-hidden="true"
                           class="iconContainer mfa-okta-phone authenticator-icon MuiBox-root emotion-20"
                           data-se="factor-beacon"
                         >

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`webauthn-enroll should render form 1`] = `
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-webauthn authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -228,6 +229,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-webauthn authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -440,6 +442,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-webauthn authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >


### PR DESCRIPTION
## Description:

This PR adds `aria-hidden` to the Authenticator button icon titles as they are redundant to the button label content.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-549614](https://oktainc.atlassian.net/browse/OKTA-549614)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



