### PR TITLE
OKTA-586845 : g3 : Removing custom validation function for confirmPassword field

### DIFF
--- a/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
+++ b/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
@@ -213,22 +213,5 @@ export const transformEnrollPasswordAuthenticator: IdxStepTransformer = ({
     },
   };
 
-  dataSchema.confirmPassword = {
-    validate: (data: FormBag['data']) => {
-      const newPw = data[passwordFieldName] as string;
-      const confirmPw = data.confirmPassword;
-      const errorMessages: WidgetMessage[] = [];
-      if (newPw && newPw !== confirmPw) {
-        errorMessages.push({
-          name: 'confirmPassword',
-          class: 'ERROR',
-          message: loc('password.enroll.error.match', 'login'),
-          i18n: { key: 'password.enroll.error.match' },
-        });
-      }
-      return errorMessages.length > 0 ? errorMessages : undefined;
-    },
-  };
-
   return formBag;
 };

--- a/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
+++ b/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
@@ -47,6 +47,7 @@ fixture('Email Magic Link OTP Terminal view')
 async function setupOtpOnly(t) {
   const terminalOtpOnlyPageObject = new TerminalOtpOnlyPageObject(t);
   await terminalOtpOnlyPageObject.navigateToPage();
+  await t.expect(terminalOtpOnlyPageObject.formExists()).eql(true);
   return terminalOtpOnlyPageObject;
 }
 


### PR DESCRIPTION
## Description:

This additional custom validation function causes the error message to be duplicated and results in the component to trigger the error even after it has been validated at a field level. 

Since the `confirmPassword` field's message is based solely from the `credentials.passcode` field, there is no need to define a custom validator for this field.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-586845](https://oktainc.atlassian.net/browse/OKTA-586845)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



