### PR TITLE
OKTA-537090 : Implementing client-side validation for password requirements

### DIFF
--- a/src/v3/src/components/Checkbox/Checkbox.tsx
+++ b/src/v3/src/components/Checkbox/Checkbox.tsx
@@ -25,7 +25,7 @@ import {
   UISchemaElementComponentWithValidationProps,
 } from '../../types';
 import { getTranslation } from '../../util';
-import FieldErrorContainer from '../FieldErrorContainer';
+import FieldLevelMessageContainer from '../FieldLevelMessageContainer';
 import { withFormValidationState } from '../hocs';
 
 const Checkbox: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
@@ -74,8 +74,8 @@ const Checkbox: UISchemaElementComponent<UISchemaElementComponentWithValidationP
         label={label as string}
       />
       {hasErrors && (
-        <FieldErrorContainer
-          errors={errors}
+        <FieldLevelMessageContainer
+          messages={errors}
           fieldName={name}
         />
       )}

--- a/src/v3/src/components/FieldLevelMessageContainer/FieldLevelMessageContainer.tsx
+++ b/src/v3/src/components/FieldLevelMessageContainer/FieldLevelMessageContainer.tsx
@@ -13,26 +13,31 @@
 import { Box, FormHelperText } from '@okta/odyssey-react-mui';
 import { FunctionComponent, h } from 'preact';
 
+import { WidgetMessage } from '../../types';
 import { buildErrorMessageIds } from '../../util';
+import WidgetMessageContainer from '../WidgetMessageContainer';
 
-type FieldErrorProps = {
-  errors: string[];
+type FieldLevelMessageProps = {
+  messages?: WidgetMessage[];
   fieldName: string;
 };
 
-const FieldErrorContainer: FunctionComponent<FieldErrorProps> = (props) => {
-  const { fieldName, errors } = props;
+const FieldLevelMessageContainer: FunctionComponent<FieldLevelMessageProps> = (props) => {
+  const { fieldName, messages } = props;
 
   const buildElementId = (errorIndex: number): string => {
-    const errorIdStr = buildErrorMessageIds(errors, fieldName);
+    if (typeof messages === 'undefined') {
+      return `${fieldName}-error`;
+    }
+    const errorIdStr = buildErrorMessageIds(messages, fieldName);
     return errorIdStr.split(' ')[errorIndex];
   };
 
-  return (
+  return typeof messages !== 'undefined' ? (
     <Box>
-      {errors.map((error: string, index: number) => (
+      {messages.map((message: WidgetMessage, index: number) => (
         <FormHelperText
-          key={error}
+          key={message}
           id={buildElementId(index)}
           role="alert"
           data-se={buildElementId(index)}
@@ -40,11 +45,11 @@ const FieldErrorContainer: FunctionComponent<FieldErrorProps> = (props) => {
           // TODO: OKTA-577905 - Temporary fix until we can upgrade to the latest version of Odyssey
           sx={{ textAlign: 'start' }}
         >
-          {error}
+          <WidgetMessageContainer message={message} />
         </FormHelperText>
       ))}
     </Box>
-  );
+  ) : null;
 };
 
-export default FieldErrorContainer;
+export default FieldLevelMessageContainer;

--- a/src/v3/src/components/FieldLevelMessageContainer/index.tsx
+++ b/src/v3/src/components/FieldLevelMessageContainer/index.tsx
@@ -10,12 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { WidgetMessage } from '../types';
+import FieldLevelMessageContainer from './FieldLevelMessageContainer';
 
-export const buildErrorMessageIds = (messages: WidgetMessage[], fieldName: string): string => {
-  if (messages.length === 1) {
-    return `${fieldName}-error`;
-  }
-  const ids = messages.map((_: WidgetMessage, index: number) => `${fieldName}-error-${index}`);
-  return ids.join(' ');
-};
+export default FieldLevelMessageContainer;

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -24,7 +24,7 @@ import {
   MessageTypeVariant,
   UISchemaElementComponent,
 } from '../../types';
-import List from '../List';
+import WidgetMessageContainer from '../WidgetMessageContainer';
 
 const InfoBox: UISchemaElementComponent<{
   uischema: InfoboxElement
@@ -36,10 +36,8 @@ const InfoBox: UISchemaElementComponent<{
   const {
     options: {
       message,
-      title,
       class: messageClass,
       dataSe,
-      listOptions,
     },
   } = uischema;
 
@@ -56,16 +54,15 @@ const InfoBox: UISchemaElementComponent<{
         {...({ 'data-se': dataSe })}
         className={`infobox-${messageClass.toLowerCase()}`}
       >
-        { title && (
+        { message.title && (
         <Typography
           component="h2"
           variant="h6"
         >
-          {title}
+          {message.title}
         </Typography>
         ) }
-        { message }
-        { listOptions && <List uischema={{ type: 'List', options: listOptions }} /> }
+        <WidgetMessageContainer message={message} />
       </Alert>
     </Box>
   );

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -37,7 +37,7 @@ import {
   UISchemaElementComponentWithValidationProps,
 } from '../../types';
 import { getTranslation } from '../../util';
-import FieldErrorContainer from '../FieldErrorContainer';
+import FieldLevelMessageContainer from '../FieldLevelMessageContainer';
 import { withFormValidationState } from '../hocs';
 
 const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
@@ -139,8 +139,8 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
         )}
       />
       {hasErrors && (
-        <FieldErrorContainer
-          errors={errors}
+        <FieldLevelMessageContainer
+          messages={errors}
           fieldName={name}
         />
       )}

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -29,7 +29,7 @@ import {
   UISchemaElementComponent, UISchemaElementComponentWithValidationProps,
 } from '../../types';
 import { getTranslation } from '../../util';
-import FieldErrorContainer from '../FieldErrorContainer';
+import FieldLevelMessageContainer from '../FieldLevelMessageContainer';
 import { withFormValidationState } from '../hocs';
 
 const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
@@ -103,8 +103,8 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
         inputRef={focusRef}
       />
       {hasErrors && (
-        <FieldErrorContainer
-          errors={errors}
+        <FieldLevelMessageContainer
+          messages={errors}
           fieldName={name}
         />
       )}

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -36,7 +36,7 @@ import {
   UISchemaElementComponentWithValidationProps,
 } from '../../types';
 import { getDefaultCountryCode, getTranslation } from '../../util';
-import FieldErrorContainer from '../FieldErrorContainer';
+import FieldLevelMessageContainer from '../FieldLevelMessageContainer';
 import { withFormValidationState } from '../hocs';
 
 const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
@@ -233,8 +233,8 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
             }}
           />
           {phoneHasErrors && (
-            <FieldErrorContainer
-              errors={errors}
+            <FieldLevelMessageContainer
+              messages={errors}
               fieldName={fieldName}
             />
           )}

--- a/src/v3/src/components/Radio/Radio.tsx
+++ b/src/v3/src/components/Radio/Radio.tsx
@@ -28,7 +28,7 @@ import {
   UISchemaElementComponentWithValidationProps,
 } from '../../types';
 import { getTranslation } from '../../util';
-import FieldErrorContainer from '../FieldErrorContainer';
+import FieldLevelMessageContainer from '../FieldLevelMessageContainer';
 import { withFormValidationState } from '../hocs';
 
 const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
@@ -91,8 +91,8 @@ const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProp
         }
       </RadioGroup>
       {hasErrors && (
-        <FieldErrorContainer
-          errors={errors}
+        <FieldLevelMessageContainer
+          messages={errors}
           fieldName={name}
         />
       )}

--- a/src/v3/src/components/Select/Select.tsx
+++ b/src/v3/src/components/Select/Select.tsx
@@ -22,7 +22,7 @@ import {
   UISchemaElementComponentWithValidationProps,
 } from '../../types';
 import { getTranslation } from '../../util';
-import FieldErrorContainer from '../FieldErrorContainer';
+import FieldLevelMessageContainer from '../FieldLevelMessageContainer';
 import { withFormValidationState } from '../hocs';
 
 const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
@@ -101,8 +101,8 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
         }
       </MuiSelect>
       {hasErrors && (
-        <FieldErrorContainer
-          errors={errors}
+        <FieldLevelMessageContainer
+          messages={errors}
           fieldName={name}
         />
       )}

--- a/src/v3/src/components/WidgetMessageContainer/index.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/index.tsx
@@ -10,6 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import FieldErrorContainer from './FieldErrorContainer';
+import WidgetMessageContainer from './WidgetMessageContainer';
 
-export default FieldErrorContainer;
+export default WidgetMessageContainer;

--- a/src/v3/src/components/hocs/withFormValidationState.tsx
+++ b/src/v3/src/components/hocs/withFormValidationState.tsx
@@ -10,14 +10,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxMessage } from '@okta/okta-auth-js';
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
-import { getMessage } from '../../../../v2/ion/i18nTransformer';
 import { useFormFieldValidation, useOnChange } from '../../hooks';
-import { FieldElement, UISchemaElementComponent } from '../../types';
-import { buildErrorMessageIds } from '../../util';
+import { FieldElement, UISchemaElementComponent, WidgetMessage } from '../../types';
+import { buildErrorMessageIds, convertIdxMessageToWidgetMessage } from '../../util';
 import { getDisplayName } from './getDisplayName';
 
 export type RendererComponent<T> = {
@@ -45,11 +43,10 @@ export const withFormValidationState: WrappedFunctionComponent<
         },
       },
     } = uischema;
-    const errorsFromSchema = messages?.value?.length
-      // @ts-ignore Message interface defined in v2/i18nTransformer JsDoc is incorrect
-      && messages.value.map((message: IdxMessage) => getMessage(message));
+    const errorsFromSchema: WidgetMessage[] = messages?.value?.length
+      && convertIdxMessageToWidgetMessage(messages?.value);
     const [touched, setTouched] = useState<boolean>(false);
-    const [errors, setErrors] = useState<string[] | undefined>();
+    const [errors, setErrors] = useState<WidgetMessage[] | undefined>();
     const onValidateHandler = useFormFieldValidation(uischema);
     const onChangeHandler = useOnChange(uischema);
 

--- a/src/v3/src/constants/passwordConstants.ts
+++ b/src/v3/src/constants/passwordConstants.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export const PASSWORD_REQUIREMENTS_KEYS = {
+export const PASSWORD_REQUIREMENTS_KEYS: Record<'complexity' | 'age', { [key: string]: string }> = {
   complexity: {
     minLength: 'password.complexity.length.description',
     minLowerCase: 'password.complexity.lowercase.description',

--- a/src/v3/src/hooks/useFormFieldValidation.ts
+++ b/src/v3/src/hooks/useFormFieldValidation.ts
@@ -12,33 +12,33 @@
 
 import { StateUpdater, useCallback } from 'preact/hooks';
 
-import { getMessage } from '../../../v2/ion/i18nTransformer';
 import { useWidgetContext } from '../contexts';
-import { DataSchema, FieldElement } from '../types';
+import { DataSchema, FieldElement, WidgetMessage } from '../types';
+import { convertIdxMessageToWidgetMessage } from '../util';
 
 export const useFormFieldValidation = (
   uischema: FieldElement,
 ): (
-  setErrors?: StateUpdater<string[] | undefined>, value?: string | boolean | number
+  setErrors?: StateUpdater<WidgetMessage[] | undefined>, value?: string | boolean | number
   ) => void => {
   const { name } = uischema.options.inputMeta;
   const { dataSchemaRef, data } = useWidgetContext();
 
   return useCallback((
-    setErrors?: StateUpdater<string[] | undefined>,
+    setErrors?: StateUpdater<WidgetMessage[] | undefined>,
     value?: string | boolean | number,
   ) => {
     const validator = dataSchemaRef.current?.[name] as DataSchema;
     if (typeof validator?.validate === 'function') {
       const updatedData = { ...data, ...(value !== undefined && { [name]: value }) };
       const messages = validator.validate({ ...updatedData });
-      const matchingMessages = messages?.filter(
-        (message) => (message.name === undefined || message.name === name) && message.i18n?.key,
+      const widgetMessages = convertIdxMessageToWidgetMessage(messages);
+      const matchingMessages = widgetMessages?.filter(
+        (message) => (message.name === undefined || message.name === name)
+          && typeof message.message !== 'undefined',
       );
       if (matchingMessages?.length) {
-        // @ts-ignore Message interface defined in v2/i18nTransformer JsDoc is incorrect
-        const translatedMessages: string[] = matchingMessages.map((message) => getMessage(message));
-        setErrors?.(translatedMessages);
+        setErrors?.(matchingMessages);
         return;
       }
     }

--- a/src/v3/src/hooks/useOnSubmitValidation.ts
+++ b/src/v3/src/hooks/useOnSubmitValidation.ts
@@ -15,11 +15,11 @@ import clone from 'lodash/clone';
 import { useCallback } from 'preact/hooks';
 
 import { useWidgetContext } from '../contexts';
-import { IdxMessageWithName } from '../types';
+import { WidgetMessage } from '../types';
 import { loc, resetMessagesToInputs } from '../util';
 
 export const useOnSubmitValidation = (): (
-messages: Record<string, IdxMessageWithName[]>) => Promise<void> => {
+messages: Record<string, WidgetMessage[]>) => Promise<void> => {
   const {
     setIdxTransaction,
     setIsClientTransaction,
@@ -27,7 +27,7 @@ messages: Record<string, IdxMessageWithName[]>) => Promise<void> => {
     idxTransaction: currentTransaction,
   } = useWidgetContext();
 
-  return useCallback(async (messages: Record<string, IdxMessageWithName[]>) => {
+  return useCallback(async (messages: Record<string, WidgetMessage[]>) => {
     const newTransaction = clone(currentTransaction);
     resetMessagesToInputs(newTransaction!.nextStep!.inputs!, messages);
     setMessage({

--- a/src/v3/src/transformer/layout/recovery/transformRequestActivation.test.ts
+++ b/src/v3/src/transformer/layout/recovery/transformRequestActivation.test.ts
@@ -35,7 +35,11 @@ describe('Identity Request Activation Transformer Tests', () => {
     expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[1] as InfoboxElement).options?.message)
-      .toBe('idx.expired.activation.token');
+      .toEqual({
+        class: 'ERROR',
+        i18n: { key: 'idx.expired.activation.token' },
+        message: 'idx.expired.activation.token',
+      });
     expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
       .toBe('oie.activation.request.email.button');
   });

--- a/src/v3/src/transformer/layout/recovery/transformRequestActivation.ts
+++ b/src/v3/src/transformer/layout/recovery/transformRequestActivation.ts
@@ -42,7 +42,11 @@ export const transformRequestActivation: IdxStepTransformer = ({ formBag, transa
     type: 'InfoBox',
     options: {
       class: 'ERROR',
-      message: loc('idx.expired.activation.token', 'login'),
+      message: {
+        class: 'ERROR',
+        message: loc('idx.expired.activation.token', 'login'),
+        i18n: { key: 'idx.expired.activation.token' },
+      },
       dataSe: 'callout',
     },
   };

--- a/src/v3/src/transformer/messages/transform.test.ts
+++ b/src/v3/src/transformer/messages/transform.test.ts
@@ -55,9 +55,12 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
     expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.class)
       .toBe('ERROR');
     expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.message)
-      .toBe(OV_OVERRIDE_MESSAGE_KEY.OV_FORCE_FIPS_COMPLIANCE_UPGRAGE_KEY_IOS);
-    expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.title)
-      .toBe('oie.okta_verify.enroll.force.upgrade.title');
+      .toEqual({
+        class: 'ERROR',
+        i18n: { key: 'oie.authenticator.app.non_fips_compliant_enrollment_device_incompatible' },
+        message: 'oie.authenticator.app.non_fips_compliant_enrollment_device_incompatible',
+        title: 'oie.okta_verify.enroll.force.upgrade.title',
+      });
   });
 
   it('should add title when OV QR enroll biometrics key exists in transaction', () => {
@@ -74,8 +77,11 @@ describe('Enroll Authenticator Selector Transformer Tests', () => {
     expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.class)
       .toBe('ERROR');
     expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.message)
-      .toBe(OV_OVERRIDE_MESSAGE_KEY.OV_QR_ENROLL_ENABLE_BIOMETRICS_KEY);
-    expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.title)
-      .toBe('oie.authenticator.app.method.push.enroll.enable.biometrics.title');
+      .toEqual({
+        class: 'ERROR',
+        i18n: { key: 'oie.authenticator.app.method.push.enroll.enable.biometrics' },
+        message: 'oie.authenticator.app.method.push.enroll.enable.biometrics',
+        title: 'oie.authenticator.app.method.push.enroll.enable.biometrics.title',
+      });
   });
 });

--- a/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
@@ -11,14 +11,8 @@
  */
 
 import { PASSWORD_REQUIREMENTS_KEYS } from '../../constants';
-import {
-  AgeRequirements,
-  ComplexityRequirements,
-} from '../../types';
-import {
-  getAgeItems,
-  getComplexityItems,
-} from './passwordSettingsUtils';
+import { ComplexityRequirements } from '../../types';
+import { getComplexityItems } from './passwordSettingsUtils';
 
 jest.mock('@okta/courage', () => ({
   loc: jest.fn().mockImplementation(
@@ -43,6 +37,15 @@ describe('getComplexityItems', () => {
 
     const result = getComplexityItems(complexity);
     expect(result).toEqual([{ ruleKey: 'lastName', label: PASSWORD_REQUIREMENTS_KEYS.complexity.excludeLastName }]);
+  });
+
+  it('should return excludeUsername item', () => {
+    const complexity = {
+      excludeAttributes: ['username'],
+    } as unknown as ComplexityRequirements;
+
+    const result = getComplexityItems(complexity);
+    expect(result).toEqual([{ ruleKey: 'username', label: PASSWORD_REQUIREMENTS_KEYS.complexity.excludeUsername }]);
   });
 
   it('should return minLength item with value', () => {
@@ -76,50 +79,6 @@ describe('getComplexityItems', () => {
       { ruleKey: 'minLowerCase', label: PASSWORD_REQUIREMENTS_KEYS.complexity.minLowerCase },
       { ruleKey: 'minNumber', label: PASSWORD_REQUIREMENTS_KEYS.complexity.minNumber },
       { ruleKey: 'minSymbol', label: PASSWORD_REQUIREMENTS_KEYS.complexity.minSymbol },
-    ]);
-  });
-});
-
-describe('getAgeItems', () => {
-  it('should return historyCount item with value', () => {
-    const age = {
-      historyCount: 5,
-    } as unknown as AgeRequirements;
-
-    const result = getAgeItems(age);
-    expect(result).toEqual([{ ruleKey: 'historyCount', label: PASSWORD_REQUIREMENTS_KEYS.age.historyCount }]);
-  });
-
-  it('should return minAgeMinutes as minutes', () => {
-    const age = {
-      minAgeMinutes: 40,
-    } as unknown as AgeRequirements;
-
-    const result = getAgeItems(age);
-    expect(result).toEqual([
-      { ruleKey: 'minAgeMinutes', label: PASSWORD_REQUIREMENTS_KEYS.age.minAgeMinutes },
-    ]);
-  });
-
-  it('should return minAgeMinutes as hours', () => {
-    const age = {
-      minAgeMinutes: 120,
-    } as unknown as AgeRequirements;
-
-    const result = getAgeItems(age);
-    expect(result).toEqual([
-      { ruleKey: 'minAgeMinutes', label: PASSWORD_REQUIREMENTS_KEYS.age.minAgeHours },
-    ]);
-  });
-
-  it('should return minAgeMinutes as days', () => {
-    const age = {
-      minAgeMinutes: 2880,
-    } as unknown as AgeRequirements;
-
-    const result = getAgeItems(age);
-    expect(result).toEqual([
-      { ruleKey: 'minAgeMinutes', label: PASSWORD_REQUIREMENTS_KEYS.age.minAgeDays },
     ]);
   });
 });

--- a/src/v3/src/transformer/password/passwordSettingsUtils.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.ts
@@ -12,7 +12,6 @@
 
 import { PASSWORD_REQUIREMENTS_KEYS } from '../../constants';
 import {
-  AgeRequirements,
   ComplexityKeys,
   ComplexityRequirements,
   GetAgeFromMinutes,
@@ -41,19 +40,16 @@ export const getComplexityItems = (complexity?: ComplexityRequirements): ListIte
   }
 
   Object.entries(complexity).forEach(([key, value]) => {
-    if (key === 'excludeAttributes' && value.length > 0) {
-      if (value.includes('firstName')) {
-        items.push({
-          ruleKey: 'firstName',
-          label: loc(PASSWORD_REQUIREMENTS_KEYS.complexity.excludeFirstName, 'login'),
+    if (key === 'excludeAttributes' && Array.isArray(value) && value.length > 0) {
+      value
+        .filter((rule) => ['username', 'firstName', 'lastName'].includes(rule))
+        .forEach((ruleAttr: string) => {
+          const ruleExclusionKey = `exclude${ruleAttr.charAt(0).toUpperCase() + ruleAttr.slice(1)}`;
+          items.push({
+            ruleKey: ruleAttr,
+            label: loc(PASSWORD_REQUIREMENTS_KEYS.complexity[ruleExclusionKey], 'login'),
+          });
         });
-      }
-      if (value.includes('lastName')) {
-        items.push({
-          ruleKey: 'lastName',
-          label: loc(PASSWORD_REQUIREMENTS_KEYS.complexity.excludeLastName, 'login'),
-        });
-      }
     } else if (key === 'minLength' && value > 0) {
       items.push({
         ruleKey: key,
@@ -71,33 +67,6 @@ export const getComplexityItems = (complexity?: ComplexityRequirements): ListIte
   return items;
 };
 
-export const getAgeItems = (age?: AgeRequirements): ListItem[] => {
-  const items: ListItem[] = [];
-
-  if (!age) {
-    return items;
-  }
-
-  if (age.historyCount > 0) {
-    items.push({
-      ruleKey: 'historyCount',
-      label: loc(PASSWORD_REQUIREMENTS_KEYS.age.historyCount, 'login', [age.historyCount]),
-    });
-  }
-
-  if (age.minAgeMinutes > 0) {
-    const { unitLabel, value } = getAgeFromMinutes(age.minAgeMinutes);
-
-    items.push({
-      ruleKey: 'minAgeMinutes',
-      label: loc(unitLabel, 'login', [value]),
-    });
-  }
-
-  return items;
-};
-
-// eslint-disable-next-line arrow-body-style
-export const buildPasswordRequirementListItems = (data: PasswordSettings): ListItem[] => {
-  return getComplexityItems(data.complexity);
-};
+export const buildPasswordRequirementListItems = (
+  data: PasswordSettings,
+): ListItem[] => getComplexityItems(data.complexity);

--- a/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
+++ b/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
@@ -4,6 +4,9 @@ exports[`Enroll Profile Transformer Tests should add link to log in when select-
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
@@ -85,6 +88,9 @@ exports[`Enroll Profile Transformer Tests should add password requirements along
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
@@ -187,6 +193,9 @@ exports[`Enroll Profile Transformer Tests should add password requirements along
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],

--- a/src/v3/src/transformer/terminal/__snapshots__/transformTerminalMessages.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformTerminalMessages.test.ts.snap
@@ -45,8 +45,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "oie.tooManyRequests",
-          "title": undefined,
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "tooManyRequests",
+            },
+            "message": "oie.tooManyRequests",
+          },
         },
         "type": "InfoBox",
       },
@@ -74,8 +79,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "idx.operation.cancelled.on.other.device",
-          "title": undefined,
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "idx.operation.cancelled.on.other.device",
+            },
+            "message": "idx.operation.cancelled.on.other.device",
+          },
         },
         "type": "InfoBox",
       },
@@ -110,8 +120,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "idx.session.expired",
-          "title": undefined,
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "idx.session.expired",
+            },
+            "message": "idx.session.expired",
+          },
         },
         "type": "InfoBox",
       },
@@ -139,8 +154,14 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "core.auth.factor.signedNonce.error.invalidDevice",
-          "title": "user.fail.verifyIdentity",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "core.auth.factor.signedNonce.error.invalidDevice",
+            },
+            "message": "core.auth.factor.signedNonce.error.invalidDevice",
+            "title": "user.fail.verifyIdentity",
+          },
         },
         "type": "InfoBox",
       },
@@ -168,8 +189,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "idx.return.link.expired",
-          "title": undefined,
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "idx.return.link.expired",
+            },
+            "message": "idx.return.link.expired",
+          },
         },
         "type": "InfoBox",
       },
@@ -196,7 +222,13 @@ Object {
       Object {
         "options": Object {
           "class": "ERROR",
-          "message": "oform.error.unexpected",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "oform.error.unexpected",
+            },
+            "message": "oform.error.unexpected",
+          },
         },
         "type": "InfoBox",
       },
@@ -224,8 +256,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "Test error message",
-          "title": undefined,
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "some.test.key",
+            },
+            "message": "Test error message",
+          },
         },
         "type": "InfoBox",
       },

--- a/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
@@ -13,7 +13,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "oform.error.unexpected",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "oform.error.unexpected",
+            },
+            "message": "oform.error.unexpected",
+          },
         },
         "type": "InfoBox",
       },
@@ -36,7 +42,10 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "Custom error message",
+          "message": Object {
+            "class": "ERROR",
+            "message": "Custom error message",
+          },
         },
         "type": "InfoBox",
       },
@@ -59,7 +68,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "oform.error.unexpected",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "oform.error.unexpected",
+            },
+            "message": "oform.error.unexpected",
+          },
         },
         "type": "InfoBox",
       },
@@ -82,7 +97,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "oie.configuration.error",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "oie.configuration.error",
+            },
+            "message": "oie.configuration.error",
+          },
         },
         "type": "InfoBox",
       },
@@ -105,7 +126,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "oie.feature.disabled",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "oie.feature.disabled",
+            },
+            "message": "oie.feature.disabled",
+          },
         },
         "type": "InfoBox",
       },
@@ -128,7 +155,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "oie.invalid.recovery.token",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "oie.invalid.recovery.token",
+            },
+            "message": "oie.invalid.recovery.token",
+          },
         },
         "type": "InfoBox",
       },

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.test.ts
@@ -60,7 +60,11 @@ describe('Terminal Message Transformer Tests', () => {
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(1);
     expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
-    expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.message).toBe('oform.error.unexpected');
+    expect((updatedFormBag.uischema.elements[0] as InfoboxElement).options?.message).toEqual({
+      class: 'ERROR',
+      i18n: { key: 'oform.error.unexpected' },
+      message: 'oform.error.unexpected',
+    });
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
     ).options?.class).toBe('ERROR');
@@ -97,7 +101,11 @@ describe('Terminal Message Transformer Tests', () => {
     expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe(mockErrorMessage);
+    ).options?.message).toEqual({
+      class: 'ERROR',
+      i18n: { key: 'some.test.key' },
+      message: 'Test error message',
+    });
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
     ).options?.class).toBe('ERROR');
@@ -117,7 +125,11 @@ describe('Terminal Message Transformer Tests', () => {
     expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe('idx.return.link.expired');
+    ).options?.message).toEqual({
+      class: 'ERROR',
+      i18n: { key: 'idx.return.link.expired' },
+      message: 'idx.return.link.expired',
+    });
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
     ).options?.class).toBe('ERROR');
@@ -155,7 +167,11 @@ describe('Terminal Message Transformer Tests', () => {
     expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe('idx.operation.cancelled.on.other.device');
+    ).options?.message).toEqual({
+      class: 'ERROR',
+      i18n: { key: 'idx.operation.cancelled.on.other.device' },
+      message: 'idx.operation.cancelled.on.other.device',
+    });
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
     ).options?.class).toBe('ERROR');
@@ -177,7 +193,11 @@ describe('Terminal Message Transformer Tests', () => {
     expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe('oie.tooManyRequests');
+    ).options?.message).toEqual({
+      class: 'ERROR',
+      i18n: { key: 'tooManyRequests' },
+      message: 'oie.tooManyRequests',
+    });
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
     ).options?.class).toBe('ERROR');
@@ -197,7 +217,11 @@ describe('Terminal Message Transformer Tests', () => {
     expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe(TERMINAL_KEY.SESSION_EXPIRED);
+    ).options?.message).toEqual({
+      class: 'ERROR',
+      i18n: { key: 'idx.session.expired' },
+      message: 'idx.session.expired',
+    });
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
     ).options?.class).toBe('ERROR');
@@ -217,13 +241,15 @@ describe('Terminal Message Transformer Tests', () => {
     expect(updatedFormBag.uischema.elements[0].type).toBe('InfoBox');
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.message).toBe('core.auth.factor.signedNonce.error.invalidDevice');
+    ).options?.message).toEqual({
+      class: 'ERROR',
+      i18n: { key: 'core.auth.factor.signedNonce.error.invalidDevice' },
+      message: 'core.auth.factor.signedNonce.error.invalidDevice',
+      title: 'user.fail.verifyIdentity',
+    });
     expect((
       updatedFormBag.uischema.elements[0] as InfoboxElement
     ).options?.class).toBe('ERROR');
-    expect((
-      updatedFormBag.uischema.elements[0] as InfoboxElement
-    ).options?.title).toBe('user.fail.verifyIdentity');
   });
 
   it('should return custom formBag when message key contains idx.enter.otp.in.original.tab', () => {

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.ts
@@ -10,8 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxMessage } from '@okta/okta-auth-js';
-
 import {
   OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP,
   OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE,
@@ -20,30 +18,23 @@ import {
 import {
   DescriptionElement,
   InfoboxElement,
-  Modify,
   TerminalKeyTransformer,
   UISchemaLayout,
+  WidgetMessage,
 } from '../../types';
-import { containsMessageKey, containsMessageKeyPrefix, loc } from '../../util';
+import {
+  containsMessageKey, containsMessageKeyPrefix, containsOneOfMessageKeys, loc,
+} from '../../util';
 import { transactionMessageTransformer } from '../i18n';
 import { transformEmailMagicLinkOTPOnly } from './transformEmailMagicLinkOTPOnlyElements';
 
-type ModifiedIdxMessage = Modify<IdxMessage, {
-  class?: string;
-  i18n?: {
-    key: string;
-    params?: unknown[];
-  };
-  title?: string;
-}>;
-
-const appendMessageElements = (uischema: UISchemaLayout, messages: ModifiedIdxMessage[]): void => {
+const appendMessageElements = (uischema: UISchemaLayout, messages: WidgetMessage[]): void => {
   messages.forEach((message) => {
     if (!message.class || message.class === 'INFO') {
       const messageElement: DescriptionElement = {
         type: 'Description',
         contentType: 'subtitle',
-        options: { content: message.message },
+        options: { content: (message.message! as string) },
       };
       uischema.elements.push(messageElement);
     } else {
@@ -51,10 +42,9 @@ const appendMessageElements = (uischema: UISchemaLayout, messages: ModifiedIdxMe
       const infoBoxElement: InfoboxElement = {
         type: 'InfoBox',
         options: {
-          message: message.message,
+          message,
           class: messageClass,
           dataSe: 'callout',
-          title: message.title,
         },
       };
       uischema.elements.push(infoBoxElement);
@@ -66,30 +56,35 @@ const appendBiometricsErrorBox = (
   uischema: UISchemaLayout,
   isBiometricsRequiredDesktop = false,
 ) => {
-  const bulletPoints = [
+  const listMessages: WidgetMessage[] = [
     loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point1', 'login'),
     loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point2', 'login'),
     loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point3', 'login'),
-  ];
+  ].map((msg: string) => ({ class: 'INFO', message: msg }));
 
   // Add an additional bullet point for desktop devices
   if (isBiometricsRequiredDesktop) {
-    bulletPoints.push(
-      loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point4', 'login'),
-    );
+    listMessages.push({
+      class: 'INFO',
+      message: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point4', 'login'),
+    });
   }
 
   uischema.elements.push({
     type: 'InfoBox',
     options: {
-      message: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.description', 'login'),
-      title: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.title', 'login'),
       class: 'ERROR',
-      contentType: 'string',
       dataSe: 'callout',
       listOptions: {
         type: 'ul',
-        items: bulletPoints,
+        items: listMessages,
+      },
+      message: {
+        type: 'list',
+        class: 'ERROR',
+        title: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.title', 'login'),
+        description: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.description', 'login'),
+        message: listMessages,
       },
     },
   } as InfoboxElement);
@@ -102,7 +97,11 @@ export const transformTerminalMessages: TerminalKeyTransformer = (transaction, f
     uischema.elements.push({
       type: 'InfoBox',
       options: {
-        message: loc('oform.error.unexpected', 'login'),
+        message: {
+          class: 'ERROR',
+          message: loc('oform.error.unexpected', 'login'),
+          i18n: { key: 'oform.error.unexpected' },
+        },
         class: 'ERROR',
       },
     } as InfoboxElement);
@@ -114,7 +113,11 @@ export const transformTerminalMessages: TerminalKeyTransformer = (transaction, f
       uischema.elements.push({
         type: 'InfoBox',
         options: {
-          message: loc('error.unsupported.response', 'login'),
+          message: {
+            class: 'ERROR',
+            message: loc('error.unsupported.response', 'login'),
+            i18n: { key: 'error.unsupported.response' },
+          },
           class: 'ERROR',
         },
       } as InfoboxElement);
@@ -124,37 +127,42 @@ export const transformTerminalMessages: TerminalKeyTransformer = (transaction, f
 
   transactionMessageTransformer(transaction);
 
-  const displayedMessages: ModifiedIdxMessage[] = messages;
+  const displayedMessages: WidgetMessage[] = messages.map((message) => (message));
 
-  if (containsMessageKey(TERMINAL_KEY.OPERATION_CANCELED_ON_OTHER_DEVICE_KEY, messages)) {
+  if (containsMessageKey(TERMINAL_KEY.OPERATION_CANCELED_ON_OTHER_DEVICE_KEY, displayedMessages)) {
     displayedMessages[0].message = loc('idx.operation.cancelled.on.other.device', 'login');
     displayedMessages.push({ message: loc('oie.consent.enduser.deny.description', 'login') });
-  } else if (containsMessageKey(TERMINAL_KEY.UNLOCK_ACCOUNT_KEY, messages)) {
+  } else if (containsMessageKey(TERMINAL_KEY.UNLOCK_ACCOUNT_KEY, displayedMessages)) {
     displayedMessages[0].message = loc(TERMINAL_KEY.UNLOCK_ACCOUNT_KEY, 'login');
-  } else if (containsMessageKey(TERMINAL_KEY.RETURN_TO_ORIGINAL_TAB_KEY, messages)) {
+  } else if (containsMessageKey(TERMINAL_KEY.RETURN_TO_ORIGINAL_TAB_KEY, displayedMessages)) {
     displayedMessages[0].message = loc('oie.consent.enduser.email.allow.description', 'login');
     displayedMessages.push({ message: loc('oie.return.to.original.tab', 'login') });
-  } else if (containsMessageKey(TERMINAL_KEY.TOO_MANY_REQUESTS, messages)) {
+  } else if (containsMessageKey(TERMINAL_KEY.TOO_MANY_REQUESTS, displayedMessages)) {
     displayedMessages[0].message = loc('oie.tooManyRequests', 'login');
-  } else if (containsMessageKey(TERMINAL_KEY.RETURN_LINK_EXPIRED_KEY, messages)) {
+  } else if (containsMessageKey(TERMINAL_KEY.RETURN_LINK_EXPIRED_KEY, displayedMessages)) {
     displayedMessages[0].class = 'ERROR';
-  } else if (containsMessageKey(TERMINAL_KEY.SESSION_EXPIRED, messages)) {
+  } else if (containsMessageKey(TERMINAL_KEY.SESSION_EXPIRED, displayedMessages)) {
     displayedMessages[0].class = 'ERROR';
     displayedMessages[0].message = loc(TERMINAL_KEY.SESSION_EXPIRED, 'login');
-  } else if (containsMessageKeyPrefix('core.auth.factor.signedNonce.error', messages)) {
+  } else if (containsMessageKeyPrefix('core.auth.factor.signedNonce.error', displayedMessages)) {
     // custom title for signed nonce errors
     displayedMessages[0].title = loc('user.fail.verifyIdentity', 'login');
-  } else if (containsMessageKey(TERMINAL_KEY.IDX_RETURN_LINK_OTP_ONLY, messages)) {
+  } else if (containsMessageKey(TERMINAL_KEY.IDX_RETURN_LINK_OTP_ONLY, displayedMessages)) {
     return transformEmailMagicLinkOTPOnly(transaction, formBag);
-  } else if (containsMessageKey(OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE, messages)) {
-    appendBiometricsErrorBox(uischema);
-    return formBag;
-  } else if (containsMessageKey(OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP, messages)) {
-    appendBiometricsErrorBox(uischema, true);
+  } else if (
+    containsOneOfMessageKeys(
+      [OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE, OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP],
+      displayedMessages,
+    )
+  ) {
+    appendBiometricsErrorBox(
+      uischema,
+      containsMessageKey(OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP, displayedMessages),
+    );
     return formBag;
   }
 
-  appendMessageElements(uischema, messages);
+  appendMessageElements(uischema, displayedMessages);
 
   return formBag;
 };

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
@@ -37,7 +37,11 @@ describe('Unhandled Error Transformer Tests', () => {
       expect(formBag.uischema.elements.length).toBe(1);
       const el = formBag.uischema.elements[0] as InfoboxElement;
       expect(el.type).toBe('InfoBox');
-      expect(el.options?.message).toBe('oform.error.unexpected');
+      expect(el.options?.message).toEqual({
+        class: 'ERROR',
+        i18n: { key: 'oform.error.unexpected' },
+        message: 'oform.error.unexpected',
+      });
       expect(el.options?.class).toBe('ERROR');
     });
 
@@ -54,7 +58,10 @@ describe('Unhandled Error Transformer Tests', () => {
       expect(formBag.uischema.elements.length).toBe(1);
       const el = formBag.uischema.elements[0] as InfoboxElement;
       expect(el.type).toBe('InfoBox');
-      expect(el.options?.message).toBe(mockErrorMessage);
+      expect(el.options?.message).toEqual({
+        class: 'ERROR',
+        message: 'Custom error message',
+      });
       expect(el.options?.class).toBe('ERROR');
     });
   });
@@ -82,7 +89,11 @@ describe('Unhandled Error Transformer Tests', () => {
       expect(formBag.uischema.elements.length).toBe(1);
       const el = formBag.uischema.elements[0] as InfoboxElement;
       expect(el.type).toBe('InfoBox');
-      expect(el.options?.message).toBe('oform.error.unexpected');
+      expect(el.options?.message).toEqual({
+        class: 'ERROR',
+        i18n: { key: 'oform.error.unexpected' },
+        message: 'oform.error.unexpected',
+      });
       expect(el.options?.class).toBe('ERROR');
     });
 
@@ -98,7 +109,12 @@ describe('Unhandled Error Transformer Tests', () => {
       expect(formBag).toMatchSnapshot();
       expect(formBag.uischema.elements.length).toBe(1);
       expect(formBag.uischema.elements[0].type).toBe('InfoBox');
-      expect((formBag.uischema.elements[0] as InfoboxElement).options?.message).toBe('oie.invalid.recovery.token');
+      expect((formBag.uischema.elements[0] as InfoboxElement).options?.message)
+        .toEqual({
+          class: 'ERROR',
+          i18n: { key: 'oie.invalid.recovery.token' },
+          message: 'oie.invalid.recovery.token',
+        });
       expect((
         formBag.uischema.elements[0] as InfoboxElement
       ).options?.class).toBe('ERROR');
@@ -117,7 +133,11 @@ describe('Unhandled Error Transformer Tests', () => {
       expect(formBag.uischema.elements.length).toBe(1);
       const el = formBag.uischema.elements[0] as InfoboxElement;
       expect(el.type).toBe('InfoBox');
-      expect(el.options?.message).toBe('oie.feature.disabled');
+      expect(el.options?.message).toEqual({
+        class: 'ERROR',
+        i18n: { key: 'oie.feature.disabled' },
+        message: 'oie.feature.disabled',
+      });
       expect(el.options?.class).toBe('ERROR');
     });
 
@@ -133,7 +153,11 @@ describe('Unhandled Error Transformer Tests', () => {
       expect(formBag.uischema.elements.length).toBe(1);
       const el = formBag.uischema.elements[0] as InfoboxElement;
       expect(el.type).toBe('InfoBox');
-      expect(el.options?.message).toBe('oie.configuration.error');
+      expect(el.options?.message).toEqual({
+        class: 'ERROR',
+        i18n: { key: 'oie.configuration.error' },
+        message: 'oie.configuration.error',
+      });
       expect(el.options?.class).toBe('ERROR');
     });
   });

--- a/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/webauthn/__snapshots__/transformWebAuthNAuthenticator.test.ts.snap
@@ -24,7 +24,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "oie.webauthn.error.not.supported",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "oie.webauthn.error.not.supported",
+            },
+            "message": "oie.webauthn.error.not.supported",
+          },
         },
         "type": "InfoBox",
       },
@@ -36,6 +42,7 @@ Object {
               "content": Object {
                 "elements": Array [
                   Object {
+                    "noMargin": true,
                     "options": Object {
                       "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.title",
                       "level": 6,
@@ -44,6 +51,7 @@ Object {
                     "type": "Heading",
                   },
                   Object {
+                    "noMargin": true,
                     "options": Object {
                       "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description1",
                     },
@@ -56,6 +64,7 @@ Object {
                     "type": "Description",
                   },
                   Object {
+                    "noMargin": true,
                     "options": Object {
                       "content": "oie.verify.webauthn.cant.verify.security.key.title",
                       "level": 6,
@@ -129,6 +138,7 @@ Object {
               "content": Object {
                 "elements": Array [
                   Object {
+                    "noMargin": true,
                     "options": Object {
                       "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.title",
                       "level": 6,
@@ -137,6 +147,7 @@ Object {
                     "type": "Heading",
                   },
                   Object {
+                    "noMargin": true,
                     "options": Object {
                       "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description1",
                     },
@@ -149,6 +160,7 @@ Object {
                     "type": "Description",
                   },
                   Object {
+                    "noMargin": true,
                     "options": Object {
                       "content": "oie.verify.webauthn.cant.verify.security.key.title",
                       "level": 6,
@@ -300,6 +312,7 @@ Object {
               "content": Object {
                 "elements": Array [
                   Object {
+                    "noMargin": true,
                     "options": Object {
                       "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.title",
                       "level": 6,
@@ -308,6 +321,7 @@ Object {
                     "type": "Heading",
                   },
                   Object {
+                    "noMargin": true,
                     "options": Object {
                       "content": "oie.verify.webauthn.cant.verify.biometric.authenticator.description1",
                     },
@@ -320,6 +334,7 @@ Object {
                     "type": "Description",
                   },
                   Object {
+                    "noMargin": true,
                     "options": Object {
                       "content": "oie.verify.webauthn.cant.verify.security.key.title",
                       "level": 6,
@@ -374,7 +389,13 @@ Object {
         "options": Object {
           "class": "ERROR",
           "dataSe": "callout",
-          "message": "oie.webauthn.error.not.supported",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "oie.webauthn.error.not.supported",
+            },
+            "message": "oie.webauthn.error.not.supported",
+          },
         },
         "type": "InfoBox",
       },

--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.test.ts
@@ -77,7 +77,11 @@ describe('WebAuthN Transformer Tests', () => {
       expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
         .toBe('oie.enroll.webauthn.title');
       expect((updatedFormBag.uischema.elements[1] as InfoboxElement).options.message)
-        .toBe('oie.webauthn.error.not.supported');
+        .toEqual({
+          class: 'ERROR',
+          i18n: { key: 'oie.webauthn.error.not.supported' },
+          message: 'oie.webauthn.error.not.supported',
+        });
     });
 
     it('should render title, description and button elements when WebAuthN API is available', () => {
@@ -207,7 +211,11 @@ describe('WebAuthN Transformer Tests', () => {
       expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
         .toBe('oie.verify.webauth.title');
       expect((updatedFormBag.uischema.elements[1] as InfoboxElement).options.message)
-        .toBe('oie.webauthn.error.not.supported');
+        .toEqual({
+          class: 'ERROR',
+          i18n: { key: 'oie.webauthn.error.not.supported' },
+          message: 'oie.webauthn.error.not.supported',
+        });
       expect(updatedFormBag.uischema.elements[2].type).toBe('Accordion');
       expect((updatedFormBag.uischema.elements[2] as AccordionLayout).elements.length).toBe(1);
       expect((updatedFormBag.uischema.elements[2] as AccordionLayout).elements[0].options.summary)

--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
@@ -81,6 +81,7 @@ const getCantVerifyChallengeContent = (): UISchemaLayout => ({
   elements: [
     {
       type: 'Heading',
+      noMargin: true,
       options: {
         level: 6,
         visualLevel: 3,
@@ -89,6 +90,7 @@ const getCantVerifyChallengeContent = (): UISchemaLayout => ({
     } as HeadingElement,
     {
       type: 'Description',
+      noMargin: true,
       options: { content: loc('oie.verify.webauthn.cant.verify.biometric.authenticator.description1', 'login') },
     } as DescriptionElement,
     {
@@ -97,6 +99,7 @@ const getCantVerifyChallengeContent = (): UISchemaLayout => ({
     } as DescriptionElement,
     {
       type: 'Heading',
+      noMargin: true,
       options: {
         level: 6,
         visualLevel: 3,
@@ -192,7 +195,11 @@ export const transformWebAuthNAuthenticator: IdxStepTransformer = ({ transaction
     uischema.elements.unshift({
       type: 'InfoBox',
       options: {
-        message: loc('oie.webauthn.error.not.supported', 'login'),
+        message: {
+          class: 'ERROR',
+          message: loc('oie.webauthn.error.not.supported', 'login'),
+          i18n: { key: 'oie.webauthn.error.not.supported' },
+        },
         class: 'ERROR',
         dataSe: 'callout',
       },

--- a/src/v3/src/types/component.ts
+++ b/src/v3/src/types/component.ts
@@ -17,6 +17,7 @@ import {
   ButtonElement,
   FieldElement,
   UISchemaElement,
+  WidgetMessage,
 } from './schema';
 
 export type TesterFunction = (
@@ -27,10 +28,10 @@ export type UISchemaElementComponentWithValidationProps = {
   uischema: FieldElement;
   type?: string;
   setTouched?: StateUpdater<boolean>,
-  errors?: string[],
-  setErrors?: StateUpdater<string[] | undefined>,
+  errors?: WidgetMessage[],
+  setErrors?: StateUpdater<WidgetMessage[] | undefined>,
   onValidateHandler?: (
-    setErrors?: StateUpdater<string[] | undefined>,
+    setErrors?: StateUpdater<WidgetMessage[] | undefined>,
     value?: string | boolean | number,
   ) => void,
   handleChange?: (value: string | number | boolean) => void;

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -55,8 +55,6 @@ export type WidgetMessage = Modify<IdxMessage, {
   description?: string;
 }>;
 
-export type IdxMessageWithName = IdxMessage & { name?: string; };
-
 export type AutoCompleteValue = 'username'
 | 'current-password'
 | 'one-time-code'
@@ -444,11 +442,9 @@ export interface SpinnerElement extends UISchemaElement {
 
 export interface InfoboxElement extends UISchemaElement {
   options: {
-    message: string;
+    message: WidgetMessage;
     class: string;
-    title?: string;
     dataSe?: string;
-    listOptions?: ListElement['options'];
   }
 }
 
@@ -514,7 +510,7 @@ export interface HiddenInputElement extends UISchemaElement {
   options: { name: string; value: string; };
 }
 
-type ValidateFunction = (data: FormBag['data']) => IdxMessageWithName[] | undefined;
+type ValidateFunction = (data: FormBag['data']) => WidgetMessage[] | undefined;
 
 export interface DataSchema {
   validate?: ValidateFunction;

--- a/src/v3/src/util/buildPasswordRequirementNotMetErrorList.ts
+++ b/src/v3/src/util/buildPasswordRequirementNotMetErrorList.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { ListItem, PasswordValidation, WidgetMessage } from '../types';
+import { loc } from './locUtil';
+
+export const buildPasswordRequirementNotMetErrorList = (
+  passwordRequirements: ListItem[],
+  passwordValidations: PasswordValidation,
+  fieldName: string,
+): WidgetMessage[] => {
+  const widgetMessages: WidgetMessage[] = [];
+  const errorMessages: string[] = [];
+
+  passwordRequirements.forEach((requirement: ListItem) => {
+    const ruleValue = passwordValidations[requirement.ruleKey];
+    if (ruleValue === false) {
+      errorMessages.push(requirement.label);
+    }
+  });
+
+  if (errorMessages.length > 0) {
+    // TODO: OKTA-581769 - Update the translation key which would include the colon
+    widgetMessages.push({
+      description: loc('registration.error.password.passwordRequirementsNotMet', 'login'),
+      message: errorMessages.map((message: string) => ({
+        class: 'ERROR', i18n: { key: '' }, name: fieldName, message,
+      } as WidgetMessage)),
+    });
+  }
+
+  return widgetMessages;
+};

--- a/src/v3/src/util/getValidationMessages.ts
+++ b/src/v3/src/util/getValidationMessages.ts
@@ -14,7 +14,7 @@ import {
   ActionParams,
   DataSchema,
   FormBag,
-  IdxMessageWithName,
+  WidgetMessage,
 } from '../types';
 
 export const getValidationMessages = (
@@ -22,10 +22,10 @@ export const getValidationMessages = (
   fieldsToValidate: string[],
   data: FormBag['data'],
   params?: ActionParams,
-): Record<string, IdxMessageWithName[]> | undefined => {
+): Record<string, WidgetMessage[]> | undefined => {
   // aggregate field level messages based on validation rules in each field
   const messages = Object.entries(dataSchema)
-    .reduce((acc: Record<string, IdxMessageWithName[]>, [name, elementSchema]) => {
+    .reduce((acc: Record<string, WidgetMessage[]>, [name, elementSchema]) => {
       if (fieldsToValidate.includes(name) && typeof elementSchema.validate === 'function') {
         const validationMessages = elementSchema.validate({
           // data & params are passed here for validation in case a required field

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -17,6 +17,7 @@ import {
   NextStep,
 } from '@okta/okta-auth-js';
 
+import { getMessage } from '../../../v2/ion/i18nTransformer';
 import {
   AUTHENTICATOR_KEY,
   DEVICE_ENROLLMENT_TYPE,
@@ -26,10 +27,10 @@ import {
 import {
   AppInfo,
   AuthCoinProps,
-  IdxMessageWithName,
   IWidgetContext,
   RequiredKeys,
   UserInfo,
+  WidgetMessage,
   WidgetProps,
 } from '../types';
 import { getAuthenticatorKey } from './getAuthenticatorKey';
@@ -56,21 +57,21 @@ export const getAppInfo = (transaction: IdxTransaction): AppInfo => {
 
 export const containsMessageKey = (
   key: string,
-  messages?: IdxMessage[],
+  messages?: WidgetMessage[],
 ): boolean => (messages?.some((message) => message.i18n?.key === key) ?? false);
 
 export const containsMessageKeyPrefix = (
   prefix: string,
-  messages?: IdxMessage[],
+  messages?: WidgetMessage[],
 ): boolean => (messages?.some((message) => message.i18n?.key?.startsWith(prefix)) ?? false);
 
 export const containsOneOfMessageKeys = (
   keys: string[],
-  messages?: IdxMessage[],
+  messages?: WidgetMessage[],
 ): boolean => keys.some((key) => containsMessageKey(key, messages));
 
 export const updatePasswordRequirementsNotMetMessage = (
-  messages: IdxMessageWithName[],
+  messages: IdxMessage[],
 ): IdxMessage[] => (
   messages.map((message) => {
     if (message.i18n?.key?.includes('password.passwordRequirementsNotMet')) {
@@ -215,3 +216,16 @@ export const updateTransactionWithNextStep = (
     nextStep,
   });
 };
+
+export const convertIdxMessageToWidgetMessage = (
+  messages?: any[],
+): WidgetMessage[] | undefined => messages?.map((message) => {
+  // If message is an array, it has already been translated earlier in the flow
+  if (Array.isArray(message?.message)) {
+    return message as WidgetMessage;
+  }
+  return {
+    ...(message as IdxMessage),
+    message: getMessage(message),
+  };
+});

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -12,6 +12,7 @@
 
 export * from './browserUtils';
 export * from './buildErrorMessageIds';
+export * from './buildPasswordRequirementNotMetErrorList';
 export * from './clipboard';
 export * from './cookieUtils';
 export * from './environmentUtils';

--- a/src/v3/src/util/passwordUtils.test.ts
+++ b/src/v3/src/util/passwordUtils.test.ts
@@ -124,6 +124,17 @@ describe('PasswordUtils Tests', () => {
   });
 
   describe('Validate ExcludeAttributes', () => {
+    it('should validate excludeAttributes when username is to be excluded', () => {
+      userInfo = { identifier: 'tester.user+123@okta.com' };
+
+      expect(validatePassword('tester.user', userInfo, { complexity: { excludeAttributes: ['username'] } })?.username)
+        .toEqual(false);
+      expect(validatePassword('tester.user@okta.com', userInfo, { complexity: { excludeAttributes: ['username'] } })?.username)
+        .toEqual(false);
+      expect(validatePassword('tester.user+123@okta.com', userInfo, { complexity: { excludeAttributes: ['username'] } })?.username)
+        .toEqual(false);
+    });
+
     it('should validate excludeAttributes when firstName is to be excluded', () => {
       userInfo = { profile: { firstName: 'Tester', lastName: 'Doe' } };
 

--- a/src/v3/src/util/passwordUtils.ts
+++ b/src/v3/src/util/passwordUtils.ts
@@ -151,8 +151,8 @@ const excludeAttributes = (
   password: string,
   ruleVal: unknown,
   userInfo: UserInfo,
-): { [key: string]: boolean } => {
-  const ruleValidations: { [key: string]: boolean } = {};
+): PasswordValidation => {
+  const ruleValidations: PasswordValidation = {};
   if (Array.isArray(ruleVal)) {
     ruleVal.forEach((attr) => {
       const validatorFn = ValidatorFunctions[`exclude${attr.charAt(0).toUpperCase() + attr.slice(1)}Validator`];
@@ -172,7 +172,7 @@ export const validatePassword = (
 ): PasswordValidation => {
   let passwordValidations: PasswordValidation = {};
 
-  if (!settings || (!settings.complexity && !settings.age)) {
+  if (!settings?.complexity || Object.keys(settings.complexity).length === 0) {
     return passwordValidations;
   }
 

--- a/src/v3/src/util/resetMessagesToInputs.ts
+++ b/src/v3/src/util/resetMessagesToInputs.ts
@@ -12,11 +12,11 @@
 
 import { Input } from '@okta/okta-auth-js';
 
-import { IdxMessageWithName } from '../types';
+import { WidgetMessage } from '../types';
 
 export function resetMessagesToInputs(
   inputs: Input[],
-  messagesByField: Record<string, IdxMessageWithName[]>,
+  messagesByField: Record<string, WidgetMessage[]>,
 ): void {
   const fn = (items: Input[], namePrefix: string) => {
     items.forEach((input) => {

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -1,5 +1,681 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`authenticator-expired-password-with-enrollment-authenticator should present field level error message of (failed) password requirements 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-2"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader authCoinSpacing MuiBox-root emotion-3"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-4"
+          />
+          <div
+            class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
+            data-se="factor-beacon"
+          >
+            <svg
+              aria-labelledby="mfa-okta-password"
+              fill="none"
+              height="48"
+              role="img"
+              viewBox="0 0 48 48"
+              width="48"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="mfa-okta-password"
+              >
+                Password
+              </title>
+              <circle
+                class="siwFillBg"
+                cx="24"
+                cy="24"
+                fill="#F5F5F6"
+                r="24"
+              />
+              <path
+                class="siwFillSecondary"
+                d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
+                fill="#A7B5EC"
+              />
+              <path
+                class="siwFillPrimary"
+                d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
+                fill="#00297A"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root emotion-6"
+        >
+          <div
+            class="identifier-container MuiBox-root emotion-7"
+          >
+            <div
+              class="identifierContainer MuiBox-root emotion-8"
+            >
+              <span
+                class="userIconContainer MuiBox-root emotion-9"
+              >
+                <svg
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
+                  fill="none"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                  <title>
+                    User
+                  </title>
+                </svg>
+              </span>
+              <span
+                class="identifier no-translate identifierSpan MuiBox-root emotion-9"
+                data-se="identifier"
+              >
+                testUser@okta.com
+              </span>
+            </div>
+          </div>
+          <form
+            class="o-form siwForm"
+            data-se="o-form"
+            novalidate=""
+          >
+            <div
+              class="MuiBox-root emotion-12"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-13"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon emotion-14"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                    fill="none"
+                    focusable="false"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M13.983 14.6471C13.4706 15 12.6329 15 10.9575 15H5.04248C3.36707 15 2.52937 15 2.01699 14.6471C1.56939 14.3387 1.26655 13.8615 1.17816 13.3252C1.07698 12.7114 1.43367 11.9534 2.14706 10.4374L5.10455 4.15277C6.02878 2.18879 6.49089 1.2068 7.12576 0.898255C7.6777 0.630012 8.32225 0.630012 8.87419 0.898255C9.50906 1.2068 9.97117 2.18879 10.8954 4.15277L13.8529 10.4374C14.5663 11.9534 14.923 12.7114 14.8218 13.3252C14.7334 13.8615 14.4306 14.3387 13.983 14.6471ZM7.99998 10C7.72383 10 7.49998 9.77614 7.49998 9.5L7.49998 5H8.49998L8.49998 9.5C8.49998 9.77614 8.27612 10 7.99998 10ZM7.99998 13C8.14831 13 8.29332 12.956 8.41665 12.8736C8.53999 12.7912 8.63612 12.6741 8.69288 12.537C8.74965 12.4 8.7645 12.2492 8.73556 12.1037C8.70662 11.9582 8.6352 11.8246 8.53031 11.7197C8.42542 11.6148 8.29178 11.5434 8.14629 11.5144C8.00081 11.4855 7.85001 11.5003 7.71296 11.5571C7.57592 11.6139 7.45878 11.71 7.37637 11.8333C7.29396 11.9567 7.24998 12.1017 7.24998 12.25C7.24998 12.4489 7.32899 12.6397 7.46964 12.7803C7.6103 12.921 7.80106 13 7.99998 13Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message emotion-16"
+                >
+                  We found some errors. Please review the form and make corrections.
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-17"
+            >
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-19"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h4 emotion-20"
+                    data-se="o-form-head"
+                    id="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut8eqcFiHicejNIP0g4_1"
+                  >
+                    Your password has expired
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <figure
+                  class="MuiBox-root emotion-22"
+                  data-se="password-authenticator--rules"
+                  id="reenroll-authenticator_PasswordRequirements_okta_password_aut8eqcFiHicejNIP0g4_2"
+                >
+                  <figcaption
+                    class="password-authenticator--heading MuiBox-root emotion-9"
+                  >
+                    Password requirements:
+                  </figcaption>
+                  <ul
+                    class="MuiBox-root emotion-24"
+                    id="password-authenticator--list"
+                  >
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            At least 8 characters
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            A lowercase letter
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            An uppercase letter
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            A number
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            No parts of your username
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </figure>
+              </div>
+              <div
+                class="MuiBox-root emotion-9"
+              >
+                <input
+                  class="hidden"
+                  id="username"
+                  name="username"
+                  type="text"
+                />
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-63"
+                    for="credentials.passcode"
+                  >
+                    New password
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    required="true"
+                  >
+                    <input
+                      aria-describedby=" credentials.passcode-error reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut8eqcFiHicejNIP0g4_1 reenroll-authenticator_PasswordRequirements_okta_password_aut8eqcFiHicejNIP0g4_2 "
+                      aria-invalid="true"
+                      autocomplete="new-password"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-65"
+                      data-se="credentials.passcode"
+                      id="credentials.passcode"
+                      name="credentials.passcode"
+                      required=""
+                      type="password"
+                    />
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-66"
+                    >
+                      <button
+                        aria-controls="credentials.passcode"
+                        aria-label="Show password"
+                        aria-pressed="false"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                          fill="none"
+                          focusable="false"
+                          viewBox="0 0 16 16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M3.89765 11.5506C2.89626 10.6994 2.04176 9.50056 1.15617 8C2.04176 6.49944 2.89626 5.30062 3.89765 4.44944C4.96916 3.53865 6.24031 3 8 3C9.75969 3 11.0308 3.53865 12.1024 4.44944C13.1037 5.30062 13.9582 6.49944 14.8438 8C13.9582 9.50056 13.1037 10.6994 12.1024 11.5506C11.0308 12.4613 9.75969 13 8 13C6.24031 13 4.96916 12.4613 3.89765 11.5506ZM8 14C12 14 14 11.5 16 8C14 4.5 12 2 8 2C4 2 2 4.5 0 8C2 11.5 4 14 8 14ZM11 8C11 9.65685 9.65685 11 8 11C6.34315 11 5 9.65685 5 8C5 6.34315 6.34315 5 8 5C9.65685 5 11 6.34315 11 8ZM12 8C12 10.2091 10.2091 12 8 12C5.79086 12 4 10.2091 4 8C4 5.79086 5.79086 4 8 4C10.2091 4 12 5.79086 12 8Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-9"
+                  >
+                    <p
+                      class="MuiFormHelperText-root Mui-error emotion-70"
+                      data-se="credentials.passcode-error"
+                      id="credentials.passcode-error"
+                      role="alert"
+                    >
+                      <div
+                        class="MuiBox-root emotion-71"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-72"
+                        >
+                          Password requirements were not met
+                        </p>
+                        <ul
+                          class="MuiList-root MuiList-dense emotion-73"
+                        >
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                          >
+                            At least 8 characters
+                          </li>
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                          >
+                            An uppercase letter
+                          </li>
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                          >
+                            A number
+                          </li>
+                        </ul>
+                      </div>
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-63"
+                    for="confirmPassword"
+                  >
+                    Re-enter password
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    required="true"
+                  >
+                    <input
+                      aria-describedby=" confirmPassword-error reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut8eqcFiHicejNIP0g4_1 reenroll-authenticator_PasswordRequirements_okta_password_aut8eqcFiHicejNIP0g4_2 "
+                      aria-invalid="true"
+                      autocomplete="new-password"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-65"
+                      data-se="confirmPassword"
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      required=""
+                      type="password"
+                    />
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-66"
+                    >
+                      <button
+                        aria-controls="confirmPassword"
+                        aria-label="Show re-enter password"
+                        aria-pressed="false"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                          fill="none"
+                          focusable="false"
+                          viewBox="0 0 16 16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M3.89765 11.5506C2.89626 10.6994 2.04176 9.50056 1.15617 8C2.04176 6.49944 2.89626 5.30062 3.89765 4.44944C4.96916 3.53865 6.24031 3 8 3C9.75969 3 11.0308 3.53865 12.1024 4.44944C13.1037 5.30062 13.9582 6.49944 14.8438 8C13.9582 9.50056 13.1037 10.6994 12.1024 11.5506C11.0308 12.4613 9.75969 13 8 13C6.24031 13 4.96916 12.4613 3.89765 11.5506ZM8 14C12 14 14 11.5 16 8C14 4.5 12 2 8 2C4 2 2 4.5 0 8C2 11.5 4 14 8 14ZM11 8C11 9.65685 9.65685 11 8 11C6.34315 11 5 9.65685 5 8C5 6.34315 6.34315 5 8 5C9.65685 5 11 6.34315 11 8ZM12 8C12 10.2091 10.2091 12 8 12C5.79086 12 4 10.2091 4 8C4 5.79086 5.79086 4 8 4C10.2091 4 12 5.79086 12 8Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-9"
+                  >
+                    <p
+                      class="MuiFormHelperText-root Mui-error emotion-70"
+                      data-se="confirmPassword-error"
+                      id="confirmPassword-error"
+                      role="alert"
+                    >
+                      This field cannot be left blank
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                  data-se="password-authenticator--matches"
+                >
+                  <ul
+                    class="MuiBox-root emotion-89"
+                    id="credentials.newPassword-list"
+                  >
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                incomplete
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            Passwords must match
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <button
+                  aria-describedby="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut8eqcFiHicejNIP0g4_1"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-98"
+                  data-type="save"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Change Password
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-100"
+                  data-se="switchAuthenticator"
+                  href="javascript:void(0)"
+                >
+                  Return to authenticator list
+                </a>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-100"
+                  data-se="cancel"
+                  href="javascript:void(0)"
+                >
+                  Back to sign in
+                </a>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
 exports[`authenticator-expired-password-with-enrollment-authenticator should render form 1`] = `
 <div>
   <div

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -94,6 +95,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -182,10 +184,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -226,10 +228,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -270,10 +272,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -314,10 +316,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -358,10 +360,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -595,10 +597,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -1,5 +1,670 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`authenticator-expired-password should present field level error message of (failed) password requirements 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-2"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader authCoinSpacing MuiBox-root emotion-3"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-4"
+          />
+          <div
+            class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
+            data-se="factor-beacon"
+          >
+            <svg
+              aria-labelledby="mfa-okta-password"
+              fill="none"
+              height="48"
+              role="img"
+              viewBox="0 0 48 48"
+              width="48"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="mfa-okta-password"
+              >
+                Password
+              </title>
+              <circle
+                class="siwFillBg"
+                cx="24"
+                cy="24"
+                fill="#F5F5F6"
+                r="24"
+              />
+              <path
+                class="siwFillSecondary"
+                d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
+                fill="#A7B5EC"
+              />
+              <path
+                class="siwFillPrimary"
+                d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
+                fill="#00297A"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root emotion-6"
+        >
+          <div
+            class="identifier-container MuiBox-root emotion-7"
+          >
+            <div
+              class="identifierContainer MuiBox-root emotion-8"
+            >
+              <span
+                class="userIconContainer MuiBox-root emotion-9"
+              >
+                <svg
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
+                  fill="none"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                  <title>
+                    User
+                  </title>
+                </svg>
+              </span>
+              <span
+                class="identifier no-translate identifierSpan MuiBox-root emotion-9"
+                data-se="identifier"
+              >
+                tester8@test.com
+              </span>
+            </div>
+          </div>
+          <form
+            class="o-form siwForm"
+            data-se="o-form"
+            novalidate=""
+          >
+            <div
+              class="MuiBox-root emotion-12"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-13"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon emotion-14"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                    fill="none"
+                    focusable="false"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M13.983 14.6471C13.4706 15 12.6329 15 10.9575 15H5.04248C3.36707 15 2.52937 15 2.01699 14.6471C1.56939 14.3387 1.26655 13.8615 1.17816 13.3252C1.07698 12.7114 1.43367 11.9534 2.14706 10.4374L5.10455 4.15277C6.02878 2.18879 6.49089 1.2068 7.12576 0.898255C7.6777 0.630012 8.32225 0.630012 8.87419 0.898255C9.50906 1.2068 9.97117 2.18879 10.8954 4.15277L13.8529 10.4374C14.5663 11.9534 14.923 12.7114 14.8218 13.3252C14.7334 13.8615 14.4306 14.3387 13.983 14.6471ZM7.99998 10C7.72383 10 7.49998 9.77614 7.49998 9.5L7.49998 5H8.49998L8.49998 9.5C8.49998 9.77614 8.27612 10 7.99998 10ZM7.99998 13C8.14831 13 8.29332 12.956 8.41665 12.8736C8.53999 12.7912 8.63612 12.6741 8.69288 12.537C8.74965 12.4 8.7645 12.2492 8.73556 12.1037C8.70662 11.9582 8.6352 11.8246 8.53031 11.7197C8.42542 11.6148 8.29178 11.5434 8.14629 11.5144C8.00081 11.4855 7.85001 11.5003 7.71296 11.5571C7.57592 11.6139 7.45878 11.71 7.37637 11.8333C7.29396 11.9567 7.24998 12.1017 7.24998 12.25C7.24998 12.4489 7.32899 12.6397 7.46964 12.7803C7.6103 12.921 7.80106 13 7.99998 13Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message emotion-16"
+                >
+                  We found some errors. Please review the form and make corrections.
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-17"
+            >
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-19"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h4 emotion-20"
+                    data-se="o-form-head"
+                    id="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut2h3ffszv3me6O31d7_1"
+                  >
+                    Your password has expired
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <figure
+                  class="MuiBox-root emotion-22"
+                  data-se="password-authenticator--rules"
+                  id="reenroll-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
+                >
+                  <figcaption
+                    class="password-authenticator--heading MuiBox-root emotion-9"
+                  >
+                    Password requirements:
+                  </figcaption>
+                  <ul
+                    class="MuiBox-root emotion-24"
+                    id="password-authenticator--list"
+                  >
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            At least 8 characters
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            A lowercase letter
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            An uppercase letter
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            A number
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            No parts of your username
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </figure>
+              </div>
+              <div
+                class="MuiBox-root emotion-9"
+              >
+                <input
+                  class="hidden"
+                  id="username"
+                  name="username"
+                  type="text"
+                />
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-63"
+                    for="credentials.passcode"
+                  >
+                    New password
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    required="true"
+                  >
+                    <input
+                      aria-describedby=" credentials.passcode-error reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut2h3ffszv3me6O31d7_1 reenroll-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2 "
+                      aria-invalid="true"
+                      autocomplete="new-password"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-65"
+                      data-se="credentials.passcode"
+                      id="credentials.passcode"
+                      name="credentials.passcode"
+                      required=""
+                      type="password"
+                    />
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-66"
+                    >
+                      <button
+                        aria-controls="credentials.passcode"
+                        aria-label="Show password"
+                        aria-pressed="false"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                          fill="none"
+                          focusable="false"
+                          viewBox="0 0 16 16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M3.89765 11.5506C2.89626 10.6994 2.04176 9.50056 1.15617 8C2.04176 6.49944 2.89626 5.30062 3.89765 4.44944C4.96916 3.53865 6.24031 3 8 3C9.75969 3 11.0308 3.53865 12.1024 4.44944C13.1037 5.30062 13.9582 6.49944 14.8438 8C13.9582 9.50056 13.1037 10.6994 12.1024 11.5506C11.0308 12.4613 9.75969 13 8 13C6.24031 13 4.96916 12.4613 3.89765 11.5506ZM8 14C12 14 14 11.5 16 8C14 4.5 12 2 8 2C4 2 2 4.5 0 8C2 11.5 4 14 8 14ZM11 8C11 9.65685 9.65685 11 8 11C6.34315 11 5 9.65685 5 8C5 6.34315 6.34315 5 8 5C9.65685 5 11 6.34315 11 8ZM12 8C12 10.2091 10.2091 12 8 12C5.79086 12 4 10.2091 4 8C4 5.79086 5.79086 4 8 4C10.2091 4 12 5.79086 12 8Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-9"
+                  >
+                    <p
+                      class="MuiFormHelperText-root Mui-error emotion-70"
+                      data-se="credentials.passcode-error"
+                      id="credentials.passcode-error"
+                      role="alert"
+                    >
+                      <div
+                        class="MuiBox-root emotion-71"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-72"
+                        >
+                          Password requirements were not met
+                        </p>
+                        <ul
+                          class="MuiList-root MuiList-dense emotion-73"
+                        >
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                          >
+                            At least 8 characters
+                          </li>
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                          >
+                            An uppercase letter
+                          </li>
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                          >
+                            A number
+                          </li>
+                        </ul>
+                      </div>
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-63"
+                    for="confirmPassword"
+                  >
+                    Re-enter password
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    required="true"
+                  >
+                    <input
+                      aria-describedby=" confirmPassword-error reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut2h3ffszv3me6O31d7_1 reenroll-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2 "
+                      aria-invalid="true"
+                      autocomplete="new-password"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-65"
+                      data-se="confirmPassword"
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      required=""
+                      type="password"
+                    />
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-66"
+                    >
+                      <button
+                        aria-controls="confirmPassword"
+                        aria-label="Show re-enter password"
+                        aria-pressed="false"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                          fill="none"
+                          focusable="false"
+                          viewBox="0 0 16 16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M3.89765 11.5506C2.89626 10.6994 2.04176 9.50056 1.15617 8C2.04176 6.49944 2.89626 5.30062 3.89765 4.44944C4.96916 3.53865 6.24031 3 8 3C9.75969 3 11.0308 3.53865 12.1024 4.44944C13.1037 5.30062 13.9582 6.49944 14.8438 8C13.9582 9.50056 13.1037 10.6994 12.1024 11.5506C11.0308 12.4613 9.75969 13 8 13C6.24031 13 4.96916 12.4613 3.89765 11.5506ZM8 14C12 14 14 11.5 16 8C14 4.5 12 2 8 2C4 2 2 4.5 0 8C2 11.5 4 14 8 14ZM11 8C11 9.65685 9.65685 11 8 11C6.34315 11 5 9.65685 5 8C5 6.34315 6.34315 5 8 5C9.65685 5 11 6.34315 11 8ZM12 8C12 10.2091 10.2091 12 8 12C5.79086 12 4 10.2091 4 8C4 5.79086 5.79086 4 8 4C10.2091 4 12 5.79086 12 8Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-9"
+                  >
+                    <p
+                      class="MuiFormHelperText-root Mui-error emotion-70"
+                      data-se="confirmPassword-error"
+                      id="confirmPassword-error"
+                      role="alert"
+                    >
+                      This field cannot be left blank
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                  data-se="password-authenticator--matches"
+                >
+                  <ul
+                    class="MuiBox-root emotion-89"
+                    id="credentials.newPassword-list"
+                  >
+                    <li
+                      class="MuiBox-root emotion-25"
+                    >
+                      <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <div
+                          class="MuiBox-root emotion-27"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                incomplete
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                          >
+                            Passwords must match
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <button
+                  aria-describedby="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut2h3ffszv3me6O31d7_1"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-98"
+                  data-type="save"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Change Password
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-100"
+                  data-se="cancel"
+                  href="javascript:void(0)"
+                >
+                  Back to sign in
+                </a>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
 exports[`authenticator-expired-password should render form 1`] = `
 <div>
   <div

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-expired-password should present field level error message
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -94,6 +95,7 @@ exports[`authenticator-expired-password should present field level error message
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="tester8@test.com"
               >
                 tester8@test.com
               </span>
@@ -182,10 +184,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -226,10 +228,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -270,10 +272,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -314,10 +316,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -358,10 +360,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
                               fill="none"
                               focusable="false"
@@ -595,10 +597,10 @@ exports[`authenticator-expired-password should present field level error message
                           class="MuiBox-root emotion-27"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-28"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
             class="MuiTypography-root MuiTypography-h1 emotion-4"
           />
           <div
+            aria-hidden="true"
             class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
             data-se="factor-beacon"
           >
@@ -94,6 +95,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
               <span
                 class="identifier no-translate identifierSpan MuiBox-root emotion-9"
                 data-se="identifier"
+                title="testUser@okta.com"
               >
                 testUser@okta.com
               </span>
@@ -197,10 +199,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -241,10 +243,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -285,10 +287,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -329,10 +331,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -373,10 +375,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -417,10 +419,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -461,10 +463,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -505,10 +507,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
@@ -747,10 +749,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           class="MuiBox-root emotion-30"
                         >
                           <div
+                            aria-hidden="true"
                             class="passwordRequirementIcon MuiBox-root emotion-31"
                           >
                             <svg
-                              aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
                               fill="none"
                               focusable="false"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -1,5 +1,834 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`authenticator-expiry-warning-password should present field level error message of (failed) password requirements 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-2"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader authCoinSpacing MuiBox-root emotion-3"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-4"
+          />
+          <div
+            class="iconContainer mfa-okta-password authCoinOverlay MuiBox-root emotion-5"
+            data-se="factor-beacon"
+          >
+            <svg
+              aria-labelledby="mfa-okta-password"
+              fill="none"
+              height="48"
+              role="img"
+              viewBox="0 0 48 48"
+              width="48"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="mfa-okta-password"
+              >
+                Password
+              </title>
+              <circle
+                class="siwFillBg"
+                cx="24"
+                cy="24"
+                fill="#F5F5F6"
+                r="24"
+              />
+              <path
+                class="siwFillSecondary"
+                d="M11 17h-1V9h8v1h-7v7Zm28 0h-1v-7h-7V9h8v8ZM18 39h-8v-8h1v7h7v1Zm21 0h-8v-1h7v-7h1v8Z"
+                fill="#A7B5EC"
+              />
+              <path
+                class="siwFillPrimary"
+                d="m14.91 22.067-1.829 1.064V21h-1v2.131l-1.83-1.064-.502.866L11.585 24l-1.836 1.067.502.866 1.83-1.064V27h1v-2.131l1.829 1.064.503-.866L13.576 24l1.837-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L19.531 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L21.523 24l1.836-1.067-.503-.866Zm7.946 0-1.829 1.064V21h-1v2.131l-1.829-1.064-.503.866L27.477 24l-1.836 1.067.503.866 1.83-1.064V27h1v-2.131l1.828 1.064.503-.866L29.47 24l1.836-1.067-.503-.866Zm8.448.866-.501-.866-1.83 1.064V21h-1v2.131l-1.83-1.064-.502.866L35.424 24l-1.837 1.067.503.866 1.829-1.064V27h1v-2.131l1.83 1.064.502-.866L37.415 24l1.836-1.067Z"
+                fill="#00297A"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root emotion-6"
+        >
+          <div
+            class="identifier-container MuiBox-root emotion-7"
+          >
+            <div
+              class="identifierContainer MuiBox-root emotion-8"
+            >
+              <span
+                class="userIconContainer MuiBox-root emotion-9"
+              >
+                <svg
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
+                  fill="none"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                  <title>
+                    User
+                  </title>
+                </svg>
+              </span>
+              <span
+                class="identifier no-translate identifierSpan MuiBox-root emotion-9"
+                data-se="identifier"
+              >
+                testUser@okta.com
+              </span>
+            </div>
+          </div>
+          <form
+            class="o-form siwForm"
+            data-se="o-form"
+            novalidate=""
+          >
+            <div
+              class="MuiBox-root emotion-12"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-13"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon emotion-14"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                    fill="none"
+                    focusable="false"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M13.983 14.6471C13.4706 15 12.6329 15 10.9575 15H5.04248C3.36707 15 2.52937 15 2.01699 14.6471C1.56939 14.3387 1.26655 13.8615 1.17816 13.3252C1.07698 12.7114 1.43367 11.9534 2.14706 10.4374L5.10455 4.15277C6.02878 2.18879 6.49089 1.2068 7.12576 0.898255C7.6777 0.630012 8.32225 0.630012 8.87419 0.898255C9.50906 1.2068 9.97117 2.18879 10.8954 4.15277L13.8529 10.4374C14.5663 11.9534 14.923 12.7114 14.8218 13.3252C14.7334 13.8615 14.4306 14.3387 13.983 14.6471ZM7.99998 10C7.72383 10 7.49998 9.77614 7.49998 9.5L7.49998 5H8.49998L8.49998 9.5C8.49998 9.77614 8.27612 10 7.99998 10ZM7.99998 13C8.14831 13 8.29332 12.956 8.41665 12.8736C8.53999 12.7912 8.63612 12.6741 8.69288 12.537C8.74965 12.4 8.7645 12.2492 8.73556 12.1037C8.70662 11.9582 8.6352 11.8246 8.53031 11.7197C8.42542 11.6148 8.29178 11.5434 8.14629 11.5144C8.00081 11.4855 7.85001 11.5003 7.71296 11.5571C7.57592 11.6139 7.45878 11.71 7.37637 11.8333C7.29396 11.9567 7.24998 12.1017 7.24998 12.25C7.24998 12.4489 7.32899 12.6397 7.46964 12.7803C7.6103 12.921 7.80106 13 7.99998 13Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message emotion-16"
+                >
+                  We found some errors. Please review the form and make corrections.
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-17"
+            >
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-19"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h4 emotion-20"
+                    data-se="o-form-head"
+                    id="reenroll-authenticator-warning_Title_Your_password_will_expire_in_4_days_okta_password_aut6ci0ZJwJCQ5v6f0g4_1"
+                  >
+                    Your password will expire in 4 days
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-19"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-23"
+                    data-se="o-form-explain"
+                    id="reenroll-authenticator-warning_Description_When_your_password_expires_you_will_be_locked_out_of_your_Okta_account_okta_password_aut6ci0ZJwJCQ5v6f0g4_2"
+                  >
+                    When your password expires you will be locked out of your Okta account.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <figure
+                  class="MuiBox-root emotion-25"
+                  data-se="password-authenticator--rules"
+                  id="reenroll-authenticator-warning_PasswordRequirements_okta_password_aut6ci0ZJwJCQ5v6f0g4_3"
+                >
+                  <figcaption
+                    class="password-authenticator--heading MuiBox-root emotion-9"
+                  >
+                    Password requirements:
+                  </figcaption>
+                  <ul
+                    class="MuiBox-root emotion-27"
+                    id="password-authenticator--list"
+                  >
+                    <li
+                      class="MuiBox-root emotion-28"
+                    >
+                      <div
+                        class="MuiBox-root emotion-29"
+                      >
+                        <div
+                          class="MuiBox-root emotion-30"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                          >
+                            At least 8 characters
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-28"
+                    >
+                      <div
+                        class="MuiBox-root emotion-29"
+                      >
+                        <div
+                          class="MuiBox-root emotion-30"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                          >
+                            A lowercase letter
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-28"
+                    >
+                      <div
+                        class="MuiBox-root emotion-29"
+                      >
+                        <div
+                          class="MuiBox-root emotion-30"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                          >
+                            An uppercase letter
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-28"
+                    >
+                      <div
+                        class="MuiBox-root emotion-29"
+                      >
+                        <div
+                          class="MuiBox-root emotion-30"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                          >
+                            A number
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-28"
+                    >
+                      <div
+                        class="MuiBox-root emotion-29"
+                      >
+                        <div
+                          class="MuiBox-root emotion-30"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                          >
+                            A symbol
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-28"
+                    >
+                      <div
+                        class="MuiBox-root emotion-29"
+                      >
+                        <div
+                          class="MuiBox-root emotion-30"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                          >
+                            No parts of your username
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-28"
+                    >
+                      <div
+                        class="MuiBox-root emotion-29"
+                      >
+                        <div
+                          class="MuiBox-root emotion-30"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                          >
+                            Does not include your first name
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                    <li
+                      class="MuiBox-root emotion-28"
+                    >
+                      <div
+                        class="MuiBox-root emotion-29"
+                      >
+                        <div
+                          class="MuiBox-root emotion-30"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                info
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                          >
+                            Does not include your last name
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </figure>
+              </div>
+              <div
+                class="MuiBox-root emotion-9"
+              >
+                <input
+                  class="hidden"
+                  id="username"
+                  name="username"
+                  type="text"
+                />
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-87"
+                    for="credentials.passcode"
+                  >
+                    New password
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-88"
+                    required="true"
+                  >
+                    <input
+                      aria-describedby=" credentials.passcode-error reenroll-authenticator-warning_Title_Your_password_will_expire_in_4_days_okta_password_aut6ci0ZJwJCQ5v6f0g4_1 reenroll-authenticator-warning_Description_When_your_password_expires_you_will_be_locked_out_of_your_Okta_account_okta_password_aut6ci0ZJwJCQ5v6f0g4_2 reenroll-authenticator-warning_PasswordRequirements_okta_password_aut6ci0ZJwJCQ5v6f0g4_3 "
+                      aria-invalid="true"
+                      autocomplete="new-password"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-89"
+                      data-se="credentials.passcode"
+                      id="credentials.passcode"
+                      name="credentials.passcode"
+                      required=""
+                      type="password"
+                    />
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-90"
+                    >
+                      <button
+                        aria-controls="credentials.passcode"
+                        aria-label="Show password"
+                        aria-pressed="false"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-91"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                          fill="none"
+                          focusable="false"
+                          viewBox="0 0 16 16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M3.89765 11.5506C2.89626 10.6994 2.04176 9.50056 1.15617 8C2.04176 6.49944 2.89626 5.30062 3.89765 4.44944C4.96916 3.53865 6.24031 3 8 3C9.75969 3 11.0308 3.53865 12.1024 4.44944C13.1037 5.30062 13.9582 6.49944 14.8438 8C13.9582 9.50056 13.1037 10.6994 12.1024 11.5506C11.0308 12.4613 9.75969 13 8 13C6.24031 13 4.96916 12.4613 3.89765 11.5506ZM8 14C12 14 14 11.5 16 8C14 4.5 12 2 8 2C4 2 2 4.5 0 8C2 11.5 4 14 8 14ZM11 8C11 9.65685 9.65685 11 8 11C6.34315 11 5 9.65685 5 8C5 6.34315 6.34315 5 8 5C9.65685 5 11 6.34315 11 8ZM12 8C12 10.2091 10.2091 12 8 12C5.79086 12 4 10.2091 4 8C4 5.79086 5.79086 4 8 4C10.2091 4 12 5.79086 12 8Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-9"
+                  >
+                    <p
+                      class="MuiFormHelperText-root Mui-error emotion-94"
+                      data-se="credentials.passcode-error"
+                      id="credentials.passcode-error"
+                      role="alert"
+                    >
+                      <div
+                        class="MuiBox-root emotion-95"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-96"
+                        >
+                          Password requirements were not met
+                        </p>
+                        <ul
+                          class="MuiList-root MuiList-dense emotion-97"
+                        >
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                          >
+                            At least 8 characters
+                          </li>
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                          >
+                            An uppercase letter
+                          </li>
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                          >
+                            A number
+                          </li>
+                          <li
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                          >
+                            A symbol
+                          </li>
+                        </ul>
+                      </div>
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-87"
+                    for="confirmPassword"
+                  >
+                    Re-enter password
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-88"
+                    required="true"
+                  >
+                    <input
+                      aria-describedby=" confirmPassword-error reenroll-authenticator-warning_Title_Your_password_will_expire_in_4_days_okta_password_aut6ci0ZJwJCQ5v6f0g4_1 reenroll-authenticator-warning_Description_When_your_password_expires_you_will_be_locked_out_of_your_Okta_account_okta_password_aut6ci0ZJwJCQ5v6f0g4_2 reenroll-authenticator-warning_PasswordRequirements_okta_password_aut6ci0ZJwJCQ5v6f0g4_3 "
+                      aria-invalid="true"
+                      autocomplete="new-password"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-89"
+                      data-se="confirmPassword"
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      required=""
+                      type="password"
+                    />
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-90"
+                    >
+                      <button
+                        aria-controls="confirmPassword"
+                        aria-label="Show re-enter password"
+                        aria-pressed="false"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-91"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                          fill="none"
+                          focusable="false"
+                          viewBox="0 0 16 16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M3.89765 11.5506C2.89626 10.6994 2.04176 9.50056 1.15617 8C2.04176 6.49944 2.89626 5.30062 3.89765 4.44944C4.96916 3.53865 6.24031 3 8 3C9.75969 3 11.0308 3.53865 12.1024 4.44944C13.1037 5.30062 13.9582 6.49944 14.8438 8C13.9582 9.50056 13.1037 10.6994 12.1024 11.5506C11.0308 12.4613 9.75969 13 8 13C6.24031 13 4.96916 12.4613 3.89765 11.5506ZM8 14C12 14 14 11.5 16 8C14 4.5 12 2 8 2C4 2 2 4.5 0 8C2 11.5 4 14 8 14ZM11 8C11 9.65685 9.65685 11 8 11C6.34315 11 5 9.65685 5 8C5 6.34315 6.34315 5 8 5C9.65685 5 11 6.34315 11 8ZM12 8C12 10.2091 10.2091 12 8 12C5.79086 12 4 10.2091 4 8C4 5.79086 5.79086 4 8 4C10.2091 4 12 5.79086 12 8Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-9"
+                  >
+                    <p
+                      class="MuiFormHelperText-root Mui-error emotion-94"
+                      data-se="confirmPassword-error"
+                      id="confirmPassword-error"
+                      role="alert"
+                    >
+                      This field cannot be left blank
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                  data-se="password-authenticator--matches"
+                >
+                  <ul
+                    class="MuiBox-root emotion-114"
+                    id="credentials.newPassword-list"
+                  >
+                    <li
+                      class="MuiBox-root emotion-28"
+                    >
+                      <div
+                        class="MuiBox-root emotion-29"
+                      >
+                        <div
+                          class="MuiBox-root emotion-30"
+                        >
+                          <div
+                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
+                              fill="none"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <title>
+                                incomplete
+                              </title>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiBox-root emotion-9"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                          >
+                            Passwords must match
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <button
+                  aria-describedby="reenroll-authenticator-warning_Title_Your_password_will_expire_in_4_days_okta_password_aut6ci0ZJwJCQ5v6f0g4_1 reenroll-authenticator-warning_Description_When_your_password_expires_you_will_be_locked_out_of_your_Okta_account_okta_password_aut6ci0ZJwJCQ5v6f0g4_2"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-123"
+                  data-type="save"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Change Password
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <a
+                  aria-describedby="reenroll-authenticator-warning_Title_Your_password_will_expire_in_4_days_okta_password_aut6ci0ZJwJCQ5v6f0g4_1 reenroll-authenticator-warning_Description_When_your_password_expires_you_will_be_locked_out_of_your_Okta_account_okta_password_aut6ci0ZJwJCQ5v6f0g4_2"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-125"
+                  data-se="skip"
+                  href="javascript:void(0)"
+                >
+                  Remind me later
+                </a>
+              </div>
+              <div
+                class="MuiBox-root emotion-18"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-125"
+                  data-se="cancel"
+                  href="javascript:void(0)"
+                >
+                  Back to sign in
+                </a>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
 exports[`authenticator-expiry-warning-password should render form 1`] = `
 <div>
   <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -230,7 +230,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                               class="MuiBox-root emotion-12"
                             >
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-33"
@@ -243,7 +243,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                                 </div>
                               </div>
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-14"
@@ -271,7 +271,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                                 </div>
                               </div>
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-33"
@@ -559,7 +559,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                               class="MuiBox-root emotion-12"
                             >
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-33"
@@ -572,7 +572,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                                 </div>
                               </div>
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-14"
@@ -600,7 +600,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                                 </div>
                               </div>
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-33"
@@ -888,7 +888,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                               class="MuiBox-root emotion-12"
                             >
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-33"
@@ -901,7 +901,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                                 </div>
                               </div>
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-14"
@@ -929,7 +929,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                                 </div>
                               </div>
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-33"

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -230,7 +230,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                               class="MuiBox-root emotion-12"
                             >
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-33"
@@ -243,7 +243,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                                 </div>
                               </div>
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-14"
@@ -271,7 +271,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                                 </div>
                               </div>
                               <div
-                                class="MuiBox-root emotion-13"
+                                class="MuiBox-root emotion-9"
                               >
                                 <div
                                   class="MuiBox-root emotion-33"

--- a/src/v3/test/integration/authenticator-enroll-data-phone.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-data-phone.test.tsx
@@ -52,7 +52,7 @@ describe('authenticator-enroll-data-phone', () => {
   it('should send correct payload when selecting sms', async () => {
     const {
       authClient, user, findByTestId, findByText,
-    } = await setup({ mockResponse });
+    } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
     await findByText(/Set up phone authentication/);
     await findByText(/Enter your phone number to receive a verification code via SMS./);

--- a/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
@@ -43,7 +43,7 @@ describe('authenticator-enroll-security-question', () => {
     it('should send correct payload', async () => {
       const {
         authClient, user, findByTestId, findByText,
-      } = await setup({ mockResponse });
+      } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
       await findByText(/Set up security question/);
 

--- a/src/v3/test/integration/authenticator-expired-password-with-enrollment-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-expired-password-with-enrollment-authenticator.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { within } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup, updateDynamicAttribute } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/authenticator-expired-password-with-enrollment-authenticator.json';
@@ -48,5 +49,34 @@ describe('authenticator-expired-password-with-enrollment-authenticator', () => {
         credentials: { passcode: password },
       }),
     );
+  });
+
+  it('should present field level error message of (failed) password requirements', async () => {
+    const {
+      authClient, user, findByTestId, findByText, container,
+    } = await setup({ mockResponse });
+
+    await findByText(/Your password has expired/);
+    await findByText(/Password requirements/);
+
+    const submitButton = await findByText('Change Password', { selector: 'button' });
+    const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+
+    await user.type(newPasswordEle, 'abc');
+    // Must blur field to trigger error
+    await user.tab();
+
+    const passwordRequirementsErrorWrapper = await findByTestId(
+      'credentials.passcode-error',
+    ) as HTMLDivElement;
+    await within(passwordRequirementsErrorWrapper).findByText(/Password requirements were not met/);
+
+    await user.click(submitButton);
+
+    const confirmPasswordError = await findByTestId('confirmPassword-error');
+
+    expect(confirmPasswordError.innerHTML).toBe('This field cannot be left blank');
+    expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/v3/test/integration/authenticator-expired-password.test.tsx
+++ b/src/v3/test/integration/authenticator-expired-password.test.tsx
@@ -80,7 +80,7 @@ describe('authenticator-expired-password', () => {
   it('should not make network request when only confirm password has a value', async () => {
     const {
       authClient, user, findByTestId, findByText,
-    } = await setup({ mockResponse });
+    } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
     await findByText(/Your password has expired/);
     await findByText(/Password requirements/);
@@ -89,6 +89,8 @@ describe('authenticator-expired-password', () => {
     const confirmPasswordEle = await findByTestId('confirmPassword') as HTMLInputElement;
 
     // the new password field is auto focused, so it will trigger the error once we nav away
+    await user.tab();
+    // tab to the confirm password field
     await user.tab();
     const val = 'abc123';
     await user.type(confirmPasswordEle, val);
@@ -151,5 +153,34 @@ describe('authenticator-expired-password', () => {
     expect(newPasswordError.innerHTML).toBe('This field cannot be left blank');
     expect(confirmPasswordError.innerHTML).toBe('This field cannot be left blank');
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
+  });
+
+  it('should present field level error message of (failed) password requirements', async () => {
+    const {
+      authClient, user, findByTestId, findByText, container,
+    } = await setup({ mockResponse });
+
+    await findByText(/Your password has expired/);
+    await findByText(/Password requirements/);
+
+    const submitButton = await findByText('Change Password', { selector: 'button' });
+    const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+
+    await user.type(newPasswordEle, 'abc');
+    // Must blur field to trigger error
+    await user.tab();
+
+    const passwordRequirementsErrorWrapper = await findByTestId(
+      'credentials.passcode-error',
+    ) as HTMLDivElement;
+    await within(passwordRequirementsErrorWrapper).findByText(/Password requirements were not met/);
+
+    await user.click(submitButton);
+
+    const confirmPasswordError = await findByTestId('confirmPassword-error');
+
+    expect(confirmPasswordError.innerHTML).toBe('This field cannot be left blank');
+    expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/v3/test/integration/authenticator-expiry-warning-password.test.tsx
+++ b/src/v3/test/integration/authenticator-expiry-warning-password.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { within } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup, updateDynamicAttribute } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/authenticator-expiry-warning-password.json';
@@ -49,5 +50,34 @@ describe('authenticator-expiry-warning-password', () => {
         credentials: { passcode: password },
       }),
     );
+  });
+
+  it('should present field level error message of (failed) password requirements', async () => {
+    const {
+      authClient, user, findByTestId, findByText, container,
+    } = await setup({ mockResponse });
+
+    await findByText(/Your password will expire in/);
+    await findByText(/Password requirements/);
+
+    const submitButton = await findByText('Change Password', { selector: 'button' });
+    const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+
+    await user.type(newPasswordEle, 'abc');
+    // Must blur the field to see error message
+    await user.tab();
+
+    const passwordRequirementsErrorWrapper = await findByTestId(
+      'credentials.passcode-error',
+    ) as HTMLDivElement;
+    await within(passwordRequirementsErrorWrapper).findByText(/Password requirements were not met/);
+
+    await user.click(submitButton);
+
+    const confirmPasswordError = await findByTestId('confirmPassword-error');
+
+    expect(confirmPasswordError.innerHTML).toBe('This field cannot be left blank');
+    expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -158,7 +158,7 @@ describe('identify-with-password', () => {
         findByTestId,
         queryByTestId,
         findByText,
-      } = await setup({ mockResponse });
+      } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
       const identifierEle = await findByTestId('identifier') as HTMLInputElement;
       await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -104,7 +104,7 @@ test.meta('v3', false).requestHooks(logger, successMock)('should succeed when sa
   const answerRequestBody = JSON.parse(answerRequestBodyString);
   await t.expect(answerRequestBody).eql({
     credentials: {
-      passcode: 'abcdabcd',
+      passcode: 'abcdabcdA3@',
     },
     stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
   });

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -119,8 +119,8 @@ test.requestHooks(logger, successMock)('should succeed when session revocation i
   await checkA11y(t);
   const successPage = new SuccessPageObject(t);
 
-  await enrollPasswordPage.fillPassword('abcdabcd');
-  await enrollPasswordPage.fillConfirmPassword('abcdabcd');
+  await enrollPasswordPage.fillPassword('abcdabcdA3@');
+  await enrollPasswordPage.fillConfirmPassword('abcdabcdA3@');
   await enrollPasswordPage.checkSessionRevocationToggle();
   await enrollPasswordPage.clickNextButton();
 
@@ -132,7 +132,7 @@ test.requestHooks(logger, successMock)('should succeed when session revocation i
   const answerRequestBody = JSON.parse(answerRequestBodyString);
   await t.expect(answerRequestBody).eql({
     credentials: {
-      passcode: 'abcdabcd',
+      passcode: 'abcdabcdA3@',
       revokeSessions: true
     },
     stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -68,7 +68,7 @@ test.requestHooks(successMock)('should have both password and confirmPassword fi
   await t.expect(enrollPasswordPage.getConfirmPasswordError()).eql('This field cannot be left blank');
 
   // password must match
-  await enrollPasswordPage.fillPassword('abcd');
+  await enrollPasswordPage.fillPassword('Abcdef1@');
   await enrollPasswordPage.fillConfirmPassword('1234');
   await enrollPasswordPage.clickNextButton();
   await enrollPasswordPage.waitForErrorBox();
@@ -92,8 +92,8 @@ test.meta('v3', false).requestHooks(logger, successMock)('should succeed when sa
   await checkA11y(t);
   const successPage = new SuccessPageObject(t);
 
-  await enrollPasswordPage.fillPassword('abcdabcd');
-  await enrollPasswordPage.fillConfirmPassword('abcdabcd');
+  await enrollPasswordPage.fillPassword('abcdabcdA3@');
+  await enrollPasswordPage.fillConfirmPassword('abcdabcdA3@');
   await enrollPasswordPage.clickNextButton();
 
   const { request: {
@@ -147,8 +147,8 @@ test.requestHooks(errorMock)('should show a callout when server-side field error
   const enrollPasswordPage = await setup(t);
   await checkA11y(t);
 
-  await enrollPasswordPage.fillPassword('abcdabcd');
-  await enrollPasswordPage.fillConfirmPassword('abcdabcd');
+  await enrollPasswordPage.fillPassword('abcdabcdA3@');
+  await enrollPasswordPage.fillConfirmPassword('abcdabcdA3@');
   await enrollPasswordPage.clickNextButton();
 
   await enrollPasswordPage.waitForErrorBox();

--- a/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
@@ -109,7 +109,7 @@ test
     await t.expect(passwordExpiryWarningPage.getConfirmPasswordError()).eql('This field cannot be left blank');
 
     // password must match
-    await passwordExpiryWarningPage.fillPassword('abcd');
+    await passwordExpiryWarningPage.fillPassword('abcdabcdA3@');
     await passwordExpiryWarningPage.fillConfirmPassword('1234');
     await passwordExpiryWarningPage.clickChangePasswordButton();
     await passwordExpiryWarningPage.waitForErrorBox();
@@ -134,8 +134,8 @@ test
     await checkA11y(t);
     const successPage = new SuccessPageObject(t);
 
-    await passwordExpiryWarningPage.fillPassword('abcdabcd');
-    await passwordExpiryWarningPage.fillConfirmPassword('abcdabcd');
+    await passwordExpiryWarningPage.fillPassword('abcdabcdA3@');
+    await passwordExpiryWarningPage.fillConfirmPassword('abcdabcdA3@');
     await passwordExpiryWarningPage.clickChangePasswordButton();
 
     const pageUrl = await successPage.getPageUrl();
@@ -147,7 +147,7 @@ test
     await t.expect(method).eql('post');
     const requestBody = JSON.parse(body);
     await t.expect(requestBody).eql({
-      credentials: { passcode: 'abcdabcd' },
+      credentials: { passcode: 'abcdabcdA3@' },
       stateHandle: '022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP'
     });
   });

--- a/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
@@ -68,7 +68,7 @@ test
     await t.expect(resetPasswordPage.getConfirmPasswordError()).eql('This field cannot be left blank');
 
     // password must match
-    await resetPasswordPage.fillPassword('abcd');
+    await resetPasswordPage.fillPassword('abcdabcdA3@');
     await resetPasswordPage.fillConfirmPassword('1234');
     await resetPasswordPage.clickResetPasswordButton();
     await resetPasswordPage.waitForErrorBox();
@@ -92,8 +92,8 @@ test
     await checkA11y(t);
     const successPage = new SuccessPageObject(t);
 
-    await resetPasswordPage.fillPassword('abcdabcd');
-    await resetPasswordPage.fillConfirmPassword('abcdabcd');
+    await resetPasswordPage.fillPassword('abcdabcdA3@');
+    await resetPasswordPage.fillConfirmPassword('abcdabcdA3@');
     await resetPasswordPage.clickResetPasswordButton();
 
     const pageUrl = await successPage.getPageUrl();
@@ -108,7 +108,7 @@ test
     await t.expect(requestBody).eql({
       'stateHandle': '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
       'credentials': {
-        'passcode': 'abcdabcd'
+        'passcode': 'abcdabcdA3@'
       },
     });
   });


### PR DESCRIPTION
## Description:

Adding commit from 0.1 to 0.5 : 

OKTA-537090 : Implementing client-side validation for password requirements (#3029) a20a3fe9a

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-586862](https://oktainc.atlassian.net/browse/OKTA-586862)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



