### PR TITLE
OKTA-587187 : g3 : Fixing return to authenticator list link

### DIFF
--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -190,7 +190,7 @@ export const updateTransactionWithNextStep = (
   nextStep: NextStep,
   widgetContext: IWidgetContext,
 ): void => {
-  const { setIdxTransaction, setMessage } = widgetContext;
+  const { setIdxTransaction, setMessage, setStepToRender } = widgetContext;
   const availableSteps = transaction.availableSteps?.filter(
     ({ name }) => name !== nextStep.name,
   ) || [];
@@ -202,6 +202,7 @@ export const updateTransactionWithNextStep = (
   );
 
   setMessage(undefined);
+  setStepToRender(undefined);
   setIdxTransaction({
     ...transaction,
     messages: [],

--- a/src/v3/test/integration/flow-okta-verify-enrollment.test.tsx
+++ b/src/v3/test/integration/flow-okta-verify-enrollment.test.tsx
@@ -323,4 +323,32 @@ describe('flow-okta-verify-enrollment', () => {
     await findByText(/When prompted, tap Scan a QR code/);
     await findByAltText('QR code');
   });
+
+  // eslint-disable-next-line jest/expect-expect
+  it('qr polling -> channel selection -> Return to authenticator list -> authenticator selection', async () => {
+    const {
+      user, findByText, findByAltText, findAllByRole, findByRole,
+    } = await createTestContext();
+
+    // qr polling
+    await findByText(/Set up Okta Verify/);
+    await findByText(/When prompted, tap Scan a QR code/);
+    await findByAltText('QR code');
+    await user.click(await findByText(/Can't scan\?/));
+
+    // channel selection
+    await findByText(/More options/);
+    await findByText(/Email me a setup link/);
+    await findByText(/Text me a setup link/);
+    await user.click(await findByText(/Next/));
+
+    // data enrollment
+    const [returnToAuthListLink] = await findAllByRole('link', { name: 'Return to authenticator list' });
+    await user.click(returnToAuthListLink);
+
+    // authenticator selection
+    await findByText(/Set up security methods/);
+    await findByText(/Security methods help protect your account by ensuring only you have access./);
+    await user.click(await findByRole('button', { name: 'Okta Verify' }));
+  });
 });


### PR DESCRIPTION
## Description:
The purpose of this PR is to fix the return to authenticator list link. When using OV, when clicking the link, it would display an empty page with a single button. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-587187](https://oktainc.atlassian.net/browse/OKTA-587187)

### Reviewers:

### Screenshot/Video:

https://user-images.githubusercontent.com/97472729/224794957-300e4652-58a6-41e8-adf6-8a786fe59563.mov



### Downstream Monolith Build:



