### PR TITLE
OKTA-566356 : g3 : Fixing spec test for SIW v3 polling

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -61,7 +61,7 @@ test_suites:
     - name: parity-v3
       script_path: /root/okta/okta-signin-widget/scripts
       sort_order: '9'
-      timeout: '30'
+      timeout: '40'
       script_name: parity-v3
       criteria: MERGE
       queue_name: small

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "build:types": "yarn clean:types && yarn generate:types && yarn copy:types",
     "start:mock-server": "MOCK_SERVER_PORT=3030 nodemon --delay 500ms -e js,json --watch playground --exec 'node playground/mocks/server.js'",
     "test:parity-setup": "mkdir -p test-reports/testcafe && yarn generate-config && yarn workspace v3 build && yarn workspace v3 serve",
-    "test:parity-run": "yarn test -t testcafe --config-file .testcaferc-parity.js -c 6 chrome:headless --reporter spec,xunit:build2/reports/junit/testcafe-results.xml",
+    "test:parity-run": "yarn test -t testcafe --config-file .testcaferc-parity.js -c 2 chrome:headless --reporter spec,xunit:build2/reports/junit/testcafe-results.xml",
     "test:parity-ci": "yarn codegen && run-p -r test:parity-setup test:parity-run"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "build:types": "yarn clean:types && yarn generate:types && yarn copy:types",
     "start:mock-server": "MOCK_SERVER_PORT=3030 nodemon --delay 500ms -e js,json --watch playground --exec 'node playground/mocks/server.js'",
     "test:parity-setup": "mkdir -p test-reports/testcafe && yarn generate-config && yarn workspace v3 build && yarn workspace v3 serve",
-    "test:parity-run": "yarn test -t testcafe --config-file .testcaferc-parity.js -c 4 chrome:headless --reporter spec,xunit:build2/reports/junit/testcafe-results.xml",
+    "test:parity-run": "yarn test -t testcafe --config-file .testcaferc-parity.js -c 6 chrome:headless --reporter spec,xunit:build2/reports/junit/testcafe-results.xml",
     "test:parity-ci": "yarn codegen && run-p -r test:parity-setup test:parity-run"
   },
   "devDependencies": {

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -511,8 +511,7 @@ test.meta('v3', false)
     )).eql(0);
   });
 
-// Disabled in v3 - OKTA-566356
-test.meta('v3', false)
+test
   .requestHooks(logger, dynamicRefreshShortIntervalMock)('continue polling on form error with dynamic polling', async t => {
     const challengeEmailPageObject = await setup(t);
     await checkA11y(t);
@@ -526,6 +525,7 @@ test.meta('v3', false)
       record => record.response.statusCode === 200 &&
         record.request.url.match(/poll/)
     )).eql(2);
+    logger.clear();
 
     await t.removeRequestHooks(dynamicRefreshShortIntervalMock);
     await t.addRequestHooks(invalidOTPMockContinuePoll);
@@ -536,6 +536,7 @@ test.meta('v3', false)
       record => record.response.statusCode === 200 &&
         record.request.url.match(/poll/)
     )).eql(3);
+    logger.clear();
 
     await challengeEmailPageObject.verifyFactor('credentials.passcode', 'xyz');
     await challengeEmailPageObject.clickNextButton('Verify');

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -544,7 +544,7 @@ test
     await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
     await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
     await t.wait(5000);
-    // TODO - In v3 there are more than 5 poll requests in 5 seconds
+    // In v3 there is an extra poll request compared to v2
     const expectedPollCount = userVariables.v3 ? 5 : 4;
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, RequestLogger, ClientFunction } from 'testcafe';
+import { RequestMock, RequestLogger, ClientFunction, userVariables } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import ChallengeEmailPageObject from '../framework/page-objects/ChallengeEmailPageObject';
@@ -545,10 +545,11 @@ test
     await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
     await t.wait(5000);
     // TODO - In v3 there are more than 5 poll requests in 5 seconds
+    const expectedPollCount = userVariables.v3 ? 5 : 4;
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&
         record.request.url.match(/poll/)
-    )).eql(5);
+    )).eql(expectedPollCount);
   });
 
 test


### PR DESCRIPTION
## Description:

The purpose of this PR is to re-enable the spec parity test for polling.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-566356](https://oktainc.atlassian.net/browse/OKTA-566356)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



