### PR TITLE
OKTA-585934 : g3 : Re-enable test for v2 parity

### DIFF
--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -99,7 +99,7 @@ test.requestHooks(logger, successMock)('should succeed when same values are fill
     body: answerRequestBodyString,
   }
   } = logger.requests[0];
-  const expectedResponse = {
+  const expectedPayload = {
     credentials: {
       passcode: 'abcdabcdA3@',
     },
@@ -109,11 +109,11 @@ test.requestHooks(logger, successMock)('should succeed when same values are fill
   // and the user does not check it, we send 'false' by default for the value
   // V2 will ignore the boolean field unless they check and uncheck it.
   if (userVariables.v3) {
-    expectedResponse.credentials.revokeSessions = false;
+    expectedPayload.credentials.revokeSessions = false;
   }
 
   const answerRequestBody = JSON.parse(answerRequestBodyString);
-  await t.expect(answerRequestBody).eql(expectedResponse);
+  await t.expect(answerRequestBody).eql(expectedPayload);
 
   const pageUrl = await successPage.getPageUrl();
   await t.expect(pageUrl)


### PR DESCRIPTION
## Description:
The purpose of this PR is to re-enable the disabled v3 parity spec. Initially, we thought we needed to implement the FF showRevokeSessions to control the ability to display or not display the revoke sessions check box, but after some research, we can see that this FF is only used with v1. In v2, if the user does not check the box, it does not send the property in the payload, however, if one checks and unchecks it, it is included in the payload with the `false` value. This seems like an issue with v2 and how it handles checkboxes.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-585934](https://oktainc.atlassian.net/browse/OKTA-585934)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



