### PR TITLE
OKTA-575631 : g3 : Utilizing newly added translation keys

### DIFF
--- a/src/v3/src/components/Button/Button.tsx
+++ b/src/v3/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Button as OdyButton, CircularProgress } from '@okta/odyssey-react-mui';
+import { Button as OdyButton } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 
 import { useWidgetContext } from '../../contexts';
@@ -20,6 +20,7 @@ import {
   ClickHandler,
   UISchemaElementComponent,
 } from '../../types';
+import Spinner from '../Spinner';
 
 const Button: UISchemaElementComponent<{
   uischema: ButtonElement
@@ -76,16 +77,7 @@ const Button: UISchemaElementComponent<{
       className={classes}
       // Fixes text overflow
       sx={{ display: 'flex', whiteSpace: 'normal' }}
-      startIcon={
-        loading ? (
-          <CircularProgress
-            // TODO: OKTA-518793 - replace english string with key once created
-            aria-label="Loading..."
-            aria-valuetext="Loading..."
-            sx={{ color: 'white' }}
-          />
-        ) : Icon && <Icon />
-      }
+      startIcon={loading ? <Spinner color="white" /> : Icon && <Icon />}
       aria-describedby={ariaDescribedBy}
       data-type={dataType}
       data-se={dataSe}

--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -13,6 +13,13 @@
 import { Input } from '@okta/okta-auth-js';
 
 import { FieldElement, Renderer } from '../../types';
+import {
+  isCheckboxFieldElement,
+  isInputTextFieldElement,
+  isPhoneNumberElement,
+  isRadioFieldElement,
+  isSelectFieldElement,
+} from '../../util';
 import AuthenticatorButtonList from '../AuthenticatorButton';
 import AutoSubmit from '../AutoSubmit';
 import Button from '../Button';
@@ -134,14 +141,7 @@ export default [
     renderer: HiddenInput,
   },
   {
-    tester: (uischema: FieldElement) => {
-      const {
-        options: {
-          inputMeta: { name } = {},
-        } = {},
-      } = uischema;
-      return name?.endsWith('phoneNumber');
-    },
+    tester: (element: FieldElement) => isPhoneNumberElement(element),
     renderer: PhoneAuthenticator,
   },
   {
@@ -165,35 +165,15 @@ export default [
     renderer: Divider,
   },
   {
-    tester: ({
-      options: {
-        inputMeta: { options } = {} as Input,
-        format,
-        customOptions,
-      },
-    }: FieldElement) => (Array.isArray(customOptions) || Array.isArray(options)) && format === 'radio',
+    tester: (element: FieldElement) => isRadioFieldElement(element),
     renderer: Radio,
   },
   {
-    tester: ({
-      options: {
-        inputMeta: { options } = {} as Input,
-        format,
-        customOptions,
-      },
-    }: FieldElement) => (Array.isArray(customOptions) || Array.isArray(options)) && format === 'select',
+    tester: (element: FieldElement) => isSelectFieldElement(element),
     renderer: Select,
   },
   {
-    tester: ({
-      options: {
-        type: defaultType,
-        inputMeta: {
-          type, options, name, secret,
-        } = {} as Input,
-      },
-    }: FieldElement) => ((type === 'string' || defaultType === 'string') && !options && !secret)
-      || (name === 'credentials.passcode' && !secret),
+    tester: (element: FieldElement) => isInputTextFieldElement(element),
     renderer: InputText,
   },
   {
@@ -201,7 +181,7 @@ export default [
     renderer: InputPassword,
   },
   {
-    tester: ({ options: { inputMeta: { type } = {} as Input } }: FieldElement) => type === 'boolean',
+    tester: (element: FieldElement) => isCheckboxFieldElement(element),
     renderer: Checkbox,
   },
   {

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -57,6 +57,8 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
   const label = getTranslation(translations, 'label');
   const hint = getTranslation(translations, 'hint');
   const explain = getTranslation(translations, 'bottomExplain');
+  const showVisibilityToggleLabel = getTranslation(translations, 'showToggleLabel');
+  const hideVisibilityToggleLabel = getTranslation(translations, 'hideToggleLabel');
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
   const parsedExplainContent = useHtmlContentParser(explain);
   const hasErrors = typeof errors !== 'undefined';
@@ -118,8 +120,7 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
           <InputAdornment position="end">
             <Tooltip title={showPassword ? getTranslation(translations, 'hide') : getTranslation(translations, 'show')}>
               <IconButton
-                // TODO: OKTA-558040 request translation keys for aria labels
-                aria-label={getTranslation(translations, 'visibilityToggleLabel')}
+                aria-label={showPassword ? hideVisibilityToggleLabel : showVisibilityToggleLabel}
                 aria-pressed={showPassword}
                 aria-controls={name}
                 onClick={handleClickShowPassword}

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -57,8 +57,6 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
   const label = getTranslation(translations, 'label');
   const hint = getTranslation(translations, 'hint');
   const explain = getTranslation(translations, 'bottomExplain');
-  const showVisibilityToggleLabel = getTranslation(translations, 'showToggleLabel');
-  const hideVisibilityToggleLabel = getTranslation(translations, 'hideToggleLabel');
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
   const parsedExplainContent = useHtmlContentParser(explain);
   const hasErrors = typeof errors !== 'undefined';
@@ -120,7 +118,7 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
           <InputAdornment position="end">
             <Tooltip title={showPassword ? getTranslation(translations, 'hide') : getTranslation(translations, 'show')}>
               <IconButton
-                aria-label={showPassword ? hideVisibilityToggleLabel : showVisibilityToggleLabel}
+                aria-label={getTranslation(translations, 'visibilityToggleLabel')}
                 aria-pressed={showPassword}
                 aria-controls={name}
                 onClick={handleClickShowPassword}

--- a/src/v3/src/components/PIVButton/PIVButton.tsx
+++ b/src/v3/src/components/PIVButton/PIVButton.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box, Button as OdyButton, CircularProgress } from '@okta/odyssey-react-mui';
+import { Box, Button as OdyButton } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 
@@ -22,6 +22,7 @@ import {
   UISchemaElementComponent,
 } from '../../types';
 import { getTranslation } from '../../util';
+import Spinner from '../Spinner';
 
 const PIVButton: UISchemaElementComponent<{
   uischema: PIVButtonElement
@@ -66,15 +67,7 @@ const PIVButton: UISchemaElementComponent<{
     >
       {
         showLoading
-          ? (
-            <CircularProgress
-              id="okta-spinner"
-              data-se="okta-spinner"
-              // TODO: OKTA-518793 - replace english string with key once created
-              aria-label="Loading..."
-              aria-valuetext="Loading..."
-            />
-          )
+          ? <Spinner dataSe="okta-spinner" />
           : (
             <OdyButton
               data-se="button"
@@ -83,7 +76,7 @@ const PIVButton: UISchemaElementComponent<{
               aria-describedby={ariaDescribedBy}
               fullWidth
             >
-              { btnLabel }
+              {btnLabel}
             </OdyButton>
           )
       }

--- a/src/v3/src/components/Select/Select.tsx
+++ b/src/v3/src/components/Select/Select.tsx
@@ -36,6 +36,7 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
   const { loading } = useWidgetContext();
   const { focus, required, translations = [] } = uischema;
   const label = getTranslation(translations, 'label');
+  const emptyOptionLabel = getTranslation(translations, 'empty-option-label');
   const {
     attributes,
     inputMeta: {
@@ -46,6 +47,19 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
   } = uischema.options;
   const focusRef = useAutoFocus<HTMLSelectElement>(focus);
   const hasErrors = typeof errors !== 'undefined';
+
+  const getOptions = (): IdxOption[] | undefined => {
+    if (Array.isArray(customOptions) || Array.isArray(options)) {
+      return customOptions ?? options;
+    }
+
+    if (typeof options === 'object') {
+      return Object.entries(options)
+        .filter(([key, val]) => key !== '' && val !== '')
+        .map(([key, val]) => ({ label: val, value: key } as IdxOption));
+    }
+    return undefined;
+  };
 
   return (
     <FormControl
@@ -85,11 +99,10 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
               value=""
               key="empty"
             >
-              {/* TODO: OKTA-518793 - need translation key for this string */}
-              Select an Option
+              {emptyOptionLabel}
             </option>,
           ].concat(
-            (customOptions ?? options)?.map((option: IdxOption) => (
+            getOptions()?.map((option: IdxOption) => (
               <option
                 key={option.value}
                 value={option.value as string}

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -13,25 +13,34 @@
 import { Box, CircularProgress } from '@okta/odyssey-react-mui';
 import { FunctionComponent, h } from 'preact';
 
-const Spinner: FunctionComponent<{
-  label?: string;
-  valueText?: string;
-}> = ({
-  label,
-  valueText,
-}) => (
-  <Box
-    display="flex"
-    flexDirection="column"
-    justifyContent="center"
-    alignItems="center"
-  >
-    <CircularProgress
-      // TODO: OKTA-518793 - replace english string with key once created
-      aria-label={label || 'Loading...'}
-      aria-valuetext={valueText || 'Loading...'}
-    />
-  </Box>
-);
+import { SpinnerElement } from '../../types';
+import { loc } from '../../util';
+
+type SpinnerProps = { dataSe?: string; color?: string; };
+const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
+  props,
+) => {
+  const { dataSe = undefined, color = undefined } = 'type' in props
+    ? {}
+    : props as SpinnerProps;
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <CircularProgress
+        id={dataSe}
+        data-se={dataSe}
+        // Using loc here because this component is not only used by transformers
+        // but also directly in widget component
+        aria-label={loc('processing.alt.text', 'login')}
+        aria-valuetext={loc('processing.alt.text', 'login')}
+        sx={{ color }}
+      />
+    </Box>
+  );
+};
 
 export default Spinner;

--- a/src/v3/src/transformer/i18n/transform.test.ts
+++ b/src/v3/src/transformer/i18n/transform.test.ts
@@ -51,6 +51,9 @@ jest.mock('./transformLaunchAuthenticatorButton', () => ({
 jest.mock('./transformOpenOktaVerifyFPButton', () => ({
   transformOpenOktaVerifyFPButton: () => () => ({}),
 }));
+jest.mock('./transformDefaultSelectOptionLabel', () => ({
+  transformDefaultSelectOptionLabel: () => ({}),
+}));
 
 /* eslint-disable global-require */
 const mocked = {
@@ -66,6 +69,7 @@ const mocked = {
   passwordMatches: require('./transformPasswordMatches'),
   launchAuthenticator: require('./transformLaunchAuthenticatorButton'),
   openOktaVerifyFP: require('./transformOpenOktaVerifyFPButton'),
+  defaultSelectOptionLabel: require('./transformDefaultSelectOptionLabel'),
 };
 /* eslint-enable global-require */
 
@@ -83,6 +87,7 @@ describe('i18n Transformer Tests', () => {
     jest.spyOn(mocked.passwordMatches, 'transformPasswordMatches');
     jest.spyOn(mocked.launchAuthenticator, 'transformLaunchAuthenticatorButton');
     jest.spyOn(mocked.openOktaVerifyFP, 'transformOpenOktaVerifyFPButton');
+    jest.spyOn(mocked.defaultSelectOptionLabel, 'transformDefaultSelectOptionLabel');
 
     const formBag = getStubFormBag();
     const mockOptions = {
@@ -106,5 +111,6 @@ describe('i18n Transformer Tests', () => {
     expect(mocked.passwordMatches.transformPasswordMatches).toHaveBeenCalled();
     expect(mocked.launchAuthenticator.transformLaunchAuthenticatorButton).toHaveBeenCalled();
     expect(mocked.openOktaVerifyFP.transformOpenOktaVerifyFPButton).toHaveBeenCalled();
+    expect(mocked.defaultSelectOptionLabel.transformDefaultSelectOptionLabel).toHaveBeenCalled();
   });
 });

--- a/src/v3/src/transformer/i18n/transform.ts
+++ b/src/v3/src/transformer/i18n/transform.ts
@@ -14,6 +14,7 @@ import { flow } from 'lodash';
 
 import { TransformStepFnWithOptions } from '../../types';
 import { transformAuthenticatorButton } from './transformAuthenticatorButton';
+import { transformDefaultSelectOptionLabel } from './transformDefaultSelectOptionLabel';
 import { transformField } from './transformField';
 import { transformIdentifierHint } from './transformIdentifierHint';
 import { transformInputPassword } from './transformInputPassword';
@@ -39,4 +40,5 @@ export const transformI18n: TransformStepFnWithOptions = (options) => (formbag) 
   transformLaunchAuthenticatorButton,
   transformOpenOktaVerifyFPButton,
   transformPasswordMatches(options),
+  transformDefaultSelectOptionLabel,
 )(formbag);

--- a/src/v3/src/transformer/i18n/transformDefaultSelectOptionLabel.ts
+++ b/src/v3/src/transformer/i18n/transformDefaultSelectOptionLabel.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { FormBag, TransformStepFn } from '../../types';
+import { traverseLayout } from '../util';
+import { addTranslation } from './util';
+
+export const transformDefaultSelectOptionLabel: TransformStepFn = (formbag: FormBag) => {
+  const { uischema } = formbag;
+
+  traverseLayout({
+    layout: uischema,
+    // Making this avaialable for any field in case it is customized to be a select type
+    predicate: (element) => element.type === 'Field',
+    callback: (element) => {
+      addTranslation({
+        element,
+        name: 'empty-option-label',
+        i18nKey: 'select.default_value',
+      });
+    },
+  });
+
+  return formbag;
+};

--- a/src/v3/src/transformer/i18n/transformInputPassword.ts
+++ b/src/v3/src/transformer/i18n/transformInputPassword.ts
@@ -28,27 +28,39 @@ export const transformInputPassword: TransformStepFn = (formBag: FormBag) => {
       addTranslation({
         element,
         name: 'show',
-        i18nKey: 'mfa.challenge.answer.showAnswer',
+        i18nKey: 'sensitive.input.show',
       });
       addTranslation({
         element,
         name: 'hide',
-        i18nKey: 'mfa.challenge.answer.hideAnswer',
+        i18nKey: 'sensitive.input.hide',
       });
 
       const { options: { inputMeta: { name: fieldName } } } = (element as FieldElement);
-      let showLabel = 'Show password';
+      let showLabelKey = 'oie.password.showPassword';
       if (fieldName === 'confirmPassword') {
-        showLabel = 'Show re-enter password';
+        showLabelKey = 'oie.password.showConfirmPassword';
       } else if (fieldName === 'credentials.answer') {
-        showLabel = 'Show answer';
+        showLabelKey = 'oie.challenge.answer.showAnswer';
       }
-      // TODO: OKTA-558040 request translation keys for labels
       addTranslation({
         element,
-        name: 'visibilityToggleLabel',
+        name: 'showToggleLabel',
+        i18nKey: showLabelKey,
+      });
+
+      // TODO: OKTA-587112 request translation keys for hide labels
+      let hideLabelKey = 'Hide password';
+      if (fieldName === 'confirmPassword') {
+        hideLabelKey = 'Hide re-entered password';
+      } else if (fieldName === 'credentials.answer') {
+        hideLabelKey = 'Hide answer';
+      }
+      addTranslation({
+        element,
+        name: 'hideToggleLabel',
         i18nKey: '',
-        defaultValue: showLabel,
+        defaultValue: hideLabelKey,
       });
     },
   });

--- a/src/v3/src/transformer/i18n/transformInputPassword.ts
+++ b/src/v3/src/transformer/i18n/transformInputPassword.ts
@@ -45,22 +45,8 @@ export const transformInputPassword: TransformStepFn = (formBag: FormBag) => {
       }
       addTranslation({
         element,
-        name: 'showToggleLabel',
+        name: 'visibilityToggleLabel',
         i18nKey: showLabelKey,
-      });
-
-      // TODO: OKTA-587112 request translation keys for hide labels
-      let hideLabelKey = 'Hide password';
-      if (fieldName === 'confirmPassword') {
-        hideLabelKey = 'Hide re-entered password';
-      } else if (fieldName === 'credentials.answer') {
-        hideLabelKey = 'Hide answer';
-      }
-      addTranslation({
-        element,
-        name: 'hideToggleLabel',
-        i18nKey: '',
-        defaultValue: hideLabelKey,
       });
     },
   });

--- a/src/v3/src/transformer/redirect/redirectTransformer.test.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.test.ts
@@ -11,13 +11,10 @@
  */
 
 import { IdxTransaction } from '@okta/okta-auth-js';
-import { InterstitialRedirectView } from 'src/constants';
-import { getStubTransaction } from 'src/mocks/utils/utils';
-import {
-  DescriptionElement, RedirectElement,
-  SpinnerElement, WidgetProps,
-} from 'src/types';
 
+import { InterstitialRedirectView } from '../../constants';
+import { getStubTransaction } from '../../mocks/utils/utils';
+import { DescriptionElement, RedirectElement, WidgetProps } from '../../types';
 import { redirectTransformer } from '.';
 
 describe('Success Redirect Transform Tests', () => {
@@ -76,8 +73,6 @@ describe('Success Redirect Transform Tests', () => {
     expect(formBag.uischema.elements[1].type).toBe('Redirect');
     expect((formBag.uischema.elements[1] as RedirectElement).options?.url).toBe(REDIRECT_URL);
     expect(formBag.uischema.elements[2].type).toBe('Spinner');
-    expect((formBag.uischema.elements[2] as SpinnerElement).options?.label).toBe('Loading...');
-    expect((formBag.uischema.elements[2] as SpinnerElement).options?.valueText).toBe('Loading...');
   });
 
   it('should add generic description & redirect elements for DEFAULT Interstitial view '
@@ -101,8 +96,6 @@ describe('Success Redirect Transform Tests', () => {
     expect(formBag.uischema.elements[1].type).toBe('Redirect');
     expect((formBag.uischema.elements[1] as RedirectElement).options?.url).toBe(REDIRECT_URL);
     expect(formBag.uischema.elements[2].type).toBe('Spinner');
-    expect((formBag.uischema.elements[2] as SpinnerElement).options?.label).toBe('Loading...');
-    expect((formBag.uischema.elements[2] as SpinnerElement).options?.valueText).toBe('Loading...');
   });
 
   it('should add app name to description element for DEFAULT Interstitial view '
@@ -123,8 +116,5 @@ describe('Success Redirect Transform Tests', () => {
     expect(formBag.uischema.elements[1].type).toBe('Redirect');
     expect((formBag.uischema.elements[1] as RedirectElement).options?.url).toBe(REDIRECT_URL);
     expect(formBag.uischema.elements[2].type).toBe('Spinner');
-    expect((formBag.uischema.elements[2] as SpinnerElement).options?.label).toBe('Loading...');
-    expect((formBag.uischema.elements[2] as SpinnerElement).options?.valueText)
-      .toBe('Loading...');
   });
 });

--- a/src/v3/src/transformer/redirect/redirectTransformer.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.ts
@@ -43,8 +43,6 @@ export const redirectTransformer = (
   if (interstitialBeforeLoginRedirect === InterstitialRedirectView.DEFAULT) {
     uischema.elements.push({
       type: 'Spinner',
-      // TODO: OKTA-518793 - replace english string with key once created
-      options: { label: 'Loading...', valueText: 'Loading...' },
     } as SpinnerElement);
   }
 

--- a/src/v3/src/transformer/terminal/__snapshots__/transformTerminalTransaction.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformTerminalTransaction.test.ts.snap
@@ -10,10 +10,6 @@ Object {
   "uischema": Object {
     "elements": Array [
       Object {
-        "options": Object {
-          "label": "Loading...",
-          "valueText": "Loading...",
-        },
         "type": "Spinner",
       },
       Object {
@@ -70,10 +66,6 @@ Object {
   "uischema": Object {
     "elements": Array [
       Object {
-        "options": Object {
-          "label": "Loading...",
-          "valueText": "Loading...",
-        },
         "type": "Spinner",
       },
       Object {

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
@@ -14,7 +14,6 @@ import { IdxContext, IdxStatus, IdxTransaction } from '@okta/okta-auth-js';
 import {
   FormBag,
   LinkElement,
-  SpinnerElement,
   SuccessCallback,
   TitleElement,
   WidgetProps,
@@ -116,8 +115,6 @@ describe('Terminal Transaction Transformer Tests', () => {
       expect(formBag).toMatchSnapshot();
       expect(formBag.uischema.elements.length).toBe(2);
       expect(formBag.uischema.elements[0].type).toBe('Spinner');
-      expect((formBag.uischema.elements[0] as SpinnerElement).options?.label).toBe('Loading...');
-      expect((formBag.uischema.elements[0] as SpinnerElement).options?.valueText).toBe('Loading...');
       expect(formBag.uischema.elements[1].type).toBe('SuccessCallback');
       expect((formBag.uischema.elements[1] as SuccessCallback).options?.data)
         .toEqual({ status: IdxStatus.SUCCESS, tokens: mockTokens });
@@ -136,8 +133,6 @@ describe('Terminal Transaction Transformer Tests', () => {
       expect(formBag).toMatchSnapshot();
       expect(formBag.uischema.elements.length).toBe(2);
       expect(formBag.uischema.elements[0].type).toBe('Spinner');
-      expect((formBag.uischema.elements[0] as SpinnerElement).options?.label).toBe('Loading...');
-      expect((formBag.uischema.elements[0] as SpinnerElement).options?.valueText).toBe('Loading...');
       expect(formBag.uischema.elements[1].type).toBe('SuccessCallback');
       expect((formBag.uischema.elements[1] as SuccessCallback).options?.data)
         .toEqual({

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -166,11 +166,6 @@ const buildFormBagForInteractionCodeFlow = (
   const formBag: FormBag = createForm();
   formBag.uischema.elements.push({
     type: 'Spinner',
-    options: {
-      // TODO: OKTA-518793 - replace english string with key once created
-      label: 'Loading...',
-      valueText: 'Loading...',
-    },
   } as SpinnerElement);
 
   if (isRemediationMode) {

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -434,10 +434,6 @@ export interface QRCodeElement extends UISchemaElement {
 
 export interface SpinnerElement extends UISchemaElement {
   type: 'Spinner';
-  options: {
-    label: string;
-    valueText: string;
-  };
 }
 
 export interface InfoboxElement extends UISchemaElement {

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -35,6 +35,7 @@ export * from './languageUtils';
 export * from './locUtil';
 export * from './passwordUtils';
 export * from './removeFieldLevelMessages';
+export * from './rendererUtils';
 export * from './resetMessagesToInputs';
 export * from './settingsUtils';
 export * from './setUrlQueryParams';

--- a/src/v3/src/util/rendererUtils.ts
+++ b/src/v3/src/util/rendererUtils.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Input } from '@okta/okta-auth-js';
+
+import { FieldElement } from '../types';
+
+export const isCheckboxFieldElement = ({
+  options: { inputMeta: { type } = {} as Input },
+}: FieldElement): boolean => (
+  typeof type !== 'undefined' && ['boolean', 'checkbox'].includes(type)
+);
+
+export const isInputTextFieldElement = ({
+  options: {
+    type: defaultType,
+    inputMeta: {
+      type, options, name, secret,
+    } = {} as Input,
+  },
+}: FieldElement): boolean => (
+  ((type === 'string' || defaultType === 'string') && !options && !secret)
+      || (name === 'credentials.passcode' && !secret)
+);
+
+export const isPhoneNumberElement = ({
+  options: { inputMeta: { name } = {} as Input } = {} as FieldElement['options'],
+}: FieldElement): boolean => (name?.endsWith('phoneNumber'));
+
+export const isRadioFieldElement = ({
+  options: {
+    inputMeta: { options, type } = {} as Input,
+    format,
+    customOptions,
+  },
+}: FieldElement): boolean => (
+  Array.isArray(customOptions) || Array.isArray(options)) && ([format, type].includes('radio')
+);
+
+export const isSelectFieldElement = ({
+  options: {
+    inputMeta: { options, type } = {} as Input,
+    format,
+    customOptions,
+  },
+}: FieldElement): boolean => (
+  (Array.isArray(customOptions) || Array.isArray(options) || typeof options === 'object')
+  && [format, type].includes('select')
+);

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -565,7 +565,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-76"
                         data-mui-internal-clone-element="true"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -703,7 +703,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                         <option
                           value=""
                         >
-                          Select an Option
+                          Select an option
                         </option>
                         <option
                           value="disliked_food"
@@ -1198,7 +1198,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                         <option
                           value=""
                         >
-                          Select an Option
+                          Select an option
                         </option>
                         <option
                           value="disliked_food"
@@ -1396,27 +1396,31 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     <span
                       class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-52"
                     >
-                      <span
-                        aria-label="Loading..."
-                        aria-valuetext="Loading..."
-                        class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-53"
-                        role="progressbar"
-                        style="width: 1.14285714rem; height: 1.14285714rem;"
+                      <div
+                        class="MuiBox-root emotion-53"
                       >
-                        <svg
-                          class="MuiCircularProgress-svg emotion-54"
-                          viewBox="22 22 44 44"
+                        <span
+                          aria-label="Processing..."
+                          aria-valuetext="Processing..."
+                          class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-54"
+                          role="progressbar"
+                          style="width: 1.14285714rem; height: 1.14285714rem;"
                         >
-                          <circle
-                            class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-55"
-                            cx="44"
-                            cy="44"
-                            fill="none"
-                            r="18"
-                            stroke-width="8"
-                          />
-                        </svg>
-                      </span>
+                          <svg
+                            class="MuiCircularProgress-svg emotion-55"
+                            viewBox="22 22 44 44"
+                          >
+                            <circle
+                              class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-56"
+                              cx="44"
+                              cy="44"
+                              fill="none"
+                              r="18"
+                              stroke-width="8"
+                            />
+                          </svg>
+                        </span>
+                      </div>
                     </span>
                     Verify
                   </button>
@@ -1426,7 +1430,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                 class="MuiBox-root emotion-14"
               >
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                   data-se="switchAuthenticator"
                   href="javascript:void(0)"
                 >
@@ -1437,7 +1441,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                 class="MuiBox-root emotion-14"
               >
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                   data-se="cancel"
                   href="javascript:void(0)"
                 >
@@ -1746,7 +1750,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                         <option
                           value=""
                         >
-                          Select an Option
+                          Select an option
                         </option>
                         <option
                           value="disliked_food"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -1035,7 +1035,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                         <option
                           value=""
                         >
-                          Select an Option
+                          Select an option
                         </option>
                         <option
                           value="disliked_food"
@@ -1511,7 +1511,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                         <option
                           value=""
                         >
-                          Select an Option
+                          Select an option
                         </option>
                         <option
                           value="disliked_food"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-23"
                         data-mui-internal-clone-element="true"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -537,7 +537,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
                         data-mui-internal-clone-element="true"
@@ -1143,7 +1143,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
                         data-mui-internal-clone-element="true"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -537,7 +537,7 @@ exports[`authenticator-expired-password should present field level error message
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
                         data-mui-internal-clone-element="true"
@@ -1132,7 +1132,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
                         data-mui-internal-clone-element="true"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -689,7 +689,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-91"
                         data-mui-internal-clone-element="true"
@@ -1443,7 +1443,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-86"
                         data-mui-internal-clone-element="true"

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -985,29 +985,33 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
                 <div
                   class="MuiBox-root emotion-15"
                 >
-                  <span
-                    aria-label="Loading..."
-                    aria-valuetext="Loading..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-16"
-                    data-se="okta-spinner"
-                    id="okta-spinner"
-                    role="progressbar"
-                    style="width: 1.14285714rem; height: 1.14285714rem;"
+                  <div
+                    class="MuiBox-root emotion-16"
                   >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-17"
-                      viewBox="22 22 44 44"
+                    <span
+                      aria-label="Processing..."
+                      aria-valuetext="Processing..."
+                      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-17"
+                      data-se="okta-spinner"
+                      id="okta-spinner"
+                      role="progressbar"
+                      style="width: 1.14285714rem; height: 1.14285714rem;"
                     >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-18"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="18"
-                        stroke-width="8"
-                      />
-                    </svg>
-                  </span>
+                      <svg
+                        class="MuiCircularProgress-svg emotion-18"
+                        viewBox="22 22 44 44"
+                      >
+                        <circle
+                          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-19"
+                          cx="44"
+                          cy="44"
+                          fill="none"
+                          r="18"
+                          stroke-width="8"
+                        />
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -553,7 +553,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-76"
                         data-mui-internal-clone-element="true"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -465,7 +465,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
                         data-mui-internal-clone-element="true"
@@ -1048,7 +1048,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                     >
                       <button
                         aria-controls="confirmPassword"
-                        aria-label="Show re-enter password"
+                        aria-label="Show re-entered password"
                         aria-pressed="false"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
                         data-mui-internal-clone-element="true"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -265,7 +265,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                       <option
                         value=""
                       >
-                        Select an Option
+                        Select an option
                       </option>
                       <option
                         value="AF"
@@ -1582,7 +1582,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                       <option
                         value=""
                       >
-                        Select an Option
+                        Select an option
                       </option>
                       <option
                         value="GMT"
@@ -2031,7 +2031,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                       <option
                         value=""
                       >
-                        Select an Option
+                        Select an option
                       </option>
                       <option
                         value="AF"
@@ -3324,7 +3324,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                       <option
                         value=""
                       >
-                        Select an Option
+                        Select an option
                       </option>
                       <option
                         value="GMT"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -1446,8 +1446,8 @@ exports[`identify-with-password renders the loading state first 1`] = `
             class="MuiBox-root emotion-6"
           >
             <span
-              aria-label="Loading..."
-              aria-valuetext="Loading..."
+              aria-label="Processing..."
+              aria-valuetext="Processing..."
               class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-7"
               role="progressbar"
               style="width: 1.14285714rem; height: 1.14285714rem;"

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -46,8 +46,7 @@ describe('identify-with-password', () => {
 
   it('renders the loading state first', async () => {
     const { container, findByLabelText } = await setup({ mockResponse });
-    // TODO: OKTA-518793 - replace english string with key once created
-    await findByLabelText('Loading...');
+    await findByLabelText('Processing...');
     expect(container).toMatchSnapshot();
   });
 

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -450,7 +450,7 @@ export default class BaseFormObject {
   }
 
   getSpinner() {
-    return within(this.el).queryByLabelText('Loading...');
+    return within(this.el).queryByLabelText('Processing...');
   }
 
   getButtonIcon(buttonName) {

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -118,14 +118,15 @@ test.requestHooks(requestLogger, EnrollProfileSignUpWithAdditionalFieldsMock)('s
 
   requestLogger.clear();
   await t.expect(await enrollProfilePage.dropDownExistsByLabel('Country')).eql(true);
-  await t.expect(await enrollProfilePage.form.getValueFromDropdown('userProfile.country')).eql('Select an Option');
+  const defaultOptionLabel = userVariables.v3 ? 'Select an option' : 'Select an Option';
+  await t.expect(await enrollProfilePage.form.getValueFromDropdown('userProfile.country')).eql(defaultOptionLabel);
   await enrollProfilePage.selectValueFromDropdown('userProfile.country', 1);
 
   await t.expect(await enrollProfilePage.formFieldExistsByLabel('Country code')).eql(true);
   await enrollProfilePage.setTextBoxValue('userProfile.countryCode', 'US');
 
   await t.expect(await enrollProfilePage.dropDownExistsByLabel('Time zone')).eql(true);
-  await t.expect(await enrollProfilePage.getValueFromDropdown('userProfile.timezone')).eql('Select an Option');
+  await t.expect(await enrollProfilePage.getValueFromDropdown('userProfile.timezone')).eql(defaultOptionLabel);
   await enrollProfilePage.selectValueFromDropdown('userProfile.timezone', 1);
 });
 


### PR DESCRIPTION
## Description:
The purpose of this PR is to utilize the new translation keys that were created on master which are now available after backporting. 

These include: 
`select.default_value` : Default option label for select boxes
`sensitive.input.hide` : Eye icon for protected input fields
`sensitive.input.show` : Eye icon for protected input fields
`processing.alt.text`: alt text label for Progress indicator

This covers 3 tickets: 
https://oktainc.atlassian.net/browse/OKTA-575631
https://oktainc.atlassian.net/browse/OKTA-575632
https://oktainc.atlassian.net/browse/OKTA-575636

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-575631](https://oktainc.atlassian.net/browse/OKTA-575631)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



