### PR TITLE
OKTA-587104 : g3 : Replacing deleted translation key for EML Flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,8 @@
 *    @glenfannin-okta @leemchale-okta @lesterchoi-okta @shawyu-okta @shuowu-okta
 
 # Localization: pseudo-loc, i18n, etc.
-packages/@okta/pseudo-loc/    @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta
-packages/@okta/i18n/          @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta
-test/testcafe/spec-en-leaks/  @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta
+packages/@okta/pseudo-loc/    @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta @queeniechen-okta @michaeltamaki-okta
+test/testcafe/spec-en-leaks/  @nikhilvenkatraman-okta @mauriciocastillosilva-okta @zihanwang-okta @queeniechen-okta @michaeltamaki-okta
 
 # SIW Next (v3)
 src/v3/                       @glenfannin-okta @leemchale-okta @lesterchoi-okta @shawyu-okta @shuowu-okta

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -960,7 +960,6 @@ oie.email.verify.subtitle.text.without.email = Send a verification email by clic
 oie.email.verify.alternate.magicLinkToEmailAddress = We sent an email to <$1>{0}</$1>. 
 oie.email.verify.alternate.magicLinkToYourEmail = We sent you a verification email. 
 oie.email.verify.alternate.instructions = Click the verification link in your email to continue or enter the code below.
-oie.email.verify.alternate.showCodeTextField = Enter a code from the email instead
 oie.email.verify.alternate.show.verificationCode.text = Enter a verification code instead
 oie.email.verify.alternate.verificationCode.instructions = Enter the verification code in the text box.
 oie.email.enroll.subtitle = Please check your email and enter the code below.

--- a/src/v3/src/transformer/layout/email/__snapshots__/transformEmailAuthenticatorEnroll.test.ts.snap
+++ b/src/v3/src/transformer/layout/email/__snapshots__/transformEmailAuthenticatorEnroll.test.ts.snap
@@ -214,7 +214,7 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "oie.email.verify.alternate.showCodeTextField",
+                "label": "oie.email.verify.alternate.show.verificationCode.text",
                 "options": Object {
                   "nextStepIndex": 1,
                   "type": "button",
@@ -311,7 +311,7 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "oie.email.verify.alternate.showCodeTextField",
+                "label": "oie.email.verify.alternate.show.verificationCode.text",
                 "options": Object {
                   "nextStepIndex": 1,
                   "type": "button",
@@ -408,7 +408,7 @@ Object {
                 "type": "Description",
               },
               Object {
-                "label": "oie.email.verify.alternate.showCodeTextField",
+                "label": "oie.email.verify.alternate.show.verificationCode.text",
                 "options": Object {
                   "nextStepIndex": 1,
                   "type": "button",

--- a/src/v3/src/transformer/layout/email/__snapshots__/transformEmailAuthenticatorVerify.test.ts.snap
+++ b/src/v3/src/transformer/layout/email/__snapshots__/transformEmailAuthenticatorVerify.test.ts.snap
@@ -221,7 +221,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
-                "label": "oie.email.verify.alternate.showCodeTextField",
+                "label": "oie.email.verify.alternate.show.verificationCode.text",
                 "options": Object {
                   "nextStepIndex": 1,
                   "type": "button",
@@ -328,7 +328,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
-                "label": "oie.email.verify.alternate.showCodeTextField",
+                "label": "oie.email.verify.alternate.show.verificationCode.text",
                 "options": Object {
                   "nextStepIndex": 1,
                   "type": "button",
@@ -435,7 +435,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
-                "label": "oie.email.verify.alternate.showCodeTextField",
+                "label": "oie.email.verify.alternate.show.verificationCode.text",
                 "options": Object {
                   "nextStepIndex": 1,
                   "type": "button",
@@ -555,7 +555,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
-                "label": "oie.email.verify.alternate.showCodeTextField",
+                "label": "oie.email.verify.alternate.show.verificationCode.text",
                 "options": Object {
                   "nextStepIndex": 1,
                   "type": "button",
@@ -662,7 +662,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
-                "label": "oie.email.verify.alternate.showCodeTextField",
+                "label": "oie.email.verify.alternate.show.verificationCode.text",
                 "options": Object {
                   "nextStepIndex": 1,
                   "type": "button",
@@ -769,7 +769,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
-                "label": "oie.email.verify.alternate.showCodeTextField",
+                "label": "oie.email.verify.alternate.show.verificationCode.text",
                 "options": Object {
                   "nextStepIndex": 1,
                   "type": "button",

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.test.ts
@@ -98,7 +98,7 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
       expect(layoutOne.elements[3].type).toBe('StepperButton');
       expect((layoutOne.elements[3] as StepperButtonElement).label)
-        .toBe('oie.email.verify.alternate.showCodeTextField');
+        .toBe('oie.email.verify.alternate.show.verificationCode.text');
 
       const layoutTwo = stepperElements[1];
 
@@ -162,7 +162,7 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
       expect(layoutOne.elements[3].type).toBe('StepperButton');
       expect((layoutOne.elements[3] as StepperButtonElement).label)
-        .toBe('oie.email.verify.alternate.showCodeTextField');
+        .toBe('oie.email.verify.alternate.show.verificationCode.text');
 
       const layoutTwo = stepperElements[1];
 
@@ -224,7 +224,7 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
       expect(layoutOne.elements[2].type).toBe('StepperButton');
       expect((layoutOne.elements[2] as StepperButtonElement).label)
-        .toBe('oie.email.verify.alternate.showCodeTextField');
+        .toBe('oie.email.verify.alternate.show.verificationCode.text');
 
       const layoutTwo = stepperElements[1];
 

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
@@ -113,7 +113,7 @@ export const transformEmailAuthenticatorEnroll: IdxStepTransformer = ({ transact
 
   const showCodeStepperButton: StepperButtonElement = {
     type: 'StepperButton',
-    label: loc('oie.email.verify.alternate.showCodeTextField', 'login'),
+    label: loc('oie.email.verify.alternate.show.verificationCode.text', 'login'),
     options: {
       type: ButtonType.BUTTON,
       variant: 'secondary',

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.test.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.test.ts
@@ -97,7 +97,7 @@ describe('Email Authenticator Verify Transformer Tests', () => {
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
       expect(layoutOne.elements[3].type).toBe('StepperButton');
       expect((layoutOne.elements[3] as StepperButtonElement).label)
-        .toBe('oie.email.verify.alternate.showCodeTextField');
+        .toBe('oie.email.verify.alternate.show.verificationCode.text');
 
       const layoutTwo = stepperElements[1];
 
@@ -161,7 +161,7 @@ describe('Email Authenticator Verify Transformer Tests', () => {
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
       expect(layoutOne.elements[3].type).toBe('StepperButton');
       expect((layoutOne.elements[3] as StepperButtonElement).label)
-        .toBe('oie.email.verify.alternate.showCodeTextField');
+        .toBe('oie.email.verify.alternate.show.verificationCode.text');
 
       const layoutTwo = stepperElements[1];
 
@@ -223,7 +223,7 @@ describe('Email Authenticator Verify Transformer Tests', () => {
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
       expect(layoutOne.elements[2].type).toBe('StepperButton');
       expect((layoutOne.elements[2] as StepperButtonElement).label)
-        .toBe('oie.email.verify.alternate.showCodeTextField');
+        .toBe('oie.email.verify.alternate.show.verificationCode.text');
 
       const layoutTwo = stepperElements[1];
 
@@ -425,7 +425,7 @@ describe('Email Authenticator Verify Transformer Tests', () => {
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
       expect(layoutOne.elements[3].type).toBe('StepperButton');
       expect((layoutOne.elements[3] as StepperButtonElement).label)
-        .toBe('oie.email.verify.alternate.showCodeTextField');
+        .toBe('oie.email.verify.alternate.show.verificationCode.text');
 
       const layoutTwo = stepperElements[1];
 
@@ -489,7 +489,7 @@ describe('Email Authenticator Verify Transformer Tests', () => {
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
       expect(layoutOne.elements[3].type).toBe('StepperButton');
       expect((layoutOne.elements[3] as StepperButtonElement).label)
-        .toBe('oie.email.verify.alternate.showCodeTextField');
+        .toBe('oie.email.verify.alternate.show.verificationCode.text');
 
       const layoutTwo = stepperElements[1];
 
@@ -551,7 +551,7 @@ describe('Email Authenticator Verify Transformer Tests', () => {
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
       expect(layoutOne.elements[2].type).toBe('StepperButton');
       expect((layoutOne.elements[2] as StepperButtonElement).label)
-        .toBe('oie.email.verify.alternate.showCodeTextField');
+        .toBe('oie.email.verify.alternate.show.verificationCode.text');
 
       const layoutTwo = stepperElements[1];
 

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.ts
@@ -113,7 +113,7 @@ export const transformEmailAuthenticatorVerify: IdxStepTransformer = ({ transact
 
   const showCodeStepperButton: StepperButtonElement = {
     type: 'StepperButton',
-    label: loc('oie.email.verify.alternate.showCodeTextField', 'login'),
+    label: loc('oie.email.verify.alternate.show.verificationCode.text', 'login'),
     options: {
       type: ButtonType.BUTTON,
       variant: 'secondary',

--- a/src/v3/test/e2e/tests/a11y.ts
+++ b/src/v3/test/e2e/tests/a11y.ts
@@ -59,7 +59,7 @@ test.page(
   await takeScreenshot(t, 'authenticator-verification-email-step1');
 
   await t
-    .click(Selector('button').withExactText('Enter a code from the email instead'));
+    .click(Selector('button').withExactText('Enter a verification code instead'));
 
   await checkA11y(t);
   await takeScreenshot(t, 'authenticator-verification-email-step2');
@@ -69,7 +69,7 @@ test.page(
   'http://localhost:3000/?siw-use-mocks=true&siw-mock-response=/idp/idx/challenge/error-401-invalid-otp-passcode',
 )('error-401-invalid-otp-passcode', async (t) => {
   await t
-    .click(Selector('button').withExactText('Enter a code from the email instead'));
+    .click(Selector('button').withExactText('Enter a verification code instead'));
 
   await checkA11y(t);
   await takeScreenshot(t, 'error-401-invalid-otp-passcode');

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                     tabindex="0"
                     type="button"
                   >
-                    Enter a code from the email instead
+                    Enter a verification code instead
                   </button>
                 </div>
               </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     tabindex="0"
                     type="button"
                   >
-                    Enter a code from the email instead
+                    Enter a verification code instead
                   </button>
                 </div>
               </div>
@@ -386,7 +386,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     tabindex="0"
                     type="button"
                   >
-                    Enter a code from the email instead
+                    Enter a verification code instead
                   </button>
                 </div>
               </div>

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -53,7 +53,7 @@ describe('Email authenticator verification when email magic link = undefined', (
       // renders the form
       await findByText(/Verify with your email/);
       const codeEntryBtn = await findByRole(
-        'button', { name: 'Enter a code from the email instead' },
+        'button', { name: 'Enter a verification code instead' },
       ) as HTMLButtonElement;
       expect(codeEntryBtn).not.toHaveFocus();
       expect(container).toMatchSnapshot();
@@ -77,7 +77,7 @@ describe('Email authenticator verification when email magic link = undefined', (
       // renders the form
       await findByText(/Verify with your email/);
       const codeEntryBtn = await findByRole(
-        'button', { name: 'Enter a code from the email instead' },
+        'button', { name: 'Enter a verification code instead' },
       ) as HTMLButtonElement;
       await waitFor(() => expect(codeEntryBtn).toHaveFocus());
       // Advance system time to show resend email reminder element
@@ -111,7 +111,7 @@ describe('Email authenticator verification when email magic link = undefined', (
         widgetOptions: { features: { autoFocus: true } },
       });
       await findByText(/Verify with your email/);
-      await user.click(await findByText(/Enter a code from the email instead/));
+      await user.click(await findByText(/Enter a verification code instead/));
       await findByText(/Enter Code/);
 
       // Advance system time to show resend email reminder element
@@ -166,7 +166,7 @@ describe('Email authenticator verification when email magic link = undefined', (
       await findByText(/Verify with your email/);
 
       // render otp challenge form
-      const nextPageBtn = await findByText(/Enter a code from the email instead/);
+      const nextPageBtn = await findByText(/Enter a verification code instead/);
       await user.click(nextPageBtn);
       await findByText(/Enter Code/);
       expect(container).toMatchSnapshot();
@@ -244,7 +244,7 @@ describe('Email authenticator verification when email magic link = undefined', (
     await findByText(/Verify with your email/);
     await findByText(/We sent an email to/);
 
-    const nextPageBtn = await findByText(/Enter a code from the email instead/);
+    const nextPageBtn = await findByText(/Enter a verification code instead/);
 
     await user.click(nextPageBtn);
     await findByText(/Enter Code/);
@@ -277,7 +277,7 @@ describe('Email authenticator verification when email magic link = undefined', (
     await findByText(/Verify with your email/);
     await findByText(/We sent an email to/);
 
-    const nextPageBtn = await findByText(/Enter a code from the email instead/);
+    const nextPageBtn = await findByText(/Enter a verification code instead/);
 
     await user.click(nextPageBtn);
     await findByText(/Enter Code/);
@@ -316,7 +316,7 @@ describe('Email authenticator verification when email magic link = undefined', (
     await findByText(/Verify with your email/);
     await findByText(/We sent an email to/);
 
-    const nextPageBtn = await findByText(/Enter a code from the email instead/);
+    const nextPageBtn = await findByText(/Enter a verification code instead/);
 
     await user.click(nextPageBtn);
     await findByText(/Enter Code/);

--- a/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
@@ -42,9 +42,6 @@ export default class ChallengeEmailPageObject extends ChallengeFactorPageObject 
   }
 
   getEnterCodeInsteadButton() {
-    if (userVariables.v3) {
-      return this.form.getButton('Enter a code from the email instead');
-    }
     return this.form.getButton('Enter a verification code instead');
   }
 }

--- a/test/testcafe/framework/page-objects/EnrollEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollEmailPageObject.js
@@ -3,7 +3,7 @@ import { Selector, userVariables } from 'testcafe';
 
 const CODE_FIELD_NAME = 'credentials.passcode';
 const ENTER_CODE_FROM_EMAIL_CLASS = '.enter-auth-code-instead-link';
-const ENTER_CODE_FROM_EMAIL_TEXT = 'Enter a code from the email instead';
+const ENTER_CODE_FROM_EMAIL_TEXT = 'Enter a verification code instead';
 const RESEND_EMAIL = '.resend-email-view';
 const RESEND_LINK = '.resend-link';
 


### PR DESCRIPTION
## Description:
This PR fixes the english leak caused by the replacement of a translation key. I confirmed this key is completely deleted from all *.properties files in master and only existed in login.properties because of the merge. Replaced this key in code and removed all references.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-587104](https://oktainc.atlassian.net/browse/OKTA-587104)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



