### PR TITLE
g3: Clears `isClientTransaction` on return to authenticator list

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    // 'identify',
+    'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -48,7 +48,7 @@ const idx = {
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'error-internal-server-error',
     // 'authenticator-enroll-security-question',
-    'authenticator-enroll-select-authenticator',
+    // 'authenticator-enroll-select-authenticator',
     // 'authenticator-enroll-select-authenticator-with-skip',
     // 'authenticator-enroll-webauthn',
     // 'authenticator-verification-data-phone-sms-then-voice',
@@ -106,8 +106,6 @@ const idx = {
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-enroll-custom-app-push',
     // 'request-activation-email'    
-    // 'error-authenticator-enroll-phone-invalid-number',
-    // 'response-3',
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',
@@ -120,11 +118,7 @@ const idx = {
     // 'authenticator-enroll-security-question',
     // 'authenticator-enroll-google-authenticator',
     // 'authenticator-enroll-email-first-emailmagiclink-true',
-    // 'error-authenticator-enroll-phone-invalid-number',
-    // 'response-2',
-    // 'response-4',
-    // 'error-400-response-5',
-    // 'error-400-response-6',
+    'error-authenticator-enroll-phone-invalid-number',
   ],
   '/idp/idx/identify': [
     // 'authenticator-verification-data-ov-only-without-device-known',
@@ -143,7 +137,7 @@ const idx = {
     // 'error-unsupported-idx-response'
   ],
   '/idp/idx/challenge/answer': [
-    // 'error-401-invalid-otp-passcode',
+    'error-401-invalid-otp-passcode',
     // 'error-401-invalid-otp-passcode',
     // 'error-429-too-many-request-operation-ratelimit',
     // 'error-429-too-many-request',
@@ -153,17 +147,15 @@ const idx = {
     // 'error-authenticator-enroll-security-question',
     // 'error-authenticator-webauthn-failure',
     // 'error-authenticator-enroll-password-common',
+    'error-authenticator-reset-password-requirement',
+    'error-authenticator-enroll-security-question-html-tags',
+    'error-authenticator-enroll-password-common',
     // 'error-authenticator-reset-password-requirement',
     // 'error-authenticator-enroll-security-question-html-tags',
-    // 'error-authenticator-enroll-password-common',
-    // 'error-authenticator-reset-password-requirement',
-    // 'error-authenticator-enroll-security-question-html-tags',
-    'response-3',
   ],
   '/idp/idx/challenge/send': [
     // 'authenticator-enroll-ov-sms',
-    // 'authenticator-enroll-ov-email',
-    'error-authenticator-enroll-phone-invalid-number',
+    'authenticator-enroll-ov-email',
   ],
   '/idp/idx/challenge/resend': [
     'authenticator-enroll-ov-sms',

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    'identify',
+    // 'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -48,7 +48,7 @@ const idx = {
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'error-internal-server-error',
     // 'authenticator-enroll-security-question',
-    // 'authenticator-enroll-select-authenticator',
+    'authenticator-enroll-select-authenticator',
     // 'authenticator-enroll-select-authenticator-with-skip',
     // 'authenticator-enroll-webauthn',
     // 'authenticator-verification-data-phone-sms-then-voice',
@@ -106,6 +106,8 @@ const idx = {
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-enroll-custom-app-push',
     // 'request-activation-email'    
+    // 'error-authenticator-enroll-phone-invalid-number',
+    // 'response-3',
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',
@@ -118,7 +120,11 @@ const idx = {
     // 'authenticator-enroll-security-question',
     // 'authenticator-enroll-google-authenticator',
     // 'authenticator-enroll-email-first-emailmagiclink-true',
-    'error-authenticator-enroll-phone-invalid-number',
+    // 'error-authenticator-enroll-phone-invalid-number',
+    // 'response-2',
+    // 'response-4',
+    // 'error-400-response-5',
+    // 'error-400-response-6',
   ],
   '/idp/idx/identify': [
     // 'authenticator-verification-data-ov-only-without-device-known',
@@ -137,7 +143,7 @@ const idx = {
     // 'error-unsupported-idx-response'
   ],
   '/idp/idx/challenge/answer': [
-    'error-401-invalid-otp-passcode',
+    // 'error-401-invalid-otp-passcode',
     // 'error-401-invalid-otp-passcode',
     // 'error-429-too-many-request-operation-ratelimit',
     // 'error-429-too-many-request',
@@ -147,15 +153,17 @@ const idx = {
     // 'error-authenticator-enroll-security-question',
     // 'error-authenticator-webauthn-failure',
     // 'error-authenticator-enroll-password-common',
-    'error-authenticator-reset-password-requirement',
-    'error-authenticator-enroll-security-question-html-tags',
-    'error-authenticator-enroll-password-common',
     // 'error-authenticator-reset-password-requirement',
     // 'error-authenticator-enroll-security-question-html-tags',
+    // 'error-authenticator-enroll-password-common',
+    // 'error-authenticator-reset-password-requirement',
+    // 'error-authenticator-enroll-security-question-html-tags',
+    'response-3',
   ],
   '/idp/idx/challenge/send': [
     // 'authenticator-enroll-ov-sms',
-    'authenticator-enroll-ov-email',
+    // 'authenticator-enroll-ov-email',
+    'error-authenticator-enroll-phone-invalid-number',
   ],
   '/idp/idx/challenge/resend': [
     'authenticator-enroll-ov-sms',

--- a/playground/mocks/data/idp/idx/authenticator-enroll-data-phone-voice.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-data-phone-voice.json
@@ -11,7 +11,7 @@
           "create-form"
         ],
         "name": "authenticator-enrollment-data",
-        "href": "http://localhost:3000/idp/idx/challenge",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
         "method": "POST",
         "accepts": "application/vnd.okta.v1+json",
         "value": [

--- a/playground/mocks/data/idp/idx/authenticator-enroll-data-phone.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-data-phone.json
@@ -11,7 +11,7 @@
           "create-form"
         ],
         "name": "authenticator-enrollment-data",
-        "href": "http://localhost:3000/idp/idx/challenge",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
         "method": "POST",
         "accepts": "application/vnd.okta.v1+json",
         "value": [

--- a/playground/mocks/data/idp/idx/error-authenticator-enroll-phone-invalid-number.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-enroll-phone-invalid-number.json
@@ -7,6 +7,60 @@
     "type":"array",
     "value":[
       {
+        "rel": [
+          "create-form"
+        ],
+        "name": "authenticator-enrollment-data",
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "label": "Phone",
+            "form": {
+              "value": [
+                {
+                  "name": "id",
+                  "required": true,
+                  "id":"aut23bgproCCEkFom0g4",
+                  "mutable": false
+                },
+                {
+                  "name": "methodType",
+                  "type": "string",
+                  "required": true,
+                  "options": [
+                    {
+                      "label": "SMS",
+                      "value": "sms"
+                    },
+                    {
+                      "type": "voice"
+                    }
+                  ]
+                },
+                {
+                  "name": "phoneNumber",
+                  "required": true
+                }
+              ]
+            }
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02A2CNDXsH6luRQV4R-GOWt2_ynSdb3UWg-3Ce_-sN",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
         "rel":[
           "create-form"
         ],
@@ -115,6 +169,42 @@
         "class":"ERROR"
       }
     ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "resend": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "resend",
+        "href": "http://localhost:3000/idp/idx/challenge/resend",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02A2CNDXsH6luRQV4R-GOWt2_ynSdb3UWg-3Ce_-sN",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      "type": "phone",
+      "key": "phone_number",
+      "id":"aut23bgproCCEkFom0g4",
+      "displayName": "Phone",
+      "methods": [
+        {
+          "type": "sms"
+        },
+        {
+          "type": "voice"
+        }
+      ]
+    }
   },
   "authenticators":{
     "type":"array",

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -206,7 +206,7 @@ export const updateTransactionWithNextStep = (
   nextStep: NextStep,
   widgetContext: IWidgetContext,
 ): void => {
-  const { setIdxTransaction, setMessage, setStepToRender } = widgetContext;
+  const { setIdxTransaction, setIsClientTransaction, setMessage, setStepToRender } = widgetContext;
   const availableSteps = transaction.availableSteps?.filter(
     ({ name }) => name !== nextStep.name,
   ) || [];
@@ -219,6 +219,7 @@ export const updateTransactionWithNextStep = (
 
   setMessage(undefined);
   setStepToRender(undefined);
+  setIsClientTransaction(false);
   setIdxTransaction({
     ...transaction,
     messages: [],

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -206,7 +206,9 @@ export const updateTransactionWithNextStep = (
   nextStep: NextStep,
   widgetContext: IWidgetContext,
 ): void => {
-  const { setIdxTransaction, setIsClientTransaction, setMessage, setStepToRender } = widgetContext;
+  const {
+    setIdxTransaction, setIsClientTransaction, setMessage, setStepToRender,
+  } = widgetContext;
   const availableSteps = transaction.availableSteps?.filter(
     ({ name }) => name !== nextStep.name,
   ) || [];

--- a/test/testcafe/framework/page-objects/FactorEnrollPhonePageObject.js
+++ b/test/testcafe/framework/page-objects/FactorEnrollPhonePageObject.js
@@ -1,7 +1,5 @@
 import BasePageObject from './BasePageObject';
 
-const confirmPasswordFieldName = 'confirmPassword';
-
 export default class EnrollPhonePageObject extends BasePageObject {
   constructor(t) {
     super(t);
@@ -19,12 +17,8 @@ export default class EnrollPhonePageObject extends BasePageObject {
     return this.form.setTextBoxValue('Phone number', value, true);
   }
 
-  getConfirmPasswordError() {
-    return this.form.getTextBoxErrorMessage(confirmPasswordFieldName);
-  }
-
   hasErrorBox() {
-    return this.form.hasErrorBox();
+    return this.form.getErrorBox().exists;
   }
 
   getErrorBoxText() {

--- a/test/testcafe/framework/page-objects/FactorEnrollPhonePageObject.js
+++ b/test/testcafe/framework/page-objects/FactorEnrollPhonePageObject.js
@@ -1,0 +1,33 @@
+import BasePageObject from './BasePageObject';
+
+const confirmPasswordFieldName = 'confirmPassword';
+
+export default class EnrollPhonePageObject extends BasePageObject {
+  constructor(t) {
+    super(t);
+  }
+
+  clickReceiveSmsCodeButton() {
+    return this.form.clickButton('Receive a code via SMS');
+  }
+
+  phoneNumberFieldExists() {
+    return this.form.fieldByLabelExists('Phone number');
+  }
+
+  fillPhoneNumber(value) {
+    return this.form.setTextBoxValue('Phone number', value, true);
+  }
+
+  getConfirmPasswordError() {
+    return this.form.getTextBoxErrorMessage(confirmPasswordFieldName);
+  }
+
+  hasErrorBox() {
+    return this.form.hasErrorBox();
+  }
+
+  getErrorBoxText() {
+    return this.form.getErrorBoxText();
+  }
+}

--- a/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
@@ -10,7 +10,7 @@ import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
 const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorEnrollDataPhone)
-  .onRequestTo('http://localhost:3000/idp/idx/challenge')
+  .onRequestTo('http://localhost:3000/idp/idx/credential/enroll')
   .respond(xhrSuccess)
   .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
   .respond(oktaDashboardContent);
@@ -18,7 +18,7 @@ const mock = RequestMock()
 const voiceOnlyOptionMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorEnrollDataPhoneVoice)
-  .onRequestTo('http://localhost:3000/idp/idx/challenge')
+  .onRequestTo('http://localhost:3000/idp/idx/credential/enroll')
   .respond(xhrSuccess)
   .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
   .respond(oktaDashboardContent);

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -27,7 +27,7 @@ const mockEnrollAuthenticatorPassword = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/credential/enroll')
   .respond(xhrAuthenticatorEnrollPassword);
 
-const mockEnrollAuthenticatorPhoneSms = RequestMock()
+const mockEnrollAuthenticatorPhoneSmsInvalidPhone = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrSelectAuthenticators)
   .onRequestTo('http://localhost:3000/idp/idx/credential/enroll')
@@ -37,9 +37,11 @@ const mockEnrollAuthenticatorPhoneSms = RequestMock()
     const body = req.body.toString('utf-8');
     const bodyJson = JSON.parse(body);
     if (bodyJson?.authenticator?.methodType) {
+      // if we POST with methodType its the enroll call when the user enters a phone number
       res.statusCode = '400';
       res.setBody(xhrAuthenticatorEnrollPhoneInvalidNumber);
     } else {
+      // if we POST with methodType its the enroll call when the user clicks the authenticator from the list
       res.statusCode = '200';
       res.setBody(xhrAuthenticatorEnrollDataPhone);
     }
@@ -278,7 +280,7 @@ test.requestHooks(requestLogger, mockEnrollAuthenticatorPassword)('select passwo
   await t.expect(req3.body).eql('{"authenticator":{"id":"autwa6eD9o02iBbtv0g3"},"stateHandle":"02CqFbzJ_zMGCqXut-1CNXfafiTkh9wGlbFqi9Xupt"}');
 });
 
-test.requestHooks(requestLogger, mockEnrollAuthenticatorPhoneSms)('select enroll phone sms, enter invalid phone, hit switch authenticator, and re-select phone', async t => {
+test.requestHooks(requestLogger, mockEnrollAuthenticatorPhoneSmsInvalidPhone)('select enroll phone sms, enter invalid phone, hit switch authenticator, and re-select phone', async t => {
   const selectFactorPage = await setup(t);
   await checkA11y(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Set up security methods');

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -289,7 +289,6 @@ test.requestHooks(requestLogger, mockEnrollAuthenticatorPhoneSms)('select enroll
   await t.expect(enrollPhonePage.phoneNumberFieldExists()).eql(true);
   await enrollPhonePage.fillPhoneNumber('123'); // an invalid phone number
   await enrollPhonePage.clickReceiveSmsCodeButton();
-  await t.debug();
   await t.expect(enrollPhonePage.getErrorBoxText()).eql('Invalid Phone Number.');
   await enrollPhonePage.clickReturnToAuthenticatorListLink();
   // re-select phone

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -302,19 +302,31 @@ test.requestHooks(requestLogger, mockEnrollAuthenticatorPhoneSmsInvalidPhone)('s
   const req1 = requestLogger.requests[0].request;
   await t.expect(req1.url).eql('http://localhost:3000/idp/idx/introspect');
 
+  // clicking phone in authenticator list
   const req2 = requestLogger.requests[1].request;
   await t.expect(req2.url).eql('http://localhost:3000/idp/idx/credential/enroll');
   await t.expect(req2.method).eql('post');
-  // await t.expect(req2.body).eql('{"authenticator":{"id":"autwa6eD9o02iBbtv0g3"},"stateHandle":"02CqFbzJ_zMGCqXut-1CNXfafiTkh9wGlbFqi9Xupt"}');
+  const req2Body = JSON.parse(req2.body);
+  await t.expect(req2Body?.authenticator?.id).notEql(undefined);
+  await t.expect(req2Body?.stateHandle).notEql(undefined);
 
+  // clicking send sms button
   const req3 = requestLogger.requests[2].request;
   await t.expect(req3.url).eql('http://localhost:3000/idp/idx/credential/enroll');
   await t.expect(req3.method).eql('post');
-  // await t.expect(req3.body).eql('{"authenticator":{"id":"autwa6eD9o02iBbtv0g3"},"stateHandle":"02CqFbzJ_zMGCqXut-1CNXfafiTkh9wGlbFqi9Xupt"}');
+  const req3Body = JSON.parse(req3.body);
+  await t.expect(req3Body?.authenticator?.id).notEql(undefined);
+  await t.expect(req3Body?.authenticator?.methodType).eql('sms');
+  await t.expect(req3Body?.authenticator?.phoneNumber).eql('+1123');
+  await t.expect(req3Body?.stateHandle).notEql(undefined);
 
-  const req4 = requestLogger.requests[2].request;
+  // clicking phone in authenticator list
+  const req4 = requestLogger.requests[3].request;
   await t.expect(req4.url).eql('http://localhost:3000/idp/idx/credential/enroll');
   await t.expect(req4.method).eql('post');
+  const req4Body = JSON.parse(req4.body);
+  await t.expect(req4Body?.authenticator?.id).notEql(undefined);
+  await t.expect(req4Body?.stateHandle).notEql(undefined);
 });
 
 test.requestHooks(mockOptionalAuthenticatorEnrollment)('should skip optional enrollment and go to success', async t => {


### PR DESCRIPTION
## Description:

Set `isClientTransaction=false` when returning to authenticator list to ensure the transaction state is reset properly in this transition since we don't use an API call to move between these views.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-592217](https://oktainc.atlassian.net/browse/OKTA-592217)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



