### PR TITLE
OKTA-519332 : NumberChallengePushView_spec SIW v3 parity update

### DIFF
--- a/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
@@ -2,7 +2,6 @@ import { Selector, userVariables } from 'testcafe';
 import ChallengeFactorPageObject from './ChallengeFactorPageObject';
 
 const FORM_INFOBOX_WARNING = '.okta-form-infobox-warning';
-const FORM_INFOBOX_ERROR = '[data-se="o-form-error-container"] [data-se="callout"]';
 const RESEND_NUMBER_CHALLENGE_BUTTON = '.okta-form-infobox-warning .resend-number-challenge';
 const FORM_INFOBOX_ERROR_TITLE = '[data-se="o-form-error-container"] [data-se="callout"] > h3';
 const FORM_SELECTOR = '.okta-verify-send-push-form';
@@ -37,11 +36,11 @@ export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPa
   }
 
   async waitForErrorBox() {
-    await this.form.el.find(FORM_INFOBOX_ERROR).exists;
+    await this.form.waitForErrorBox();
   }
 
   getErrorBox() {
-    return this.form.getElement(FORM_INFOBOX_ERROR);
+    return this.form.getErrorBox();
   }
 
   getErrorTitle() {
@@ -49,6 +48,10 @@ export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPa
   }
 
   getWarningBox() {
+    if (userVariables.v3) {
+      return this.form.getAlertBox();
+    }
+
     return this.form.getElement(FORM_INFOBOX_WARNING);
   }
 

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -229,13 +229,13 @@ export default class BaseFormObject {
     return within(this.el).queryAllByRole('alert');
   }
 
-  getAlertBoxByIndex(index = 0) {
-    return this.getAllAlertBox().nth(index);
+  getAlertBox() {
+    return this.getAllAlertBoxes().nth(0);
   }
 
   getErrorBoxCount() {
     if (userVariables.v3) {
-      return this.getAllAlertBox().count;
+      return this.getAllAlertBoxes().count;
     }
 
     return this.el.find(FORM_INFOBOX_ERROR).count;
@@ -243,7 +243,7 @@ export default class BaseFormObject {
 
   getErrorBox() {
     if (userVariables.v3) {
-      return this.getAlertBoxByIndex(0);
+      return this.getAlertBox();
     }
 
     return this.el.find(FORM_INFOBOX_ERROR);
@@ -259,7 +259,7 @@ export default class BaseFormObject {
 
   getAlertBoxText() {
     if (userVariables.v3) {
-      return this.getAlertBoxByIndex(0).innerText;
+      return this.getAlertBox().innerText;
     } else {
       // Not implemented/required in v2
     }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -270,9 +270,6 @@ export default class BaseFormObject {
   }
 
   hasAlertBox(index = 0) {
-    if (index === undefined) {
-      index = 0;
-    }
     return within(this.el).queryAllByRole('alert').nth(index).exists;
   }
 

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -270,7 +270,10 @@ export default class BaseFormObject {
   }
 
   hasAlertBox(index = 0) {
-    return this.getAlertBoxByIndex(index).exists;
+    if (index === undefined) {
+      index = 0;
+    }
+    return within(this.el).queryAllByRole('alert').nth(index).exists;
   }
 
   getAllErrorBoxTexts() {

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -225,21 +225,33 @@ export default class BaseFormObject {
     }).exists;
   }
 
-  getAlertBox() {
-    return within(this.el).getByRole('alert');
+  getAllAlertBox() {
+    return within(this.el).queryAllByRole('alert');
+  }
+
+  getAlertBox(index = 0) {
+    return this.getAllAlertBox().nth(index);
   }
 
   getErrorBoxCount() {
     if (userVariables.v3) {
-      return within(this.el).queryAllByRole('alert').count;
+      return this.getAllAlertBox().count;
     }
 
     return this.el.find(FORM_INFOBOX_ERROR).count;
   }
 
+  getErrorBox(index = 0) {
+    if (userVariables.v3) {
+      return this.getAlertBox(index);
+    }
+
+    return this.el.find(FORM_INFOBOX_ERROR);
+  }
+
   getErrorBoxText() {
     if (userVariables.v3) {
-      return within(this.el).queryAllByRole('alert').nth(0).innerText;
+      return this.getErrorBox().innerText;
     }
 
     return this.el.find(FORM_INFOBOX_ERROR).innerText;
@@ -251,7 +263,7 @@ export default class BaseFormObject {
 
   getAlertBoxText() {
     if (userVariables.v3) {
-      return within(this.el).queryAllByRole('alert').nth(0).innerText;
+      return this.getAlertBox().innerText;
     } else {
       // Not implemented/required in v2
     }
@@ -261,11 +273,8 @@ export default class BaseFormObject {
     return within(this.el).queryByRole('alert').exists;
   }
 
-  hasAlertBox(index) {
-    if (index === undefined) {
-      index = 0;
-    }
-    return within(this.el).queryAllByRole('alert').nth(index).exists;
+  hasAlertBox(index = 0) {
+    return this.getAlertBox(index).exists;
   }
 
   getAllErrorBoxTexts() {

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -225,11 +225,11 @@ export default class BaseFormObject {
     }).exists;
   }
 
-  getAllAlertBox() {
+  getAllAlertBoxes() {
     return within(this.el).queryAllByRole('alert');
   }
 
-  getAlertBox(index = 0) {
+  getAlertBoxByIndex(index = 0) {
     return this.getAllAlertBox().nth(index);
   }
 
@@ -241,20 +241,16 @@ export default class BaseFormObject {
     return this.el.find(FORM_INFOBOX_ERROR).count;
   }
 
-  getErrorBox(index = 0) {
+  getErrorBox() {
     if (userVariables.v3) {
-      return this.getAlertBox(index);
+      return this.getAlertBoxByIndex(0);
     }
 
     return this.el.find(FORM_INFOBOX_ERROR);
   }
 
   getErrorBoxText() {
-    if (userVariables.v3) {
-      return this.getErrorBox().innerText;
-    }
-
-    return this.el.find(FORM_INFOBOX_ERROR).innerText;
+    return this.getErrorBox().innerText;
   }
 
   getErrorBoxHtml() {
@@ -263,7 +259,7 @@ export default class BaseFormObject {
 
   getAlertBoxText() {
     if (userVariables.v3) {
-      return this.getAlertBox().innerText;
+      return this.getAlertBoxByIndex(0).innerText;
     } else {
       // Not implemented/required in v2
     }
@@ -274,7 +270,7 @@ export default class BaseFormObject {
   }
 
   hasAlertBox(index = 0) {
-    return this.getAlertBox(index).exists;
+    return this.getAlertBoxByIndex(index).exists;
   }
 
   getAllErrorBoxTexts() {

--- a/test/testcafe/spec/NumberChallengePushView_spec.js
+++ b/test/testcafe/spec/NumberChallengePushView_spec.js
@@ -59,7 +59,7 @@ test
   });
 
 test
-  .meta('v3', false)
+  .meta('v3', false) // OKTA-587189 - disabled in v3 due to immediate polling issue
   .requestHooks(logger, numberChallengeWaitMock)('Calls resend when we click the resend link from within the warning modal', async t => {
     const challengeOktaVerifyPushPageObject = await setup(t);
     await checkA11y(t);

--- a/test/testcafe/spec/NumberChallengePushView_spec.js
+++ b/test/testcafe/spec/NumberChallengePushView_spec.js
@@ -4,7 +4,6 @@ import ChallengeOktaVerifyPushPageObject from '../framework/page-objects/Challen
 import { checkConsoleMessages } from '../framework/shared';
 
 import numberChallenge from '../../../playground/mocks/data/idp/idx/authenticator-verification-number-challenge';
-import success from '../../../playground/mocks/data/idp/idx/success';
 import serverError from '../../../playground/mocks/data/idp/idx/error-internal-server-error.json';
 
 const logger = RequestLogger(/challenge|challenge\/poll/,
@@ -18,7 +17,7 @@ const numberChallengeSuccessMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(numberChallenge)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
-  .respond(success);
+  .respond(numberChallenge);
 
 const numberChallengeWaitMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -35,11 +34,12 @@ const serverErrorMock = RequestMock()
   .respond(serverError);
 
 
-fixture('Number Challenge Okta Verify Push');
+fixture('Number Challenge Okta Verify Push').meta('v3', true);
 
 async function setup(t) {
   const challengeOktaVerifyPushPageObject = new ChallengeOktaVerifyPushPageObject(t);
   await challengeOktaVerifyPushPageObject.navigateToPage();
+  await challengeOktaVerifyPushPageObject.formExists();
   return challengeOktaVerifyPushPageObject;
 }
 
@@ -59,6 +59,7 @@ test
   });
 
 test
+  .meta('v3', false)
   .requestHooks(logger, numberChallengeWaitMock)('Calls resend when we click the resend link from within the warning modal', async t => {
     const challengeOktaVerifyPushPageObject = await setup(t);
     await checkA11y(t);
@@ -87,10 +88,10 @@ test
     await checkA11y(t);
     // wait and see that there is only one call for poll
     await t.wait(5000);
-    let warningBox = challengeOktaVerifyPushPageObject.getWarningBox();
     await t.expect(logger.count(() => true)).eql(1);
     await challengeOktaVerifyPushPageObject.waitForErrorBox();
-    await t.expect(warningBox.visible).notOk();
-    const error = challengeOktaVerifyPushPageObject.getErrorBox().textContent;
+    // Check that the reminder prompt is not displayed
+    await t.expect(challengeOktaVerifyPushPageObject.form.getErrorBoxCount()).eql(1);
+    const error = challengeOktaVerifyPushPageObject.getErrorBoxText();
     await t.expect(error).contains('Internal Server Error');
   });

--- a/test/testcafe/spec/NumberChallengePushView_spec.js
+++ b/test/testcafe/spec/NumberChallengePushView_spec.js
@@ -91,7 +91,7 @@ test
     await t.expect(logger.count(() => true)).eql(1);
     await challengeOktaVerifyPushPageObject.waitForErrorBox();
     // Check that the reminder prompt is not displayed
-    await t.expect(challengeOktaVerifyPushPageObject.form.getErrorBoxCount()).eql(1);
+    await t.expect(challengeOktaVerifyPushPageObject.form.getAllAlertBoxes().count).eql(1);
     const error = challengeOktaVerifyPushPageObject.getErrorBoxText();
     await t.expect(error).contains('Internal Server Error');
   });


### PR DESCRIPTION
## Description:

This PR updates the `NumberChallengePushView` spec test for parity with SIW v3.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-519332](https://oktainc.atlassian.net/browse/OKTA-519332)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



