### PR TITLE
OKTA-549558 : Adds translation key for identifier icon title text

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -33,6 +33,7 @@ sensitive.input.show = Show
 sensitive.input.hide = Hide
 processing.alt.text = Processing...
 logo.default.alt.text = Logo
+identifier.icon.alt.text = User
 
 skip.to.main.content = Skip to main content
 

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -25,6 +25,7 @@ sensitive.input.show = 》Šĥöŵ 한Ӝฐโ《
 sensitive.input.hide = 》Ĥîðé 한Ӝฐโ《
 processing.alt.text = 》Þŕöçéššîñĝ··· ⾼ئ䀕ヸ€홝한Ӝฐโ《
 logo.default.alt.text = 》Ļöĝö 한Ӝฐโ《
+identifier.icon.alt.text = 》Ûšéŕ 한Ӝฐโ《
 skip.to.main.content = 》Šķîþ ţö ɱåîñ çöñţéñţ €홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 minutes.oneMinute = 》ɱîñûţé €홝한Ӝฐโ《
 minutes = 》{0} ɱîñûţéš €홝한Ӝฐโ《


### PR DESCRIPTION
## Description:

This PR adds a translation key for the user identifier icon title text.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-549558](https://oktainc.atlassian.net/browse/OKTA-549558)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



