### PR TITLE
chore: update codeowner for i18n related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,5 @@
 *    @sherizada-okta @mauriciocastillosilva-okta @magizh-okta @robertdamphousse-okta @TianGan-okta @aarongranick-okta @shuowu-okta @lesterchoi-okta @jaredperreault-okta @vijetmahabaleshwar-okta @venkatakommisetty-okta @glenfannin-okta @shawyu-okta
 
 # Localization: pseudo-loc, i18n, etc.
-packages/@okta/pseudo-loc/    @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta
-packages/@okta/i18n/          @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta
-test/testcafe/spec-en-leaks/  @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta
+packages/@okta/pseudo-loc/    @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta @queeniechen-okta @michaeltamaki-okta
+test/testcafe/spec-en-leaks/  @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta @queeniechen-okta @michaeltamaki-okta


### PR DESCRIPTION
## Description:

- No need for globalization team to review changes in properties files
- Adding missing team emails to codeowners for globalization-related tests and utils

Resolves: OKTA-588923

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-588923](https://oktainc.atlassian.net/browse/OKTA-588923)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



