### PR TITLE
Updates the invalid-otp-passcode mock with correct authenticator ID

### DIFF
--- a/playground/mocks/data/idp/idx/error-401-invalid-otp-passcode.json
+++ b/playground/mocks/data/idp/idx/error-401-invalid-otp-passcode.json
@@ -183,7 +183,7 @@
       },
       "type": "email",
       "key": "okta_email",
-      "id": "eaexdyjzXZ3iWikza0g3",
+      "id": "eae1d4u7aVB3VBbI70g4",
       "displayName": "Email",
       "methods": [
         {

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -504,7 +504,6 @@ test.meta('v3', false)
     await challengeEmailPageObject.verifyFactor('credentials.passcode', 'xyz');
     await challengeEmailPageObject.clickNextButton('Verify');
     await challengeEmailPageObject.waitForErrorBox();
-    // TODO OKTA-566356 - The invalid code error doesn't show up in v3
     await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
     await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
     await t.wait(5000);


### PR DESCRIPTION
## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-585943](https://oktainc.atlassian.net/browse/OKTA-585943)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



