### PR TITLE
g3: Adds back link to ODA Android enrollment screens

### DIFF
--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -48,6 +48,7 @@ import ReminderPrompt from '../ReminderPrompt';
 import Select from '../Select';
 import Spinner from '../Spinner';
 import StepperButton from '../StepperButton';
+import StepperLink from '../StepperLink';
 import StepperNavigator from '../StepperNavigator';
 import StepperRadio from '../StepperRadio';
 import SuccessCallback from '../SuccessCallback';
@@ -101,6 +102,10 @@ export default [
   {
     tester: ({ type }) => type === 'StepperButton',
     renderer: StepperButton,
+  },
+  {
+    tester: ({ type }) => type === 'StepperLink',
+    renderer: StepperLink,
   },
   {
     tester: ({ type }) => type === 'StepperRadio',

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -63,12 +63,15 @@ const Link: UISchemaElementComponent<{
   return (
     typeof href === 'undefined' ? (
       <LinkMui
-        // eslint-disable-next-line no-script-url
-        href="javascript:void(0)"
         onClick={onClick}
         aria-describedby={ariaDescribedBy}
         ref={focusRef}
         data-se={dataSe}
+        sx={{
+          '&:hover': {
+            cursor: 'pointer',
+          },
+        }}
       >
         {label}
       </LinkMui>

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -74,6 +74,7 @@ const Link: UISchemaElementComponent<{
           '&:hover': {
             cursor: 'pointer',
           },
+          verticalAlign: 'baseline',
         }}
       >
         {label}

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -63,6 +63,9 @@ const Link: UISchemaElementComponent<{
   return (
     typeof href === 'undefined' ? (
       <LinkMui
+        component="button"
+        variant="body1"
+        role="link"
         onClick={onClick}
         aria-describedby={ariaDescribedBy}
         ref={focusRef}

--- a/src/v3/src/components/StepperButton/StepperButton.tsx
+++ b/src/v3/src/components/StepperButton/StepperButton.tsx
@@ -36,9 +36,9 @@ const StepperButton: UISchemaElementComponent<{
 
   const handleClick = () => {
     if (typeof nextStepIndex === 'function') {
-      setStepIndex!(nextStepIndex(widgetContext));
+      setStepIndex(nextStepIndex(widgetContext));
     } else {
-      setStepIndex!(nextStepIndex);
+      setStepIndex(nextStepIndex);
     }
   };
 

--- a/src/v3/src/components/StepperLink/StepperLink.tsx
+++ b/src/v3/src/components/StepperLink/StepperLink.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Link } from '@okta/odyssey-react-mui';
+import { h } from 'preact';
+
+import { useStepperContext, useWidgetContext } from '../../contexts';
+import { useAutoFocus } from '../../hooks';
+import { StepperLinkElement, UISchemaElementComponent } from '../../types';
+
+const StepperLink: UISchemaElementComponent<{
+  uischema: StepperLinkElement
+}> = ({ uischema }) => {
+  const { setStepIndex } = useStepperContext();
+  const {
+    label,
+    focus,
+    ariaDescribedBy,
+    options: {
+      dataSe,
+      nextStepIndex,
+    },
+  } = uischema;
+
+  const focusRef = useAutoFocus<HTMLButtonElement>(focus);
+  const widgetContext = useWidgetContext();
+
+  const handleClick = () => {
+    if (typeof nextStepIndex === 'function') {
+      setStepIndex!(nextStepIndex(widgetContext));
+    } else {
+      setStepIndex!(nextStepIndex);
+    }
+  };
+
+  return (
+    <Link
+      onClick={handleClick}
+      aria-describedby={ariaDescribedBy}
+      ref={focusRef}
+      data-se={dataSe}
+      sx={{
+        '&:hover': {
+          cursor: 'pointer',
+        },
+      }}
+    >
+      {label}
+    </Link>
+  );
+};
+
+export default StepperLink;

--- a/src/v3/src/components/StepperLink/StepperLink.tsx
+++ b/src/v3/src/components/StepperLink/StepperLink.tsx
@@ -54,6 +54,7 @@ const StepperLink: UISchemaElementComponent<{
       sx={{
         '&:hover': {
           cursor: 'pointer',
+          verticalAlign: 'baseline',
         },
       }}
     >

--- a/src/v3/src/components/StepperLink/StepperLink.tsx
+++ b/src/v3/src/components/StepperLink/StepperLink.tsx
@@ -44,6 +44,9 @@ const StepperLink: UISchemaElementComponent<{
 
   return (
     <LinkMui
+      component="button"
+      variant="body1"
+      role="link"
       onClick={handleClick}
       aria-describedby={ariaDescribedBy}
       ref={focusRef}

--- a/src/v3/src/components/StepperLink/StepperLink.tsx
+++ b/src/v3/src/components/StepperLink/StepperLink.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Link } from '@okta/odyssey-react-mui';
+import { Link as LinkMui } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 
 import { useStepperContext, useWidgetContext } from '../../contexts';
@@ -43,7 +43,7 @@ const StepperLink: UISchemaElementComponent<{
   };
 
   return (
-    <Link
+    <LinkMui
       onClick={handleClick}
       aria-describedby={ariaDescribedBy}
       ref={focusRef}
@@ -55,7 +55,7 @@ const StepperLink: UISchemaElementComponent<{
       }}
     >
       {label}
-    </Link>
+    </LinkMui>
   );
 };
 

--- a/src/v3/src/components/StepperLink/StepperLink.tsx
+++ b/src/v3/src/components/StepperLink/StepperLink.tsx
@@ -36,9 +36,9 @@ const StepperLink: UISchemaElementComponent<{
 
   const handleClick = () => {
     if (typeof nextStepIndex === 'function') {
-      setStepIndex!(nextStepIndex(widgetContext));
+      setStepIndex(nextStepIndex(widgetContext));
     } else {
-      setStepIndex!(nextStepIndex);
+      setStepIndex(nextStepIndex);
     }
   };
 

--- a/src/v3/src/components/StepperLink/index.tsx
+++ b/src/v3/src/components/StepperLink/index.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import StepperLink from './StepperLink';
+
+export default StepperLink;

--- a/src/v3/src/transformer/terminal/odaEnrollment/__snapshots__/transformOdaEnrollmentAndroidAppLink.test.ts.snap
+++ b/src/v3/src/transformer/terminal/odaEnrollment/__snapshots__/transformOdaEnrollmentAndroidAppLink.test.ts.snap
@@ -192,6 +192,15 @@ Object {
                 "type": "List",
                 "viewIndex": 1,
               },
+              Object {
+                "contentType": "footer",
+                "label": "oform.back",
+                "options": Object {
+                  "nextStepIndex": 0,
+                },
+                "type": "StepperLink",
+                "viewIndex": 1,
+              },
             ],
             "type": "VerticalLayout",
           },
@@ -273,6 +282,14 @@ Object {
                   "type": "ol",
                 },
                 "type": "List",
+              },
+              Object {
+                "contentType": "footer",
+                "label": "oform.back",
+                "options": Object {
+                  "nextStepIndex": 0,
+                },
+                "type": "StepperLink",
               },
             ],
             "type": "VerticalLayout",

--- a/src/v3/src/transformer/terminal/odaEnrollment/__snapshots__/transformOdaEnrollmentAndroidAppLink.test.ts.snap
+++ b/src/v3/src/transformer/terminal/odaEnrollment/__snapshots__/transformOdaEnrollmentAndroidAppLink.test.ts.snap
@@ -229,7 +229,6 @@ Object {
                           "noMargin": true,
                           "options": Object {
                             "content": "enroll.oda.without.account.step1",
-                            "dataSe": "download-ov",
                           },
                           "type": "Description",
                         },

--- a/src/v3/src/transformer/terminal/odaEnrollment/transformOdaEnrollmentAndroidAppLink.test.ts
+++ b/src/v3/src/transformer/terminal/odaEnrollment/transformOdaEnrollmentAndroidAppLink.test.ts
@@ -17,6 +17,7 @@ import {
   DescriptionElement,
   ListElement,
   StepperLayout,
+  StepperLinkElement,
   TitleElement,
   UISchemaLayout,
   WidgetProps,
@@ -60,11 +61,14 @@ describe('Terminal ODA enrollment Android App Link transformer', () => {
     expect((layoutOne.elements[0] as TitleElement).options.content)
       .toBe('enroll.title.oda.with.account');
 
-    expect(layoutTwo.elements.length).toBe(4);
+    expect(layoutTwo.elements.length).toBe(5);
     expect((layoutTwo.elements[0] as TitleElement).options.content)
       .toBe('enroll.title.oda.with.account');
 
-    expect(layoutThree.elements.length).toBe(3);
+    expect((layoutTwo.elements[4] as StepperLinkElement).label)
+      .toBe('oform.back');
+
+    expect(layoutThree.elements.length).toBe(4);
     expect((layoutThree.elements[0] as TitleElement).options.content)
       .toBe('enroll.title.oda.without.account');
 
@@ -76,5 +80,7 @@ describe('Terminal ODA enrollment Android App Link transformer', () => {
     expect((layoutThreeListItemThree.elements[1] as DescriptionElement).type).toBe('Description');
     expect((layoutThreeListItemThree.elements[1] as DescriptionElement).options.content)
       .toBe('<span class="no-translate">https://okta.com</span>');
+    expect((layoutThree.elements[3] as StepperLinkElement).label)
+      .toBe('oform.back');
   });
 });

--- a/src/v3/src/transformer/terminal/odaEnrollment/transformOdaEnrollmentAndroidAppLink.ts
+++ b/src/v3/src/transformer/terminal/odaEnrollment/transformOdaEnrollmentAndroidAppLink.ts
@@ -19,6 +19,7 @@ import {
   IdxStepTransformer,
   ListElement,
   StepperButtonElement,
+  StepperLinkElement,
   TitleElement,
   UISchemaElement,
   UISchemaLayout,
@@ -200,6 +201,14 @@ export const transformOdaEnrollmentAndroidAppLink: IdxStepTransformer = ({
               ],
             },
           },
+          {
+            type: 'StepperLink',
+            contentType: 'footer',
+            label: loc('oform.back', 'login'),
+            options: {
+              nextStepIndex: 0,
+            },
+          } as StepperLinkElement,
         ].map((ele: UISchemaElement) => ({ ...ele, viewIndex: 1 })),
       } as UISchemaLayout,
       // Android App Link without Account
@@ -277,6 +286,14 @@ export const transformOdaEnrollmentAndroidAppLink: IdxStepTransformer = ({
               ],
             },
           } as ListElement,
+          {
+            type: 'StepperLink',
+            contentType: 'footer',
+            label: loc('oform.back', 'login'),
+            options: {
+              nextStepIndex: 0,
+            },
+          } as StepperLinkElement,
         ],
       } as UISchemaLayout,
     ],

--- a/src/v3/src/transformer/terminal/odaEnrollment/transformOdaEnrollmentAndroidAppLink.ts
+++ b/src/v3/src/transformer/terminal/odaEnrollment/transformOdaEnrollmentAndroidAppLink.ts
@@ -238,7 +238,6 @@ export const transformOdaEnrollmentAndroidAppLink: IdxStepTransformer = ({
                       noMargin: true,
                       options: {
                         content: loc('enroll.oda.without.account.step1', 'login', [OKTA_VERIFY_APP_URL.ANDROID]),
-                        dataSe: 'download-ov',
                       },
                     } as DescriptionElement,
                   ],

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -498,6 +498,15 @@ export interface StepperButtonElement extends UISchemaElement {
   }
 }
 
+export interface StepperLinkElement extends UISchemaElement {
+  type: 'StepperLink',
+  label: string;
+  options: Omit<LinkElement['options'], 'step'>
+  & {
+    nextStepIndex: number | ((widgetContext: IWidgetContext) => number);
+  }
+}
+
 export interface StepperNavigatorElement extends UISchemaElement {
   type: 'StepperNavigator',
   options: {

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -158,13 +158,13 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -334,13 +334,13 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -510,13 +510,13 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -154,13 +154,13 @@ exports[`authenticator-email-verification-data should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-22"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -1559,24 +1559,24 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -3146,24 +3146,24 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -4757,24 +4757,24 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -187,24 +187,24 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -160,24 +160,24 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -268,24 +268,24 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -556,24 +556,24 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -843,24 +843,24 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1131,24 +1131,24 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -666,24 +666,24 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-101"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-101"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -641,13 +641,13 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-64"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-64"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -870,24 +870,24 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -212,24 +212,24 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -379,24 +379,24 @@ exports[`authenticator-enroll-security-question-error custom question should sho
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -897,24 +897,24 @@ exports[`authenticator-enroll-security-question-error predefined question should
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1420,24 +1420,24 @@ exports[`authenticator-enroll-security-question-error predefined question should
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1938,24 +1938,24 @@ exports[`authenticator-enroll-security-question-error predefined question should
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -379,24 +379,24 @@ exports[`authenticator-enroll-security-question custom question fails client sid
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -740,24 +740,24 @@ exports[`authenticator-enroll-security-question custom question renders correct 
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-50"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-50"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1212,24 +1212,24 @@ exports[`authenticator-enroll-security-question predefined question renders corr
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-51"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-51"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-51"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-51"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1684,24 +1684,24 @@ exports[`authenticator-enroll-security-question predefined question should rende
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-51"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-51"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-51"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-51"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -481,13 +481,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-56"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -1581,13 +1581,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-154"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-154"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -229,24 +229,24 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -324,13 +324,13 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-46"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -650,24 +650,24 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
               <div
                 class="MuiBox-root emotion-18"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-100"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-18"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-100"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1244,24 +1244,24 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-85"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-85"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -650,13 +650,13 @@ exports[`authenticator-expired-password should present field level error message
               <div
                 class="MuiBox-root emotion-18"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-100"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1233,13 +1233,13 @@ exports[`authenticator-expired-password should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-85"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -802,24 +802,24 @@ exports[`authenticator-expiry-warning-password should present field level error 
               <div
                 class="MuiBox-root emotion-18"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-125"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-125"
                   data-se="skip"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Remind me later
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-18"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-125"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-125"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1543,24 +1543,24 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-109"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-109"
                   data-se="skip"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Remind me later
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-109"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-109"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -221,24 +221,24 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="forgot-password"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Forgot password?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="unlock"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Unlock account?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-7"
@@ -268,13 +268,13 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -507,24 +507,24 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="forgot-password"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Forgot password?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="unlock"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Unlock account?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-7"
@@ -554,13 +554,13 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -793,24 +793,24 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="forgot-password"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Forgot password?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="unlock"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Unlock account?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-7"
@@ -840,13 +840,13 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -694,13 +694,13 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-106"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-106"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -566,13 +566,13 @@ exports[`authenticator-reset-password should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-85"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1149,13 +1149,13 @@ exports[`authenticator-reset-password should render form with custom brand name 
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-85"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -446,13 +446,13 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-52"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -446,13 +446,13 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-52"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -184,24 +184,24 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-25"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-25"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -160,13 +160,13 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-22"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -193,13 +193,13 @@ exports[`Email authenticator verification when email magic link = false Tests sh
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -166,13 +166,13 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -393,13 +393,13 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -607,13 +607,13 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -867,24 +867,24 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1182,24 +1182,24 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-19"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1286,13 +1286,13 @@ exports[`Email authenticator verification when email magic link = undefined rend
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-14"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1500,13 +1500,13 @@ exports[`Email authenticator verification when email magic link = undefined shou
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -256,24 +256,24 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -257,24 +257,24 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -497,24 +497,24 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -178,24 +178,24 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -175,24 +175,24 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -165,24 +165,24 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -165,24 +165,24 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -358,24 +358,24 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
@@ -135,24 +135,24 @@ exports[`authenticator-verification-ov-resend-push-notification renders form 1`]
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-19"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-19"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -236,24 +236,24 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -218,24 +218,24 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -197,13 +197,13 @@ exports[`authenticator-verification-security-question renders form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -1777,13 +1777,13 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-170"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-170"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -246,24 +246,24 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                   data-se="forgot-password"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Forgot password?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -308,24 +308,24 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-48"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-48"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -636,24 +636,24 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-48"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-48"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -964,24 +964,24 @@ exports[`authenticator-verification-webauthn should render form with required us
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-48"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-48"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -214,13 +214,13 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -1559,24 +1559,24 @@ exports[`byol loading custom language should load custom language with "language
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -3146,24 +3146,24 @@ exports[`byol loading custom language should load custom language with assets.ba
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -4733,24 +4733,24 @@ exports[`byol loading default language should not load custom language when the 
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -6320,24 +6320,24 @@ exports[`byol loading default language should not load custom language with "lan
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -1816,13 +1816,13 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-74"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-74"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -3539,13 +3539,13 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -198,13 +198,13 @@ exports[`enroll-profile-new should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -233,13 +233,13 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -495,13 +495,13 @@ exports[`enroll-profile-with-password should show custom error message and preve
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -757,13 +757,13 @@ exports[`enroll-profile-with-password should show custom field level error messa
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -1006,13 +1006,13 @@ exports[`enroll-profile-with-password should show generic error message and prev
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -1342,13 +1342,13 @@ exports[`enroll-profile-with-password should show validation error messages on a
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-56"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -199,24 +199,24 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                   data-se="skip"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Skip Profile
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -252,13 +252,13 @@ exports[`enroll-profile-update-required-field fails client side validation with 
               <div
                 class="MuiBox-root emotion-17"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -475,13 +475,13 @@ exports[`enroll-profile-update-required-field should render form with one requir
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -571,13 +571,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-97"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-97"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -1138,13 +1138,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-92"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-92"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -1660,13 +1660,13 @@ exports[`enroll-profile-with-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-85"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
                     data-se="back"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign In
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -76,13 +76,13 @@ exports[`error-account-creation should render form 1`] = `
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-14"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -113,13 +113,13 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-19"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -76,13 +76,13 @@ exports[`error-session-expired should render form 1`] = `
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-14"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -179,24 +179,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -468,24 +468,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -692,24 +692,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -931,24 +931,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1204,24 +1204,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1411,24 +1411,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1618,24 +1618,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -1907,24 +1907,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -3388,24 +3388,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -3627,24 +3627,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-14"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -3900,24 +3900,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -308,24 +308,24 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways Mui-focusVisible emotion-48"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button Mui-focusVisible emotion-48"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Verify with something else
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-48"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -93,13 +93,13 @@ exports[`identify-recovery renders form 1`] = `
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-18"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -250,13 +250,13 @@ exports[`identify-with-password Client-side field change validation tests fails 
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                   data-se="forgot-password"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Forgot password?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-12"
@@ -286,13 +286,13 @@ exports[`identify-with-password Client-side field change validation tests fails 
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -554,13 +554,13 @@ exports[`identify-with-password Client-side field change validation tests should
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                   data-se="forgot-password"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Forgot password?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-12"
@@ -590,13 +590,13 @@ exports[`identify-with-password Client-side field change validation tests should
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -858,13 +858,13 @@ exports[`identify-with-password Client-side field change validation tests should
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                   data-se="forgot-password"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Forgot password?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-12"
@@ -894,13 +894,13 @@ exports[`identify-with-password Client-side field change validation tests should
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -1103,13 +1103,13 @@ exports[`identify-with-password renders form with focus 1`] = `
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                   data-se="forgot-password"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Forgot password?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-7"
@@ -1139,13 +1139,13 @@ exports[`identify-with-password renders form with focus 1`] = `
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>
@@ -1348,13 +1348,13 @@ exports[`identify-with-password renders form without focus 1`] = `
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                   data-se="forgot-password"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Forgot password?
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-7"
@@ -1384,13 +1384,13 @@ exports[`identify-with-password renders form without focus 1`] = `
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="enroll"
-                    href="javascript:void(0)"
+                    role="link"
                   >
                     Sign up
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
@@ -338,7 +338,7 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
                             >
                               <p
                                 class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-14"
-                                data-se="download-ov"
+                                data-se="o-form-explain"
                               >
                                 If you don’t have Okta Verify installed, 
                                 <a
@@ -433,6 +433,16 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
                       </li>
                     </ol>
                   </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
+                    role="link"
+                  >
+                    Back
+                  </button>
                 </div>
               </div>
             </div>
@@ -730,6 +740,16 @@ exports[`oda-enrollment-android-applink should render view when "Yes, I already 
                       </li>
                     </ol>
                   </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <button
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
+                    role="link"
+                  >
+                    Back
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -196,24 +196,24 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -223,24 +223,24 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1453,24 +1453,24 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -2934,24 +2934,24 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -114,13 +114,13 @@ exports[`terminal-return-email-error should render form 1`] = `
               <div
                 class="MuiBox-root emotion-8"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-15"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-15"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -102,13 +102,13 @@ exports[`unlock-account-success renders form 1`] = `
               <div
                 class="MuiBox-root emotion-12"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-19"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -293,13 +293,13 @@ exports[`user-unlock-account renders form 1`] = `
               <div
                 class="MuiBox-root emotion-7"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -178,24 +178,24 @@ exports[`webauthn-enroll should render form 1`] = `
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-23"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-23"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -392,24 +392,24 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-23"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-23"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>
@@ -613,24 +613,24 @@ exports[`webauthn-enroll should render form with user verification and edge brow
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                   data-se="switchAuthenticator"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Return to authenticator list
-                </a>
+                </button>
               </div>
               <div
                 class="MuiBox-root emotion-13"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                <button
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                   data-se="cancel"
-                  href="javascript:void(0)"
+                  role="link"
                 >
                   Back to sign in
-                </a>
+                </button>
               </div>
             </div>
           </form>

--- a/src/v3/test/integration/error-authenticator-enrollment-not-allowed.test.tsx
+++ b/src/v3/test/integration/error-authenticator-enrollment-not-allowed.test.tsx
@@ -23,10 +23,10 @@ describe('error-authenticator-enrollment-not-allowed', () => {
 
   it('should send correct payload when clicking back to sign in link', async () => {
     const {
-      authClient, user, findByText,
+      authClient, user, findByRole,
     } = await setup({ mockResponse });
 
-    const cancelEle = await findByText('Back to sign in', { selector: 'a' });
+    const cancelEle = await findByRole('link', { name: 'Back to sign in' });
 
     await user.click(cancelEle);
     expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(

--- a/src/v3/test/integration/flow-enroll-profile-identify-transition-clear-errors.test.tsx
+++ b/src/v3/test/integration/flow-enroll-profile-identify-transition-clear-errors.test.tsx
@@ -20,6 +20,7 @@ describe('flow-enroll-profile-transition-clear-errors', () => {
       user,
       queryByText,
       findByText,
+      findByRole,
       authClient,
     } = await setup({
       mockResponses: {
@@ -43,7 +44,7 @@ describe('flow-enroll-profile-transition-clear-errors', () => {
       expect.anything(),
     );
     await findByText(/We found some errors./);
-    const signinLink = await findByText('Sign In', { selector: 'a' });
+    const signinLink = await findByRole('link', { name: 'Sign In' });
     await user.click(signinLink);
     await findByText(/Sign In/);
     expect(queryByText(/We found some errors./)).toBeNull();

--- a/test/testcafe/framework/page-objects/DeviceEnrollmentTerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceEnrollmentTerminalPageObject.js
@@ -25,7 +25,7 @@ export default class DeviceEnrollmentTerminalPageObject extends BasePageObject {
   }
 
   getBackLink() {
-    return Selector('[data-se="back-to-preselect"]');
+    return this.form.getLink('Back');
   }
 
   async clickBackLink() {
@@ -36,11 +36,10 @@ export default class DeviceEnrollmentTerminalPageObject extends BasePageObject {
     return this.getBackLink().innerText;
   }
 
-  getHeader() {
-    return this.form.getTitle();
-  }
-
   getSubHeader() {
+    if (userVariables.v3) {
+      return this.form.getSubtitle();
+    }
     return this.getTextContent('[data-se="subheader"]');
   }
 
@@ -52,6 +51,9 @@ export default class DeviceEnrollmentTerminalPageObject extends BasePageObject {
   }
 
   getContentByIndex(idx = 1) {
+    if (userVariables.v3) {
+      return this.getTextContent(`ol li:nth-of-type(${idx})`);
+    }
     return this.getTextContent(`.o-form-fieldset-container ol li:nth-of-type(${idx})`);
   }
 

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -38,7 +38,7 @@ export default class IdentityPageObject extends BasePageObject {
   }
 
   getSignupLinkText() {
-    return Selector(ENROLL_SELECTOR).textContent;
+    return this.form.getLink('Sign up').textContent;
   }
 
   getNeedhelpLinkText() {
@@ -220,7 +220,7 @@ export default class IdentityPageObject extends BasePageObject {
   }
 
   async clickSignUpLink() {
-    await this.t.click(Selector(ENROLL_SELECTOR));
+    await this.t.click(this.form.getLink('Sign up'));
   }
 
   getUnlockAccountLink(name = 'Unlock account?') {

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -2,7 +2,6 @@ import { Selector, userVariables } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 const CALLOUT_SELECTOR = '[data-se="callout"]';
-const ENROLL_SELECTOR = 'a[data-se="enroll"]';
 const NEEDHELP_SELECTOR = 'a[data-se="help"]';
 const FORGOT_PASSWORD_SELECTOR = 'a[data-se="forgot-password"]';
 const CUSTOM_HELP_LINK_SELECTOR = '.auth-footer .js-help';
@@ -45,13 +44,8 @@ export default class IdentityPageObject extends BasePageObject {
     return Selector(NEEDHELP_SELECTOR).textContent;
   }
 
-  getForgotPasswordLinkText() {
-    return Selector(FORGOT_PASSWORD_SELECTOR).textContent;
-  }
-
   async hasForgotPasswordLinkText() {
-    const elCount = await Selector(FORGOT_PASSWORD_SELECTOR).count;
-    return elCount === 1;
+    return this.form.getLink('Forgot password?').exists;
   }
 
   async clickOktaVerifyButton() {

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -258,7 +258,6 @@ test
     await deviceEnrollmentTerminalPage.clickWithOVAccount();
     await deviceEnrollmentTerminalPage.clickNextButton();
     await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Additional setup required to use Okta FastPass');
-    await t.debug();
     await t.expect(deviceEnrollmentTerminalPage.getSubHeader()).eql('Okta FastPass is a security method that can sign you in without needing your username.');
     await t.expect(deviceEnrollmentTerminalPage.hasText('Already have Okta FastPass enabled for your account?')).eql(true);
     await t.expect(deviceEnrollmentTerminalPage.getContentByIndex(1)).eql('On this device, open the Okta Verify app.');

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -30,7 +30,7 @@ test
   .requestHooks(logger, iosOdaMock)('shows the correct content in iOS ODA terminal view', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await checkA11y(t);
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Download Okta Verify');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Download Okta Verify');
     await t.expect(deviceEnrollmentTerminalPage.getBeaconClass()).contains('mfa-okta-verify');
     const content = deviceEnrollmentTerminalPage.getContentText();
     await t.expect(content).contains('To sign in using Okta Verify, you will need to set up');
@@ -53,7 +53,7 @@ test
   .requestHooks(logger, androidOdaLoopbackMock)('shows the correct content in Android ODA Loopback terminal view', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await checkA11y(t);
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Download Okta Verify');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Download Okta Verify');
     await t.expect(deviceEnrollmentTerminalPage.getBeaconClass()).contains('mfa-okta-verify');
     const content = deviceEnrollmentTerminalPage.getContentText();
     await t.expect(content).contains('To sign in using Okta Verify, you will need to set up');
@@ -69,7 +69,7 @@ test.meta('v3', false) // mdm not enabled in v3
   .requestHooks(logger, mdmMock)('shows the correct content in MDM terminal view', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await checkA11y(t);
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Additional setup required');
     const content = deviceEnrollmentTerminalPage.getContentText();
     await t.expect(content).contains('To access this app, your device needs to meet your organization');
     await t.expect(content).contains('s security requirements. Follow the instructions below to continue.');
@@ -104,7 +104,7 @@ test
       }
     });
     await checkA11y(t);
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Download Okta Verify');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Download Okta Verify');
     await t.expect(deviceEnrollmentTerminalPage.getBeaconClass()).contains('mfa-okta-verify');
     const content = deviceEnrollmentTerminalPage.getContentText();
     await t.expect(content).contains('To sign in using Okta Verify, you will need to set up');
@@ -141,7 +141,7 @@ test.meta('v3', false) // mdm not enabled in v3
       }
     });
     await checkA11y(t);
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Additional setup required');
     const content = deviceEnrollmentTerminalPage.getContentText();
     await t.expect(content).contains('To access this app, your device needs to meet your organization');
     await t.expect(content).contains('s security requirements. Follow the instructions below to continue.');
@@ -153,7 +153,7 @@ test.meta('v3', false) // mdm not enabled in v3
     await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://anotherSampleEnrollmentlink.com');
   });
 
-test.meta('v3', false) // OKTA-588701 - Back link needs to be added
+test
   .requestHooks()('shows the correct content in Android ODA terminal view', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -173,7 +173,7 @@ test.meta('v3', false) // OKTA-588701 - Back link needs to be added
       }
     });
     await checkA11y(t);
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required to use Okta FastPass');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Additional setup required to use Okta FastPass');
     await t.expect(deviceEnrollmentTerminalPage.getBeaconClass()).contains('mfa-okta-verify');
     const content = deviceEnrollmentTerminalPage.getContentText();
     await t.expect(content).contains('On this device, do you already have an Okta Verify account for testOrg?');
@@ -195,10 +195,10 @@ test.meta('v3', false) // OKTA-588701 - Back link needs to be added
 
     await deviceEnrollmentTerminalPage.clickBackLink();
     await t.expect(deviceEnrollmentTerminalPage.getBackLink().exists).eql(false);
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required to use Okta FastPass');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Additional setup required to use Okta FastPass');
   });
 
-test.meta('v3', false) // OKTA-588701 - Back link needs to be added
+test
   .requestHooks()('shows the correct content in Android ODA terminal view when Okta Verify is not installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -221,7 +221,7 @@ test.meta('v3', false) // OKTA-588701 - Back link needs to be added
     // switch to the next page when OV account is not setup
     await deviceEnrollmentTerminalPage.clickWithoutOVAccount();
     await deviceEnrollmentTerminalPage.clickNextButton();
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Set up an Okta Verify account');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Set up an Okta Verify account');
     await t.expect(deviceEnrollmentTerminalPage.getSubHeader()).eql('To sign in with Okta FastPass, you’ll need to set up Okta Verify on this device.');
     await t.expect(deviceEnrollmentTerminalPage.getContentByIndex(1)).contains('If you don’t have Okta Verify installed,');
     await t.expect(deviceEnrollmentTerminalPage.getContentByIndex(1)).contains('download the app.');
@@ -234,7 +234,7 @@ test.meta('v3', false) // OKTA-588701 - Back link needs to be added
     await t.expect(deviceEnrollmentTerminalPage.getBackLinkText()).eql('Back');
   });
 
-test.meta('v3', false) // OKTA-588701 - Back link needs to be added
+test
   .requestHooks()('shows the correct content in Android ODA terminal view when Okta Verify is installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -257,9 +257,10 @@ test.meta('v3', false) // OKTA-588701 - Back link needs to be added
     // go back then switch to the next page when OV account is setup
     await deviceEnrollmentTerminalPage.clickWithOVAccount();
     await deviceEnrollmentTerminalPage.clickNextButton();
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required to use Okta FastPass');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Additional setup required to use Okta FastPass');
+    await t.debug();
     await t.expect(deviceEnrollmentTerminalPage.getSubHeader()).eql('Okta FastPass is a security method that can sign you in without needing your username.');
-    await t.expect(deviceEnrollmentTerminalPage.getTextContent('.subtitle ')).eql('Already have Okta FastPass enabled for your account?');
+    await t.expect(deviceEnrollmentTerminalPage.hasText('Already have Okta FastPass enabled for your account?')).eql(true);
     await t.expect(deviceEnrollmentTerminalPage.getContentByIndex(1)).eql('On this device, open the Okta Verify app.');
     await t.expect(deviceEnrollmentTerminalPage.getContentByIndex(2)).eql('On the list of accounts, tap your account for https://rain.okta1.com.');
     await t.expect(deviceEnrollmentTerminalPage.getContentByIndex(3)).eql('Under the “Okta FastPass” section, tap Setup, then follow the instructions.');
@@ -287,7 +288,7 @@ test.meta('v3', false) // mdm not enabled in v3
       }
     });
     await checkA11y(t);
-    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required');
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Additional setup required');
     const content = deviceEnrollmentTerminalPage.getContentText();
     await t.expect(content).contains('To access this app, your device needs to meet your organization');
     await t.expect(content).contains('s security requirements. Follow the instructions below to continue.');

--- a/test/testcafe/spec/IdentifyWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyWithCaptcha_spec.js
@@ -58,7 +58,6 @@ test.requestHooks(identifyRequestLogger, identifyMockwithHCaptcha)('should sign 
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.fillPasswordField('random password 123');
   await t.expect(await identityPage.hasForgotPasswordLinkText()).ok();
-  await t.expect(await identityPage.getForgotPasswordLinkText()).eql('Forgot password?');
 
   await t.expect(await identityPage.hasShowTogglePasswordIcon()).ok();
 
@@ -83,7 +82,6 @@ test.requestHooks(identifyRequestLogger, reCaptchaRequestLogger, identifyMockWit
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.fillPasswordField('random password 123');
   await t.expect(await identityPage.hasForgotPasswordLinkText()).ok();
-  await t.expect(await identityPage.getForgotPasswordLinkText()).eql('Forgot password?');
   
   await t.expect(await identityPage.hasShowTogglePasswordIcon()).ok();
   

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -99,7 +99,6 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have 
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.fillPasswordField('random password 123');
   await t.expect(await identityPage.hasForgotPasswordLinkText()).ok();
-  await t.expect(await identityPage.getForgotPasswordLinkText()).eql('Forgot password?');
 
   await t.expect(await identityPage.hasShowTogglePasswordIcon()).ok();
   await t.expect(identityPage.getSaveButtonLabel()).eql('Sign in');


### PR DESCRIPTION
## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-588701](https://oktainc.atlassian.net/browse/OKTA-588701)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



