### PR TITLE
OKTA-586845 : g3 : Enable field level confirm password error message

### DIFF
--- a/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
@@ -61,6 +61,7 @@ const PasswordMatches: UISchemaElementComponent<{
         component="ul"
         id="credentials.newPassword-list"
         sx={{ listStyle: 'none', padding: '0', marginBlockStart: '0' }}
+        aria-hidden
       >
         <PasswordRequirementListItem
           status={isMatching ? 'complete' : 'incomplete'}

--- a/src/v3/src/transformer/password/__snapshots__/transformEnrollPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformEnrollPasswordAuthenticator.test.ts.snap
@@ -16,9 +16,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "enroll-authenticator",
     },
@@ -99,9 +96,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "enroll-authenticator",
     },
@@ -204,9 +198,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "enroll-authenticator",
     },
@@ -309,9 +300,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "enroll-authenticator",
     },

--- a/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordAuthenticator.test.ts.snap
@@ -16,9 +16,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },
@@ -129,9 +126,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },
@@ -242,9 +236,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },

--- a/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordWarningAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordWarningAuthenticator.test.ts.snap
@@ -16,9 +16,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },
@@ -123,9 +120,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },
@@ -230,9 +224,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },
@@ -336,9 +327,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },
@@ -450,9 +438,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },
@@ -563,9 +548,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },

--- a/src/v3/src/transformer/password/__snapshots__/transformResetPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformResetPasswordAuthenticator.test.ts.snap
@@ -16,9 +16,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },
@@ -129,9 +126,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },
@@ -242,9 +236,6 @@ Object {
       "confirmPassword",
       "passwordMatchesValidation",
     ],
-    "passwordMatchesValidation": Object {
-      "validate": [Function],
-    },
     "submit": Object {
       "step": "challenge-authenticator",
     },

--- a/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
+++ b/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
@@ -201,24 +201,32 @@ export const transformEnrollPasswordAuthenticator: IdxStepTransformer = ({
         );
         errorMessages.push(...requirementNotMetMessages);
       }
+      if (newPw && confirmPw && newPw !== confirmPw) {
+        errorMessages.push({
+          name: 'confirmPassword',
+          class: 'ERROR',
+          message: loc('password.enroll.error.match', 'login'),
+          i18n: { key: 'password.enroll.error.match' },
+        });
+      }
       return errorMessages.length > 0 ? errorMessages : undefined;
     },
   };
-  dataSchema.passwordMatchesValidation = {
+
+  dataSchema.confirmPassword = {
     validate: (data: FormBag['data']) => {
-      const newPw = data[passwordFieldName];
+      const newPw = data[passwordFieldName] as string;
       const confirmPw = data.confirmPassword;
-      if (newPw !== confirmPw) {
-        // This error is not displayed by the component, however it is used to block
-        // form submission by marking the field as invalid
-        return [{
-          name: 'passwordMatchesValidation',
+      const errorMessages: WidgetMessage[] = [];
+      if (newPw && newPw !== confirmPw) {
+        errorMessages.push({
+          name: 'confirmPassword',
           class: 'ERROR',
-          message: loc('password.error.match', 'login'),
-          i18n: { key: 'password.error.match' },
-        }];
+          message: loc('password.enroll.error.match', 'login'),
+          i18n: { key: 'password.enroll.error.match' },
+        });
       }
-      return undefined;
+      return errorMessages.length > 0 ? errorMessages : undefined;
     },
   };
 

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -600,6 +600,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-90"
                     id="generated"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -258,6 +258,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-35"
                     id="generated"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -584,6 +584,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-89"
                     id="credentials.newPassword-list"
                   >
@@ -1177,6 +1178,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-74"
                     id="generated"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -584,6 +584,7 @@ exports[`authenticator-expired-password should present field level error message
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-89"
                     id="credentials.newPassword-list"
                   >
@@ -1166,6 +1167,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-74"
                     id="generated"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -736,6 +736,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-114"
                     id="credentials.newPassword-list"
                   >
@@ -1476,6 +1477,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-98"
                     id="generated"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -588,6 +588,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-88"
                     id="credentials.newPassword-list"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -500,6 +500,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-74"
                     id="generated"
                   >
@@ -1082,6 +1083,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   data-se="password-authenticator--matches"
                 >
                   <ul
+                    aria-hidden="true"
                     class="MuiBox-root emotion-74"
                     id="generated"
                   >

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -74,11 +74,11 @@ test.requestHooks(successMock)('should have both password and confirmPassword fi
   await enrollPasswordPage.waitForErrorBox();
   await t.expect(enrollPasswordPage.hasPasswordError()).eql(false);
 
-  // In v3, we do not show the error for password match on the field, but rather display the
-  // 'incomplete'/'complete' checkmark next to the 'Passwords must match' label below the
-  // two password fields, so we check this state differently.
+  // In v3, we display the incomplete/complete checkmark next to the 'Passwords must match'
+  // list item label below the confirm password field in addition to the field level error message
   if (userVariables.v3) {
     await t.expect(enrollPasswordPage.hasPasswordMatchRequirementStatus(false)).eql(true);
+    await t.expect(enrollPasswordPage.getConfirmPasswordError()).eql('Passwords must match');
   } else {
     await t.expect(enrollPasswordPage.getConfirmPasswordError()).eql('New passwords must match');
   }

--- a/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
@@ -123,11 +123,11 @@ test
     await expiredPasswordPage.waitForErrorBox();
     await t.expect(expiredPasswordPage.hasPasswordError()).eql(false);
 
-    // In v3, we do not show the error for password match on the field, but rather display the
-    // 'incomplete'/'complete' checkmark next to the 'Passwords must match' label below the
-    // two password fields, so we check this state differently.
+    // In v3, we display the incomplete/complete checkmark next to the 'Passwords must match'
+    // list item label below the confirm password field in addition to the field level error message
     if (userVariables.v3) {
       await t.expect(expiredPasswordPage.hasPasswordMatchRequirementStatus(false)).eql(true);
+      await t.expect(expiredPasswordPage.getConfirmPasswordError()).eql('Passwords must match');
     } else {
       await t.expect(expiredPasswordPage.getConfirmPasswordError()).eql('New passwords must match');
     }

--- a/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
@@ -115,11 +115,11 @@ test
     await passwordExpiryWarningPage.waitForErrorBox();
     await t.expect(passwordExpiryWarningPage.hasPasswordError()).eql(false);
 
-    // In v3, we do not show the error for password match on the field, but rather display the
-    // 'incomplete'/'complete' checkmark next to the 'Passwords must match' label below the
-    // two password fields, so we check this state differently.
+    // In v3, we display the incomplete/complete checkmark next to the 'Passwords must match'
+    // list item label below the confirm password field in addition to the field level error message
     if (userVariables.v3) {
       await t.expect(passwordExpiryWarningPage.hasPasswordMatchRequirementStatus(false)).eql(true);
+      await t.expect(passwordExpiryWarningPage.getConfirmPasswordError()).eql('Passwords must match');
     } else {
       await t.expect(passwordExpiryWarningPage.getConfirmPasswordError()).eql('New passwords must match');
     }

--- a/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
@@ -74,11 +74,11 @@ test
     await resetPasswordPage.waitForErrorBox();
     await t.expect(resetPasswordPage.hasPasswordError()).eql(false);
 
-    // In v3, we do not show the error for password match on the field, but rather display the
-    // 'incomplete'/'complete' checkmark next to the 'Passwords must match' label below the
-    // two password fields, so we check this state differently.
+    // In v3, we display the incomplete/complete checkmark next to the 'Passwords must match'
+    // list item label below the confirm password field in addition to the field level error message
     if (userVariables.v3) {
       await t.expect(resetPasswordPage.hasPasswordMatchRequirementStatus(false)).eql(true);
+      await t.expect(resetPasswordPage.getConfirmPasswordError()).eql('Passwords must match');
     } else {
       await t.expect(resetPasswordPage.getConfirmPasswordError()).eql('New passwords must match');
     }


### PR DESCRIPTION
## Description:

The purpose of this PR is to add a field level message to confirm password field to support screenreaders.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-586845](https://oktainc.atlassian.net/browse/OKTA-586845)

### Reviewers:
cc: @alexdahl-okta 

### Screenshot/Video:
**Design UX proposed flow:** 

![image](https://user-images.githubusercontent.com/97472729/225089189-83b5c91d-d718-45c6-a34a-3cbec5e04ef8.png)

**SIW Demo implementation:**

https://user-images.githubusercontent.com/97472729/225089339-d1f6c45c-7894-4d6f-825d-363adb912c24.mov



### Downstream Monolith Build:



