### PR TITLE
Support remember me when launch OV

### DIFF
--- a/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-challenge-not-received-with-remember-me.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-challenge-not-received-with-remember-me.json
@@ -1,0 +1,101 @@
+{
+    "stateHandle": "02Su_kH3sC3blG075ZdSW5v0N-oiOpK3HqGmR5TS1b",
+    "version": "1.0.0",
+    "expiresAt": "2020-12-18T21:48:11.000Z",
+
+    "intent": "LOGIN",
+    "remediation": {
+        "type": "array",
+        "value": [
+            {
+                "rel": ["create-form"],
+                "name": "identify",
+                "href": "http://localhost:3000/idp/idx/identify",
+                "method": "POST",
+                "accepts": "application/vnd.okta.v1+json",
+                "value": [
+                    {
+                        "name": "identifier",
+                        "label": "Username"
+                    },
+                    {
+                        "name":"rememberMe",
+                        "type":"boolean",
+                        "label":"Remember this device"
+                    },
+                    {
+                        "name": "stateHandle",
+                        "required": true,
+                        "value": "02Su_kH3sC3blG075ZdSW5v0N-oiOpK3HqGmR5TS1b",
+                        "visible": false,
+                        "mutable": false
+                    }
+                ]
+            },
+            {
+                "rel": ["create-form"],
+                "name": "launch-authenticator",
+                "href": "http://localhost:3000/idp/idx/authenticators/okta-verify/launch",
+                "method": "POST",
+                "accepts": "application/vnd.okta.v1+json",
+                "value": [
+                    {
+                        "name": "stateHandle",
+                        "required": true,
+                        "value": "02Su_kH3sC3blG075ZdSW5v0N-oiOpK3HqGmR5TS1b",
+                        "visible": false,
+                        "mutable": false
+                    }
+                ]
+            },
+            {
+                "rel": ["create-form"],
+                "name": "select-enroll-profile",
+                "href": "http://localhost:3000/idp/idx/enroll",
+                "method": "POST",
+                "accepts": "application/vnd.okta.v1+json",
+                "value": [
+                    {
+                        "name": "stateHandle",
+                        "required": true,
+                        "value": "02Su_kH3sC3blG075ZdSW5v0N-oiOpK3HqGmR5TS1b",
+                        "visible": false,
+                        "mutable": false
+                    }
+                ]
+            }
+        ]
+    },
+    "cancel": {
+        "rel": ["create-form"],
+        "name": "cancel",
+        "href": "http://localhost:3000/idp/idx/cancel",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+            {
+                "name": "stateHandle",
+                "required": true,
+                "value": "02Su_kH3sC3blG075ZdSW5v0N-oiOpK3HqGmR5TS1b",
+                "visible": false,
+                "mutable": false
+            }
+        ]
+    },
+    "context": {
+        "rel": ["create-form"],
+        "name": "context",
+        "href": "http://localhost:3000/idp/idx/context",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+            {
+                "name": "stateHandle",
+                "required": true,
+                "value": "02Su_kH3sC3blG075ZdSW5v0N-oiOpK3HqGmR5TS1b",
+                "visible": false,
+                "mutable": false
+            }
+        ]
+    }
+}

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -174,6 +174,8 @@ export default Controller.extend({
 
     // Build options to invoke or throw error for invalid action
     if (FORMS.LAUNCH_AUTHENTICATOR === actionPath && actionParams) {
+      //https://oktainc.atlassian.net/browse/OKTA-562885  a temp solution to send rememberMe when click the launch OV buttion.
+      //will redesign to handle FastPass silent probing case where no username and rememberMe opiton at all.
       invokeOptions = {
         ...invokeOptions,
         actions: [{

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -173,7 +173,15 @@ export default Controller.extend({
     }
 
     // Build options to invoke or throw error for invalid action
-    if (idx['neededToProceed'].find(item => item.name === actionPath)) {
+    if (FORMS.LAUNCH_AUTHENTICATOR === actionPath && actionParams) {
+      invokeOptions = {
+        ...invokeOptions,
+        actions: [{
+          name: actionPath,
+          params: actionParams
+        }]
+      };
+    } else if (idx['neededToProceed'].find(item => item.name === actionPath)) {
       invokeOptions = { ...invokeOptions, step: actionPath };
     } else if (_.isFunction(idx['actions'][actionPath])) {
       invokeOptions = {

--- a/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
+++ b/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
@@ -61,7 +61,7 @@ export default View.extend({
           if (this.options.isRequired) {
             appState.trigger('saveForm', this.model);
           } else {
-            appState.trigger('invokeAction', FORMS.LAUNCH_AUTHENTICATOR);
+            appState.trigger('invokeAction', FORMS.LAUNCH_AUTHENTICATOR, {"rememberMe": this.model.get('rememberMe')});
           }
         }, isUVapproach || isAppLinkapproach ? UNIVERSAL_LINK_POST_DELAY : 0);
       }

--- a/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
+++ b/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
@@ -61,7 +61,7 @@ export default View.extend({
           if (this.options.isRequired) {
             appState.trigger('saveForm', this.model);
           } else {
-            appState.trigger('invokeAction', FORMS.LAUNCH_AUTHENTICATOR, {"rememberMe": this.model.get('rememberMe')});
+            appState.trigger('invokeAction', FORMS.LAUNCH_AUTHENTICATOR, {'rememberMe': this.model.get('rememberMe')});
           }
         }, isUVapproach || isAppLinkapproach ? UNIVERSAL_LINK_POST_DELAY : 0);
       }

--- a/test/testcafe/spec/LaunchOVWithRememberMe_spec.js
+++ b/test/testcafe/spec/LaunchOVWithRememberMe_spec.js
@@ -1,0 +1,38 @@
+import { RequestLogger, RequestMock } from 'testcafe';
+import { checkA11y } from '../framework/a11y';
+import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
+import loopbackChallengeNotReceived from '../../../playground/mocks/data/idp/idx/identify-with-device-probing-loopback-challenge-not-received-with-remember-me';
+
+const logger = RequestLogger('http://localhost:3000/idp/idx/authenticators/okta-verify/launch', {logRequestBody: true, stringifyRequestBody: true});
+
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(loopbackChallengeNotReceived)
+  .onRequestTo('http://localhost:3000/idp/idx/authenticators/okta-verify/launch')
+  .respond('');
+
+fixture('Launch OV with rememberMe')
+  .requestHooks(logger, mock);
+
+
+async function setup(t) {
+  const identityPage = new IdentityPageObject(t);
+  await identityPage.navigateToPage();
+  return identityPage;
+}
+
+//same for CU, AL and UL
+test('check rememberMe value', async t => {
+  const identityPage = await setup(t);
+  await checkA11y(t);
+  await identityPage.checkRememberMe();
+  await identityPage.clickOktaVerifyButton();
+  await t.expect(logger.requests[0].request.body.toString().includes('"rememberMe":true')).eql(true);
+});
+
+test('check no rememberMe value', async t => {
+  const identityPage = await setup(t);
+  await checkA11y(t);
+  await identityPage.clickOktaVerifyButton();
+  await t.expect(logger.requests[0].request.body.toString().includes('"rememberMe"')).eql(false); //in this case, rememberMe doesn't exists in request body
+});


### PR DESCRIPTION
## Description:

Fix the customer urgent issue
This is a temp solution as of now, in the future need fix FastPass silent probing case where no rememberMe option at all
Slack discussion: https://okta.slack.com/archives/CAZH2MWEL/p1673970736851989

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-562885](https://oktainc.atlassian.net/browse/OKTA-562885)

### Reviewers:
@jaredperreault-okta  @okta/device-platform 
### Screenshot/Video:

https://user-images.githubusercontent.com/83233935/226646631-3ad13b34-3a2a-4f27-b5b6-0a421d146239.mov



### Downstream Monolith Build:



