### PR TITLE
Okta 511637 fix whitespace trimming in password field

### DIFF
--- a/packages/@okta/courage-dist/esm/src/courage/util/StringUtil.js
+++ b/packages/@okta/courage-dist/esm/src/courage/util/StringUtil.js
@@ -31,6 +31,14 @@ const parseLocale = locale => {
 /* eslint max-len: 0*/
 
 /**
+ * Returns the user's locale as defined by window.okta.locale
+ */
+
+
+function getRawLocale() {
+  return window && window.okta && window.okta.locale || 'en';
+}
+/**
  * Returns the language bundle based on the current locale.
  * - If a locale is not provided, default to English ('en')
  * - Legacy Support: If the named language bundle does not exist, fall back to the default named bundle.
@@ -44,7 +52,7 @@ function getBundle(bundleName) {
     return Bundles[oktaUnderscore.keys(Bundles)[0]];
   }
 
-  const locale = parseLocale(window && window.okta && window.okta.locale) || 'en';
+  const locale = parseLocale(getRawLocale());
   return Bundles[`${bundleName}_${locale}`] || Bundles[bundleName];
 }
 /**
@@ -95,6 +103,22 @@ function emitL10nError(key, bundleName, reason) {
 const StringUtil =
 /** @lends module:Okta.internal.util.StringUtil */
 {
+  /** @static */
+  getRawLocale: function () {
+    return getRawLocale();
+  },
+
+  /** @static */
+  getParsedLocale: function () {
+    return parseLocale(getRawLocale());
+  },
+
+  /** @static */
+  isLocaleBundleExist: function (bundleName, locale) {
+    const parsedLocale = parseLocale(locale);
+    return !!Bundles[`${bundleName}_${parsedLocale}`];
+  },
+
   /** @static */
   sprintf: function () {
     const args = Array.prototype.slice.apply(arguments);

--- a/packages/@okta/courage-dist/esm/src/courage/views/forms/inputs/PasswordBox.js
+++ b/packages/@okta/courage-dist/esm/src/courage/views/forms/inputs/PasswordBox.js
@@ -28,6 +28,14 @@ var PasswordBox = TextBox.extend({
 
     TextBox.prototype.postRender.apply(this, arguments);
   },
+
+  /**
+   * @Override
+   * Overrides the default val method in order to avoid whitespace trimming
+   */
+  val: function () {
+    return this.$('input[type="' + this.options.type + '"]').val();
+  },
   __showPasswordToggle: function () {
     return this.options.params && this.options.params.showPasswordToggle;
   },

--- a/packages/@okta/courage-dist/types/courage/util/StringUtil.d.ts
+++ b/packages/@okta/courage-dist/types/courage/util/StringUtil.d.ts
@@ -1,5 +1,11 @@
 declare const StringUtil: {
     /** @static */
+    getRawLocale: () => string;
+    /** @static */
+    getParsedLocale: () => any;
+    /** @static */
+    isLocaleBundleExist(bundleName: any, locale: string): boolean;
+    /** @static */
     sprintf: () => any;
     /**
      * Converts a URI encoded query string into a hash map

--- a/packages/@okta/courage-dist/types/courage/util/handlebars-wrapper.d.ts
+++ b/packages/@okta/courage-dist/types/courage/util/handlebars-wrapper.d.ts
@@ -1,7 +1,6 @@
 import Handlebars from 'handlebars';
 import './handlebars/handle-url';
 import './handlebars/helper-base64';
-import './handlebars/helper-date';
 import './handlebars/helper-i18n';
 import './handlebars/helper-img';
 import './handlebars/helper-markdown';

--- a/packages/@okta/courage-dist/types/courage/util/handlebars/helper-date.d.ts
+++ b/packages/@okta/courage-dist/types/courage/util/handlebars/helper-date.d.ts
@@ -1,2 +1,0 @@
-import Handlebars from 'handlebars';
-export default Handlebars;

--- a/packages/@okta/courage-for-signin-widget/package.json
+++ b/packages/@okta/courage-for-signin-widget/package.json
@@ -22,11 +22,12 @@
     "build:esm": "rollup -c",
     "build": "yarn clean && yarn build:types && yarn build:esm && yarn lint && yarn copy",
     "build:babel": "rm -rf target/babel && yarn babel src -x .ts,.js --out-dir target/babel",
-    "patch": "yarn patch:hbs && yarn patch:hbs2 && yarn patch:qtip && yarn patch:i18n",
+    "patch": "yarn patch:hbs && yarn patch:hbs2 && yarn patch:qtip && yarn patch:i18n && yarn patch:date",
     "patch:hbs": "find ./node_modules/@okta/courage/src -type f | xargs sed -i '' -e \"s/import hbs from 'handlebars-inline-precompile'/import hbs from '@okta\\/handlebars-inline-precompile'/g\"",
     "patch:hbs2": "find ./node_modules/@okta/babel-plugin-handlebars-inline-precompile -type f | xargs sed -i '' -e \"s/'handlebars-inline-precompile'/'@okta\\/handlebars-inline-precompile'/g\"",
     "patch:qtip": "find ./node_modules/@okta/courage/src -type f | xargs sed -i '' -e \"s/import 'qtip'/import '@okta\\/qtip'/g\"",
-    "patch:i18n": "find ./node_modules/@okta/courage/src -type f | xargs sed -i '' -e \"s/from 'okta-i18n-bundles'/from '@okta\\/okta-i18n-bundles'/g\""
+    "patch:i18n": "find ./node_modules/@okta/courage/src -type f | xargs sed -i '' -e \"s/from 'okta-i18n-bundles'/from '@okta\\/okta-i18n-bundles'/g\"",
+    "patch:date": "find ./node_modules/@okta/courage/src -type f | xargs sed -i '' -e \"s/import '.\\/handlebars\\/helper-date'/\\/\\/ helper-date removed/g\""
   },
   "engines": {
     "node": ">=12.22.0",
@@ -42,7 +43,7 @@
     "@babel/plugin-transform-shorthand-properties": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@okta/babel-plugin-handlebars-inline-precompile": "3.1.0-beta.4200.gf3d0a27",
-    "@okta/courage": "4.5.0-7508-g9ac6f5c",
+    "@okta/courage": "4.5.0-7729-gdf1c695",
     "@okta/eslint-plugin-okta-ui": "0.1.0-beta.4181.g1f38f27",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.1",

--- a/packages/@okta/courage-for-signin-widget/rollup.config.js
+++ b/packages/@okta/courage-for-signin-widget/rollup.config.js
@@ -68,15 +68,6 @@ export default {
       delimiters: ['', ''],
       preventAssignment: true
     }),
-    replace({
-      // remove moment / helper-date
-      include: ['**/courage/util/handlebars-wrapper.*'],
-      values: {
-        'import "./handlebars/helper-date";': '// helper-date removed by rollup'
-      },
-      delimiters: ['', ''],
-      preventAssignment: true
-    }),
     commonjs(),
     resolve({
       extensions,

--- a/packages/@okta/courage-for-signin-widget/yarn.lock
+++ b/packages/@okta/courage-for-signin-widget/yarn.lock
@@ -487,10 +487,10 @@
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
 
-"@okta/courage@4.5.0-7508-g9ac6f5c":
-  version "4.5.0-7508-g9ac6f5c"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-7508-g9ac6f5c.tgz#cb440be63dc73b9c8a6c89efb66b9a0a311be3a4"
-  integrity sha1-y0QL5j3HO5yKbInvtmuaCjEb46Q=
+"@okta/courage@4.5.0-7729-gdf1c695":
+  version "4.5.0-7729-gdf1c695"
+  resolved "https://artifacts.aue1e.internal:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-7729-gdf1c695.tgz#88730483fa4a028a503977ea5c7dbe47d910edea"
+  integrity sha1-iHMEg/pKAopQOXfqXH2+R9kQ7eo=
   dependencies:
     "@okta/jquery.simplemodal" "1.4.19-g8b711ea"
     "@types/backbone" "^1.4.10"

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -217,4 +217,8 @@ export default class IdentityPageObject extends BasePageObject {
   getCustomIdpButtonLabel(index) {
     return Selector(CUSTOM_IDP_BUTTON).nth(index).textContent;
   }
+
+  async clickShowPasswordIcon() {
+    await this.t.click(Selector('.password-toggle .button-show'));
+  }
 }

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -174,3 +174,26 @@ test.requestHooks(identifyWithPasswordErrorMock)('should show custom access deni
   await identityPage.waitForErrorBox();
   await t.expect(identityPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><ul class="custom-links"><li><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a></li><li><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></li></ul></div>');
 });
+
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not trim whitespace characters from password when password field is in plain text view', async t => {
+  const identityPage = await setup(t);
+  await checkA11y(t);
+
+  await identityPage.fillIdentifierField('Test Identifier');
+  await identityPage.clickShowPasswordIcon();
+  await identityPage.fillPasswordField('  password with whitespace  ');
+  await identityPage.clickNextButton();
+
+  await t.expect(identifyRequestLogger.count(() => true)).eql(1);
+  const req = identifyRequestLogger.requests[0].request;
+  const reqBody = JSON.parse(req.body);
+  await t.expect(reqBody).eql({
+    identifier: 'Test Identifier',
+    credentials: {
+      passcode: '  password with whitespace  ',
+    },
+    stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw',
+  });
+  await t.expect(req.method).eql('post');
+  await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
+});


### PR DESCRIPTION
## Description:

- Fixes issue with trimming whitespace from the beginning and end of Password field value when the Show Password icon is clicked.
- Pulls in latest Courage changes.
- Fixes issue with building Courage for SIW cause by the date format package dependency.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-511637](https://oktainc.atlassian.net/browse/OKTA-511637)

### Reviewers:

@jakebacher2-okta 

### Screenshot/Video:

https://okta.box.com/s/4okw5hpj83uwt6lto7eosomq0890bayu

### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-d4bbe9a-6407bf74&page=1&pageSize=6&sha=fecfefe22d4c0ec987b9c5a8c746b42d6dcb4f18&tab=main

