### PR TITLE
OKTA-520690 : Applying fix for Header/Footer styling when SIW is okta hosted

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -13,7 +13,6 @@
 import './style.module.css';
 
 import { ScopedCssBaseline } from '@mui/material';
-import * as Tokens from '@okta/odyssey-design-tokens';
 import { MuiThemeProvider, OdysseyCacheProvider } from '@okta/odyssey-react-mui';
 import {
   AuthApiError,
@@ -316,7 +315,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
                 fontWeight: 'bold',
                 wordBreak: 'break-all',
               },
-              '--ColorTextSub': Tokens.ColorPaletteNeutral600,
             }}
           >
             <AuthContainer>

--- a/src/v3/src/components/Widget/style.module.css
+++ b/src/v3/src/components/Widget/style.module.css
@@ -1,6 +1,3 @@
-:global(.bgStyle) {
-  background-image: none;
-}
 :global(.clearfix) {
   display: block;
 }

--- a/src/v3/src/components/Widget/style.module.css
+++ b/src/v3/src/components/Widget/style.module.css
@@ -69,14 +69,18 @@
   color: #6e6e78;
 }
 :global(.auth .footer .copyright) {
-  float: inline-start;
-  color: var(--ColorTextSub);
+  /* stylelint-disable-next-line liberty/use-logical-spec */
+  float: left;
+  /* TODO: OKTA-586564 replace hardcoded value */
+  color: #6e6e78;
 }
 :global(.auth .footer .copyright a) {
-  color: var(--ColorTextSub);
+  /* TODO: OKTA-586564 replace hardcoded value */
+  color: #6e6e78;
 }
 :global(.auth .footer .privacy-policy) {
-  float: inline-end;
+  /* stylelint-disable-next-line liberty/use-logical-spec */
+  float: right;
 }
 :global(.login-bg-image) {
   background-repeat: no-repeat;
@@ -110,7 +114,8 @@
   text-align: center;
 }
 :global(.okta-container .applogin-banner .applogin-container p) {
-  color: var(--ColorTextSub);
+  /* TODO: OKTA-586564 replace hardcoded value */
+  color: #6e6e78;
 }
 @media only screen and (max-width: 400px) {
   :global(.okta-container .applogin-banner .applogin-container) {


### PR DESCRIPTION
## Description:

The purpose of this PR is to correct the styling for the header and footer content when SIW is okta hosted. CSS property defined in child component is not available to parent, so had to hard code the value. Additionally, the `float: inline-start/end` value does not seem to be respected so had to switch to `float: left/right`

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-520690](https://oktainc.atlassian.net/browse/OKTA-520690)

### Reviewers:

### Screenshot/Video:
<img width="1783" alt="image" src="https://user-images.githubusercontent.com/97472729/223858438-b91011cb-aee1-482a-8dbd-4d43abb007bd.png">


### Downstream Monolith Build:



