### PR TITLE
OKTA-543070 : g3 : Identifier overflow fix in g3 SIW

### DIFF
--- a/src/v3/src/components/IdentifierContainer/IdentifierContainer.tsx
+++ b/src/v3/src/components/IdentifierContainer/IdentifierContainer.tsx
@@ -59,6 +59,7 @@ const IdentifierContainer: FunctionComponent = () => {
       justifyContent="center"
       alignItems="center"
       marginBlockEnd={4}
+      maxWidth={1}
       className={mainContainerClasses}
       sx={(theme) => ({
         '--PrimaryFill': theme.palette.primary.main,
@@ -87,6 +88,7 @@ const IdentifierContainer: FunctionComponent = () => {
           component="span"
           className={identifierSpanClasses}
           data-se="identifier"
+          title={identifier}
         >
           {identifier}
         </Box>

--- a/src/v3/src/components/IdentifierContainer/style.module.css
+++ b/src/v3/src/components/IdentifierContainer/style.module.css
@@ -1,6 +1,9 @@
 .identifierContainer {
   border-radius: 36px;
   background-color: var(--BackgroundFill);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .identifierSpan {

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester13@test.com"
               >
                 tester13@test.com
               </span>
@@ -1695,6 +1696,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester13@test.com"
               >
                 tester13@test.com
               </span>
@@ -3285,6 +3287,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester13@test.com"
               >
                 tester13@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -167,6 +167,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester19@test.com"
               >
                 tester19@test.com
               </span>
@@ -464,6 +465,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester19@test.com"
               >
                 tester19@test.com
               </span>
@@ -753,6 +755,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester19@test.com"
               >
                 tester19@test.com
               </span>
@@ -1040,6 +1043,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester19@test.com"
               >
                 tester19@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester47@test.com"
               >
                 tester47@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="tester13@test.com"
               >
                 tester13@test.com
               </span>
@@ -762,6 +763,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester13@test.com"
               >
                 tester13@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester3@test.com"
               >
                 tester3@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester35@test.com"
               >
                 tester35@test.com
               </span>
@@ -504,6 +505,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester35@test.com"
               >
                 tester35@test.com
               </span>
@@ -1024,6 +1026,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester35@test.com"
               >
                 tester35@test.com
               </span>
@@ -1545,6 +1548,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester35@test.com"
               >
                 tester35@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester14@test.com"
               >
                 tester14@test.com
               </span>
@@ -504,6 +505,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester14@test.com"
               >
                 tester14@test.com
               </span>
@@ -868,6 +870,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester14@test.com"
               >
                 tester14@test.com
               </span>
@@ -1343,6 +1346,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester14@test.com"
               >
                 tester14@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -772,6 +773,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-expired-password should present field level error message
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester8@test.com"
               >
                 tester8@test.com
               </span>
@@ -761,6 +762,7 @@ exports[`authenticator-expired-password should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester8@test.com"
               >
                 tester8@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -925,6 +926,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta.com"
               >
                 tester@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-reset-password should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester8@test.com"
               >
                 tester8@test.com
               </span>
@@ -677,6 +678,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester8@test.com"
               >
                 tester8@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="firstname.lastname@example.com"
               >
                 firstname.lastname@example.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="firstname.lastname@example.com"
               >
                 firstname.lastname@example.com
               </span>
@@ -278,6 +279,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="firstname.lastname@example.com"
               >
                 firstname.lastname@example.com
               </span>
@@ -505,6 +507,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="firstname.lastname@example.com"
               >
                 firstname.lastname@example.com
               </span>
@@ -720,6 +723,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -991,6 +995,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -1399,6 +1404,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="firstname.lastname@example.com"
               >
                 firstname.lastname@example.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -167,6 +167,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>
@@ -394,6 +395,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>
@@ -285,6 +286,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester.test@okta.com"
               >
                 tester.test@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>
@@ -450,6 +451,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>
@@ -778,6 +780,7 @@ exports[`authenticator-verification-webauthn should render form with required us
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`byol loading custom language should load custom language with "language
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -1695,6 +1696,7 @@ exports[`byol loading custom language should load custom language with assets.ba
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -3285,6 +3287,7 @@ exports[`byol loading default language should not load custom language when the 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -4875,6 +4878,7 @@ exports[`byol loading default language should not load custom language with "lan
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`email-challenge-consent should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -327,6 +328,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -293,6 +294,7 @@ exports[`enroll-profile-update should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>
@@ -298,6 +299,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>
@@ -588,6 +590,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>
@@ -813,6 +816,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>
@@ -1051,6 +1055,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>
@@ -1325,6 +1330,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>
@@ -1532,6 +1538,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>
@@ -1739,6 +1746,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>
@@ -2029,6 +2037,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>
@@ -3512,6 +3521,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester3@test.com"
               >
                 tester3@test.com
               </span>
@@ -3750,6 +3760,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>
@@ -1574,6 +1575,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester2@test.com"
               >
                 tester2@test.com
               </span>

--- a/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`request-activation-email renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`terminal-return-email renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="test@okta.com"
               >
                 test@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="test@okta.com"
               >
                 test@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="test@okta.com"
               >
                 test@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="test@okta.com"
               >
                 test@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="test@okta.com"
               >
                 test@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -95,6 +95,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="test@okta.com"
               >
                 test@okta.com
               </span>

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`unlock-account-success renders form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-8"
                 data-se="identifier"
+                title="tester@okta1.com"
               >
                 tester@okta1.com
               </span>

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`webauthn-enroll should render form 1`] = `
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester5@test.com"
               >
                 tester5@test.com
               </span>
@@ -321,6 +322,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester5@test.com"
               >
                 tester5@test.com
               </span>
@@ -534,6 +536,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester5@test.com"
               >
                 tester5@test.com
               </span>


### PR DESCRIPTION
## Description:
The purpose of this PR is to display long identifiers (which would cause text overflow outside of the SIW container) truncated with an ellipsis and show the built-in tooltip on hover of the full identifier value.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-543070](https://oktainc.atlassian.net/browse/OKTA-543070)

### Reviewers:

### Screenshot/Video:
<img width="598" alt="Screen Shot 2023-03-06 at 2 46 27 PM" src="https://user-images.githubusercontent.com/97472729/223217492-783162de-23c4-4156-9a3c-e6d09c6a15c0.png">

<img width="575" alt="Screen Shot 2023-03-06 at 2 46 42 PM" src="https://user-images.githubusercontent.com/97472729/223217549-570f6772-c5c3-41b6-9020-32022d11e828.png">

<img width="1664" alt="Screen Shot 2023-03-06 at 2 57 14 PM" src="https://user-images.githubusercontent.com/97472729/223217597-d2aada10-2cf1-44a6-aa38-9ecff1765388.png">

<img width="581" alt="Screen Shot 2023-03-06 at 2 47 20 PM" src="https://user-images.githubusercontent.com/97472729/223217617-5db8c81d-2907-486c-96e7-5450ae165da3.png">


### Downstream Monolith Build:



