### PR TITLE
OKTA-547451 : g3 : Updating icon for password requirements list component

### DIFF
--- a/src/v3/src/components/Icon/CheckCircle.tsx
+++ b/src/v3/src/components/Icon/CheckCircle.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { FunctionComponent, h } from 'preact';
+
+import { IconProps } from '../../types';
+
+export const CheckCircle: FunctionComponent<IconProps> = ({ name, description }) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-labelledby={name}
+  >
+    <title id={name}>{description}</title>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M15 8C15 11.866 11.866 15 8 15C4.13401 15 1 11.866 1 8C1 4.13401 4.13401 1 8 1C11.866 1 15 4.13401 15 8ZM8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16ZM7.35554 10.3536L11.3555 6.35359L10.6484 5.64648L7.00199 9.29293L5.35554 7.64648L4.64844 8.35359L6.64844 10.3536C6.8437 10.5489 7.16028 10.5489 7.35554 10.3536Z"
+      fill="currentColor"
+    />
+  </svg>
+);

--- a/src/v3/src/components/Icon/index.tsx
+++ b/src/v3/src/components/Icon/index.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+export * from './CheckCircle';
 export * from './CustomAppIcon';
 export * from './CustomOTPIcon';
 export * from './DuoIcon';

--- a/src/v3/src/components/List/List.tsx
+++ b/src/v3/src/components/List/List.tsx
@@ -95,7 +95,8 @@ const List: UISchemaElementComponent<{
               disableGutters
               disablePadding
               key={typeof item === 'string' ? item : getElementKey(item, index)}
-              sx={{ display: 'list-item' }}
+              // TODO: OKTA-577905 - (textAlign: 'start') Temporary fix until we can upgrade to the latest version of Odyssey
+              sx={{ display: 'list-item', textAlign: 'start' }}
             >
               {typeof item === 'string' ? item : renderLayout(item) }
             </ListItem>

--- a/src/v3/src/components/PasswordRequirements/Icon.tsx
+++ b/src/v3/src/components/PasswordRequirements/Icon.tsx
@@ -15,6 +15,7 @@ import classNames from 'classnames/bind';
 import { FunctionComponent, h } from 'preact';
 
 import { PasswordRequirementStatus } from '../../types';
+import { CheckCircle } from '../Icon';
 
 type PasswordRequirementIconProps = {
   status: PasswordRequirementStatus;
@@ -36,13 +37,22 @@ const Icon: FunctionComponent<PasswordRequirementIconProps> = (
       className={iconClasses}
       marginInlineEnd={1}
       display="flex"
+      aria-hidden
     >
-      <OdyIcon
-        aria-hidden
-        titleAccess={status}
-        name={statusToIconProps[status].name}
-        color={statusToIconProps[status].color}
-      />
+      {
+        statusToIconProps[status].name === 'check-circle-filled' ? (
+          <CheckCircle
+            name="complete"
+            description="complete"
+          />
+        ) : (
+          <OdyIcon
+            titleAccess={status}
+            name={statusToIconProps[status].name}
+            color={statusToIconProps[status].color}
+          />
+        )
+      }
     </Box>
   );
 };

--- a/src/v3/src/components/PasswordRequirements/Icon.tsx
+++ b/src/v3/src/components/PasswordRequirements/Icon.tsx
@@ -40,6 +40,7 @@ const Icon: FunctionComponent<PasswordRequirementIconProps> = (
       aria-hidden
     >
       {
+        // Using a custom Icon for the Success/Check Instead of default ODY Icon
         statusToIconProps[status].name === 'check-circle-filled' ? (
           <CheckCircle
             name="complete"

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { green } from '@mui/material/colors';
 import { Box, Typography } from '@okta/odyssey-react-mui';
 import { FunctionComponent, h } from 'preact';
 
@@ -25,6 +26,7 @@ const PasswordRequirementListItem: FunctionComponent<PasswordRequirementProps> =
     <Box
       component="li"
       sx={{ marginBlockEnd: (theme) => theme.spacing(2) }}
+      color={status === 'complete' ? green[600] : undefined}
     >
       <Box
         display="flex"

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { green } from '@mui/material/colors';
+import * as Tokens from '@okta/odyssey-design-tokens';
 import { Box, Typography } from '@okta/odyssey-react-mui';
 import { FunctionComponent, h } from 'preact';
 
@@ -26,7 +26,7 @@ const PasswordRequirementListItem: FunctionComponent<PasswordRequirementProps> =
     <Box
       component="li"
       sx={{ marginBlockEnd: (theme) => theme.spacing(2) }}
-      color={status === 'complete' ? green[600] : undefined}
+      color={status === 'complete' ? Tokens.ColorPaletteGreen600 : undefined}
     >
       <Box
         display="flex"

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -43,7 +43,8 @@ const WidgetMessageContainer: FunctionComponent<{ message?: WidgetMessage }> = (
               return (
                 <ListItem
                   key={wm.message}
-                  sx={{ display: 'list-item' }}
+                  // TODO: OKTA-577905 - (textAlign: 'start') Temporary fix until we can upgrade to the latest version of Odyssey
+                  sx={{ display: 'list-item', textAlign: 'start' }}
                   dense
                   disablePadding
                 >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -151,10 +151,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -195,10 +195,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -239,10 +239,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -283,10 +283,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -327,10 +327,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -371,10 +371,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -415,10 +415,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -613,10 +613,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-77"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -273,10 +273,10 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                           class="MuiBox-root emotion-38"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-39"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -184,10 +184,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -228,10 +228,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -272,10 +272,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -316,10 +316,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -360,10 +360,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -597,10 +597,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
                               fill="none"
                               focusable="false"
@@ -829,10 +829,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -873,10 +873,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -917,10 +917,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -961,10 +961,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -1005,10 +1005,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -1191,10 +1191,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -184,10 +184,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -228,10 +228,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -272,10 +272,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -316,10 +316,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -360,10 +360,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -597,10 +597,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
                               fill="none"
                               focusable="false"
@@ -818,10 +818,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -862,10 +862,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -906,10 +906,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -950,10 +950,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -994,10 +994,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -1180,10 +1180,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -199,10 +199,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -243,10 +243,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -287,10 +287,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -331,10 +331,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -375,10 +375,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -419,10 +419,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -463,10 +463,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -507,10 +507,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -749,10 +749,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
                               fill="none"
                               focusable="false"
@@ -997,10 +997,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-25"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -1041,10 +1041,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-25"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -1085,10 +1085,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-25"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -1129,10 +1129,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-25"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -1173,10 +1173,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-25"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -1217,10 +1217,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-25"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -1261,10 +1261,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-25"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -1305,10 +1305,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-25"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
                               fill="none"
                               focusable="false"
@@ -1491,10 +1491,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-25"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-26"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-87"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -151,10 +151,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -195,10 +195,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -239,10 +239,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -283,10 +283,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -327,10 +327,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -371,10 +371,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -415,10 +415,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -601,10 +601,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-77"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -151,10 +151,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -195,10 +195,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -239,10 +239,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -283,10 +283,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -327,10 +327,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -513,10 +513,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"
@@ -734,10 +734,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -778,10 +778,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -822,10 +822,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -866,10 +866,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -910,10 +910,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
                               fill="none"
                               focusable="false"
@@ -1096,10 +1096,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           class="MuiBox-root emotion-22"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-23"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
                               fill="none"
                               focusable="false"


### PR DESCRIPTION
## Description:

The purpose of this PR is to update the check icon for the Password Requirements component. 
Figma: https://www.figma.com/file/fRtV1jrbpFYP7AfH9Jzm8B/Okta-Sign-In-Widget-Design-Kit?node-id=507%3A4654&t=lTfaUYGnELzRzLXZ-0

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-547451](https://oktainc.atlassian.net/browse/OKTA-547451)

### Reviewers:

### Screenshot/Video:
<img width="613" alt="image" src="https://user-images.githubusercontent.com/97472729/223219364-4a1c55ee-afd7-40fd-b052-b27d85d3d8c6.png">

<img width="1460" alt="image" src="https://user-images.githubusercontent.com/97472729/223219639-00b52333-d458-4840-a660-c33c25f68a03.png">


### Downstream Monolith Build:



