### PR TITLE
Enables safe mode and safe mode polling screens

### DIFF
--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -51,7 +51,12 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
 
           if ([UISchemaLayoutType.HORIZONTAL, UISchemaLayoutType.VERTICAL]
             .includes((element as UISchemaLayout).type)) {
-            return <Layout uischema={element as UISchemaLayout} />;
+            return (
+              <Layout
+                key={(element as UISchemaLayout).key}
+                uischema={element as UISchemaLayout}
+              />
+            );
           }
 
           return (

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -42,7 +42,12 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
           const elementKey = getElementKey(element, index);
 
           if (element.type === UISchemaLayoutType.STEPPER) {
-            return <Stepper uischema={element as StepperLayout} />;
+            return (
+              <Stepper
+                key={(element as StepperLayout).key}
+                uischema={element as StepperLayout}
+              />
+            );
           }
 
           if (element.type === UISchemaLayoutType.ACCORDION) {
@@ -51,12 +56,7 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
 
           if ([UISchemaLayoutType.HORIZONTAL, UISchemaLayoutType.VERTICAL]
             .includes((element as UISchemaLayout).type)) {
-            return (
-              <Layout
-                key={(element as UISchemaLayout).key}
-                uischema={element as UISchemaLayout}
-              />
-            );
+            return <Layout uischema={element as UISchemaLayout} />
           }
 
           return (

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -51,12 +51,22 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
           }
 
           if (element.type === UISchemaLayoutType.ACCORDION) {
-            return <Accordion uischema={element as AccordionLayout} />;
+            return (
+              <Accordion
+                key={(element as AccordionLayout).key}
+                uischema={element as AccordionLayout}
+              />
+            );
           }
 
           if ([UISchemaLayoutType.HORIZONTAL, UISchemaLayoutType.VERTICAL]
             .includes((element as UISchemaLayout).type)) {
-            return <Layout uischema={element as UISchemaLayout} />;
+            return (
+              <Layout
+                key={(element as UISchemaLayout).key}
+                uischema={element as UISchemaLayout}
+              />
+            );
           }
 
           return (

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -39,8 +39,8 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
     >
       {
         elements.map((element, index) => {
-          const elementKey = getElementKey(element, index);
-
+          // for the layout element types attach the explicitly set key if
+          // one was added to the uischema in the transformer
           if (element.type === UISchemaLayoutType.STEPPER) {
             return (
               <Stepper
@@ -68,6 +68,8 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
               />
             );
           }
+
+          const elementKey = getElementKey(element, index);
 
           return (
             <ElementContainer

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -56,7 +56,7 @@ const Layout: FunctionComponent<{ uischema: UISchemaLayout }> = ({ uischema }) =
 
           if ([UISchemaLayoutType.HORIZONTAL, UISchemaLayoutType.VERTICAL]
             .includes((element as UISchemaLayout).type)) {
-            return <Layout uischema={element as UISchemaLayout} />
+            return <Layout uischema={element as UISchemaLayout} />;
           }
 
           return (

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -29,7 +29,7 @@ const Spinner: FunctionComponent<SpinnerProps | {
     : props as SpinnerProps;
 
   // eslint-disable-next-line react/destructuring-assignment
-  const delayMs = 'uischema' in props ? props.uischema.options.delayMs : null;
+  const delayMs = 'uischema' in props ? props.uischema.options?.delayMs : null;
   // show by default unless there is a delay set
   const [show, setShow] = useState(typeof delayMs !== 'number');
 

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -12,18 +12,37 @@
 
 import { Box, CircularProgress } from '@okta/odyssey-react-mui';
 import { FunctionComponent, h } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
 
 import { SpinnerElement } from '../../types';
 import { loc } from '../../util';
 
 type SpinnerProps = { dataSe?: string; color?: string; };
-const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
+
+const Spinner: FunctionComponent<SpinnerProps | {
+  uischema: SpinnerElement
+}> = (
   props,
 ) => {
-  const { dataSe = undefined, color = undefined } = 'type' in props
+  const { dataSe = undefined, color = undefined } = 'uischema' in props
     ? {}
     : props as SpinnerProps;
-  return (
+
+  const delay = 'uischema' in props ? props.uischema.options.delayMs : null;
+  // show by default unless there is a delay set
+  const [show, setShow] = useState(typeof delay === 'number' ? false : true);
+
+  useEffect(() => {
+    if (typeof delay !== 'number') {
+      return;
+    }
+    const ref = setTimeout(() => setShow(true), delay);
+    return () => {
+      clearTimeout(ref);
+    };
+  }, [])
+
+  return show ? (
     <Box
       display="flex"
       flexDirection="column"
@@ -40,7 +59,7 @@ const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
         sx={{ color }}
       />
     </Box>
-  );
+  ) : null;
 };
 
 export default Spinner;

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -12,40 +12,18 @@
 
 import { Box, CircularProgress } from '@okta/odyssey-react-mui';
 import { FunctionComponent, h } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
 
 import { SpinnerElement } from '../../types';
 import { loc } from '../../util';
 
 type SpinnerProps = { dataSe?: string; color?: string; };
-
-const Spinner: FunctionComponent<SpinnerProps | {
-  uischema: SpinnerElement
-}> = (
+const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
   props,
 ) => {
-  const { dataSe = undefined, color = undefined } = 'uischema' in props
+  const { dataSe = undefined, color = undefined } = 'type' in props
     ? {}
     : props as SpinnerProps;
-
-  // eslint-disable-next-line react/destructuring-assignment
-  const delayMs = 'uischema' in props ? props.uischema.options?.delayMs : null;
-  // show by default unless there is a delay set
-  const [show, setShow] = useState(typeof delayMs !== 'number');
-
-  useEffect(() => {
-    let ref: ReturnType<typeof setTimeout>;
-
-    if (typeof delayMs === 'number') {
-      ref = setTimeout(() => setShow(true), delayMs);
-    }
-
-    return () => {
-      clearTimeout(ref);
-    };
-  }, [delayMs]);
-
-  return show ? (
+  return (
     <Box
       display="flex"
       flexDirection="column"
@@ -62,7 +40,7 @@ const Spinner: FunctionComponent<SpinnerProps | {
         sx={{ color }}
       />
     </Box>
-  ) : null;
+  );
 };
 
 export default Spinner;

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -28,19 +28,22 @@ const Spinner: FunctionComponent<SpinnerProps | {
     ? {}
     : props as SpinnerProps;
 
-  const delay = 'uischema' in props ? props.uischema.options.delayMs : null;
+  // eslint-disable-next-line react/destructuring-assignment
+  const delayMs = 'uischema' in props ? props.uischema.options.delayMs : null;
   // show by default unless there is a delay set
-  const [show, setShow] = useState(typeof delay === 'number' ? false : true);
+  const [show, setShow] = useState(typeof delayMs !== 'number');
 
   useEffect(() => {
-    if (typeof delay !== 'number') {
-      return;
+    let ref: ReturnType<typeof setTimeout>;
+
+    if (typeof delayMs === 'number') {
+      ref = setTimeout(() => setShow(true), delayMs);
     }
-    const ref = setTimeout(() => setShow(true), delay);
+
     return () => {
       clearTimeout(ref);
     };
-  }, [])
+  }, [delayMs]);
 
   return show ? (
     <Box

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -164,6 +164,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     }
 
     if ([IdxStatus.TERMINAL, IdxStatus.SUCCESS].includes(idxTransaction.status)
+        || idxTransaction.nextStep?.name === IDX_STEP.SKIP // force safe mode to be terminal
         || !idxTransaction.nextStep) {
       return transformTerminalTransaction(idxTransaction, widgetProps, bootstrap);
     }

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -66,6 +66,7 @@ import {
   transformIdentityRecovery,
   transformRequestActivation,
 } from './recovery';
+import { transformSafeModePoll } from './safeMode';
 import {
   transformSecurityQuestionEnroll,
   transformSecurityQuestionVerify,
@@ -370,6 +371,12 @@ const TransformerMap: {
   [IDX_STEP.SELECT_ENROLLMENT_CHANNEL]: {
     [AUTHENTICATOR_KEY.OV]: {
       transform: transformOktaVerifyChannelSelection,
+      buttonConfig: { showDefaultSubmit: false },
+    },
+  },
+  [IDX_STEP.POLL]: {
+    [AUTHENTICATOR_KEY.DEFAULT]: {
+      transform: transformSafeModePoll,
       buttonConfig: { showDefaultSubmit: false },
     },
   },

--- a/src/v3/src/transformer/layout/safeMode/__snapshots__/transformSafeModePoll.test.ts.snap
+++ b/src/v3/src/transformer/layout/safeMode/__snapshots__/transformSafeModePoll.test.ts.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Transform Safe Mode Poll Tests renders safe mode poll view 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "elements": Array [
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "poll.form.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "poll.form.message",
+                },
+                "type": "Description",
+                "viewIndex": 0,
+              },
+              Object {
+                "options": Object {
+                  "callback": [Function],
+                },
+                "type": "StepperNavigator",
+                "viewIndex": 0,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "poll.form.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "type": "Spinner",
+                "viewIndex": 1,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+        ],
+        "key": "random-string",
+        "type": "Stepper",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/layout/safeMode/index.ts
+++ b/src/v3/src/transformer/layout/safeMode/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export * from './transformSafeModePoll';

--- a/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.test.ts
+++ b/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.test.ts
@@ -50,8 +50,10 @@ describe('Transform Safe Mode Poll Tests', () => {
     expect(updatedFormBag.uischema.elements.length).toBe(1);
     expect((updatedFormBag.uischema.elements[0] as UISchemaLayout).type)
       .toBe(UISchemaLayoutType.STEPPER);
-    
-    const [step1, step2] = (updatedFormBag.uischema.elements[0] as UISchemaLayout).elements as UISchemaLayout[];
+
+    const [step1, step2] = (
+      updatedFormBag.uischema.elements[0] as UISchemaLayout
+    ).elements as UISchemaLayout[];
 
     expect(step1.type).toBe(UISchemaLayoutType.VERTICAL);
     expect(step1.elements.length).toBe(3);

--- a/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.test.ts
+++ b/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IDX_STEP } from 'src/constants';
+import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
+import {
+  DescriptionElement,
+  TitleElement,
+  UISchemaLayout,
+  UISchemaLayoutType,
+  WidgetProps,
+} from 'src/types';
+
+import { transformSafeModePoll } from './transformSafeModePoll';
+
+jest.mock('src/util/generateRandomString', () => ({
+  generateRandomString: () => 'random-string',
+}));
+
+describe('Transform Safe Mode Poll Tests', () => {
+  const transaction = getStubTransactionWithNextStep();
+  const formBag = getStubFormBag();
+  const widgetProps: WidgetProps = {};
+
+  beforeEach(() => {
+    formBag.uischema.elements = [];
+    transaction.nextStep = {
+      name: IDX_STEP.POLL,
+      refresh: 2000,
+    };
+  });
+
+  it('renders safe mode poll view', () => {
+    const updatedFormBag = transformSafeModePoll({
+      transaction,
+      formBag,
+      widgetProps,
+    });
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(1);
+    expect((updatedFormBag.uischema.elements[0] as UISchemaLayout).type)
+      .toBe(UISchemaLayoutType.STEPPER);
+    
+    const [step1, step2] = (updatedFormBag.uischema.elements[0] as UISchemaLayout).elements as UISchemaLayout[];
+
+    expect(step1.type).toBe(UISchemaLayoutType.VERTICAL);
+    expect(step1.elements.length).toBe(3);
+    expect((step1.elements[0] as TitleElement).options.content)
+      .toBe('poll.form.title');
+    expect((step1.elements[1] as DescriptionElement).options.content)
+      .toBe('poll.form.message');
+    expect((step1.elements[2]).type)
+      .toBe('StepperNavigator');
+
+    expect(step2.type).toBe(UISchemaLayoutType.VERTICAL);
+    expect(step2.elements.length).toBe(2);
+    expect((step2.elements[0] as TitleElement).options.content)
+      .toBe('poll.form.title');
+    expect((step2.elements[1]).type)
+      .toBe('Spinner');
+  });
+});

--- a/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.ts
+++ b/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.ts
@@ -13,8 +13,13 @@
 import {
   DescriptionElement,
   IdxStepTransformer,
+  IStepperContext,
   SpinnerElement,
+  StepperNavigatorElement,
   TitleElement,
+  UISchemaElement,
+  UISchemaLayout,
+  UISchemaLayoutType,
 } from '../../../types';
 import { generateRandomString, loc } from '../../../util';
 
@@ -54,19 +59,38 @@ export const transformSafeModePoll: IdxStepTransformer = ({
 
   const spinnerElement = {
     type: 'Spinner',
-    // random key to force re-render of this element during polling
-    key: generateRandomString(),
-    options: {
-      // show spinner for a maximum of one second before view re-renders
-      delayMs: Math.max(pollIntervalMs - 1000, 0),
-    },
   } as SpinnerElement;
 
-  uischema.elements.push(
-    titleElement,
-    descriptionElement,
-    spinnerElement,
-  );
+  const stepperNavigatorElement: StepperNavigatorElement = {
+    type: 'StepperNavigator',
+    options: {
+      callback: (stepperContext: IStepperContext) => {
+        const { setStepIndex } = stepperContext;
+        setTimeout(() => setStepIndex!(1), Math.max(pollIntervalMs - 1000, 0));
+      },
+    },
+  };
+
+  uischema.elements.push({
+    type: UISchemaLayoutType.STEPPER,
+    key: generateRandomString(),
+    elements: [
+      {
+        type: UISchemaLayoutType.VERTICAL,
+        elements: [
+          titleElement,
+          descriptionElement,
+          stepperNavigatorElement,
+        ].map((ele: UISchemaElement) => ({ ...ele, viewIndex: 0 })),
+      } as UISchemaLayout,
+      {
+        type: UISchemaLayoutType.VERTICAL,
+        elements: [
+          titleElement,
+          spinnerElement,
+        ].map((ele: UISchemaElement) => ({ ...ele, viewIndex: 1 })),
+      } as UISchemaLayout],
+  });
 
   return formBag;
 };

--- a/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.ts
+++ b/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.ts
@@ -10,14 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { generateRandomString, loc } from '../../../util';
-
 import {
   DescriptionElement,
   IdxStepTransformer,
   SpinnerElement,
   TitleElement,
 } from '../../../types';
+import { generateRandomString, loc } from '../../../util';
 
 export const transformSafeModePoll: IdxStepTransformer = ({
   transaction,
@@ -47,7 +46,7 @@ export const transformSafeModePoll: IdxStepTransformer = ({
       content: loc(
         'poll.form.message',
         'login',
-        [pollIntervalSec], 
+        [pollIntervalSec],
         { $1: { element: 'span' } },
       ),
     },

--- a/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.ts
+++ b/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.ts
@@ -66,6 +66,8 @@ export const transformSafeModePoll: IdxStepTransformer = ({
     options: {
       callback: (stepperContext: IStepperContext) => {
         const { setStepIndex } = stepperContext;
+        // show the second step (with the spinner) at most one second before the
+        // call to the endpoint happens
         setTimeout(() => setStepIndex!(1), Math.max(pollIntervalMs - 1000, 0));
       },
     },
@@ -73,6 +75,8 @@ export const transformSafeModePoll: IdxStepTransformer = ({
 
   uischema.elements.push({
     type: UISchemaLayoutType.STEPPER,
+    // Always re-render this stepper and children components when this transformer is
+    // called so that the stepper gets reset after the polling happens
     key: generateRandomString(),
     elements: [
       {

--- a/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.ts
+++ b/src/v3/src/transformer/layout/safeMode/transformSafeModePoll.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { generateRandomString, loc } from '../../../util';
+
+import {
+  DescriptionElement,
+  IdxStepTransformer,
+  SpinnerElement,
+  TitleElement,
+} from '../../../types';
+
+export const transformSafeModePoll: IdxStepTransformer = ({
+  transaction,
+  formBag,
+}) => {
+  const { uischema } = formBag;
+
+  const titleElement: TitleElement = {
+    type: 'Title',
+    options: {
+      content: loc('poll.form.title', 'login'),
+    },
+  };
+
+  const pollIntervalMs = transaction.nextStep?.refresh;
+
+  if (typeof pollIntervalMs !== 'number') {
+    return formBag;
+  }
+
+  const pollIntervalSec = Math.ceil(pollIntervalMs / 1000);
+
+  const descriptionElement: DescriptionElement = {
+    type: 'Description',
+    contentType: 'subtitle',
+    options: {
+      content: loc(
+        'poll.form.message',
+        'login',
+        [pollIntervalSec], 
+        { $1: { element: 'span' } },
+      ),
+    },
+  };
+
+  const spinnerElement = {
+    type: 'Spinner',
+    // random key to force re-render of this element during polling
+    key: generateRandomString(),
+    options: {
+      // show spinner for a maximum of one second before view re-renders
+      delayMs: Math.max(pollIntervalMs - 1000, 0),
+    },
+  } as SpinnerElement;
+
+  uischema.elements.push(
+    titleElement,
+    descriptionElement,
+    spinnerElement,
+  );
+
+  return formBag;
+};

--- a/src/v3/src/transformer/terminal/__snapshots__/transformTerminalTransaction.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformTerminalTransaction.test.ts.snap
@@ -278,6 +278,27 @@ Object {
 }
 `;
 
+exports[`Terminal Transaction Transformer Tests should add title only for idx.error.server.safe.mode.enrollment.unavailable message key when intent is "CREDENTIAL_ENROLLMENT" 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.safe.mode.title",
+        },
+        "type": "Title",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
 exports[`Terminal Transaction Transformer Tests should add title when terminal key indicates to return to orig tab 1`] = `
 Object {
   "data": Object {},

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
@@ -275,6 +275,23 @@ describe('Terminal Transaction Transformer Tests', () => {
     ).options?.step).toBe('skip');
   });
 
+  it('should add title only for idx.error.server.safe.mode.enrollment.unavailable'
+    + ' message key when intent is "CREDENTIAL_ENROLLMENT"', () => {
+    const mockErrorMessage = 'Set up is temporarily unavailable due to server maintenance. Try again later.';
+    transaction.context.intent = 'CREDENTIAL_ENROLLMENT';
+    transaction.messages?.push(getMockMessage(
+      mockErrorMessage,
+      'ERROR',
+      'idx.error.server.safe.mode.enrollment.unavailable',
+    ));
+    const formBag = transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
+
+    expect(formBag).toMatchSnapshot();
+    expect(formBag.uischema.elements.length).toBe(1);
+    expect(formBag.uischema.elements[0].type).toBe('Title');
+    expect((formBag.uischema.elements[0] as TitleElement).options?.content).toBe('oie.safe.mode.title');
+  });
+
   it('should add title and try again link for'
     + ' idx.device.not.activated.consent.denied message key', () => {
     const mockErrorMessage = 'Set up is temporarily unavailable due to server maintenance. Try again later.';

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -96,6 +96,11 @@ const appendViewLinks = (
   };
 
   if (containsMessageKeyPrefix(TERMINAL_KEY.SAFE_MODE_KEY_PREFIX, transaction.messages)
+    && transaction.context.intent === 'CREDENTIAL_ENROLLMENT') {
+    return;
+  }
+
+  if (containsMessageKeyPrefix(TERMINAL_KEY.SAFE_MODE_KEY_PREFIX, transaction.messages)
       && skipStep) {
     cancelLink.options.label = loc('oie.enroll.skip.setup', 'login');
     cancelLink.options.step = skipStep.name;

--- a/src/v3/src/transformer/uischema/updateElementKeys.ts
+++ b/src/v3/src/transformer/uischema/updateElementKeys.ts
@@ -11,7 +11,7 @@
  */
 
 import {
-  TransformStepFnWithOptions,
+  TransformStepFnWithOptions, UISchemaLayoutType,
 } from '../../types';
 import {
   generateRandomString,
@@ -23,7 +23,17 @@ import { traverseLayout } from '../util';
 export const updateElementKeys: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
   traverseLayout({
     layout: formbag.uischema,
-    predicate: (element) => !!element.type,
+    predicate: (element) => {
+      if ([
+        UISchemaLayoutType.STEPPER,
+        UISchemaLayoutType.ACCORDION,
+        UISchemaLayoutType.HORIZONTAL,
+        UISchemaLayoutType.VERTICAL,
+      ].includes((element.type) as UISchemaLayoutType)) {
+        return false;
+      }
+      return !!element.type;
+    },
     callback: (element) => {
       const { nextStep: { name } = {} } = transaction;
       const authKey = getAuthenticatorKey(transaction);

--- a/src/v3/src/transformer/uischema/updateElementKeys.ts
+++ b/src/v3/src/transformer/uischema/updateElementKeys.ts
@@ -23,18 +23,13 @@ import { traverseLayout } from '../util';
 export const updateElementKeys: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
   traverseLayout({
     layout: formbag.uischema,
-    predicate: (element) => {
-      // never add a synthetic key to layout elements' uischema
-      if ([
+    // never add a synthetic key to layout elements' uischema
+    predicate: (element) => ![
         UISchemaLayoutType.STEPPER,
         UISchemaLayoutType.ACCORDION,
         UISchemaLayoutType.HORIZONTAL,
         UISchemaLayoutType.VERTICAL,
-      ].includes((element.type) as UISchemaLayoutType)) {
-        return false;
-      }
-      return !!element.type;
-    },
+      ].includes((element.type) as UISchemaLayoutType),
     callback: (element) => {
       const { nextStep: { name } = {} } = transaction;
       const authKey = getAuthenticatorKey(transaction);

--- a/src/v3/src/transformer/uischema/updateElementKeys.ts
+++ b/src/v3/src/transformer/uischema/updateElementKeys.ts
@@ -24,6 +24,7 @@ export const updateElementKeys: TransformStepFnWithOptions = ({ transaction }) =
   traverseLayout({
     layout: formbag.uischema,
     predicate: (element) => {
+      // never add a synthetic key to layout elements' uischema
       if ([
         UISchemaLayoutType.STEPPER,
         UISchemaLayoutType.ACCORDION,

--- a/src/v3/src/transformer/uischema/updateElementKeys.ts
+++ b/src/v3/src/transformer/uischema/updateElementKeys.ts
@@ -25,11 +25,11 @@ export const updateElementKeys: TransformStepFnWithOptions = ({ transaction }) =
     layout: formbag.uischema,
     // never add a synthetic key to layout elements' uischema
     predicate: (element) => ![
-        UISchemaLayoutType.STEPPER,
-        UISchemaLayoutType.ACCORDION,
-        UISchemaLayoutType.HORIZONTAL,
-        UISchemaLayoutType.VERTICAL,
-      ].includes((element.type) as UISchemaLayoutType),
+      UISchemaLayoutType.STEPPER,
+      UISchemaLayoutType.ACCORDION,
+      UISchemaLayoutType.HORIZONTAL,
+      UISchemaLayoutType.VERTICAL,
+    ].includes((element.type) as UISchemaLayoutType),
     callback: (element) => {
       const { nextStep: { name } = {} } = transaction;
       const authKey = getAuthenticatorKey(transaction);

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -171,21 +171,14 @@ export interface UISchemaElement {
   noTranslate?: boolean;
 }
 
-export interface UISchemaLayout {
-  type: UISchemaLayoutType;
-  elements: (UISchemaElement | UISchemaLayout | StepperLayout | AccordionLayout)[];
-  options?: {
-    onClick?: ClickHandler;
-  }
-}
-
-export type PickerSchema = {
-  tester: (schema: UISchemaElement) => boolean;
-  mapper?: (schema: UISchemaElement) => UISchemaElement;
-};
-export interface CustomLayout {
-  type: UISchemaLayoutType;
-  elements: (CustomLayout | UISchemaElement | PickerSchema)[];
+/**
+ * Parent interface for all Layout types with common properties
+ */
+interface Layout {
+  type: string;
+  key?: string;
+  elements: unknown[];
+  options?: Record<string, unknown>;
 }
 
 export enum UISchemaLayoutType {
@@ -195,9 +188,40 @@ export enum UISchemaLayoutType {
   ACCORDION = 'Accordion',
 }
 
+export interface UISchemaLayout extends Layout {
+  type: UISchemaLayoutType;
+  elements: (UISchemaElement | UISchemaLayout | StepperLayout | AccordionLayout)[];
+  options?: {
+    onClick?: ClickHandler;
+  }
+}
+
+export interface StepperLayout extends Layout {
+  type: UISchemaLayoutType.STEPPER;
+  elements: Omit<UISchemaLayout, 'StepperLayout'>[];
+  options?: {
+    defaultStepIndex: () => number;
+  }
+}
+
+export interface AccordionLayout extends Layout {
+  type: UISchemaLayoutType.ACCORDION;
+  elements: AccordionPanelElement[];
+}
+
+export interface CustomLayout extends Layout {
+  type: UISchemaLayoutType;
+  elements: (CustomLayout | UISchemaElement | PickerSchema)[];
+}
+
 export function isUISchemaLayoutType(type: string): boolean {
   return Object.values(UISchemaLayoutType).includes(type as UISchemaLayoutType);
 }
+
+export type PickerSchema = {
+  tester: (schema: UISchemaElement) => boolean;
+  mapper?: (schema: UISchemaElement) => UISchemaElement;
+};
 
 export interface FieldElement extends UISchemaElement {
   type: 'Field';
@@ -448,20 +472,6 @@ export interface SuccessCallback extends UISchemaElement {
   options: {
     data: Record<string, unknown>;
   }
-}
-
-export interface StepperLayout {
-  type: UISchemaLayoutType.STEPPER;
-  key?: string;
-  elements: Omit<UISchemaLayout, 'StepperLayout'>[];
-  options?: {
-    defaultStepIndex: () => number;
-  }
-}
-
-export interface AccordionLayout {
-  type: UISchemaLayoutType.ACCORDION;
-  elements: AccordionPanelElement[];
 }
 
 export interface StepperButtonElement extends UISchemaElement {

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -173,7 +173,6 @@ export interface UISchemaElement {
 
 export interface UISchemaLayout {
   type: UISchemaLayoutType;
-  key?: string;
   elements: (UISchemaElement | UISchemaLayout | StepperLayout | AccordionLayout)[];
   options?: {
     onClick?: ClickHandler;
@@ -435,12 +434,6 @@ export interface QRCodeElement extends UISchemaElement {
 
 export interface SpinnerElement extends UISchemaElement {
   type: 'Spinner';
-  options: {
-    /**
-     * Delay (in milliseconds) before spinner appears
-     */
-    delayMs?: number;
-  };
 }
 
 export interface InfoboxElement extends UISchemaElement {
@@ -459,6 +452,7 @@ export interface SuccessCallback extends UISchemaElement {
 
 export interface StepperLayout {
   type: UISchemaLayoutType.STEPPER;
+  key?: string;
   elements: Omit<UISchemaLayout, 'StepperLayout'>[];
   options?: {
     defaultStepIndex: () => number;

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -173,6 +173,7 @@ export interface UISchemaElement {
 
 export interface UISchemaLayout {
   type: UISchemaLayoutType;
+  key?: string;
   elements: (UISchemaElement | UISchemaLayout | StepperLayout | AccordionLayout)[];
   options?: {
     onClick?: ClickHandler;
@@ -434,6 +435,12 @@ export interface QRCodeElement extends UISchemaElement {
 
 export interface SpinnerElement extends UISchemaElement {
   type: 'Spinner';
+  options: {
+    /**
+     * Delay (in milliseconds) before spinner appears
+     */
+    delayMs?: number;
+  };
 }
 
 export interface InfoboxElement extends UISchemaElement {

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -182,6 +182,9 @@ export const areTransactionsEqual = (
     return false;
   }
 
+  // on the safe mode poll remediation (IDX_STEP.POLL) we _always_
+  // want to view the incoming poll transaction as unequal to force
+  // the transformer to run again and re-render the view
   if (typeof tx2 !== 'undefined' && tx2.nextStep?.name === IDX_STEP.POLL) {
     return false;
   }

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -182,13 +182,7 @@ export const areTransactionsEqual = (
     return false;
   }
 
-  const tx1RefreshInterval = typeof tx1 !== 'undefined'
-    ? tx1.nextStep?.refresh
-    : undefined;
-  const tx2RefreshInterval = typeof tx2 !== 'undefined'
-    ? tx2.nextStep?.refresh
-    : undefined;
-  if (tx1RefreshInterval !== tx2RefreshInterval) {
+  if (typeof tx2 !== 'undefined' && tx2.nextStep?.name === IDX_STEP.POLL) {
     return false;
   }
 

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -182,6 +182,16 @@ export const areTransactionsEqual = (
     return false;
   }
 
+  const tx1RefreshInterval = typeof tx1 !== 'undefined'
+    ? tx1.nextStep?.refresh
+    : undefined;
+  const tx2RefreshInterval = typeof tx2 !== 'undefined'
+    ? tx2.nextStep?.refresh
+    : undefined;
+  if (tx1RefreshInterval !== tx2RefreshInterval) {
+    return false;
+  }
+
   return true;
 };
 

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -3,8 +3,6 @@ import { Selector, ClientFunction, userVariables } from 'testcafe';
 
 const SIGNOUT_LINK = '.auth-footer .js-cancel';
 const GO_BACK_LINK = '.auth-footer .js-go-back';
-const SKIP_LINK = '.auth-footer .js-skip';
-const SKIP_SET_UP_LINK = '.auth-footer .js-skip-setup';
 const SWITCH_AUTHENTICATOR_LINK = '[data-se="switchAuthenticator"]';
 const ionMessagesSelector = '.ion-messages-container';
 const SUBTITLE_SELECTOR = '[data-se="o-form-explain"]';
@@ -165,34 +163,25 @@ export default class BasePageObject {
     await this.t.click(this.getCancelLink());
   }
 
-  async skipLinkExists() {
-    const elCount = await Selector(SKIP_LINK).count;
-    return elCount === 1;
-  }
-
+  /**
+   * @deprecated
+   */
   getSkipLinkText() {
+    const SKIP_LINK = '.auth-footer .js-skip';
+
     return Selector(SKIP_LINK).textContent;
   }
 
-  async clickSkipLink() {
-    await this.t.click(Selector(SKIP_LINK));
+  getSkipSetUpLink() {
+    return this.form.getLink('Skip set up');
   }
 
-  async skipSetUpLinkExists() {
-    const elCount = await Selector(SKIP_SET_UP_LINK).count;
-    return elCount === 1;
-  }
-
-  getSetUpSkipLinkText() {
-    return Selector(SKIP_SET_UP_LINK).textContent;
+  async clickSetUpSkipLink() {
+    await this.t.click(await this.getSkipSetUpLink());
   }
 
   getErrorBoxText() {
     return this.form.getErrorBoxText();
-  }
-
-  async clickSetUpSkipLink() {
-    await this.t.click(Selector(SKIP_SET_UP_LINK));
   }
 
   getReturnToAuthenticatorListLink() {

--- a/test/testcafe/framework/page-objects/PollingPageObject.js
+++ b/test/testcafe/framework/page-objects/PollingPageObject.js
@@ -13,8 +13,8 @@ export default class PollingPageObject extends BasePageObject {
     return this.form.getTitle();
   }
 
-  getContent() {
-    return this.form.getElement('.ion-messages-container');
+  getRetryMessage() {
+    return this.form.getByText(/We will automatically retry/);
   }
 
   getErrorMessages() {

--- a/test/testcafe/spec/PollView_spec.js
+++ b/test/testcafe/spec/PollView_spec.js
@@ -34,8 +34,7 @@ async function setup(t) {
   return identityPage;
 }
 
-// OKTA-546860 "Safe mode" UI in v3 not yet implemented
-test.meta('v3', false).requestHooks(requestLogger, identifyMock)('should make request based on timer in response', async t => {
+test.requestHooks(requestLogger, identifyMock)('should make request based on timer in response', async t => {
   let identityPage  = await setup(t);
   await checkA11y(t);
 
@@ -48,7 +47,7 @@ test.meta('v3', false).requestHooks(requestLogger, identifyMock)('should make re
   await t.expect(requestLogger.count(() => true)).eql(1);
 
   await t.expect(pollingPageObject.getHeader()).eql('Unable to complete your request');
-  await t.expect(pollingPageObject.getContent().innerText).contains('We will automatically retry in');
+  await t.expect(pollingPageObject.getRetryMessage().exists).eql(true);
   await t.wait(3000);
   await t.expect(requestLogger.count(() => true)).eql(2);
 });
@@ -61,5 +60,5 @@ test.requestHooks(requestLogger, identifyPollErrorMock)('not poll on error', asy
   await identityPage.clickSignInButton();
   const pollingPageObject = new PollingPageObject();
   await t.expect(pollingPageObject.getErrorMessages().getTextContent()).eql('Server is unable to respond at the moment.');
-  await t.expect(pollingPageObject.getContent().length).eql(0);
+  await t.expect(pollingPageObject.getRetryMessage().length).eql(0);
 });

--- a/test/testcafe/spec/SafeMode_spec.js
+++ b/test/testcafe/spec/SafeMode_spec.js
@@ -29,11 +29,13 @@ const skipRequestLogger = RequestLogger(
   }
 );
 
-fixture('Safe Mode during enrollment');
+fixture('Safe Mode during enrollment')
+  .meta('v3', true);
 
 async function setup(t) {
   const terminalPage = new TerminalPageObject(t);
   await terminalPage.navigateToPage();
+  await t.expect(terminalPage.formExists()).eql(true);
   await checkConsoleMessages({
     controller: null,
     formName: 'terminal',
@@ -48,7 +50,7 @@ test.requestHooks(skipRequestLogger, safeModeOptionalMock)('should display corre
 
   await terminalPage.waitForErrorBox();
   await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('Set up is temporarily unavailable due to server maintenance. Try again later.');
-  await t.expect(await terminalPage.skipSetUpLinkExists()).ok();
+  await t.expect((await terminalPage.getSkipSetUpLink()).exists).eql(true);
   await t.expect(await terminalPage.signoutLinkExists()).notOk();
 
   // click skip link and ensure it goes to skip endpoint
@@ -68,7 +70,7 @@ test.requestHooks(safeModeRequiredMock)('should display correct error and sign o
   await checkA11y(t);
   await terminalPage.waitForErrorBox();
   await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('Set up is temporarily unavailable due to server maintenance. Try again later.');
-  await t.expect(await terminalPage.skipSetUpLinkExists()).notOk();
+  await t.expect((await terminalPage.getSkipSetUpLink()).exists).eql(false);
   await t.expect(await terminalPage.signoutLinkExists()).ok();
 });
 
@@ -77,6 +79,6 @@ test.requestHooks(safeModeCredentialEnrollmentIntent)('should display correct er
   await checkA11y(t);
   await terminalPage.waitForErrorBox();
   await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('Set up is temporarily unavailable due to server maintenance. Try again later.');
-  await t.expect(await terminalPage.skipSetUpLinkExists()).notOk();
+  await t.expect((await terminalPage.getSkipSetUpLink()).exists).eql(false);
   await t.expect(await terminalPage.signoutLinkExists()).notOk();
 });


### PR DESCRIPTION
## Description:

* implement safe mode view
* implement safe mode polling view
* re-enable tests related to safe mode and safe mode polling

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-546860](https://oktainc.atlassian.net/browse/OKTA-546860)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



