### PR TITLE
OKTA-591835 : Focus on Title when page loads

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    // 'identify',
+    'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -48,7 +48,7 @@ const idx = {
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'error-internal-server-error',
     // 'authenticator-enroll-security-question',
-    'authenticator-enroll-select-authenticator',
+    // 'authenticator-enroll-select-authenticator',
     // 'authenticator-enroll-select-authenticator-with-skip',
     // 'authenticator-enroll-webauthn',
     // 'authenticator-verification-data-phone-sms-then-voice',
@@ -73,7 +73,6 @@ const idx = {
     // 'identify-unknown-user',
     // 'identify-with-apple-credential-sso-extension',
     // 'identify-with-apple-redirect-sso-extension',
-    // 'identify-with-universal-link-w-session',
     // 'identify-with-apple-sso-extension-fallback',
     // 'identify-with-device-launch-authenticator',
     // 'identify-with-device-probing-loopback',
@@ -119,8 +118,7 @@ const idx = {
     // 'authenticator-enroll-security-question',
     // 'authenticator-enroll-google-authenticator',
     // 'authenticator-enroll-email-first-emailmagiclink-true',
-    // 'error-authenticator-enroll-phone-invalid-number',
-    'authenticator-enroll-password',
+    'error-authenticator-enroll-phone-invalid-number',
   ],
   '/idp/idx/identify': [
     // 'authenticator-verification-data-ov-only-without-device-known',

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    'identify',
+    // 'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -48,7 +48,7 @@ const idx = {
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'error-internal-server-error',
     // 'authenticator-enroll-security-question',
-    // 'authenticator-enroll-select-authenticator',
+    'authenticator-enroll-select-authenticator',
     // 'authenticator-enroll-select-authenticator-with-skip',
     // 'authenticator-enroll-webauthn',
     // 'authenticator-verification-data-phone-sms-then-voice',
@@ -73,6 +73,7 @@ const idx = {
     // 'identify-unknown-user',
     // 'identify-with-apple-credential-sso-extension',
     // 'identify-with-apple-redirect-sso-extension',
+    // 'identify-with-universal-link-w-session',
     // 'identify-with-apple-sso-extension-fallback',
     // 'identify-with-device-launch-authenticator',
     // 'identify-with-device-probing-loopback',
@@ -118,7 +119,8 @@ const idx = {
     // 'authenticator-enroll-security-question',
     // 'authenticator-enroll-google-authenticator',
     // 'authenticator-enroll-email-first-emailmagiclink-true',
-    'error-authenticator-enroll-phone-invalid-number',
+    // 'error-authenticator-enroll-phone-invalid-number',
+    'authenticator-enroll-password',
   ],
   '/idp/idx/identify': [
     // 'authenticator-verification-data-ov-only-without-device-known',

--- a/src/v3/src/components/Title/Title.tsx
+++ b/src/v3/src/components/Title/Title.tsx
@@ -12,6 +12,8 @@
 
 import { Box, Typography } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
+import { useEffect } from 'preact/hooks';
+import { useWidgetContext } from '../../contexts';
 
 import { TitleElement, UISchemaElementComponent } from '../../types';
 
@@ -19,7 +21,13 @@ const Title: UISchemaElementComponent<{
   uischema: TitleElement
 }> = (
   { uischema: { id, options } },
-) => (
+) => {
+  const { setStatusText } = useWidgetContext();
+  useEffect(() => {
+    setStatusText(options?.content + " page has loaded")
+  }, [])
+
+  return (
   <Box
     display="flex"
     justifyContent="flex-start"
@@ -33,6 +41,6 @@ const Title: UISchemaElementComponent<{
       {options?.content}
     </Typography>
   </Box>
-);
+)};
 
 export default Title;

--- a/src/v3/src/components/Title/Title.tsx
+++ b/src/v3/src/components/Title/Title.tsx
@@ -15,6 +15,7 @@ import { h } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 
 import { TitleElement, UISchemaElementComponent } from '../../types';
+import style from './style.css';
 
 const Title: UISchemaElementComponent<{
   uischema: TitleElement
@@ -33,14 +34,12 @@ const Title: UISchemaElementComponent<{
     >
       <Typography
         id={id}
+        className={style.noOutline}
         component="h2"
         variant="h4"
         data-se="o-form-head"
         ref={titleRef}
         tabIndex={-1}
-        style={{
-          outline: 'none'
-        }}
       >
         {options?.content}
       </Typography>

--- a/src/v3/src/components/Title/Title.tsx
+++ b/src/v3/src/components/Title/Title.tsx
@@ -16,7 +16,6 @@ import { useEffect, useRef } from 'preact/hooks';
 
 import { useWidgetContext } from '../../contexts';
 import { TitleElement, UISchemaElementComponent } from '../../types';
-import style from './style.css';
 
 const Title: UISchemaElementComponent<{
   uischema: TitleElement
@@ -41,12 +40,14 @@ const Title: UISchemaElementComponent<{
     >
       <Typography
         id={id}
-        className={style.noOutline}
         component="h2"
         variant="h4"
         data-se="o-form-head"
         ref={titleRef}
         tabIndex={-1}
+        sx={{
+          outline: 'none',
+        }}
       >
         {options?.content}
       </Typography>

--- a/src/v3/src/components/Title/Title.tsx
+++ b/src/v3/src/components/Title/Title.tsx
@@ -38,6 +38,9 @@ const Title: UISchemaElementComponent<{
         data-se="o-form-head"
         ref={titleRef}
         tabIndex={-1}
+        style={{
+          outline: 'none'
+        }}
       >
         {options?.content}
       </Typography>

--- a/src/v3/src/components/Title/Title.tsx
+++ b/src/v3/src/components/Title/Title.tsx
@@ -13,8 +13,8 @@
 import { Box, Typography } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
-import { useWidgetContext } from '../../contexts';
 
+import { useWidgetContext } from '../../contexts';
 import { TitleElement, UISchemaElementComponent } from '../../types';
 import style from './style.css';
 
@@ -28,9 +28,10 @@ const Title: UISchemaElementComponent<{
   const { features: { autoFocus = false } = {} } = widgetProps;
 
   useEffect(() => {
-    if(!autoFocus) {
+    if (!autoFocus) {
       titleRef.current?.focus();
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/v3/src/components/Title/Title.tsx
+++ b/src/v3/src/components/Title/Title.tsx
@@ -13,6 +13,7 @@
 import { Box, Typography } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
+import { useWidgetContext } from '../../contexts';
 
 import { TitleElement, UISchemaElementComponent } from '../../types';
 import style from './style.css';
@@ -23,8 +24,13 @@ const Title: UISchemaElementComponent<{
   { uischema: { id, options } },
 ) => {
   const titleRef = useRef<HTMLTitleElement>(null);
+  const { widgetProps } = useWidgetContext();
+  const { features: { autoFocus = false } = {} } = widgetProps;
+
   useEffect(() => {
-    titleRef.current?.focus();
+    if(!autoFocus) {
+      titleRef.current?.focus();
+    }
   }, []);
 
   return (

--- a/src/v3/src/components/Title/Title.tsx
+++ b/src/v3/src/components/Title/Title.tsx
@@ -12,8 +12,7 @@
 
 import { Box, Typography } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
-import { useEffect } from 'preact/hooks';
-import { useWidgetContext } from '../../contexts';
+import { useEffect, useRef } from 'preact/hooks';
 
 import { TitleElement, UISchemaElementComponent } from '../../types';
 
@@ -22,25 +21,28 @@ const Title: UISchemaElementComponent<{
 }> = (
   { uischema: { id, options } },
 ) => {
-  const { setStatusText } = useWidgetContext();
+  const titleRef = useRef<HTMLTitleElement>(null);
   useEffect(() => {
-    setStatusText(options?.content + " page has loaded")
-  }, [])
+    titleRef.current?.focus();
+  }, []);
 
   return (
-  <Box
-    display="flex"
-    justifyContent="flex-start"
-  >
-    <Typography
-      id={id}
-      component="h2"
-      variant="h4"
-      data-se="o-form-head"
+    <Box
+      display="flex"
+      justifyContent="flex-start"
     >
-      {options?.content}
-    </Typography>
-  </Box>
-)};
+      <Typography
+        id={id}
+        component="h2"
+        variant="h4"
+        data-se="o-form-head"
+        ref={titleRef}
+        tabIndex={-1}
+      >
+        {options?.content}
+      </Typography>
+    </Box>
+  );
+};
 
 export default Title;

--- a/src/v3/src/components/Title/style.css
+++ b/src/v3/src/components/Title/style.css
@@ -1,3 +1,0 @@
-.noOutline {
-  outline: none
-}

--- a/src/v3/src/components/Title/style.css
+++ b/src/v3/src/components/Title/style.css
@@ -1,0 +1,3 @@
+.noOutline {
+  outline: none
+}

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -12,7 +12,7 @@
 
 import './style.module.css';
 
-import { ScopedCssBaseline } from '@mui/material';
+import { ScopedCssBaseline, Box } from '@mui/material';
 import { MuiThemeProvider, OdysseyCacheProvider } from '@okta/odyssey-react-mui';
 import {
   AuthApiError,
@@ -103,6 +103,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const languageCode = getLanguageCode(widgetProps);
   const languageDirection = getLanguageDirection(languageCode);
   const brandedTheme = mapMuiThemeFromBrand(brandColors, languageDirection, muiThemeOverrides);
+  const [statusText, setStatusText] = useState<string | null>(null);
 
   // on unmount, remove the language
   useEffect(() => () => {
@@ -324,6 +325,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       dataSchemaRef,
       loading,
       setLoading,
+      setStatusText,
       setWidgetRendered,
       loginHint,
       setloginHint,
@@ -343,6 +345,23 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
               },
             }}
           >
+            <Box
+              aria-live="assertive"
+              aria-busy={loading}
+              // style to clip the Box out so content is hidden visually but will still be read by screen reader
+              style={{
+                border: 0,
+                clip: 'rect(1px, 1px, 1px, 1px)',
+                height: '1px',
+                margin: '-1px',
+                overflow: 'hidden',
+                padding: 0,
+                position: 'absolute',
+                width: '1px',
+              }}
+            >
+                {statusText}
+            </Box>
             <AuthContainer>
               <AuthHeader
                 logo={logo}

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -12,7 +12,7 @@
 
 import './style.module.css';
 
-import { ScopedCssBaseline, Box } from '@mui/material';
+import { ScopedCssBaseline } from '@mui/material';
 import { MuiThemeProvider, OdysseyCacheProvider } from '@okta/odyssey-react-mui';
 import {
   AuthApiError,
@@ -345,8 +345,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
               },
             }}
           >
-            <Box
+            {/* <Box
               aria-live="assertive"
+              // aria-busy={loading}
               // style to clip the Box out so content is hidden visually but will still be read by screen reader
               style={{
                 border: 0,
@@ -359,8 +360,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
                 width: '1px',
               }}
             >
-                {statusText}
-            </Box>
+                {loading ? "Loading" : ""}
+            </Box> */}
             <AuthContainer>
               <AuthHeader
                 logo={logo}

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -347,7 +347,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
           >
             <Box
               aria-live="assertive"
-              aria-busy={loading}
               // style to clip the Box out so content is hidden visually but will still be read by screen reader
               style={{
                 border: 0,

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -103,7 +103,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const languageCode = getLanguageCode(widgetProps);
   const languageDirection = getLanguageDirection(languageCode);
   const brandedTheme = mapMuiThemeFromBrand(brandColors, languageDirection, muiThemeOverrides);
-  const [statusText, setStatusText] = useState<string | null>(null);
 
   // on unmount, remove the language
   useEffect(() => () => {
@@ -325,7 +324,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       dataSchemaRef,
       loading,
       setLoading,
-      setStatusText,
       setWidgetRendered,
       loginHint,
       setloginHint,
@@ -345,23 +343,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
               },
             }}
           >
-            {/* <Box
-              aria-live="assertive"
-              // aria-busy={loading}
-              // style to clip the Box out so content is hidden visually but will still be read by screen reader
-              style={{
-                border: 0,
-                clip: 'rect(1px, 1px, 1px, 1px)',
-                height: '1px',
-                margin: '-1px',
-                overflow: 'hidden',
-                padding: 0,
-                position: 'absolute',
-                width: '1px',
-              }}
-            >
-                {loading ? "Loading" : ""}
-            </Box> */}
             <AuthContainer>
               <AuthHeader
                 logo={logo}

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -42,7 +42,6 @@ export type IWidgetContext = {
   dataSchemaRef: MutableRef<FormBag['dataSchema'] | undefined>;
   loading: boolean;
   setLoading: StateUpdater<boolean>;
-  setStatusText: StateUpdater<string | null>;
   setWidgetRendered: StateUpdater<boolean>;
   loginHint?: string | null;
   setloginHint: StateUpdater<string | null>;

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -42,6 +42,7 @@ export type IWidgetContext = {
   dataSchemaRef: MutableRef<FormBag['dataSchema'] | undefined>;
   loading: boolean;
   setLoading: StateUpdater<boolean>;
+  setStatusText: StateUpdater<string | null>;
   setWidgetRendered: StateUpdater<boolean>;
   loginHint?: string | null;
   setloginHint: StateUpdater<string | null>;

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_1"
                     tabindex="-1"
@@ -218,7 +218,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_1"
                     tabindex="-1"
@@ -395,7 +395,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>
@@ -220,6 +221,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>
@@ -396,6 +398,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_1"
                     tabindex="-1"
@@ -218,7 +218,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_1"
                     tabindex="-1"
@@ -395,7 +395,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Get_a_verification_email_okta_email_1"
+                    tabindex="-1"
                   >
                     Get a verification email
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Get_a_verification_email_okta_email_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Get_a_verification_email_okta_email_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_1"
                     tabindex="-1"
@@ -1714,7 +1714,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_1"
                     tabindex="-1"
@@ -3302,7 +3302,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_1"
                     tabindex="-1"
@@ -1714,7 +1714,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_1"
                     tabindex="-1"
@@ -3302,7 +3302,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_1"
+                    tabindex="-1"
                   >
                     Set up phone authentication
                   </h2>
@@ -1716,6 +1717,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_1"
+                    tabindex="-1"
                   >
                     Set up phone authentication
                   </h2>
@@ -3303,6 +3305,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_1"
+                    tabindex="-1"
                   >
                     Set up phone authentication
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -122,6 +122,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Verify_with_your_email_okta_email_aut2m2nnGGzJy8uO80g4_2"
+                    tabindex="-1"
                   >
                     Verify with your email
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Verify_with_your_email_okta_email_aut2m2nnGGzJy8uO80g4_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Verify_with_your_email_okta_email_aut2m2nnGGzJy8uO80g4_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                       class="MuiTypography-root MuiTypography-h4 emotion-17"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_enroll-authenticator_Title_Verify_with_your_email_okta_email_aut2m2nnGGzJy8uO80g4_okta_email_aut2m2nnGGzJy8uO80g4_7"
+                      tabindex="-1"
                     >
                       Verify with your email
                     </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                     class="MuiBox-root emotion-16"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-17"
+                      class="MuiTypography-root MuiTypography-h4 emotion-17"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_enroll-authenticator_Title_Verify_with_your_email_okta_email_aut2m2nnGGzJy8uO80g4_okta_email_aut2m2nnGGzJy8uO80g4_7"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                     class="MuiBox-root emotion-16"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-17"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-17"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_enroll-authenticator_Title_Verify_with_your_email_okta_email_aut2m2nnGGzJy8uO80g4_okta_email_aut2m2nnGGzJy8uO80g4_7"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
                     tabindex="-1"
@@ -485,7 +485,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
                     tabindex="-1"
@@ -774,7 +774,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
                     tabindex="-1"
@@ -1062,7 +1062,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
                     tabindex="-1"
@@ -485,7 +485,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
                     tabindex="-1"
@@ -774,7 +774,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
                     tabindex="-1"
@@ -1062,7 +1062,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
+                    tabindex="-1"
                   >
                     Set up Google Authenticator
                   </h2>
@@ -487,6 +488,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
+                    tabindex="-1"
                   >
                     Set up Google Authenticator
                   </h2>
@@ -775,6 +777,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
+                    tabindex="-1"
                   >
                     Set up Google Authenticator
                   </h2>
@@ -1062,6 +1065,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_Google_Authenticator_google_otp_aut2m5drzzUlo4Bn81d7_1"
+                    tabindex="-1"
                   >
                     Set up Google Authenticator
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
+                    tabindex="-1"
                   >
                     Set up password
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-enroll_Title_Set_up_security_methods_aut2h3fft10VeLDPD1d7_1"
                     tabindex="-1"
@@ -788,7 +788,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-enroll_Title_Set_up_security_methods_aut2h3fft10VeLDPD1d7_1"
                     tabindex="-1"
@@ -788,7 +788,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-enroll_Title_Set_up_security_methods_aut2h3fft10VeLDPD1d7_1"
+                    tabindex="-1"
                   >
                     Set up security methods
                   </h2>
@@ -790,6 +791,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_2"
+                    tabindex="-1"
                   >
                     Set up phone authentication
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -132,6 +132,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_phone_authentication_phone_number_aut2h3fft10VeLDPD1d7_2"
+                    tabindex="-1"
                   >
                     Set up phone authentication
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                     class="MuiBox-root emotion-20"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
+                      class="MuiTypography-root MuiTypography-h4 emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_7_2"
                       tabindex="-1"
@@ -560,7 +560,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiBox-root emotion-20"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
+                      class="MuiTypography-root MuiTypography-h4 emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"
@@ -1046,7 +1046,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"
@@ -1603,7 +1603,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiBox-root emotion-20"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
+                      class="MuiTypography-root MuiTypography-h4 emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                     class="MuiBox-root emotion-20"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-21"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_7_2"
                       tabindex="-1"
@@ -560,7 +560,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiBox-root emotion-20"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-21"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"
@@ -1046,7 +1046,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"
@@ -1603,7 +1603,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiBox-root emotion-20"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-21"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -155,6 +155,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                       class="MuiTypography-root MuiTypography-h4 emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_7_2"
+                      tabindex="-1"
                     >
                       Set up security question
                     </h2>
@@ -562,6 +563,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       class="MuiTypography-root MuiTypography-h4 emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
+                      tabindex="-1"
                     >
                       Set up security question
                     </h2>
@@ -1047,6 +1049,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
+                      tabindex="-1"
                     >
                       Set up security question
                     </h2>
@@ -1603,6 +1606,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       class="MuiTypography-root MuiTypography-h4 emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
+                      tabindex="-1"
                     >
                       Set up security question
                     </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                     class="MuiBox-root emotion-20"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
+                      class="MuiTypography-root MuiTypography-h4 emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_7_2"
                       tabindex="-1"
@@ -527,7 +527,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_7_2"
                       tabindex="-1"
@@ -889,7 +889,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"
@@ -1362,7 +1362,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                     class="MuiBox-root emotion-20"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-21"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_7_2"
                       tabindex="-1"
@@ -527,7 +527,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_7_2"
                       tabindex="-1"
@@ -889,7 +889,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"
@@ -1362,7 +1362,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -155,6 +155,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                       class="MuiTypography-root MuiTypography-h4 emotion-21"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_7_2"
+                      tabindex="-1"
                     >
                       Set up security question
                     </h2>
@@ -529,6 +530,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_7_2"
+                      tabindex="-1"
                     >
                       Set up security question
                     </h2>
@@ -890,6 +892,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                       class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
+                      tabindex="-1"
                     >
                       Set up security question
                     </h2>
@@ -1362,6 +1365,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                       class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-authenticator_Title_Set_up_security_question_security_question_aut2h3fft3N1BApga1d7_2_1"
+                      tabindex="-1"
                     >
                       Set up security question
                     </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-enroll_Title_Set_up_security_methods_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-enroll_Title_Set_up_security_methods_1"
+                    tabindex="-1"
                   >
                     Set up security methods
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-enroll_Title_Set_up_security_methods_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-enroll_Title_Set_up_security_methods_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-enroll_Title_Set_up_security_methods_1"
+                    tabindex="-1"
                   >
                     Set up security methods
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-enroll_Title_Set_up_security_methods_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
                   class="MuiBox-root emotion-17"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-18"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-18"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_YubiKey_yubikey_token_aut10faWWbNaNWBaH0g4_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-18"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_YubiKey_yubikey_token_aut10faWWbNaNWBaH0g4_2"
+                    tabindex="-1"
                   >
                     Set up YubiKey
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
                   class="MuiBox-root emotion-17"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-18"
+                    class="MuiTypography-root MuiTypography-h4 emotion-18"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_YubiKey_yubikey_token_aut10faWWbNaNWBaH0g4_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
+                    tabindex="-1"
                   >
                     Your password has expired
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                   class="MuiBox-root emotion-19"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-20"
+                    class="MuiTypography-root MuiTypography-h4 emotion-20"
                     data-se="o-form-head"
                     id="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut8eqcFiHicejNIP0g4_1"
                     tabindex="-1"
@@ -795,7 +795,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                   class="MuiBox-root emotion-19"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-20"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-20"
                     data-se="o-form-head"
                     id="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut8eqcFiHicejNIP0g4_1"
                     tabindex="-1"
@@ -795,7 +795,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                     class="MuiTypography-root MuiTypography-h4 emotion-20"
                     data-se="o-form-head"
                     id="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut8eqcFiHicejNIP0g4_1"
+                    tabindex="-1"
                   >
                     Your password has expired
                   </h2>
@@ -797,6 +798,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
+                    tabindex="-1"
                   >
                     Your password has expired
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`authenticator-expired-password should present field level error message
                   class="MuiBox-root emotion-19"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-20"
+                    class="MuiTypography-root MuiTypography-h4 emotion-20"
                     data-se="o-form-head"
                     id="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"
@@ -784,7 +784,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`authenticator-expired-password should present field level error message
                   class="MuiBox-root emotion-19"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-20"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-20"
                     data-se="o-form-head"
                     id="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"
@@ -784,7 +784,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`authenticator-expired-password should present field level error message
                     class="MuiTypography-root MuiTypography-h4 emotion-20"
                     data-se="o-form-head"
                     id="reenroll-authenticator_Title_Your_password_has_expired_okta_password_aut2h3ffszv3me6O31d7_1"
+                    tabindex="-1"
                   >
                     Your password has expired
                   </h2>
@@ -786,6 +787,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
+                    tabindex="-1"
                   >
                     Your password has expired
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                   class="MuiBox-root emotion-19"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-20"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-20"
                     data-se="o-form-head"
                     id="reenroll-authenticator-warning_Title_Your_password_will_expire_in_4_days_okta_password_aut6ci0ZJwJCQ5v6f0g4_1"
                     tabindex="-1"
@@ -947,7 +947,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                   class="MuiBox-root emotion-19"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-20"
+                    class="MuiTypography-root MuiTypography-h4 emotion-20"
                     data-se="o-form-head"
                     id="reenroll-authenticator-warning_Title_Your_password_will_expire_in_4_days_okta_password_aut6ci0ZJwJCQ5v6f0g4_1"
                     tabindex="-1"
@@ -947,7 +947,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                     class="MuiTypography-root MuiTypography-h4 emotion-20"
                     data-se="o-form-head"
                     id="reenroll-authenticator-warning_Title_Your_password_will_expire_in_4_days_okta_password_aut6ci0ZJwJCQ5v6f0g4_1"
+                    tabindex="-1"
                   >
                     Your password will expire in 4 days
                   </h2>
@@ -949,6 +950,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
+                    tabindex="-1"
                   >
                     Your password will expire in 4 days
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut2h3ffszv3me6O31d7_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>
@@ -330,6 +331,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut2h3ffszv3me6O31d7_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>
@@ -616,6 +618,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut2h3ffszv3me6O31d7_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>
@@ -944,6 +947,7 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
                     class="MuiTypography-root MuiTypography-h4 emotion-10"
                     data-se="o-form-head"
                     id="piv-idp_Title_PIV_/_CAC_card_aut2h3ffszv3me6O31d7_1"
+                    tabindex="-1"
                   >
                     PIV / CAC card
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"
@@ -328,7 +328,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"
@@ -615,7 +615,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"
@@ -944,7 +944,7 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
                   class="MuiBox-root emotion-9"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-10"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-10"
                     data-se="o-form-head"
                     id="piv-idp_Title_PIV_/_CAC_card_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"
@@ -328,7 +328,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"
@@ -615,7 +615,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"
@@ -944,7 +944,7 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
                   class="MuiBox-root emotion-9"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-10"
+                    class="MuiTypography-root MuiTypography-h4 emotion-10"
                     data-se="o-form-head"
                     id="piv-idp_Title_PIV_/_CAC_card_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="reset-authenticator_Title_Reset_your_password_okta_password_aut2h3ffszv3me6O31d7_1"
+                    tabindex="-1"
                   >
                     Reset your password
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="reset-authenticator_Title_Reset_your_password_okta_password_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="reset-authenticator_Title_Reset_your_password_okta_password_aut2h3ffszv3me6O31d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"
@@ -700,7 +700,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"
@@ -700,7 +700,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
+                    tabindex="-1"
                   >
                     Reset your password
                   </h2>
@@ -702,6 +703,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="generated"
+                    tabindex="-1"
                   >
                     Reset your Acme Corp password
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Verify_its_you_with_a_security_method_okta_verify_aut13qrZReYpIib7R0g4_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Verify_its_you_with_a_security_method_okta_verify_aut13qrZReYpIib7R0g4_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Verify_its_you_with_a_security_method_okta_verify_aut13qrZReYpIib7R0g4_1"
+                    tabindex="-1"
                   >
                     Verify it's you with a security method
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Verify_its_you_with_a_security_method_okta_verify_aut13qrZReYpIib7R0g4_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Verify_its_you_with_a_security_method_okta_verify_aut13qrZReYpIib7R0g4_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Verify_its_you_with_a_security_method_okta_verify_aut13qrZReYpIib7R0g4_1"
+                    tabindex="-1"
                   >
                     Verify it's you with a security method
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Verify_with_your_phone_phone_number_sms4bvjioge7Sdu3p5d7_1"
+                    tabindex="-1"
                   >
                     Verify with your phone
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Verify_with_your_phone_phone_number_sms4bvjioge7Sdu3p5d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Verify_with_your_phone_phone_number_sms4bvjioge7Sdu3p5d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Get_a_verification_email_okta_email_1"
+                    tabindex="-1"
                   >
                     Get a verification email
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Get_a_verification_email_okta_email_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Get_a_verification_email_okta_email_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -122,6 +122,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                     class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_2"
+                    tabindex="-1"
                   >
                     Verify with your email
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-16"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-17"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-17"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_3_1"
                       tabindex="-1"
@@ -350,7 +350,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-23"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-24"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-24"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_3_1"
                       tabindex="-1"
@@ -534,7 +534,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-16"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-17"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-17"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_7_2"
                       tabindex="-1"
@@ -782,7 +782,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-21"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-22"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-22"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eaexdyjzXZ3iWikza0g3_7_2"
                       tabindex="-1"
@@ -1098,7 +1098,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-28"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-29"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-29"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eaexdyjzXZ3iWikza0g3_7_2"
                       tabindex="-1"
@@ -1430,7 +1430,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                     class="MuiBox-root emotion-16"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-17"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-17"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_7_2"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-16"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-17"
+                      class="MuiTypography-root MuiTypography-h4 emotion-17"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_3_1"
                       tabindex="-1"
@@ -350,7 +350,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-23"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-24"
+                      class="MuiTypography-root MuiTypography-h4 emotion-24"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_3_1"
                       tabindex="-1"
@@ -534,7 +534,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-16"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-17"
+                      class="MuiTypography-root MuiTypography-h4 emotion-17"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_7_2"
                       tabindex="-1"
@@ -782,7 +782,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-21"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-22"
+                      class="MuiTypography-root MuiTypography-h4 emotion-22"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eaexdyjzXZ3iWikza0g3_7_2"
                       tabindex="-1"
@@ -1098,7 +1098,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-28"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-29"
+                      class="MuiTypography-root MuiTypography-h4 emotion-29"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eaexdyjzXZ3iWikza0g3_7_2"
                       tabindex="-1"
@@ -1430,7 +1430,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                     class="MuiBox-root emotion-16"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-17"
+                      class="MuiTypography-root MuiTypography-h4 emotion-17"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_7_2"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-h4 emotion-17"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_3_1"
+                      tabindex="-1"
                     >
                       Verify with your email
                     </h2>
@@ -352,6 +353,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-h4 emotion-24"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_3_1"
+                      tabindex="-1"
                     >
                       Verify with your email
                     </h2>
@@ -535,6 +537,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-h4 emotion-17"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_7_2"
+                      tabindex="-1"
                     >
                       Verify with your email
                     </h2>
@@ -782,6 +785,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-h4 emotion-22"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eaexdyjzXZ3iWikza0g3_7_2"
+                      tabindex="-1"
                     >
                       Verify with your email
                     </h2>
@@ -1097,6 +1101,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-h4 emotion-29"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eaexdyjzXZ3iWikza0g3_7_2"
+                      tabindex="-1"
                     >
                       Verify with your email
                     </h2>
@@ -1428,6 +1433,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                       class="MuiTypography-root MuiTypography-h4 emotion-17"
                       data-se="o-form-head"
                       id="challenge-authenticator_Title_Verify_with_your_email_okta_email_eae1egri5eK5zce0V1d7_7_2"
+                      tabindex="-1"
                     >
                       Verify with your email
                     </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Google_Authenticator_google_otp_uft2nai75idszAT621d7_1"
+                    tabindex="-1"
                   >
                     Verify with Google Authenticator
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Google_Authenticator_google_otp_uft2nai75idszAT621d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Google_Authenticator_google_otp_uft2nai75idszAT621d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                   class="MuiBox-root emotion-22"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-23"
+                    class="MuiTypography-root MuiTypography-h4 emotion-23"
                     data-se="o-form-head"
                     id="challenge-poll_Title_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_2"
                     tabindex="-1"
@@ -401,7 +401,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="challenge-poll_Title_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -163,6 +163,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                     class="MuiTypography-root MuiTypography-h4 emotion-23"
                     data-se="o-form-head"
                     id="challenge-poll_Title_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_2"
+                    tabindex="-1"
                   >
                     Push notification sent
                   </h2>
@@ -403,6 +404,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                     class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="challenge-poll_Title_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_2"
+                    tabindex="-1"
                   >
                     Push notification sent
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                   class="MuiBox-root emotion-22"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-23"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-23"
                     data-se="o-form-head"
                     id="challenge-poll_Title_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_2"
                     tabindex="-1"
@@ -401,7 +401,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                     data-se="o-form-head"
                     id="challenge-poll_Title_Push_notification_sent_okta_verify_aut2h3fft4y9pDPCS1d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-poll_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Get a push notification
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-poll_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-poll_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-verification-data_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Get a push notification
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_auttheidkwh282hv8g3_1"
+                    tabindex="-1"
                   >
                     Enter a code
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_auttheidkwh282hv8g3_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_auttheidkwh282hv8g3_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Enter a code
                   </h2>
@@ -308,6 +309,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Enter a code
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -306,7 +306,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -306,7 +306,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-ov-resend-push-notification renders form 1`]
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="resend_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`authenticator-verification-ov-resend-push-notification renders form 1`]
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="resend_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Get a push notification
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`authenticator-verification-ov-resend-push-notification renders form 1`]
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="resend_Title_Get_a_push_notification_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                   class="MuiBox-root emotion-27"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-28"
+                    class="MuiTypography-root MuiTypography-h4 emotion-28"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_aut1kxbY4k3KnPvvd0g4_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                   class="MuiBox-root emotion-27"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-28"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-28"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_aut1kxbY4k3KnPvvd0g4_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -186,6 +186,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiTypography-root MuiTypography-h4 emotion-28"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Enter_a_code_okta_verify_aut1kxbY4k3KnPvvd0g4_2"
+                    tabindex="-1"
                   >
                     Enter a code
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -132,6 +132,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_phone_phone_number_sms4bvjioge7Sdu3p5d7_2"
+                    tabindex="-1"
                   >
                     Verify with your phone
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_phone_phone_number_sms4bvjioge7Sdu3p5d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                    class="MuiTypography-root MuiTypography-h4 emotion-16"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_phone_phone_number_sms4bvjioge7Sdu3p5d7_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_Security_Question_security_question_qae4ks1ygweGSuDPk5d7_1"
+                    tabindex="-1"
                   >
                     Verify with your Security Question
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_Security_Question_security_question_qae4ks1ygweGSuDPk5d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_Security_Question_security_question_qae4ks1ygweGSuDPk5d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1"
+                    tabindex="-1"
                   >
                     Verify it's you with a security method
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="select-authenticator-authenticate_Title_Verify_its_you_with_a_security_method_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
                   class="MuiBox-root emotion-20"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
+                    class="MuiTypography-root MuiTypography-h4 emotion-21"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_password_okta_password_laehspkckQ73kDbzn1d6_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-21"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_password_okta_password_laehspkckQ73kDbzn1d6_2"
+                    tabindex="-1"
                   >
                     Verify with your password
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
                   class="MuiBox-root emotion-20"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-21"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-21"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_your_password_okta_password_laehspkckQ73kDbzn1d6_2"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"
@@ -473,7 +473,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"
@@ -802,7 +802,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
+                    tabindex="-1"
                   >
                     Verify with Security Key or Biometric Authenticator
                   </h2>
@@ -475,6 +476,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
+                    tabindex="-1"
                   >
                     Verify with Security Key or Biometric Authenticator
                   </h2>
@@ -803,6 +805,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
+                    tabindex="-1"
                   >
                     Verify with Security Key or Biometric Authenticator
                   </h2>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"
@@ -473,7 +473,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"
@@ -802,7 +802,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_YubiKey_yubikey_token_ykf16jdolQhTHA5yp0g4_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_YubiKey_yubikey_token_ykf16jdolQhTHA5yp0g4_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -121,6 +121,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_YubiKey_yubikey_token_ykf16jdolQhTHA5yp0g4_1"
+                    tabindex="-1"
                   >
                     Verify with YubiKey
                   </h2>

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`byol loading custom language should load custom language with "language
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_foo_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
                     tabindex="-1"
@@ -1714,7 +1714,7 @@ exports[`byol loading custom language should load custom language with assets.ba
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_foo_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
                     tabindex="-1"
@@ -3302,7 +3302,7 @@ exports[`byol loading default language should not load custom language when the 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
                     tabindex="-1"
@@ -4890,7 +4890,7 @@ exports[`byol loading default language should not load custom language with "lan
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`byol loading custom language should load custom language with "language
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_foo_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
                     tabindex="-1"
@@ -1714,7 +1714,7 @@ exports[`byol loading custom language should load custom language with assets.ba
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_foo_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
                     tabindex="-1"
@@ -3302,7 +3302,7 @@ exports[`byol loading default language should not load custom language when the 
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
                     tabindex="-1"
@@ -4890,7 +4890,7 @@ exports[`byol loading default language should not load custom language with "lan
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`byol loading custom language should load custom language with "language
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_foo_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
+                    tabindex="-1"
                   >
                     Set up foo authentication
                   </h2>
@@ -1716,6 +1717,7 @@ exports[`byol loading custom language should load custom language with assets.ba
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_foo_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
+                    tabindex="-1"
                   >
                     Set up foo authentication
                   </h2>
@@ -3303,6 +3305,7 @@ exports[`byol loading default language should not load custom language when the 
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
+                    tabindex="-1"
                   >
                     Set up phone authentication
                   </h2>
@@ -4890,6 +4893,7 @@ exports[`byol loading default language should not load custom language with "lan
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="authenticator-enrollment-data_Title_Set_up_phone_authentication_phone_number_aid568g3mXgtID0X1SLH_1"
+                    tabindex="-1"
                   >
                     Set up phone authentication
                   </h2>

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`email-challenge-consent should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="email-challenge-consent_Title_Did_you_just_try_to_sign_in_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`email-challenge-consent should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="email-challenge-consent_Title_Did_you_just_try_to_sign_in_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`email-challenge-consent should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="email-challenge-consent_Title_Did_you_just_try_to_sign_in_1"
+                    tabindex="-1"
                   >
                     Did you just try to sign in?
                   </h2>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -1876,7 +1876,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -1876,7 +1876,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>
@@ -1878,6 +1879,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`enroll-profile-new should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`enroll-profile-new should render form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`enroll-profile-new should render form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -326,7 +326,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -589,7 +589,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -852,7 +852,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -1102,7 +1102,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -326,7 +326,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -589,7 +589,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -852,7 +852,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"
@@ -1102,7 +1102,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>
@@ -328,6 +329,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>
@@ -590,6 +592,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>
@@ -852,6 +855,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>
@@ -1101,6 +1105,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="profile-update_Title_Additional_Profile_information_1"
+                    tabindex="-1"
                   >
                     Additional Profile information
                   </h2>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="profile-update_Title_Additional_Profile_information_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="profile-update_Title_Additional_Profile_information_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -114,6 +114,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                     class="MuiTypography-root MuiTypography-h4 emotion-19"
                     data-se="o-form-head"
                     id="profile-update_Title_Additional_Profile_information_1"
+                    tabindex="-1"
                   >
                     Additional Profile information
                   </h2>
@@ -350,6 +351,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="profile-update_Title_Additional_Profile_information_1"
+                    tabindex="-1"
                   >
                     Additional Profile information
                   </h2>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                   class="MuiBox-root emotion-18"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-19"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-19"
                     data-se="o-form-head"
                     id="profile-update_Title_Additional_Profile_information_1"
                     tabindex="-1"
@@ -348,7 +348,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="profile-update_Title_Additional_Profile_information_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                   class="MuiBox-root emotion-18"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-19"
+                    class="MuiTypography-root MuiTypography-h4 emotion-19"
                     data-se="o-form-head"
                     id="profile-update_Title_Additional_Profile_information_1"
                     tabindex="-1"
@@ -348,7 +348,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="profile-update_Title_Additional_Profile_information_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -114,6 +114,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
                     class="MuiTypography-root MuiTypography-h4 emotion-19"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_in_1"
+                    tabindex="-1"
                   >
                     Sign in
                   </h2>
@@ -317,6 +318,7 @@ exports[`enroll-profile-update should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_in_1"
+                    tabindex="-1"
                   >
                     Sign in
                   </h2>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
                   class="MuiBox-root emotion-18"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-19"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-19"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_in_1"
                     tabindex="-1"
@@ -315,7 +315,7 @@ exports[`enroll-profile-update should render form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_in_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
                   class="MuiBox-root emotion-18"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-19"
+                    class="MuiTypography-root MuiTypography-h4 emotion-19"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_in_1"
                     tabindex="-1"
@@ -315,7 +315,7 @@ exports[`enroll-profile-update should render form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_in_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_NON_NULL_VALUE_1"
                     tabindex="-1"
@@ -664,7 +664,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_NON_NULL_VALUE_1"
                     tabindex="-1"
@@ -1199,7 +1199,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_NON_NULL_VALUE_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_NON_NULL_VALUE_1"
                     tabindex="-1"
@@ -664,7 +664,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_NON_NULL_VALUE_1"
                     tabindex="-1"
@@ -1199,7 +1199,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_NON_NULL_VALUE_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_NON_NULL_VALUE_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>
@@ -666,6 +667,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_NON_NULL_VALUE_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>
@@ -1200,6 +1202,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="enroll-profile_Title_Sign_up_NON_NULL_VALUE_1"
+                    tabindex="-1"
                   >
                     Sign up
                   </h2>

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_aut2h3fft4y9pDPCS1d7_2_1"
                       tabindex="-1"
@@ -320,7 +320,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -610,7 +610,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_email_link_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -885,7 +885,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-23"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-24"
+                      class="MuiTypography-root MuiTypography-h4 emotion-24"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Check_your_email_okta_verify_aut2h3fft4y9pDPCS1d7_8_2"
                       tabindex="-1"
@@ -1075,7 +1075,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -1352,7 +1352,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_aut2h3fft4y9pDPCS1d7_2_1"
                       tabindex="-1"
@@ -1560,7 +1560,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_aut2h3fft4y9pDPCS1d7_2_1"
                       tabindex="-1"
@@ -1765,7 +1765,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -2055,7 +2055,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_SMS_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -3587,7 +3587,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-23"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-24"
+                      class="MuiTypography-root MuiTypography-h4 emotion-24"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Check_your_text_messages_okta_verify_aut2h3fft4y9pDPCS1d7_12_3"
                       tabindex="-1"
@@ -3777,7 +3777,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_aut2h3fft4y9pDPCS1d7_2_1"
                       tabindex="-1"
@@ -320,7 +320,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -610,7 +610,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_email_link_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -885,7 +885,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-23"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-24"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-24"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Check_your_email_okta_verify_aut2h3fft4y9pDPCS1d7_8_2"
                       tabindex="-1"
@@ -1075,7 +1075,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -1352,7 +1352,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_aut2h3fft4y9pDPCS1d7_2_1"
                       tabindex="-1"
@@ -1560,7 +1560,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-15"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-16"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-16"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_aut2h3fft4y9pDPCS1d7_2_1"
                       tabindex="-1"
@@ -1765,7 +1765,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -2055,7 +2055,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_SMS_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -3587,7 +3587,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-23"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-24"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-24"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Check_your_text_messages_okta_verify_aut2h3fft4y9pDPCS1d7_12_3"
                       tabindex="-1"
@@ -3777,7 +3777,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                       class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_aut2h3fft4y9pDPCS1d7_2_1"
+                      tabindex="-1"
                     >
                       Set up Okta Verify
                     </h2>
@@ -322,6 +323,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     More options
                   </h2>
@@ -611,6 +613,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_email_link_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Set up Okta Verify via email link
                   </h2>
@@ -885,6 +888,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                       class="MuiTypography-root MuiTypography-h4 emotion-24"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Check_your_email_okta_verify_aut2h3fft4y9pDPCS1d7_8_2"
+                      tabindex="-1"
                     >
                       Check your email
                     </h2>
@@ -1074,6 +1078,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     More options
                   </h2>
@@ -1350,6 +1355,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                       class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_aut2h3fft4y9pDPCS1d7_2_1"
+                      tabindex="-1"
                     >
                       Set up Okta Verify
                     </h2>
@@ -1557,6 +1563,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                       class="MuiTypography-root MuiTypography-h4 emotion-16"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_aut2h3fft4y9pDPCS1d7_2_1"
+                      tabindex="-1"
                     >
                       Set up Okta Verify
                     </h2>
@@ -1761,6 +1768,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     More options
                   </h2>
@@ -2050,6 +2058,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_SMS_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Set up Okta Verify via SMS
                   </h2>
@@ -3581,6 +3590,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                       class="MuiTypography-root MuiTypography-h4 emotion-24"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Check_your_text_messages_okta_verify_aut2h3fft4y9pDPCS1d7_12_3"
+                      tabindex="-1"
                     >
                       Check your text messages
                     </h2>
@@ -3770,6 +3780,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-poll_Title_More_options_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     More options
                   </h2>

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
+                    tabindex="-1"
                   >
                     Verify with Security Key or Biometric Authenticator
                   </h2>

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="challenge-authenticator_Title_Verify_with_Security_Key_or_Biometric_Authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`identify-recovery renders form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify-recovery_Title_Reset_your_password_1"
+                    tabindex="-1"
                   >
                     Reset your password
                   </h2>

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`identify-recovery renders form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="identify-recovery_Title_Reset_your_password_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`identify-recovery renders form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify-recovery_Title_Reset_your_password_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"
@@ -379,7 +379,7 @@ exports[`identify-with-password Client-side field change validation tests should
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"
@@ -684,7 +684,7 @@ exports[`identify-with-password Client-side field change validation tests should
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"
@@ -956,7 +956,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"
@@ -1202,7 +1202,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>
@@ -381,6 +382,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>
@@ -685,6 +687,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>
@@ -956,6 +959,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>
@@ -1201,6 +1205,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
+                    tabindex="-1"
                   >
                     Sign In
                   </h2>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"
@@ -379,7 +379,7 @@ exports[`identify-with-password Client-side field change validation tests should
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"
@@ -684,7 +684,7 @@ exports[`identify-with-password Client-side field change validation tests should
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"
@@ -956,7 +956,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"
@@ -1202,7 +1202,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="identify_Title_Sign_In_aut1egri5t7iomJ3l1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
@@ -80,6 +80,7 @@ exports[`oda-enrollment-android-applink should render form 1`] = `
                     <h2
                       class="MuiTypography-root MuiTypography-h4 emotion-11"
                       data-se="o-form-head"
+                      tabindex="-1"
                     >
                       Additional setup required to use Okta FastPass
                     </h2>
@@ -296,6 +297,7 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
                     <h2
                       class="MuiTypography-root MuiTypography-h4 emotion-11"
                       data-se="o-form-head"
+                      tabindex="-1"
                     >
                       Set up an Okta Verify account
                     </h2>
@@ -534,6 +536,7 @@ exports[`oda-enrollment-android-applink should render view when "Yes, I already 
                     <h2
                       class="MuiTypography-root MuiTypography-h4 emotion-11"
                       data-se="o-form-head"
+                      tabindex="-1"
                     >
                       Additional setup required to use Okta FastPass
                     </h2>

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`oda-enrollment-android-applink should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-11"
+                      class="MuiTypography-root MuiTypography-h4 emotion-11"
                       data-se="o-form-head"
                       tabindex="-1"
                     >
@@ -295,7 +295,7 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
                     class="MuiBox-root emotion-10"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-11"
+                      class="MuiTypography-root MuiTypography-h4 emotion-11"
                       data-se="o-form-head"
                       tabindex="-1"
                     >
@@ -534,7 +534,7 @@ exports[`oda-enrollment-android-applink should render view when "Yes, I already 
                     class="MuiBox-root emotion-10"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-11"
+                      class="MuiTypography-root MuiTypography-h4 emotion-11"
                       data-se="o-form-head"
                       tabindex="-1"
                     >

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`oda-enrollment-android-applink should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-11"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-11"
                       data-se="o-form-head"
                       tabindex="-1"
                     >
@@ -295,7 +295,7 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
                     class="MuiBox-root emotion-10"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-11"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-11"
                       data-se="o-form-head"
                       tabindex="-1"
                     >
@@ -534,7 +534,7 @@ exports[`oda-enrollment-android-applink should render view when "Yes, I already 
                     class="MuiBox-root emotion-10"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-11"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-11"
                       data-se="o-form-head"
                       tabindex="-1"
                     >

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`oda-enrollment-android-loopback should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-10"
+                    class="MuiTypography-root MuiTypography-h4 emotion-10"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`oda-enrollment-android-loopback should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-10"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-10"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`oda-enrollment-android-loopback should render form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-10"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Download Okta Verify
                   </h2>

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`oda-enrollment-ios should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-10"
+                    class="MuiTypography-root MuiTypography-h4 emotion-10"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`oda-enrollment-ios should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-10"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-10"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`oda-enrollment-ios should render form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-10"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Download Okta Verify
                   </h2>

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_email_link_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_email_link_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_email_link_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Set up Okta Verify via email link
                   </h2>

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                     class="MuiBox-root emotion-22"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-23"
+                      class="MuiTypography-root MuiTypography-h4 emotion-23"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_3_1"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                     class="MuiBox-root emotion-22"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h4 emotion-23"
+                      class="MuiTypography-root MuiTypography-h4 noOutline emotion-23"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_3_1"
                       tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -162,6 +162,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                       class="MuiTypography-root MuiTypography-h4 emotion-23"
                       data-se="o-form-head"
                       id="enroll-poll_Title_Set_up_Okta_Verify_okta_verify_3_1"
+                      tabindex="-1"
                     >
                       Set up Okta Verify
                     </h2>

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_SMS_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -1594,7 +1594,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_SMS_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_SMS_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Set up Okta Verify via SMS
                   </h2>
@@ -1596,6 +1597,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_SMS_okta_verify_aut2h3fft4y9pDPCS1d7_1"
+                    tabindex="-1"
                   >
                     Set up Okta Verify via SMS
                   </h2>

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_SMS_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"
@@ -1594,7 +1594,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enrollment-channel-data_Title_Set_up_Okta_Verify_via_SMS_okta_verify_aut2h3fft4y9pDPCS1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`request-activation-email renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="request-activation-email_Title_Activation_link_has_expired_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`request-activation-email renders form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     id="request-activation-email_Title_Activation_link_has_expired_1"
+                    tabindex="-1"
                   >
                     Activation link has expired
                   </h2>

--- a/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`request-activation-email renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     id="request-activation-email_Title_Activation_link_has_expired_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-email renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-email renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`terminal-return-email renders form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Success! Return to the original tab or window
                   </h2>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Your verification code
                   </h2>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Your verification code
                   </h2>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Your verification code
                   </h2>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Your verification code
                   </h2>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Your verification code
                   </h2>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -118,6 +118,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Your verification code
                   </h2>

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -116,7 +116,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`unlock-account-success renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`unlock-account-success renders form 1`] = `
                   class="MuiBox-root emotion-13"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-14"
+                    class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
                     tabindex="-1"
                   >

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -80,6 +80,7 @@ exports[`unlock-account-success renders form 1`] = `
                   <h2
                     class="MuiTypography-root MuiTypography-h4 emotion-14"
                     data-se="o-form-head"
+                    tabindex="-1"
                   >
                     Account successfully unlocked!
                   </h2>

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`user-unlock-account renders form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="select-authenticator-unlock-account_Title_Unlock_account_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`user-unlock-account renders form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-9"
                     data-se="o-form-head"
                     id="select-authenticator-unlock-account_Title_Unlock_account_1"
+                    tabindex="-1"
                   >
                     Unlock account?
                   </h2>

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`user-unlock-account renders form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-9"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-9"
                     data-se="o-form-head"
                     id="select-authenticator-unlock-account_Title_Unlock_account_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`webauthn-enroll should render form 1`] = `
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_security_key_or_biometric_authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
+                    tabindex="-1"
                   >
                     Set up security key or biometric authenticator
                   </h2>
@@ -345,6 +346,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_security_key_or_biometric_authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
+                    tabindex="-1"
                   >
                     Set up security key or biometric authenticator
                   </h2>
@@ -559,6 +561,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
                     class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_security_key_or_biometric_authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
+                    tabindex="-1"
                   >
                     Set up security key or biometric authenticator
                   </h2>

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`webauthn-enroll should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_security_key_or_biometric_authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"
@@ -343,7 +343,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_security_key_or_biometric_authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"
@@ -558,7 +558,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_security_key_or_biometric_authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`webauthn-enroll should render form 1`] = `
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_security_key_or_biometric_authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"
@@ -343,7 +343,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_security_key_or_biometric_authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"
@@ -558,7 +558,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
                   class="MuiBox-root emotion-14"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h4 emotion-15"
+                    class="MuiTypography-root MuiTypography-h4 noOutline emotion-15"
                     data-se="o-form-head"
                     id="enroll-authenticator_Title_Set_up_security_key_or_biometric_authenticator_webauthn_aut2h3f9ovE2RV96P1d7_1"
                     tabindex="-1"

--- a/src/v3/test/integration/authenticator-enroll-email-magic-link-false.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-email-magic-link-false.test.tsx
@@ -36,6 +36,7 @@ describe('Email authenticator enroll when magic link = false Tests', () => {
     });
 
     const headerEle = await findByRole('heading', { level: 2 });
+    await waitFor(() => expect(headerEle).toHaveFocus());
     expect(headerEle.textContent).toBe('Verify with your email');
     expect(container).toMatchSnapshot();
 
@@ -43,7 +44,6 @@ describe('Email authenticator enroll when magic link = false Tests', () => {
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCode);
     expect(codeEle.value).toEqual(verificationCode);
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-enroll-email-magic-link-false.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-email-magic-link-false.test.tsx
@@ -11,6 +11,7 @@
  */
 
 import mockResponse from '@okta/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-false.json';
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('Email authenticator enroll when magic link = false Tests', () => {
@@ -42,6 +43,7 @@ describe('Email authenticator enroll when magic link = false Tests', () => {
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCode);
     expect(codeEle.value).toEqual(verificationCode);
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-enroll-phone-sms.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-phone-sms.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/credential/enroll/enroll-phone-sms-code-mfa.json';
@@ -30,6 +31,7 @@ describe('authenticator-enroll-phone-sms', () => {
       await findByText(/Set up phone authentication/);
       await findByText(/A code was sent to your phone. Enter the code below to verify./);
       await findByText(/Carrier messaging charges may apply/);
+      await waitFor(async () => expect(await findByText(/Set up phone authentication/)).toHaveFocus());
 
       const submitButton = await findByText('Verify', { selector: 'button' });
       const otpEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-enroll-phone-sms.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-phone-sms.test.tsx
@@ -28,10 +28,10 @@ describe('authenticator-enroll-phone-sms', () => {
         authClient, user, findByTestId, findByText,
       } = await setup({ mockResponse });
 
-      await findByText(/Set up phone authentication/);
+      const titleElement = await findByText(/Set up phone authentication/);
+      await waitFor(() => expect(titleElement).toHaveFocus());
       await findByText(/A code was sent to your phone. Enter the code below to verify./);
       await findByText(/Carrier messaging charges may apply/);
-      await waitFor(async () => expect(await findByText(/Set up phone authentication/)).toHaveFocus());
 
       const submitButton = await findByText('Verify', { selector: 'button' });
       const otpEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
@@ -24,7 +24,7 @@ describe('authenticator-enroll-phone-voice', () => {
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByTestId, findByText, findByRole,
+      authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Set up phone authentication/);

--- a/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
@@ -27,7 +27,8 @@ describe('authenticator-enroll-phone-voice', () => {
       authClient, user, findByTestId, findByText, findByRole,
     } = await setup({ mockResponse });
 
-    await findByText(/Set up phone authentication/);
+    const titleElement = await findByText(/Set up phone authentication/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Calling your phone. Enter the code below to verify./);
     await findByText(/Carrier messaging charges may apply/);
 

--- a/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/credential/enroll/enroll-phone-voice-code-mfa.json';
@@ -23,7 +24,7 @@ describe('authenticator-enroll-phone-voice', () => {
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByTestId, findByText,
+      authClient, user, findByTestId, findByText, findByRole,
     } = await setup({ mockResponse });
 
     await findByText(/Set up phone authentication/);
@@ -34,6 +35,7 @@ describe('authenticator-enroll-phone-voice', () => {
     const otpEle = await findByTestId('credentials.passcode') as HTMLInputElement;
 
     const otp = '123456';
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(otpEle, otp);
 
     expect(otpEle.value).toEqual(otp);

--- a/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
@@ -36,7 +36,6 @@ describe('authenticator-enroll-phone-voice', () => {
     const otpEle = await findByTestId('credentials.passcode') as HTMLInputElement;
 
     const otp = '123456';
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(otpEle, otp);
 
     expect(otpEle.value).toEqual(otp);

--- a/src/v3/test/integration/authenticator-enroll-yubikey-otp.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-yubikey-otp.test.tsx
@@ -44,7 +44,8 @@ describe('authenticator-enroll-yubikey-otp', () => {
       findByText,
     } = await setup({ mockResponse });
 
-    await waitFor(async () => expect(await findByText(/Set up YubiKey/)).toHaveFocus());
+    const titleElement = await findByText(/Set up YubiKey/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     const yubikeyCodeEl = await findByTestId('credentials.passcode');
     await user.type(yubikeyCodeEl, '1234');
     await user.click(await findByText('Set up', { selector: 'button' }));

--- a/src/v3/test/integration/authenticator-enroll-yubikey-otp.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-yubikey-otp.test.tsx
@@ -11,6 +11,7 @@
  */
 
 import mockResponse from '@okta/mocks/data/idp/idx/authenticator-enroll-yubikey.json';
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('authenticator-enroll-yubikey-otp', () => {
@@ -43,6 +44,7 @@ describe('authenticator-enroll-yubikey-otp', () => {
       findByText,
     } = await setup({ mockResponse });
 
+    await waitFor(async () => expect(await findByText(/Set up YubiKey/)).toHaveFocus());
     const yubikeyCodeEl = await findByTestId('credentials.passcode');
     await user.type(yubikeyCodeEl, '1234');
     await user.click(await findByText('Set up', { selector: 'button' }));

--- a/src/v3/test/integration/authenticator-expired-password-no-complexity.test.tsx
+++ b/src/v3/test/integration/authenticator-expired-password-no-complexity.test.tsx
@@ -28,8 +28,8 @@ describe('authenticator-expired-password-no-complexity', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Your password has expired/);
-    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
+    const titleElement = await findByText(/Your password has expired/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-expired-password-no-complexity.test.tsx
+++ b/src/v3/test/integration/authenticator-expired-password-no-complexity.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup, updateDynamicAttribute } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/authenticator-expired-password-no-complexity.json';
@@ -28,6 +29,7 @@ describe('authenticator-expired-password-no-complexity', () => {
     } = await setup({ mockResponse });
 
     await findByText(/Your password has expired/);
+    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-expired-password-with-enrollment-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-expired-password-with-enrollment-authenticator.test.tsx
@@ -28,10 +28,10 @@ describe('authenticator-expired-password-with-enrollment-authenticator', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Your password has expired/);
+    const titleElement = await findByText(/Your password has expired/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
     await findByText(/Return to authenticator list/);
-    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -57,9 +57,9 @@ describe('authenticator-expired-password-with-enrollment-authenticator', () => {
       authClient, user, findByTestId, findByText, container,
     } = await setup({ mockResponse });
 
-    await findByText(/Your password has expired/);
+    const titleElement = await findByText(/Your password has expired/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
-    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-expired-password-with-enrollment-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-expired-password-with-enrollment-authenticator.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { within } from '@testing-library/preact';
+import { within, waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup, updateDynamicAttribute } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/authenticator-expired-password-with-enrollment-authenticator.json';
@@ -31,6 +31,7 @@ describe('authenticator-expired-password-with-enrollment-authenticator', () => {
     await findByText(/Your password has expired/);
     await findByText(/Password requirements/);
     await findByText(/Return to authenticator list/);
+    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -58,6 +59,7 @@ describe('authenticator-expired-password-with-enrollment-authenticator', () => {
 
     await findByText(/Your password has expired/);
     await findByText(/Password requirements/);
+    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-expired-password.test.tsx
+++ b/src/v3/test/integration/authenticator-expired-password.test.tsx
@@ -28,9 +28,9 @@ describe('authenticator-expired-password', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Your password has expired/);
+    const titleElement = await findByText(/Your password has expired/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
-    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -59,9 +59,9 @@ describe('authenticator-expired-password', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Your password has expired/);
+    const titleElement = await findByText(/Your password has expired/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
-    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -111,9 +111,9 @@ describe('authenticator-expired-password', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Your password has expired/);
+    const titleElement = await findByText(/Your password has expired/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
-    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -162,9 +162,9 @@ describe('authenticator-expired-password', () => {
       authClient, user, findByTestId, findByText, container,
     } = await setup({ mockResponse });
 
-    await findByText(/Your password has expired/);
+    const titleElement = await findByText(/Your password has expired/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
-    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-expired-password.test.tsx
+++ b/src/v3/test/integration/authenticator-expired-password.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { within } from '@testing-library/preact';
+import { within, waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup, updateDynamicAttribute } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/authenticator-expired-password.json';
@@ -30,6 +30,7 @@ describe('authenticator-expired-password', () => {
 
     await findByText(/Your password has expired/);
     await findByText(/Password requirements/);
+    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -60,10 +61,10 @@ describe('authenticator-expired-password', () => {
 
     await findByText(/Your password has expired/);
     await findByText(/Password requirements/);
+    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
-
     await user.type(newPasswordEle, 'superSecretP@ssword12');
 
     const passwordMatchesWrapper = await findByTestId('password-authenticator--matches') as HTMLDivElement;
@@ -112,6 +113,7 @@ describe('authenticator-expired-password', () => {
 
     await findByText(/Your password has expired/);
     await findByText(/Password requirements/);
+    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -162,6 +164,7 @@ describe('authenticator-expired-password', () => {
 
     await findByText(/Your password has expired/);
     await findByText(/Password requirements/);
+    await waitFor(async () => expect(await findByText(/Your password has expired/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-expiry-warning-password.test.tsx
+++ b/src/v3/test/integration/authenticator-expiry-warning-password.test.tsx
@@ -28,11 +28,11 @@ describe('authenticator-expiry-warning-password', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Your password will expire in/);
+    const titleElement = await findByText(/Your password will expire in/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/When your password expires you will be locked out of your Okta account./);
     await findByText(/Password requirements/);
     await findByText(/Remind me later/);
-    await waitFor(async () => expect(await findByText(/Your password will expire in/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -58,9 +58,9 @@ describe('authenticator-expiry-warning-password', () => {
       authClient, user, findByTestId, findByText, container,
     } = await setup({ mockResponse });
 
-    await findByText(/Your password will expire in/);
+    const titleElement = await findByText(/Your password will expire in/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
-    await waitFor(async () => expect(await findByText(/Your password will expire in/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-expiry-warning-password.test.tsx
+++ b/src/v3/test/integration/authenticator-expiry-warning-password.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { within } from '@testing-library/preact';
+import { within, waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup, updateDynamicAttribute } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/authenticator-expiry-warning-password.json';
@@ -32,6 +32,7 @@ describe('authenticator-expiry-warning-password', () => {
     await findByText(/When your password expires you will be locked out of your Okta account./);
     await findByText(/Password requirements/);
     await findByText(/Remind me later/);
+    await waitFor(async () => expect(await findByText(/Your password will expire in/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -59,6 +60,7 @@ describe('authenticator-expiry-warning-password', () => {
 
     await findByText(/Your password will expire in/);
     await findByText(/Password requirements/);
+    await waitFor(async () => expect(await findByText(/Your password will expire in/)).toHaveFocus());
 
     const submitButton = await findByText('Change Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-reset-password-revoke-sessions.test.tsx
+++ b/src/v3/test/integration/authenticator-reset-password-revoke-sessions.test.tsx
@@ -26,7 +26,8 @@ describe('authenticator-reset-password-revoke-sessions', () => {
       authClient, user, findByTestId, findByText, findByLabelText, findByRole,
     } = await setup({ mockResponse });
 
-    await findByText(/Reset your password/);
+    const titleElement = await findByText(/Reset your password/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
 
     const submitButton = await findByRole('button', { name: 'Reset Password' });
@@ -35,7 +36,6 @@ describe('authenticator-reset-password-revoke-sessions', () => {
     const revokeSessionsCheckbox = await findByLabelText(/Sign me out of all other devices/);
 
     const password = 'superSecretP@ssword12';
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(newPasswordEle, password);
     await user.type(confirmPasswordEle, password);
 
@@ -56,7 +56,8 @@ describe('authenticator-reset-password-revoke-sessions', () => {
       authClient, user, findByTestId, findByText, findByRole,
     } = await setup({ mockResponse });
 
-    await findByText(/Reset your password/);
+    const titleElement = await findByText(/Reset your password/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
 
     const submitButton = await await findByRole('button', { name: 'Reset Password' });
@@ -64,7 +65,6 @@ describe('authenticator-reset-password-revoke-sessions', () => {
     const confirmPasswordEle = await findByTestId('confirmPassword') as HTMLInputElement;
 
     const password = 'superSecretP@ssword12';
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(newPasswordEle, password);
     await user.type(confirmPasswordEle, password);
 

--- a/src/v3/test/integration/authenticator-reset-password-revoke-sessions.test.tsx
+++ b/src/v3/test/integration/authenticator-reset-password-revoke-sessions.test.tsx
@@ -10,8 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
-
 import mockResponse from '../../src/mocks/response/idp/idx/authenticator-password-reset-revoke-sessions.json';
 
 describe('authenticator-reset-password-revoke-sessions', () => {
@@ -35,6 +35,7 @@ describe('authenticator-reset-password-revoke-sessions', () => {
     const revokeSessionsCheckbox = await findByLabelText(/Sign me out of all other devices/);
 
     const password = 'superSecretP@ssword12';
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(newPasswordEle, password);
     await user.type(confirmPasswordEle, password);
 
@@ -63,6 +64,7 @@ describe('authenticator-reset-password-revoke-sessions', () => {
     const confirmPasswordEle = await findByTestId('confirmPassword') as HTMLInputElement;
 
     const password = 'superSecretP@ssword12';
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(newPasswordEle, password);
     await user.type(confirmPasswordEle, password);
 

--- a/src/v3/test/integration/authenticator-reset-password.test.tsx
+++ b/src/v3/test/integration/authenticator-reset-password.test.tsx
@@ -38,9 +38,9 @@ describe('authenticator-reset-password', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Reset your password/);
+    const titleElement = await findByText(/Reset your password/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Password requirements/);
-    await waitFor(async () => expect(await findByText(/Reset your password/)).toHaveFocus());
 
     const submitButton = await findByText('Reset Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-reset-password.test.tsx
+++ b/src/v3/test/integration/authenticator-reset-password.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup, updateDynamicAttribute } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/challenge/answer/password-reset.json';
@@ -39,6 +40,7 @@ describe('authenticator-reset-password', () => {
 
     await findByText(/Reset your password/);
     await findByText(/Password requirements/);
+    await waitFor(async () => expect(await findByText(/Reset your password/)).toHaveFocus());
 
     const submitButton = await findByText('Reset Password', { selector: 'button' });
     const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-verification-email-magic-link-false.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email-magic-link-false.test.tsx
@@ -28,6 +28,7 @@ describe('Email authenticator verification when email magic link = false Tests',
     });
 
     const headerEle = await findByRole('heading', { level: 2 });
+    await waitFor(() => expect(headerEle).toHaveFocus());
     expect(headerEle.textContent).toBe('Verify with your email');
     expect(container).toMatchSnapshot();
 
@@ -35,7 +36,6 @@ describe('Email authenticator verification when email magic link = false Tests',
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCode);
     expect(codeEle.value).toEqual(verificationCode);
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-verification-email-magic-link-false.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email-magic-link-false.test.tsx
@@ -10,8 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
-
 import mockResponse from '../../src/mocks/response/idp/idx/challenge/authenticator-verification-email-magic-link-false.json';
 
 describe('Email authenticator verification when email magic link = false Tests', () => {
@@ -35,6 +35,7 @@ describe('Email authenticator verification when email magic link = false Tests',
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCode);
     expect(codeEle.value).toEqual(verificationCode);
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 import mockResponse from '../../src/mocks/response/idp/idx/identify/google-auth-verify.json';
 
@@ -26,6 +27,7 @@ describe('authenticator-verification-google-authenticator', () => {
       user,
       findByText,
       findByTestId,
+      findByRole,
     } = await setup({ mockResponse });
 
     await findByText(/Verify with Google Authenticator/);
@@ -35,6 +37,7 @@ describe('authenticator-verification-google-authenticator', () => {
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCode);
     expect(codeEle.value).toEqual(verificationCode);
     await user.click(submitButton);
@@ -51,6 +54,7 @@ describe('authenticator-verification-google-authenticator', () => {
       user,
       findByText,
       findByTestId,
+      findByRole,
     } = await setup({ mockResponse });
 
     await findByText(/Verify with Google Authenticator/);
@@ -61,6 +65,7 @@ describe('authenticator-verification-google-authenticator', () => {
 
     const otp = '123456';
     const verificationCodeWithSpaces = `  ${otp} `;
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCodeWithSpaces);
     expect(codeEle.value).toEqual(verificationCodeWithSpaces);
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
@@ -27,17 +27,16 @@ describe('authenticator-verification-google-authenticator', () => {
       user,
       findByText,
       findByTestId,
-      findByRole,
     } = await setup({ mockResponse });
 
-    await findByText(/Verify with Google Authenticator/);
+    const titleElement = await findByText(/Verify with Google Authenticator/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Enter the temporary code generated in your Google Authenticator app/);
 
     const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCode);
     expect(codeEle.value).toEqual(verificationCode);
     await user.click(submitButton);
@@ -57,7 +56,8 @@ describe('authenticator-verification-google-authenticator', () => {
       findByRole,
     } = await setup({ mockResponse });
 
-    await findByText(/Verify with Google Authenticator/);
+    const titleElement = await findByText(/Verify with Google Authenticator/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Enter the temporary code generated in your Google Authenticator app/);
 
     const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
@@ -65,7 +65,6 @@ describe('authenticator-verification-google-authenticator', () => {
 
     const otp = '123456';
     const verificationCodeWithSpaces = `  ${otp} `;
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCodeWithSpaces);
     expect(codeEle.value).toEqual(verificationCodeWithSpaces);
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
@@ -53,7 +53,6 @@ describe('authenticator-verification-google-authenticator', () => {
       user,
       findByText,
       findByTestId,
-      findByRole,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Verify with Google Authenticator/);

--- a/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/challenge/verify-ov-code-mfa.json';
@@ -27,6 +28,7 @@ describe('authenticator-verification-okta-verify-totp', () => {
     } = await setup({ mockResponse });
 
     await findByText(/Enter a code/);
+    await waitFor(async () => expect(await findByText(/Enter a code/)).toHaveFocus());
 
     const submitButton = await findByText('Verify', { selector: 'button' });
     const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;
@@ -50,6 +52,7 @@ describe('authenticator-verification-okta-verify-totp', () => {
     } = await setup({ mockResponse });
 
     await findByText(/Enter a code/);
+    await waitFor(async () => expect(await findByText(/Enter a code/)).toHaveFocus());
 
     const submitButton = await findByText('Verify', { selector: 'button' });
     const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
@@ -27,8 +27,8 @@ describe('authenticator-verification-okta-verify-totp', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Enter a code/);
-    await waitFor(async () => expect(await findByText(/Enter a code/)).toHaveFocus());
+    const titleElement = await findByText(/Enter a code/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Verify', { selector: 'button' });
     const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;
@@ -51,8 +51,8 @@ describe('authenticator-verification-okta-verify-totp', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Enter a code/);
-    await waitFor(async () => expect(await findByText(/Enter a code/)).toHaveFocus());
+    const titleElement = await findByText(/Enter a code/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Verify', { selector: 'button' });
     const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;

--- a/src/v3/test/integration/authenticator-verification-phone-sms.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-phone-sms.test.tsx
@@ -28,10 +28,10 @@ describe('authenticator-verification-phone-sms', () => {
       user,
       findByText,
       findByTestId,
-      findByRole,
     } = await setup({ mockResponse });
 
-    await findByText(/Verify with your phone/);
+    const titleElement = await findByText(/Verify with your phone/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/A code was sent to/);
     await findByText(/Carrier messaging charges may apply/);
 
@@ -39,7 +39,6 @@ describe('authenticator-verification-phone-sms', () => {
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCode);
     expect(codeEle.value).toEqual(verificationCode);
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-verification-phone-sms.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-phone-sms.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/challenge/sms-challenge.json';
@@ -27,6 +28,7 @@ describe('authenticator-verification-phone-sms', () => {
       user,
       findByText,
       findByTestId,
+      findByRole,
     } = await setup({ mockResponse });
 
     await findByText(/Verify with your phone/);
@@ -37,6 +39,7 @@ describe('authenticator-verification-phone-sms', () => {
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(codeEle, verificationCode);
     expect(codeEle.value).toEqual(verificationCode);
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-verification-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-security-question.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/securityquestion-verify.json';
@@ -27,6 +28,7 @@ describe('authenticator-verification-security-question', () => {
       user,
       findByText,
       findByTestId,
+      findByRole,
     } = await setup({ mockResponse });
     await findByText(/Verify with your Security Question/);
     await findByText(/What is the food you least liked as a child\?/);
@@ -34,6 +36,7 @@ describe('authenticator-verification-security-question', () => {
     const answerEl = await findByTestId('credentials.answer') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(answerEl, 'fake-answer');
     expect(answerEl.value).toEqual('fake-answer');
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-verification-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-security-question.test.tsx
@@ -28,15 +28,14 @@ describe('authenticator-verification-security-question', () => {
       user,
       findByText,
       findByTestId,
-      findByRole,
     } = await setup({ mockResponse });
-    await findByText(/Verify with your Security Question/);
+    const titleElement = await findByText(/Verify with your Security Question/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/What is the food you least liked as a child\?/);
 
     const answerEl = await findByTestId('credentials.answer') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(answerEl, 'fake-answer');
     expect(answerEl.value).toEqual('fake-answer');
     await user.click(submitButton);

--- a/src/v3/test/integration/authenticator-verification-yubikey-otp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-yubikey-otp.test.tsx
@@ -44,7 +44,8 @@ describe('authenticator-verification-yubikey-otp', () => {
       findByText,
     } = await setup({ mockResponse });
 
-    await waitFor(async () => expect(await findByText(/Verify with YubiKey/)).toHaveFocus());
+    const titleElement = await findByText(/Verify with YubiKey/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
     const yubikeyCodeEl = await findByTestId('credentials.passcode');
     await user.type(yubikeyCodeEl, '1234');
     await user.click(await findByText('Verify', { selector: 'button' }));

--- a/src/v3/test/integration/authenticator-verification-yubikey-otp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-yubikey-otp.test.tsx
@@ -11,6 +11,7 @@
  */
 
 import mockResponse from '@okta/mocks/data/idp/idx/authenticator-verification-yubikey.json';
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('authenticator-verification-yubikey-otp', () => {
@@ -43,6 +44,7 @@ describe('authenticator-verification-yubikey-otp', () => {
       findByText,
     } = await setup({ mockResponse });
 
+    await waitFor(async () => expect(await findByText(/Verify with YubiKey/)).toHaveFocus());
     const yubikeyCodeEl = await findByTestId('credentials.passcode');
     await user.type(yubikeyCodeEl, '1234');
     await user.click(await findByText('Verify', { selector: 'button' }));

--- a/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
+++ b/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
@@ -91,7 +91,6 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const address = '123 Main St';
-
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -205,7 +204,6 @@ describe('enroll-profile-with-password', () => {
     const firstName = 'tester';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
-
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -261,7 +259,6 @@ describe('enroll-profile-with-password', () => {
     const firstName = 'tester';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
-
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);

--- a/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
+++ b/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
@@ -20,6 +20,7 @@ import {
 import { IdxActionParams } from '@okta/okta-auth-js';
 import { within } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
+import { waitFor } from '@testing-library/preact';
 import { RegistrationErrorCallback, RegistrationPostSubmitCallback } from '../../../types';
 
 describe('enroll-profile-with-password', () => {
@@ -83,6 +84,7 @@ describe('enroll-profile-with-password', () => {
     const emailEle = await findByLabelText(/Email/) as HTMLInputElement;
     const addressEle = await findByLabelText(/Street Address/) as HTMLInputElement;
 
+    await waitFor(() => expect(heading).toHaveFocus());
     expect(heading.textContent).toBe('Sign up');
     expect(container).toMatchSnapshot();
 
@@ -90,7 +92,7 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const address = '123 Main St';
-    await user.tab();
+
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -193,6 +195,7 @@ describe('enroll-profile-with-password', () => {
       },
     });
     const heading = await findByRole('heading', { level: 2 });
+    await waitFor(() => expect(heading).toHaveFocus());
     expect(heading.textContent).toBe('Sign up');
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
@@ -203,7 +206,7 @@ describe('enroll-profile-with-password', () => {
     const firstName = 'tester';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
-    await user.tab();
+
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -248,6 +251,7 @@ describe('enroll-profile-with-password', () => {
       },
     });
     const heading = await findByRole('heading', { level: 2 });
+    await waitFor(() => expect(heading).toHaveFocus());
     expect(heading.textContent).toBe('Sign up');
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
@@ -258,7 +262,7 @@ describe('enroll-profile-with-password', () => {
     const firstName = 'tester';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
-    await user.tab();
+
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);

--- a/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
+++ b/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
@@ -90,6 +90,7 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const address = '123 Main St';
+    await user.tab();
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -202,6 +203,7 @@ describe('enroll-profile-with-password', () => {
     const firstName = 'tester';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
+    await user.tab();
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -256,6 +258,7 @@ describe('enroll-profile-with-password', () => {
     const firstName = 'tester';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
+    await user.tab();
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);

--- a/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
+++ b/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
@@ -18,9 +18,8 @@ import {
   RegistrationSchemaCallbackV3,
 } from 'src/types';
 import { IdxActionParams } from '@okta/okta-auth-js';
-import { within } from '@testing-library/preact';
+import { within, waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
-import { waitFor } from '@testing-library/preact';
 import { RegistrationErrorCallback, RegistrationPostSubmitCallback } from '../../../types';
 
 describe('enroll-profile-with-password', () => {

--- a/src/v3/test/integration/enroll-profile-with-password.test.tsx
+++ b/src/v3/test/integration/enroll-profile-with-password.test.tsx
@@ -57,7 +57,7 @@ describe('enroll-profile-with-password', () => {
 
   it('should display field level error when password does not fulfill requirements', async () => {
     const {
-      authClient, container, user, findByTestId, findByText, findByRole,
+      authClient, container, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Sign up/);
@@ -93,7 +93,7 @@ describe('enroll-profile-with-password', () => {
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByText, findByTestId, findByRole,
+      authClient, user, findByText, findByTestId,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Sign up/);
@@ -109,7 +109,7 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const password = 'abc123DE';
-    
+
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);

--- a/src/v3/test/integration/enroll-profile-with-password.test.tsx
+++ b/src/v3/test/integration/enroll-profile-with-password.test.tsx
@@ -11,6 +11,7 @@
  */
 
 import mockResponse from '@okta/mocks/data/idp/idx/enroll-profile-with-password.json';
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('enroll-profile-with-password', () => {
@@ -24,7 +25,7 @@ describe('enroll-profile-with-password', () => {
 
   it('should display field level error when password field is required but is not filled', async () => {
     const {
-      authClient, container, user, findByTestId, findByText,
+      authClient, container, user, findByTestId, findByText, findByRole,
     } = await setup({ mockResponse });
 
     await findByText(/Sign up/);
@@ -37,6 +38,8 @@ describe('enroll-profile-with-password', () => {
     const firstName = 'tester';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
+    // const titleElement =
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -54,7 +57,7 @@ describe('enroll-profile-with-password', () => {
 
   it('should display field level error when password does not fulfill requirements', async () => {
     const {
-      authClient, container, user, findByTestId, findByText,
+      authClient, container, user, findByTestId, findByText, findByRole,
     } = await setup({ mockResponse });
 
     await findByText(/Sign up/);
@@ -69,6 +72,7 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const password = 'abc123';
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -88,7 +92,7 @@ describe('enroll-profile-with-password', () => {
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByText, findByTestId,
+      authClient, user, findByText, findByTestId, findByRole,
     } = await setup({ mockResponse });
 
     await findByText(/Sign up/);
@@ -103,6 +107,7 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const password = 'abc123DE';
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);

--- a/src/v3/test/integration/enroll-profile-with-password.test.tsx
+++ b/src/v3/test/integration/enroll-profile-with-password.test.tsx
@@ -25,10 +25,11 @@ describe('enroll-profile-with-password', () => {
 
   it('should display field level error when password field is required but is not filled', async () => {
     const {
-      authClient, container, user, findByTestId, findByText, findByRole,
+      authClient, container, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
-    await findByText(/Sign up/);
+    const titleElement = await findByText(/Sign up/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
     const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
@@ -39,7 +40,6 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     // const titleElement =
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -60,7 +60,8 @@ describe('enroll-profile-with-password', () => {
       authClient, container, user, findByTestId, findByText, findByRole,
     } = await setup({ mockResponse });
 
-    await findByText(/Sign up/);
+    const titleElement = await findByText(/Sign up/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
     const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
@@ -72,7 +73,7 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const password = 'abc123';
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
+
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -95,7 +96,8 @@ describe('enroll-profile-with-password', () => {
       authClient, user, findByText, findByTestId, findByRole,
     } = await setup({ mockResponse });
 
-    await findByText(/Sign up/);
+    const titleElement = await findByText(/Sign up/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
     const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
@@ -107,7 +109,7 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const password = 'abc123DE';
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
+    
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);

--- a/src/v3/test/integration/enroll-profile-with-password.test.tsx
+++ b/src/v3/test/integration/enroll-profile-with-password.test.tsx
@@ -39,7 +39,6 @@ describe('enroll-profile-with-password', () => {
     const firstName = 'tester';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
-    // const titleElement =
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -73,7 +72,6 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const password = 'abc123';
-
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -109,7 +107,6 @@ describe('enroll-profile-with-password', () => {
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
     const password = 'abc123DE';
-
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);

--- a/src/v3/test/integration/flow-password-authentication-security-question-authentication.test.tsx
+++ b/src/v3/test/integration/flow-password-authentication-security-question-authentication.test.tsx
@@ -22,7 +22,6 @@ describe('Flow transition from password authentication to security question auth
       user,
       findByTestId,
       findByText,
-      findByRole,
     } = await setup({
       mockResponses: {
         '/introspect': {
@@ -37,10 +36,11 @@ describe('Flow transition from password authentication to security question auth
     });
 
     // form: identify with password
+    const titleElement = await findByText('Verify with your password');
+    await waitFor(() => expect(titleElement).toHaveFocus());
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(passwordEl, 'fake-password');
     expect(passwordEl.value).toEqual('fake-password');
     await user.click(submitButton);

--- a/src/v3/test/integration/flow-password-authentication-security-question-authentication.test.tsx
+++ b/src/v3/test/integration/flow-password-authentication-security-question-authentication.test.tsx
@@ -12,6 +12,7 @@
 
 import identifyWithPassword from '@okta/mocks/data/idp/idx/authenticator-verification-password.json';
 
+import { waitFor } from '@testing-library/preact';
 import authenticatorSecurityQuestion from '../../src/mocks/response/idp/idx/identify/securityquestion-verify.json';
 import { setup } from './util';
 
@@ -21,6 +22,7 @@ describe('Flow transition from password authentication to security question auth
       user,
       findByTestId,
       findByText,
+      findByRole,
     } = await setup({
       mockResponses: {
         '/introspect': {
@@ -38,6 +40,7 @@ describe('Flow transition from password authentication to security question auth
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(passwordEl, 'fake-password');
     expect(passwordEl.value).toEqual('fake-password');
     await user.click(submitButton);

--- a/src/v3/test/integration/flow-transition.test.tsx
+++ b/src/v3/test/integration/flow-transition.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { setup } from './util';
 
 import identifyWithPassword from '../../src/mocks/response/idp/idx/introspect/default.json';
@@ -59,6 +60,7 @@ describe('Flow transitions', () => {
     const usernameEl = await findByTestId('identifier') as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Sign in', { selector: 'button' });
+    await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
 
     await user.type(usernameEl, 'testuser@okta.com');
     expect(usernameEl.value).toEqual('testuser@okta.com');

--- a/src/v3/test/integration/flow-transition.test.tsx
+++ b/src/v3/test/integration/flow-transition.test.tsx
@@ -57,10 +57,11 @@ describe('Flow transitions', () => {
     });
 
     // form: identify-with-password
+    const titleElement = await findByText('Sign In', { selector: 'h2' });
+    await waitFor(() => expect(titleElement).toHaveFocus());
     const usernameEl = await findByTestId('identifier') as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Sign in', { selector: 'button' });
-    await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
 
     await user.type(usernameEl, 'testuser@okta.com');
     expect(usernameEl.value).toEqual('testuser@okta.com');

--- a/src/v3/test/integration/flow-yubikey-otp-to-password-verification.test.tsx
+++ b/src/v3/test/integration/flow-yubikey-otp-to-password-verification.test.tsx
@@ -13,6 +13,7 @@
 import yubikeyVerificationResponse from '@okta/mocks/data/idp/idx/authenticator-verification-yubikey.json';
 
 import identifyWithPassword from '@okta/mocks/data/idp/idx/authenticator-verification-password.json';
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('Flow transition from YubiKey verification to Password MFA', () => {
@@ -22,6 +23,7 @@ describe('Flow transition from YubiKey verification to Password MFA', () => {
       user,
       findByTestId,
       findByText,
+      findByRole,
     } = await setup({
       mockResponses: {
         '/introspect': {
@@ -37,6 +39,7 @@ describe('Flow transition from YubiKey verification to Password MFA', () => {
 
     // form: Yubikey code entry
     const yubikeyCodeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(yubikeyCodeEl, '1234abcd8520');
     expect(yubikeyCodeEl.value).toEqual('1234abcd8520');
     await user.click(await findByText('Verify', { selector: 'button' }));

--- a/src/v3/test/integration/identify-recovery.test.tsx
+++ b/src/v3/test/integration/identify-recovery.test.tsx
@@ -45,7 +45,8 @@ describe('identify-recovery', () => {
       findByText,
     } = await setup({ mockResponse });
 
-    await waitFor(async () => expect(await findByText('Reset your password')).toHaveFocus());
+    const titleElement = await findByText('Reset your password');
+    await waitFor(() => expect(titleElement).toHaveFocus());
     const usernameEl = await findByTestId('identifier');
     await user.type(usernameEl, 'testuser@okta.com');
     await user.click(await findByText('Next', { selector: 'button' }));

--- a/src/v3/test/integration/identify-recovery.test.tsx
+++ b/src/v3/test/integration/identify-recovery.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/recover/default.json';
@@ -44,6 +45,7 @@ describe('identify-recovery', () => {
       findByText,
     } = await setup({ mockResponse });
 
+    await waitFor(async () => expect(await findByText('Reset your password')).toHaveFocus());
     const usernameEl = await findByTestId('identifier');
     await user.type(usernameEl, 'testuser@okta.com');
     await user.click(await findByText('Next', { selector: 'button' }));

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import * as cookieUtils from '../../src/util/cookieUtils';
@@ -75,6 +76,7 @@ describe('identify-with-password-error-flow', () => {
     const submitButton = await findByText('Sign in', { selector: 'button' });
     const usernameEl = await findByTestId('identifier') as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
 
     const username = 'testeruser@okta1.com';
     const password = 'pass@word123';

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -73,10 +73,11 @@ describe('identify-with-password-error-flow', () => {
       },
     });
 
+    const titleElement = await findByText('Sign In', { selector: 'h2' });
+    await waitFor(() => expect(titleElement).toHaveFocus());
     const submitButton = await findByText('Sign in', { selector: 'button' });
     const usernameEl = await findByTestId('identifier') as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
-    await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
 
     const username = 'testeruser@okta1.com';
     const password = 'pass@word123';

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -162,7 +162,6 @@ describe('identify-with-password', () => {
       const identifierEle = await findByTestId('identifier') as HTMLInputElement;
       await findByTestId('credentials.passcode') as HTMLInputElement;
       await findByText('Sign in', { selector: 'button' });
-
       expect(queryByTestId('identifier-error')).toBeNull();
       expect(queryByTestId('credentials.passcode-error')).toBeNull();
 
@@ -242,6 +241,7 @@ describe('identify-with-password', () => {
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
+      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
 
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
@@ -276,6 +276,7 @@ describe('identify-with-password', () => {
       const submitButton = await findByText('Sign in', { selector: 'button' });
       const mockUsername = 'testuser@okta1.com';
 
+      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
       await user.type(usernameEl, mockUsername);
       expect(usernameEl.value).toEqual(mockUsername);
       await user.type(passwordEl, 'fake-password');
@@ -307,6 +308,7 @@ describe('identify-with-password', () => {
       const submitButton = await findByText('Sign in', { selector: 'button' });
       const mockUsername = 'testuser@okta1.com';
 
+      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
       await user.type(usernameEl, mockUsername);
       expect(usernameEl.value).toEqual(mockUsername);
       await user.type(passwordEl, 'fake-password');
@@ -331,6 +333,7 @@ describe('identify-with-password', () => {
       const submitButton = await findByText('Sign in', { selector: 'button' });
 
       const password = '   fake-password   ';
+      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
       await user.type(passwordEl, password);
@@ -357,6 +360,7 @@ describe('identify-with-password', () => {
       const rememberMeEl = await findByTestId('rememberMe');
       const submitButton = await findByText('Sign in', { selector: 'button' });
 
+      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
       await user.type(passwordEl, 'fake-password');
@@ -385,6 +389,7 @@ describe('identify-with-password', () => {
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Sign in', { selector: 'button' });
 
+    await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
     await user.type(usernameEl, 'testuser@okta.com');
     expect(usernameEl.value).toEqual('testuser@okta.com');
     await user.type(passwordEl, 'fake-password');

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -238,10 +238,11 @@ describe('identify-with-password', () => {
         authClient, user, findByTestId, findByText,
       } = await setup({ mockResponse });
 
+      const titleElement = await findByText('Sign In', { selector: 'h2' });
+      await waitFor(() => expect(titleElement).toHaveFocus());
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
-      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
 
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
@@ -271,12 +272,13 @@ describe('identify-with-password', () => {
         },
       });
 
+      const titleElement = await findByText('Sign In', { selector: 'h2' });
+      await waitFor(() => expect(titleElement).toHaveFocus());
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
       const mockUsername = 'testuser@okta1.com';
 
-      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
       await user.type(usernameEl, mockUsername);
       expect(usernameEl.value).toEqual(mockUsername);
       await user.type(passwordEl, 'fake-password');
@@ -303,12 +305,13 @@ describe('identify-with-password', () => {
         },
       });
 
+      const titleElement = await findByText('Sign In', { selector: 'h2' });
+      await waitFor(() => expect(titleElement).toHaveFocus());
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
       const mockUsername = 'testuser@okta1.com';
 
-      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
       await user.type(usernameEl, mockUsername);
       expect(usernameEl.value).toEqual(mockUsername);
       await user.type(passwordEl, 'fake-password');
@@ -328,12 +331,13 @@ describe('identify-with-password', () => {
         authClient, user, findByTestId, findByText,
       } = await setup({ mockResponse });
 
+      const titleElement = await findByText('Sign In', { selector: 'h2' });
+      await waitFor(() => expect(titleElement).toHaveFocus());
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
 
       const password = '   fake-password   ';
-      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
       await user.type(passwordEl, password);
@@ -355,12 +359,13 @@ describe('identify-with-password', () => {
         authClient, user, findByTestId, findByText,
       } = await setup({ mockResponse });
 
+      const titleElement = await findByText('Sign In', { selector: 'h2' });
+      await waitFor(() => expect(titleElement).toHaveFocus());
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const rememberMeEl = await findByTestId('rememberMe');
       const submitButton = await findByText('Sign in', { selector: 'button' });
 
-      await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
       await user.type(passwordEl, 'fake-password');
@@ -385,11 +390,12 @@ describe('identify-with-password', () => {
       authClient, user, findByTestId, findByText,
     } = await setup({ mockResponse });
 
+    const titleElement = await findByText('Sign In', { selector: 'h2' });
+    await waitFor(() => expect(titleElement).toHaveFocus());
     const usernameEl = await findByTestId('identifier') as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Sign in', { selector: 'button' });
 
-    await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
     await user.type(usernameEl, 'testuser@okta.com');
     expect(usernameEl.value).toEqual('testuser@okta.com');
     await user.type(passwordEl, 'fake-password');

--- a/src/v3/test/integration/okta-verify-email-channel-enrollment.test.tsx
+++ b/src/v3/test/integration/okta-verify-email-channel-enrollment.test.tsx
@@ -17,17 +17,17 @@ import mockResponse from '../../src/mocks/response/idp/idx/credential/enroll/enr
 describe('okta-verify-email-channel-enrollment', () => {
   it('should render email channel form and send correct payload', async () => {
     const {
-      container, findByText, findByTestId, user, authClient, findByRole,
+      container, findByText, findByTestId, user, authClient,
     } = await setup({ mockResponse });
 
-    await findByText(/Set up Okta Verify via email link/);
+    const headerEle = await findByText(/Set up Okta Verify via email link/);
+    await waitFor(() => expect(headerEle).toHaveFocus());
     await findByText(/Make sure you can access the email on your mobile device./);
     const emailEl = await findByTestId(/email/) as HTMLInputElement;
     const submitBtn = await findByText(/Send me the setup link/);
 
     expect(container).toMatchSnapshot();
 
-    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(emailEl, 'tester@okta1.com');
     expect(emailEl.value).toEqual('tester@okta1.com');
     await user.click(submitBtn);

--- a/src/v3/test/integration/okta-verify-email-channel-enrollment.test.tsx
+++ b/src/v3/test/integration/okta-verify-email-channel-enrollment.test.tsx
@@ -10,13 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 import mockResponse from '../../src/mocks/response/idp/idx/credential/enroll/enroll-ov-email-channel.json';
 
 describe('okta-verify-email-channel-enrollment', () => {
   it('should render email channel form and send correct payload', async () => {
     const {
-      container, findByText, findByTestId, user, authClient,
+      container, findByText, findByTestId, user, authClient, findByRole,
     } = await setup({ mockResponse });
 
     await findByText(/Set up Okta Verify via email link/);
@@ -26,6 +27,7 @@ describe('okta-verify-email-channel-enrollment', () => {
 
     expect(container).toMatchSnapshot();
 
+    await waitFor(async () => expect(await findByRole('heading', { level: 2 })).toHaveFocus());
     await user.type(emailEl, 'tester@okta1.com');
     expect(emailEl.value).toEqual('tester@okta1.com');
     await user.click(submitBtn);

--- a/src/v3/test/integration/user-unlock-account.test.tsx
+++ b/src/v3/test/integration/user-unlock-account.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { within } from '@testing-library/preact';
+import { within, waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/unlock-account/default.json';
@@ -41,8 +41,10 @@ describe('user-unlock-account', () => {
 
   describe('send corrent payload', () => {
     it('when select email authenticator', async () => {
-      const { authClient, user, findByTestId } = await setup({ mockResponse });
-
+      const {
+        authClient, user, findByTestId, findByText,
+      } = await setup({ mockResponse });
+      await waitFor(async () => expect(await findByText(/Unlock account\?/)).toHaveFocus());
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
@@ -59,8 +61,11 @@ describe('user-unlock-account', () => {
     });
 
     it('when select phone authenticator', async () => {
-      const { authClient, user, findByTestId } = await setup({ mockResponse });
+      const {
+        authClient, user, findByTestId, findByText,
+      } = await setup({ mockResponse });
 
+      await waitFor(async () => expect(await findByText(/Unlock account\?/)).toHaveFocus());
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');

--- a/src/v3/test/integration/user-unlock-account.test.tsx
+++ b/src/v3/test/integration/user-unlock-account.test.tsx
@@ -44,7 +44,8 @@ describe('user-unlock-account', () => {
       const {
         authClient, user, findByTestId, findByText,
       } = await setup({ mockResponse });
-      await waitFor(async () => expect(await findByText(/Unlock account\?/)).toHaveFocus());
+      const titleElement = await findByText(/Unlock account\?/);
+      await waitFor(() => expect(titleElement).toHaveFocus());
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
@@ -65,7 +66,8 @@ describe('user-unlock-account', () => {
         authClient, user, findByTestId, findByText,
       } = await setup({ mockResponse });
 
-      await waitFor(async () => expect(await findByText(/Unlock account\?/)).toHaveFocus());
+      const titleElement = await findByText(/Unlock account\?/);
+      await waitFor(() => expect(titleElement).toHaveFocus());
       const usernameEl = await findByTestId('identifier') as HTMLInputElement;
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');


### PR DESCRIPTION
## Description:

This PR adds focusing on the Title element when a new page is loaded in SIW Gen 3.  This is to prevent a screen reader from continuing to read content from a previous page.  It is also to let screen reader users know that a new page has loaded and provides context.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-591835](https://oktainc.atlassian.net/browse/OKTA-591835)

### Reviewers:

### Screenshot/Video:

https://user-images.githubusercontent.com/107433508/227124613-75e78476-40a9-48f3-b284-dcdaaac43cfc.mov

### Downstream Monolith Build:



