### PR TITLE
OKTA-547454 : g3 : Removing Loading spinner from flows

### DIFF
--- a/src/v3/src/components/Button/Button.tsx
+++ b/src/v3/src/components/Button/Button.tsx
@@ -47,6 +47,7 @@ const Button: UISchemaElementComponent<{
       step,
       stepToRender,
       classes,
+      disabled,
       onClick,
     },
   } = uischema;
@@ -71,7 +72,7 @@ const Button: UISchemaElementComponent<{
       variant={variant ?? 'primary'}
       fullWidth={wide ?? true}
       ref={focusRef}
-      disabled={loading}
+      disabled={loading || disabled}
       className={classes}
       // Fixes text overflow
       sx={{ display: 'flex', whiteSpace: 'normal' }}

--- a/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
+++ b/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.test.tsx
@@ -76,15 +76,14 @@ describe('WebAuthNControlSubmitControl Tests', () => {
     });
   });
 
-  it('should render loading spinner when there is a pending request', async () => {
+  it('should render disabled button when there is a pending request', async () => {
     mockLoading.mockReturnValue(true);
     const { queryByTestId } = render(<WebAuthNSubmitButton {...props} />);
 
-    const button = queryByTestId('button');
-    const spinner = queryByTestId('okta-spinner');
+    const button = queryByTestId('button') as HTMLButtonElement;
 
-    expect(button).toBeNull();
-    expect(spinner).toBeInTheDocument();
+    expect(button).toBeInTheDocument();
+    expect(button.getAttribute('disabled')).not.toBeUndefined();
   });
 
   it('should render webauthn verify button and handle click when known error occurs with retry label', async () => {

--- a/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.tsx
+++ b/src/v3/src/components/WebAuthNSubmitButton/WebAuthNSubmitButton.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box, Button as OdyButton, CircularProgress } from '@okta/odyssey-react-mui';
+import { Box, Button } from '@okta/odyssey-react-mui';
 import { IdxActionParams } from '@okta/okta-auth-js';
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
@@ -88,29 +88,16 @@ const WebAuthNSubmit: UISchemaElementComponent<{
       display={showLoading ? 'flex' : undefined}
       justifyContent={showLoading ? 'center' : undefined}
     >
-      {
-        showLoading
-          ? (
-            <CircularProgress
-              id="okta-spinner"
-              data-se="okta-spinner"
-              // TODO: OKTA-518793 - replace english string with key once created
-              aria-label="Loading..."
-              aria-valuetext="Loading..."
-            />
-          )
-          : (
-            <OdyButton
-              data-se="button"
-              onClick={handleClick}
-              variant="primary"
-              aria-describedby={ariaDescribedBy}
-              fullWidth
-            >
-              { label }
-            </OdyButton>
-          )
-      }
+      <Button
+        disabled={showLoading}
+        data-se="button"
+        onClick={handleClick}
+        variant="primary"
+        aria-describedby={ariaDescribedBy}
+        fullWidth
+      >
+        {label}
+      </Button>
     </Box>
   );
 };

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -167,6 +167,7 @@ const TransformerMap: {
       buttonConfig: {
         showDefaultSubmit: false,
         showDefaultCancel: false,
+        showVerifyWithOtherLink: false,
       },
     },
   },

--- a/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyDeviceChallengePoll.test.ts.snap
+++ b/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyDeviceChallengePoll.test.ts.snap
@@ -41,6 +41,15 @@ Object {
       Object {
         "contentType": "footer",
         "options": Object {
+          "label": "oie.verification.switch.authenticator",
+          "onClick": [Function],
+          "step": "select-authenticator-authenticate",
+        },
+        "type": "Link",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
           "isActionStep": true,
           "label": "goback",
           "step": "cancel",
@@ -105,6 +114,15 @@ Object {
       Object {
         "contentType": "footer",
         "options": Object {
+          "label": "oie.verification.switch.authenticator",
+          "onClick": [Function],
+          "step": "select-authenticator-authenticate",
+        },
+        "type": "Link",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
           "isActionStep": true,
           "label": "goback",
           "step": "cancel",
@@ -154,6 +172,15 @@ Object {
           "step": "challenge-poll",
         },
         "type": "OpenOktaVerifyFPButton",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "label": "oie.verification.switch.authenticator",
+          "onClick": [Function],
+          "step": "select-authenticator-authenticate",
+        },
+        "type": "Link",
       },
       Object {
         "contentType": "footer",
@@ -208,6 +235,16 @@ Object {
               Object {
                 "contentType": "footer",
                 "options": Object {
+                  "label": "oie.verification.switch.authenticator",
+                  "onClick": [Function],
+                  "step": "select-authenticator-authenticate",
+                },
+                "type": "Link",
+                "viewIndex": 0,
+              },
+              Object {
+                "contentType": "footer",
+                "options": Object {
                   "actionParams": Object {
                     "reason": "USER_CANCELED",
                     "statusCode": null,
@@ -239,6 +276,16 @@ Object {
                   "step": "device-challenge-poll",
                 },
                 "type": "OpenOktaVerifyFPButton",
+                "viewIndex": 1,
+              },
+              Object {
+                "contentType": "footer",
+                "options": Object {
+                  "label": "oie.verification.switch.authenticator",
+                  "onClick": [Function],
+                  "step": "select-authenticator-authenticate",
+                },
+                "type": "Link",
                 "viewIndex": 1,
               },
               Object {
@@ -315,6 +362,15 @@ Object {
       Object {
         "contentType": "footer",
         "options": Object {
+          "label": "oie.verification.switch.authenticator",
+          "onClick": [Function],
+          "step": "select-authenticator-authenticate",
+        },
+        "type": "Link",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
           "isActionStep": true,
           "label": "goback",
           "step": "cancel",
@@ -364,6 +420,15 @@ Object {
           "step": "device-challenge-poll",
         },
         "type": "OpenOktaVerifyFPButton",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "label": "oie.verification.switch.authenticator",
+          "onClick": [Function],
+          "step": "select-authenticator-authenticate",
+        },
+        "type": "Link",
       },
       Object {
         "contentType": "footer",

--- a/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyFPLoopbackPoll.test.ts.snap
+++ b/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyFPLoopbackPoll.test.ts.snap
@@ -43,6 +43,15 @@ Object {
       Object {
         "contentType": "footer",
         "options": Object {
+          "label": "oie.verification.switch.authenticator",
+          "onClick": [Function],
+          "step": "select-authenticator-authenticate",
+        },
+        "type": "Link",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
           "actionParams": Object {
             "reason": "USER_CANCELED",
             "statusCode": null,
@@ -98,6 +107,15 @@ Object {
           "step": "device-challenge-poll",
         },
         "type": "LoopbackProbe",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "label": "oie.verification.switch.authenticator",
+          "onClick": [Function],
+          "step": "select-authenticator-authenticate",
+        },
+        "type": "Link",
       },
       Object {
         "contentType": "footer",

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.test.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.test.ts
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   DescriptionElement,
@@ -22,6 +23,7 @@ import {
   WidgetProps,
 } from 'src/types';
 
+import * as utils from '../../../util/idxUtils';
 import { transformOktaVerifyDeviceChallengePoll } from './transformOktaVerifyDeviceChallengePoll';
 
 describe('Transform Okta Verify Device Challenge Poll Tests', () => {
@@ -43,6 +45,8 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
           },
         },
       };
+      transaction.availableSteps = [{ name: IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE }];
+      jest.spyOn(utils, 'hasMinAuthenticatorOptions').mockReturnValue(true);
     });
 
     it('should transform elements when challengeMethod is CUSTOM_URI', () => {
@@ -53,7 +57,7 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
       });
 
       expect(updatedFormBag).toMatchSnapshot();
-      expect(updatedFormBag.uischema.elements.length).toBe(6);
+      expect(updatedFormBag.uischema.elements.length).toBe(7);
       expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
         .toBe('customUri.title');
       expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
@@ -66,9 +70,11 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
         .toBe('customUri.required.content.download.linkText');
       expect((updatedFormBag.uischema.elements[4] as LinkElement).options.href)
         .toBe('https://apps.apple.com/us/app/okta-verify/id490179405');
-      expect((updatedFormBag.uischema.elements[5] as LinkElement).type)
+      expect((updatedFormBag.uischema.elements[5] as LinkElement).options.label)
+        .toBe('oie.verification.switch.authenticator');
+      expect((updatedFormBag.uischema.elements[6] as LinkElement).type)
         .toBe('Link');
-      expect((updatedFormBag.uischema.elements[5] as LinkElement).options.step)
+      expect((updatedFormBag.uischema.elements[6] as LinkElement).options.step)
         .toBe('cancel');
     });
 
@@ -91,22 +97,26 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
       const stepperLayout = updatedFormBag.uischema.elements[1];
       const [layoutOne, layoutTwo] = (stepperLayout as StepperLayout).elements;
 
-      expect(layoutOne.elements.length).toBe(3);
+      expect(layoutOne.elements.length).toBe(4);
       expect((layoutOne.elements[0] as StepperNavigatorElement).type)
         .toBe('StepperNavigator');
       expect((layoutOne.elements[1] as SpinnerElement).type)
         .toBe('Spinner');
-      expect((layoutOne.elements[2] as LinkElement).options.step)
+      expect((layoutOne.elements[2] as LinkElement).options.label)
+        .toBe('oie.verification.switch.authenticator');
+      expect((layoutOne.elements[3] as LinkElement).options.step)
         .toBe('authenticatorChallenge-cancel');
 
-      expect(layoutTwo.elements.length).toBe(3);
+      expect(layoutTwo.elements.length).toBe(4);
       expect((layoutTwo.elements[0] as DescriptionElement).options.content)
         .toBe('appLink.content');
       expect((layoutTwo.elements[1] as OpenOktaVerifyFPButtonElement).options.href)
         .toBe('okta-verify.html');
-      expect((layoutTwo.elements[2] as LinkElement).type)
+      expect((layoutTwo.elements[2] as LinkElement).options.label)
+        .toBe('oie.verification.switch.authenticator');
+      expect((layoutTwo.elements[3] as LinkElement).type)
         .toBe('Link');
-      expect((layoutTwo.elements[2] as LinkElement).options.step)
+      expect((layoutTwo.elements[3] as LinkElement).options.step)
         .toBe('cancel');
     });
 
@@ -120,7 +130,7 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
       });
 
       expect(updatedFormBag).toMatchSnapshot();
-      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect(updatedFormBag.uischema.elements.length).toBe(6);
       expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
         .toBe('universalLink.title');
       expect((updatedFormBag.uischema.elements[1] as SpinnerElement).type)
@@ -129,9 +139,11 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
         .toBe('universalLink.content');
       expect((updatedFormBag.uischema.elements[3] as OpenOktaVerifyFPButtonElement).options.href)
         .toBe('okta-verify.html');
-      expect((updatedFormBag.uischema.elements[4] as LinkElement).type)
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)
+        .toBe('oie.verification.switch.authenticator');
+      expect((updatedFormBag.uischema.elements[5] as LinkElement).type)
         .toBe('Link');
-      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.step)
+      expect((updatedFormBag.uischema.elements[5] as LinkElement).options.step)
         .toBe('cancel');
     });
   });
@@ -156,6 +168,8 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
           },
         },
       };
+      transaction.availableSteps = [{ name: IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE }];
+      jest.spyOn(utils, 'hasMinAuthenticatorOptions').mockReturnValue(true);
     });
 
     it('should transform elements when challengeMethod is CUSTOM_URI', () => {
@@ -166,7 +180,7 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
       });
 
       expect(updatedFormBag).toMatchSnapshot();
-      expect(updatedFormBag.uischema.elements.length).toBe(6);
+      expect(updatedFormBag.uischema.elements.length).toBe(7);
       expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
         .toBe('customUri.title');
       expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
@@ -179,9 +193,11 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
         .toBe('customUri.required.content.download.linkText');
       expect((updatedFormBag.uischema.elements[4] as LinkElement).options.href)
         .toBe('https://apps.apple.com/us/app/okta-verify/id490179405');
-      expect((updatedFormBag.uischema.elements[5] as LinkElement).type)
+      expect((updatedFormBag.uischema.elements[5] as LinkElement).options.label)
+        .toBe('oie.verification.switch.authenticator');
+      expect((updatedFormBag.uischema.elements[6] as LinkElement).type)
         .toBe('Link');
-      expect((updatedFormBag.uischema.elements[5] as LinkElement).options.step)
+      expect((updatedFormBag.uischema.elements[6] as LinkElement).options.step)
         .toBe('cancel');
     });
 
@@ -195,7 +211,7 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
       });
 
       expect(updatedFormBag).toMatchSnapshot();
-      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect(updatedFormBag.uischema.elements.length).toBe(6);
       expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
         .toBe('appLink.title');
       expect((updatedFormBag.uischema.elements[1] as SpinnerElement).type)
@@ -204,9 +220,11 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
         .toBe('appLink.content');
       expect((updatedFormBag.uischema.elements[3] as OpenOktaVerifyFPButtonElement).options.href)
         .toBe('okta-verify.html');
-      expect((updatedFormBag.uischema.elements[4] as LinkElement).type)
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)
+        .toBe('oie.verification.switch.authenticator');
+      expect((updatedFormBag.uischema.elements[5] as LinkElement).type)
         .toBe('Link');
-      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.step)
+      expect((updatedFormBag.uischema.elements[5] as LinkElement).options.step)
         .toBe('cancel');
     });
 
@@ -220,7 +238,7 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
       });
 
       expect(updatedFormBag).toMatchSnapshot();
-      expect(updatedFormBag.uischema.elements.length).toBe(5);
+      expect(updatedFormBag.uischema.elements.length).toBe(6);
       expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
         .toBe('universalLink.title');
       expect((updatedFormBag.uischema.elements[1] as SpinnerElement).type)
@@ -229,9 +247,11 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
         .toBe('universalLink.content');
       expect((updatedFormBag.uischema.elements[3] as OpenOktaVerifyFPButtonElement).options.href)
         .toBe('okta-verify.html');
-      expect((updatedFormBag.uischema.elements[4] as LinkElement).type)
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)
+        .toBe('oie.verification.switch.authenticator');
+      expect((updatedFormBag.uischema.elements[5] as LinkElement).type)
         .toBe('Link');
-      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.step)
+      expect((updatedFormBag.uischema.elements[5] as LinkElement).options.step)
         .toBe('cancel');
     });
   });

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
@@ -114,12 +114,12 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
     contentType: 'footer',
     options: {
       label: loc('oie.verification.switch.authenticator', 'login'),
-      step: selectVerifyStep!.name,
+      step: selectVerifyStep?.name || '',
       onClick: (widgetContext?: IWidgetContext): unknown => {
-        if (typeof widgetContext === 'undefined') {
+        if (typeof widgetContext === 'undefined' || typeof selectVerifyStep === 'undefined') {
           return;
         }
-        updateTransactionWithNextStep(transaction, selectVerifyStep!, widgetContext);
+        updateTransactionWithNextStep(transaction, selectVerifyStep, widgetContext);
       },
     },
   };

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
@@ -17,6 +17,7 @@ import {
   DescriptionElement,
   IdxStepTransformer,
   IStepperContext,
+  IWidgetContext,
   LinkElement,
   OpenOktaVerifyFPButtonElement,
   SpinnerElement,
@@ -26,7 +27,7 @@ import {
   UISchemaLayout,
   UISchemaLayoutType,
 } from '../../../types';
-import { loc } from '../../../util';
+import { hasMinAuthenticatorOptions, loc, updateTransactionWithNextStep } from '../../../util';
 
 const getTitleText = (challengeMethod: string) => {
   if (challengeMethod === CHALLENGE_METHOD.APP_LINK) {
@@ -100,6 +101,29 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
     },
   };
 
+  // Since this transformer is shared, we have to add applicable buttons manually
+  const hasMinAuthOptions = hasMinAuthenticatorOptions(
+    transaction,
+    IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE,
+    1, // Min # of auth options for link to display
+  );
+  const selectVerifyStep = transaction.availableSteps
+    ?.find(({ name }) => name === IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE);
+  const selectLink: LinkElement = {
+    type: 'Link',
+    contentType: 'footer',
+    options: {
+      label: loc('oie.verification.switch.authenticator', 'login'),
+      step: selectVerifyStep!.name,
+      onClick: (widgetContext?: IWidgetContext): unknown => {
+        if (typeof widgetContext === 'undefined') {
+          return;
+        }
+        updateTransactionWithNextStep(transaction, selectVerifyStep!, widgetContext);
+      },
+    },
+  };
+
   uischema.elements.unshift(titleElement);
 
   // if the current step is device-challenge-poll and the challenge method is APP_LINK,
@@ -124,6 +148,7 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
           elements: [
             stepperNavigatorElement,
             spinnerElement,
+            ...(selectVerifyStep && hasMinAuthOptions ? [selectLink] : []),
             // cancel polling link is displayed during delay
             {
               type: 'Link',
@@ -145,6 +170,7 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
           elements: [
             descriptionElement,
             openOktaVerifyButton,
+            ...(selectVerifyStep && hasMinAuthOptions ? [selectLink] : []),
             // update footer link to standard cancel link
             cancelLink,
           ].map((ele: UISchemaElement) => ({ ...ele, viewIndex: 1 })),
@@ -177,6 +203,9 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
     } as LinkElement);
   }
 
+  if (selectVerifyStep && hasMinAuthOptions) {
+    uischema.elements.push(selectLink);
+  }
   // standard cancel link is used when there is no delay
   uischema.elements.push(cancelLink);
 

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.test.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.test.ts
@@ -10,11 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 
 import {
   LinkElement, LoopbackProbeElement, SpinnerElement, TitleElement, WidgetProps,
 } from '../../../types';
+import * as utils from '../../../util/idxUtils';
 import { transformOktaVerifyFPLoopbackPoll } from './transformOktaVerifyFPLoopbackPoll';
 
 describe('Transform Okta Verify FP Loopback Poll', () => {
@@ -36,6 +38,8 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
           },
         },
       };
+      transaction.availableSteps = [{ name: IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE }];
+      jest.spyOn(utils, 'hasMinAuthenticatorOptions').mockReturnValue(true);
     });
 
     it('should create Loopback Poll elements for display when step is device-challenge-poll', () => {
@@ -46,7 +50,7 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
       });
 
       expect(updatedFormBag).toMatchSnapshot();
-      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect(updatedFormBag.uischema.elements.length).toBe(5);
       expect((updatedFormBag.uischema.elements[0] as TitleElement).type)
         .toBe('Title');
       expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
@@ -65,9 +69,11 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
           cancelStep: 'authenticatorChallenge-cancel',
           step: 'device-challenge-poll',
         });
-      expect((updatedFormBag.uischema.elements[3] as LinkElement).type)
+      expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
+        .toBe('oie.verification.switch.authenticator');
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).type)
         .toBe('Link');
-      expect((updatedFormBag.uischema.elements[3] as LinkElement).options.step)
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.step)
         .toBe('authenticatorChallenge-cancel');
     });
   });
@@ -92,6 +98,8 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
           },
         },
       };
+      transaction.availableSteps = [{ name: IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE }];
+      jest.spyOn(utils, 'hasMinAuthenticatorOptions').mockReturnValue(true);
     });
 
     it('should create Loopback Poll elements for display', () => {
@@ -102,7 +110,7 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
       });
 
       expect(updatedFormBag).toMatchSnapshot();
-      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect(updatedFormBag.uischema.elements.length).toBe(5);
       expect((updatedFormBag.uischema.elements[0] as TitleElement).type)
         .toBe('Title');
       expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
@@ -121,9 +129,11 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
           cancelStep: 'currentAuthenticator-cancel',
           step: 'challenge-poll',
         });
-      expect((updatedFormBag.uischema.elements[3] as LinkElement).type)
+      expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
+        .toBe('oie.verification.switch.authenticator');
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).type)
         .toBe('Link');
-      expect((updatedFormBag.uischema.elements[3] as LinkElement).options.step)
+      expect((updatedFormBag.uischema.elements[4] as LinkElement).options.step)
         .toBe('currentAuthenticator-cancel');
     });
   });

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyChallengePoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyChallengePoll.test.ts.snap
@@ -34,17 +34,20 @@ Object {
         "noTranslate": true,
         "options": Object {
           "SVGIcon": "MockSVGIcon",
+          "alignment": "center",
           "id": "code",
           "textContent": "42",
         },
         "type": "ImageWithText",
       },
       Object {
+        "contentType": "footer",
         "options": Object {
-          "label": "Loading...",
-          "valueText": "Loading...",
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
         },
-        "type": "Spinner",
+        "type": "Link",
       },
     ],
     "type": "VerticalLayout",
@@ -69,6 +72,7 @@ Object {
   "uischema": Object {
     "elements": Array [
       Object {
+        "noMargin": true,
         "options": Object {
           "actionParams": Object {
             "resend": true,
@@ -99,17 +103,98 @@ Object {
         "noTranslate": true,
         "options": Object {
           "SVGIcon": "MockSVGIcon",
+          "alignment": "center",
           "id": "code",
           "textContent": "42",
         },
         "type": "ImageWithText",
       },
       Object {
+        "contentType": "footer",
         "options": Object {
-          "label": "Loading...",
-          "valueText": "Loading...",
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
         },
-        "type": "Spinner",
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Transform Okta Verify Challenge Poll Tests should transform elements when method type is push and has enhanced security with resend avaialable and include verify with other link when additional options exist in remediation 1`] = `
+Object {
+  "data": Object {
+    "autoChallenge": undefined,
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "actionParams": Object {
+            "resend": true,
+          },
+          "content": "oie.numberchallenge.warning",
+          "contentClassname": "resend-number-challenge",
+          "contentHasHtml": true,
+          "isActionStep": true,
+          "step": "resend",
+        },
+        "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.numberchallenge.instruction",
+          "dataSe": "numberchallenge-instr-value",
+        },
+        "type": "Description",
+      },
+      Object {
+        "noTranslate": true,
+        "options": Object {
+          "SVGIcon": "MockSVGIcon",
+          "alignment": "center",
+          "id": "code",
+          "textContent": "42",
+        },
+        "type": "ImageWithText",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "label": "oie.verification.switch.authenticator",
+          "onClick": [Function],
+          "step": "select-authenticator-authenticate",
+        },
+        "type": "Link",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
+        },
+        "type": "Link",
       },
     ],
     "type": "VerticalLayout",
@@ -140,24 +225,87 @@ Object {
         "type": "Title",
       },
       Object {
+        "noMargin": true,
         "options": Object {
           "content": "oktaverify.warning",
         },
         "type": "Reminder",
       },
       Object {
-        "contentType": "subtitle",
+        "label": "oie.okta_verify.push.sent",
         "options": Object {
-          "content": "oie.okta_verify.push.sent",
+          "disabled": true,
         },
-        "type": "Description",
+        "type": "Button",
       },
       Object {
+        "contentType": "footer",
         "options": Object {
-          "label": "Loading...",
-          "valueText": "Loading...",
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
         },
-        "type": "Spinner",
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Transform Okta Verify Challenge Poll Tests should transform elements when method type is standard push only and include verify with other link when additional options exist in remediation 1`] = `
+Object {
+  "data": Object {
+    "autoChallenge": undefined,
+  },
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "content": "oktaverify.warning",
+        },
+        "type": "Reminder",
+      },
+      Object {
+        "label": "oie.okta_verify.push.sent",
+        "options": Object {
+          "disabled": true,
+        },
+        "type": "Button",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "label": "oie.verification.switch.authenticator",
+          "onClick": [Function],
+          "step": "select-authenticator-authenticate",
+        },
+        "type": "Link",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
+        },
+        "type": "Link",
       },
     ],
     "type": "VerticalLayout",

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
@@ -89,6 +89,8 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
       .toBe('oktaverify.warning');
     expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
       .toBe('oie.okta_verify.push.sent');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.disabled)
+      .toBe(true);
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('goback');
   });

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -236,6 +236,7 @@ export interface ButtonElement extends UISchemaElement {
     stepToRender?: string;
     ariaLabel?: string;
     classes?: string;
+    disabled?: boolean;
     Icon?: FunctionComponent;
     onClick?: (widgetContext: IWidgetContext) => unknown;
   };

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -106,10 +106,10 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
               class="MuiBox-root emotion-12"
             >
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-9"
               >
                 <div
-                  class="MuiBox-root emotion-13"
+                  class="MuiBox-root emotion-14"
                 >
                   <div
                     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxWarning MuiAlert-infobox emotion-15"
@@ -154,7 +154,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <div
                   class="MuiBox-root emotion-22"
@@ -169,7 +169,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <fieldset
                   aria-describedby="challenge-poll_Title_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_2 challenge-poll_Description_On_your_mobile_device,_open_the_Okta_Verify_prompt,_then_tap_<span_class=strong>52</span>_in_Okta_Verify_to_continue_okta_verify_aut2h3fft4y9pDPCS1d7_4"
@@ -210,7 +210,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                 </fieldset>
               </div>
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <div
                   class="MuiBox-root emotion-22"
@@ -231,7 +231,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <div
                   class="MuiBox-root emotion-35"
@@ -256,43 +256,25 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-13"
-              >
-                <div
-                  class="MuiBox-root emotion-40"
-                >
-                  <span
-                    aria-label="Loading..."
-                    aria-valuetext="Loading..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-41"
-                    role="progressbar"
-                    style="width: 1.14285714rem; height: 1.14285714rem;"
-                  >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-42"
-                      viewBox="22 22 44 44"
-                    >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-43"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="18"
-                        stroke-width="8"
-                      />
-                    </svg>
-                  </span>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-45"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
                   data-se="switchAuthenticator"
                   href="javascript:void(0)"
                 >
                   Verify with something else
+                </a>
+              </div>
+              <div
+                class="MuiBox-root emotion-14"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
+                  data-se="cancel"
+                  href="javascript:void(0)"
+                >
+                  Back to sign in
                 </a>
               </div>
             </div>
@@ -410,10 +392,10 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
               class="MuiBox-root emotion-12"
             >
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-9"
               />
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <div
                   class="MuiBox-root emotion-15"
@@ -428,7 +410,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <fieldset
                   aria-describedby="challenge-poll_Title_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_2 challenge-poll_Description_On_your_mobile_device,_open_the_Okta_Verify_prompt,_then_tap_<span_class=strong>52</span>_in_Okta_Verify_to_continue_okta_verify_aut2h3fft4y9pDPCS1d7_4"
@@ -469,7 +451,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                 </fieldset>
               </div>
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <div
                   class="MuiBox-root emotion-15"
@@ -490,7 +472,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <div
                   class="MuiBox-root emotion-28"
@@ -515,43 +497,25 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-13"
-              >
-                <div
-                  class="MuiBox-root emotion-33"
-                >
-                  <span
-                    aria-label="Loading..."
-                    aria-valuetext="Loading..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-34"
-                    role="progressbar"
-                    style="width: 1.14285714rem; height: 1.14285714rem;"
-                  >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-35"
-                      viewBox="22 22 44 44"
-                    >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-36"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="18"
-                        stroke-width="8"
-                      />
-                    </svg>
-                  </span>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-14"
               >
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                   data-se="switchAuthenticator"
                   href="javascript:void(0)"
                 >
                   Verify with something else
+                </a>
+              </div>
+              <div
+                class="MuiBox-root emotion-14"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                  data-se="cancel"
+                  href="javascript:void(0)"
+                >
+                  Back to sign in
                 </a>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -121,13 +121,13 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                 </div>
               </div>
               <div
-                class="MuiBox-root emotion-13"
+                class="MuiBox-root emotion-9"
               />
               <div
                 class="MuiBox-root emotion-13"
               >
                 <fieldset
-                  aria-describedby="challenge-poll_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1 challenge-poll_Description_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_4"
+                  aria-describedby="challenge-poll_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                   class="MuiFormControl-root MuiFormControl-marginNormal emotion-18"
                 >
                   <label
@@ -167,56 +167,36 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
               <div
                 class="MuiBox-root emotion-13"
               >
-                <div
-                  class="MuiBox-root emotion-14"
+                <button
+                  aria-describedby="challenge-poll_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-25"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-26"
-                    data-se="o-form-explain"
-                    id="challenge-poll_Description_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_4"
-                  >
-                    Push notification sent
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-13"
-              >
-                <div
-                  class="MuiBox-root emotion-28"
-                >
-                  <span
-                    aria-label="Loading..."
-                    aria-valuetext="Loading..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-29"
-                    role="progressbar"
-                    style="width: 1.14285714rem; height: 1.14285714rem;"
-                  >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-30"
-                      viewBox="22 22 44 44"
-                    >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-31"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="18"
-                        stroke-width="8"
-                      />
-                    </svg>
-                  </span>
-                </div>
+                  Push notification sent
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                   data-se="switchAuthenticator"
                   href="javascript:void(0)"
                 >
                   Verify with something else
+                </a>
+              </div>
+              <div
+                class="MuiBox-root emotion-13"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                  data-se="cancel"
+                  href="javascript:void(0)"
+                >
+                  Back to sign in
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## Description:

The purpose of this PR is to remove the Loading Spinner from flows that do not depict the Widget is loading something and that the user should wait. 

See Figma: https://www.figma.com/file/fRtV1jrbpFYP7AfH9Jzm8B/Okta-Sign-In-Widget-Design-Kit?node-id=71%3A3890&t=IhcOLCtuVXIvcPSr-1

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-547454](https://oktainc.atlassian.net/browse/OKTA-547454)

### Reviewers:

### Screenshot/Video:
<img width="604" alt="Screen Shot 2023-03-07 at 11 53 30 AM" src="https://user-images.githubusercontent.com/97472729/223493158-596763b8-77ea-46fb-8f45-318a6ac0acd0.png">

<img width="576" alt="Screen Shot 2023-03-07 at 11 54 15 AM" src="https://user-images.githubusercontent.com/97472729/223493189-7819602c-541e-4b8c-b63b-05d1566dc14d.png">

<img width="1008" alt="Screen Shot 2023-03-07 at 11 54 43 AM" src="https://user-images.githubusercontent.com/97472729/223493220-a51890fb-a66f-4a1f-aae3-146535cfb0c3.png">


### Downstream Monolith Build:



