### PR TITLE
OKTA-584936 : FastPass mobile show Download OV page when not installed

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -133,9 +133,11 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     try {
       if (typeof proxyIdxResponse !== 'undefined') {
         setIdxTransaction({
-          // @ts-expect-error proxyIdxResponse has missing types
+          // @ts-expect-error OKTA-589168 - RawIdxResponse type does not contain the properties from ProxyIdxResponse type yet
+          // remove ts-expect-error ASAP to avoid risk of trying to access property that does not exist
           rawIdxState: proxyIdxResponse,
-          // @ts-expect-error proxyIdxResponse has missing types
+          // @ts-expect-error OKTA-589168 - IdxContext type does not contain the properties from ProxyIdxResponse type yet
+          // remove ts-expect-error ASAP to avoid risk of trying to access property that does not exist
           context: proxyIdxResponse,
         });
         return;
@@ -227,9 +229,11 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     try {
       if (typeof proxyIdxResponse !== 'undefined') {
         setIdxTransaction({
-          // @ts-ignore proxyIdxResponse has missing types
+          // @ts-expect-error OKTA-589168 - RawIdxResponse type does not contain the properties from ProxyIdxResponse type yet
+          // remove ts-expect-error ASAP to avoid risk of trying to access property that does not exist
           rawIdxState: proxyIdxResponse,
-          // @ts-ignore proxyIdxResponse has missing types
+          // @ts-expect-error OKTA-589168 - IdxContext type does not contain the properties from ProxyIdxResponse type yet
+          // remove ts-expect-error ASAP to avoid risk of trying to access property that does not exist
           context: proxyIdxResponse,
         });
         return;

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -81,6 +81,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     logoText,
     onSuccess,
     stateToken,
+    proxyIdxResponse,
   } = widgetProps;
 
   const [data, setData] = useState<FormBag['data']>({});
@@ -130,6 +131,15 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const bootstrap = useCallback(async () => {
     await initLanguage();
     try {
+      if(typeof proxyIdxResponse !== 'undefined') {
+        setIdxTransaction({
+          // @ts-expect-error proxyIdxResponse has missing types
+          rawIdxState: proxyIdxResponse,
+          // @ts-expect-error proxyIdxResponse has missing types
+          context: proxyIdxResponse,
+        });
+        return;
+      }
       const transaction = await authClient.idx.start({
         stateHandle: stateToken,
       });
@@ -215,6 +225,15 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const resume = useCallback(async () => {
     await initLanguage();
     try {
+      if(typeof proxyIdxResponse !== 'undefined') {
+        setIdxTransaction({
+          // @ts-ignore proxyIdxResponse has missing types
+          rawIdxState: proxyIdxResponse,
+          // @ts-ignore proxyIdxResponse has missing types
+          context: proxyIdxResponse,
+        });
+        return;
+      }
       const transaction = await authClient.idx.proceed({
         stateHandle: idxTransaction?.context.stateHandle,
       });

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -131,7 +131,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const bootstrap = useCallback(async () => {
     await initLanguage();
     try {
-      if(typeof proxyIdxResponse !== 'undefined') {
+      if (typeof proxyIdxResponse !== 'undefined') {
         setIdxTransaction({
           // @ts-expect-error proxyIdxResponse has missing types
           rawIdxState: proxyIdxResponse,
@@ -225,7 +225,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const resume = useCallback(async () => {
     await initLanguage();
     try {
-      if(typeof proxyIdxResponse !== 'undefined') {
+      if (typeof proxyIdxResponse !== 'undefined') {
         setIdxTransaction({
           // @ts-ignore proxyIdxResponse has missing types
           rawIdxState: proxyIdxResponse,

--- a/test/testcafe/framework/page-objects/DeviceEnrollmentTerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceEnrollmentTerminalPageObject.js
@@ -41,7 +41,7 @@ export default class DeviceEnrollmentTerminalPageObject extends BasePageObject {
   }
 
   getSubHeader() {
-    return this.form.getSubtitle();
+    return this.getTextContent('[data-se="subheader"]');
   }
 
   getContentText() {
@@ -63,16 +63,22 @@ export default class DeviceEnrollmentTerminalPageObject extends BasePageObject {
     return this.body.find('[data-se="app-store"] .app-store-logo').getAttribute('class');
   }
 
-  getCopyButton() {
-    return this.form.getButton('Copy link to clipboard');
+  getCopyButtonLabel() {
+    if(userVariables.v3) {
+      return this.form.getButton('Copy link to clipboard').innerText;
+    }
+    return this.getTextContent(COPY_BUTTON_CLASS);
   }
 
   getCopiedValue() {
     return this.body.find(COPY_BUTTON_CLASS).getAttribute('data-clipboard-text');
   }
 
-  getCopyOrgLinkButton() {
-    return this.form.getButton('Copy sign-in URL to clipboard');
+  getCopyOrgLinkButtonLabel() {
+    if(userVariables.v3) {
+      return this.form.getButton('Copy sign-in URL to clipboard').innerText;
+    }
+    return this.getTextContent(COPY_ORG_LINK_BUTTON_CLASS);
   }
 
   getCopiedOrgLinkValue() {

--- a/test/testcafe/framework/page-objects/DeviceEnrollmentTerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceEnrollmentTerminalPageObject.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, userVariables } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 const COPY_BUTTON_CLASS = '.copy-clipboard-button';
@@ -37,14 +37,17 @@ export default class DeviceEnrollmentTerminalPageObject extends BasePageObject {
   }
 
   getHeader() {
-    return this.getTextContent('[data-se="o-form-head"]');
+    return this.form.getTitle();
   }
 
   getSubHeader() {
-    return this.getTextContent('[data-se="subheader"]');
+    return this.form.getSubtitle();
   }
 
   getContentText() {
+    if(userVariables.v3) {
+      return this.getTextContent('[data-se="o-form"]');
+    }
     return this.getTextContent('[data-se="o-form-fieldset-container"]');
   }
 
@@ -60,16 +63,16 @@ export default class DeviceEnrollmentTerminalPageObject extends BasePageObject {
     return this.body.find('[data-se="app-store"] .app-store-logo').getAttribute('class');
   }
 
-  getCopyButtonLabel() {
-    return this.getTextContent(COPY_BUTTON_CLASS);
+  getCopyButton() {
+    return this.form.getButton('Copy link to clipboard');
   }
 
   getCopiedValue() {
     return this.body.find(COPY_BUTTON_CLASS).getAttribute('data-clipboard-text');
   }
 
-  getCopyOrgLinkButtonLabel() {
-    return this.getTextContent(COPY_ORG_LINK_BUTTON_CLASS);
+  getCopyOrgLinkButton() {
+    return this.form.getButton('Copy sign-in URL to clipboard');
   }
 
   getCopiedOrgLinkValue() {

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -153,7 +153,7 @@ test.meta('v3', false) // mdm not enabled in v3
     await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://anotherSampleEnrollmentlink.com');
   });
 
-test.meta('v3', false) // Back link needs to be added
+test.meta('v3', false) // OKTA-588701 - Back link needs to be added
   .requestHooks()('shows the correct content in Android ODA terminal view', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -198,7 +198,7 @@ test.meta('v3', false) // Back link needs to be added
     await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required to use Okta FastPass');
   });
 
-test.meta('v3', false) // Back link needs to be added
+test.meta('v3', false) // OKTA-588701 - Back link needs to be added
   .requestHooks()('shows the correct content in Android ODA terminal view when Okta Verify is not installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -234,7 +234,7 @@ test.meta('v3', false) // Back link needs to be added
     await t.expect(deviceEnrollmentTerminalPage.getBackLinkText()).eql('Back');
   });
 
-test.meta('v3', false) // Back link needs to be added
+test.meta('v3', false) // OKTA-588701 - Back link needs to be added
   .requestHooks()('shows the correct content in Android ODA terminal view when Okta Verify is installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -1,4 +1,4 @@
-import {RequestLogger, RequestMock} from 'testcafe';
+import {RequestLogger, RequestMock, userVariables} from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import { renderWidget as rerenderWidget } from '../framework/shared';
 import DeviceEnrollmentTerminalPageObject from '../framework/page-objects/DeviceEnrollmentTerminalPageObject';
@@ -18,7 +18,7 @@ const mdmMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(MdmEnrollment);
 
-fixture('Device enrollment terminal view for ODA and MDM');
+fixture('Device enrollment terminal view for ODA and MDM').meta('v3', true);
 
 async function setup(t) {
   const deviceEnrollmentTerminalPageObject = new DeviceEnrollmentTerminalPageObject(t);
@@ -36,14 +36,16 @@ test
     await t.expect(content).contains('To sign in using Okta Verify, you will need to set up');
     await t.expect(content).contains('Okta Verify on this device.');
     await t.expect(content).contains('Tap the Copy Link button below.');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
-    await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
+    await t.expect(deviceEnrollmentTerminalPage.getCopyButton().exists).eql(true);
+    if (!userVariables.v3) {
+      await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
+    }
     await t.expect(content).contains('On this device, open your browser, then paste the copied link into the address bar.');
     await t.expect(content).contains('Download the Okta Verify app.');
     await t.expect(content).contains('Open Okta Verify and follow the steps to add your account.');
     await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
     await t.expect(content).contains('https://idx.okta1.com');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButtonLabel()).eql('Copy sign-in URL to clipboard');
+    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButton().exists).eql(true);
     await t.expect(content).contains('Finish setting up your account in Okta Verify, then try accessing this app again.');
   });
 
@@ -59,11 +61,11 @@ test
     await t.expect(content).contains('Open Okta Verify and follow the steps to add your account.');
     await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
     await t.expect(content).contains('https://idx.okta1.com');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButtonLabel()).eql('Copy sign-in URL to clipboard');
+    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButton().exists).eql(true);
     await t.expect(content).contains('Finish setting up your account in Okta Verify, then try accessing this app again.');
   });
 
-test
+test.meta('v3', false) // mdm not enabled in v3
   .requestHooks(logger, mdmMock)('shows the correct content in MDM terminal view', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await checkA11y(t);
@@ -108,18 +110,20 @@ test
     await t.expect(content).contains('To sign in using Okta Verify, you will need to set up');
     await t.expect(content).contains('Okta Verify on this device.');
     await t.expect(content).contains('Tap the Copy Link button below.');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
-    await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
+    await t.expect(deviceEnrollmentTerminalPage.getCopyButton().exists).eql(true);
+    if(!userVariables.v3) {
+      await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
+    }
     await t.expect(content).contains('On this device, open your browser, then paste the copied link into the address bar.');
     await t.expect(content).contains('Download the Okta Verify app.');
     await t.expect(content).contains('Open Okta Verify and follow the steps to add your account.');
     await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
     await t.expect(content).contains('https://rain.okta1.com');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButtonLabel()).eql('Copy sign-in URL to clipboard');
+    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButton().exists).eql(true);
     await t.expect(content).contains('Finish setting up your account in Okta Verify, then try accessing this app again.');
   });
 
-test
+test.meta('v3', false) // mdm not enabled in v3
   .requestHooks()('shows the correct content in iOS MDM terminal view when Okta Verify is not set up in Universal Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -149,7 +153,7 @@ test
     await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://anotherSampleEnrollmentlink.com');
   });
 
-test
+test.meta('v3', false) // Back link needs to be added
   .requestHooks()('shows the correct content in Android ODA terminal view', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -194,7 +198,7 @@ test
     await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required to use Okta FastPass');
   });
 
-test
+test.meta('v3', false) // Back link needs to be added
   .requestHooks()('shows the correct content in Android ODA terminal view when Okta Verify is not installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -230,7 +234,7 @@ test
     await t.expect(deviceEnrollmentTerminalPage.getBackLinkText()).eql('Back');
   });
 
-test
+test.meta('v3', false) // Back link needs to be added
   .requestHooks()('shows the correct content in Android ODA terminal view when Okta Verify is installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -264,7 +268,7 @@ test
     await t.expect(deviceEnrollmentTerminalPage.getBackLinkText()).eql('Back');
   });
 
-test
+test.meta('v3', false) // mdm not enabled in v3
   .requestHooks()('shows the correct content in ANDROID MDM terminal view when Okta Verify is not installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -36,7 +36,7 @@ test
     await t.expect(content).contains('To sign in using Okta Verify, you will need to set up');
     await t.expect(content).contains('Okta Verify on this device.');
     await t.expect(content).contains('Tap the Copy Link button below.');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyButton().exists).eql(true);
+    await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
     if (!userVariables.v3) {
       await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
     }
@@ -45,7 +45,7 @@ test
     await t.expect(content).contains('Open Okta Verify and follow the steps to add your account.');
     await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
     await t.expect(content).contains('https://idx.okta1.com');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButton().exists).eql(true);
+    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButtonLabel()).eql('Copy sign-in URL to clipboard');
     await t.expect(content).contains('Finish setting up your account in Okta Verify, then try accessing this app again.');
   });
 
@@ -61,7 +61,7 @@ test
     await t.expect(content).contains('Open Okta Verify and follow the steps to add your account.');
     await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
     await t.expect(content).contains('https://idx.okta1.com');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButton().exists).eql(true);
+    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButtonLabel()).eql('Copy sign-in URL to clipboard');
     await t.expect(content).contains('Finish setting up your account in Okta Verify, then try accessing this app again.');
   });
 
@@ -110,7 +110,7 @@ test
     await t.expect(content).contains('To sign in using Okta Verify, you will need to set up');
     await t.expect(content).contains('Okta Verify on this device.');
     await t.expect(content).contains('Tap the Copy Link button below.');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyButton().exists).eql(true);
+    await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
     if(!userVariables.v3) {
       await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
     }
@@ -119,7 +119,7 @@ test
     await t.expect(content).contains('Open Okta Verify and follow the steps to add your account.');
     await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
     await t.expect(content).contains('https://rain.okta1.com');
-    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButton().exists).eql(true);
+    await t.expect(deviceEnrollmentTerminalPage.getCopyOrgLinkButtonLabel()).eql('Copy sign-in URL to clipboard');
     await t.expect(content).contains('Finish setting up your account in Okta Verify, then try accessing this app again.');
   });
 


### PR DESCRIPTION
## Description:

This PR fixes the issue where an error was being thrown when pressing the FastPass button without Okta Verify installed on mobile devices.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-584936](https://oktainc.atlassian.net/browse/OKTA-584936)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



