### PR TITLE
OKTA-587104 : g3 : Localize icon titles properly

### DIFF
--- a/src/v3/src/components/AuthCoin/AuthCoin.tsx
+++ b/src/v3/src/components/AuthCoin/AuthCoin.tsx
@@ -15,7 +15,7 @@ import classNames from 'classnames';
 import { FunctionComponent, h } from 'preact';
 
 import { AuthCoinProps } from '../../types';
-import AuthCoinByAuthenticatorKey from './AuthCoinConfig';
+import { getAuthCoinConfiguration } from './authCoinConfigUtil';
 import style from './style.module.css';
 
 const AuthCoin: FunctionComponent<AuthCoinProps> = (props) => {
@@ -27,11 +27,12 @@ const AuthCoin: FunctionComponent<AuthCoinProps> = (props) => {
     description: authcoinDescr,
   } = props;
 
-  const authCoinConfig = AuthCoinByAuthenticatorKey[authenticatorKey];
+  const authCoinConfiguration = getAuthCoinConfiguration();
+  const authCoinConfigByAuthKey = authCoinConfiguration[authenticatorKey];
 
   const containerClasses = classNames(
     style.iconContainer,
-    authCoinConfig?.iconClassName,
+    authCoinConfigByAuthKey?.iconClassName,
     customClasses,
   );
 
@@ -39,12 +40,12 @@ const AuthCoin: FunctionComponent<AuthCoinProps> = (props) => {
     // TODO: OKTA-467022 - Add warning when attempted to customize non-customizeable authenticator
     // if URL is provided it should be with an authenticator
     // key that can be customized or custom push app
-    if (url && (authCoinConfig?.customizable || !authCoinConfig?.icon)) {
+    if (url && (authCoinConfigByAuthKey?.customizable || !authCoinConfigByAuthKey?.icon)) {
       return (
         <Box
           as="img"
           src={url}
-          alt={authCoinConfig.description}
+          alt={authCoinConfigByAuthKey.description}
           className="custom-logo"
           sx={{
             width: (theme) => theme.spacing(6),
@@ -53,9 +54,9 @@ const AuthCoin: FunctionComponent<AuthCoinProps> = (props) => {
         />
       );
     }
-    const name = authcoinName || authCoinConfig?.name;
-    const description = authcoinDescr || authCoinConfig?.description;
-    const AuthCoinIcon = authCoinConfig?.icon;
+    const name = authcoinName || authCoinConfigByAuthKey?.name;
+    const description = authcoinDescr || authCoinConfigByAuthKey?.description;
+    const AuthCoinIcon = authCoinConfigByAuthKey?.icon;
     return AuthCoinIcon && (
       <AuthCoinIcon
         name={name}
@@ -64,7 +65,7 @@ const AuthCoin: FunctionComponent<AuthCoinProps> = (props) => {
     );
   }
 
-  return authCoinConfig && (
+  return authCoinConfigByAuthKey && (
     <Box
       className={containerClasses}
       data-se="factor-beacon"

--- a/src/v3/src/components/AuthCoin/authCoinConfigUtil.ts
+++ b/src/v3/src/components/AuthCoin/authCoinConfigUtil.ts
@@ -42,7 +42,7 @@ type AuthCoinConfig = {
   iconClassName: string;
 };
 
-const AuthCoinByAuthenticatorKey: Record<string, AuthCoinConfig> = {
+export const getAuthCoinConfiguration = (): Record<string, AuthCoinConfig> => ({
   [AUTHENTICATOR_KEY.CUSTOM_OTP]: {
     icon: CustomOTPIcon,
     customizable: true,
@@ -183,6 +183,4 @@ const AuthCoinByAuthenticatorKey: Record<string, AuthCoinConfig> = {
     description: loc('factor.totpSoft.oktaVerify', 'login'),
     iconClassName: 'mfa-okta-verify',
   },
-};
-
-export default AuthCoinByAuthenticatorKey;
+});

--- a/src/v3/src/components/AuthHeader/AuthHeader.tsx
+++ b/src/v3/src/components/AuthHeader/AuthHeader.tsx
@@ -16,17 +16,18 @@ import { FunctionComponent, h } from 'preact';
 import { AuthCoinProps } from 'src/types';
 
 import AuthCoin from '../AuthCoin/AuthCoin';
-import AuthCoinByAuthenticatorKeyConfig from '../AuthCoin/AuthCoinConfig';
+import { getAuthCoinConfiguration } from '../AuthCoin/authCoinConfigUtil';
 import style from './style.module.css';
 
 const cx = classNames.bind(style);
 
 // TODO: maybe extract to util class if used reused
 const shouldRenderAuthCoin = (props?: AuthCoinProps): boolean => {
-  const authCoinConfig = props?.authenticatorKey
-    && AuthCoinByAuthenticatorKeyConfig[props?.authenticatorKey];
+  const authCoinConfiguration = getAuthCoinConfiguration();
+  const authCoinConfigByAuthKey = props?.authenticatorKey
+    && authCoinConfiguration[props?.authenticatorKey];
 
-  return typeof authCoinConfig !== 'undefined'
+  return typeof authCoinConfigByAuthKey !== 'undefined'
     || typeof props?.url !== 'undefined';
 };
 


### PR DESCRIPTION
## Description:

The purpose of this PR is to fix an issue that was found where icon titles were not being localized properly (i.e. Authcoin and authenticator list icons).

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-587104](https://oktainc.atlassian.net/browse/OKTA-587104)

### Reviewers:

### Screenshot/Video:

<img width="597" alt="Screen Shot 2023-03-13 at 6 16 12 PM" src="https://user-images.githubusercontent.com/97472729/224845868-3ba4e285-ea6c-48f5-95fd-a209d5f4c8e3.png">
<img width="578" alt="Screen Shot 2023-03-13 at 6 16 29 PM" src="https://user-images.githubusercontent.com/97472729/224845870-23b67a06-c20b-4876-aac5-d6769c1a9f1d.png">
<img width="539" alt="Screen Shot 2023-03-13 at 6 16 36 PM" src="https://user-images.githubusercontent.com/97472729/224845873-03db69d4-dda0-4c87-9d21-ba26a4ce3b85.png">

### Downstream Monolith Build:



