### PR TITLE
OKTA-586845 : g3 : Removing duplicate custom validation function

### DIFF
--- a/src/v3/src/transformer/password/__snapshots__/transformEnrollPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformEnrollPasswordAuthenticator.test.ts.snap
@@ -4,9 +4,6 @@ exports[`Enroll Password Authenticator Transformer Tests should add title, and p
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -84,9 +81,6 @@ exports[`Enroll Password Authenticator Transformer Tests should add title, passw
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -186,9 +180,6 @@ exports[`Enroll Password Authenticator Transformer Tests should add title, passw
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.newPassword": Object {
       "validate": [Function],
     },
@@ -288,9 +279,6 @@ exports[`Enroll Password Authenticator Transformer Tests should add title, passw
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },

--- a/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordAuthenticator.test.ts.snap
@@ -4,9 +4,6 @@ exports[`Expired Password Authenticator Transformer Tests should add updated tit
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -114,9 +111,6 @@ exports[`Expired Password Authenticator Transformer Tests should add updated tit
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -224,9 +218,6 @@ exports[`Expired Password Authenticator Transformer Tests should add updated tit
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },

--- a/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordWarningAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformExpiredPasswordWarningAuthenticator.test.ts.snap
@@ -4,9 +4,6 @@ exports[`Expired Password Warning Authenticator Transformer Tests should add upd
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -108,9 +105,6 @@ exports[`Expired Password Warning Authenticator Transformer Tests should add upd
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -212,9 +206,6 @@ exports[`Expired Password Warning Authenticator Transformer Tests should add upd
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -315,9 +306,6 @@ exports[`Expired Password Warning Authenticator Transformer Tests should add upd
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -426,9 +414,6 @@ exports[`Expired Password Warning Authenticator Transformer Tests should add upd
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -536,9 +521,6 @@ exports[`Expired Password Warning Authenticator Transformer Tests should add upd
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },

--- a/src/v3/src/transformer/password/__snapshots__/transformResetPasswordAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/password/__snapshots__/transformResetPasswordAuthenticator.test.ts.snap
@@ -4,9 +4,6 @@ exports[`Reset Password Authenticator Transformer Tests should add updated title
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -114,9 +111,6 @@ exports[`Reset Password Authenticator Transformer Tests should add updated title
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },
@@ -224,9 +218,6 @@ exports[`Reset Password Authenticator Transformer Tests should add updated title
 Object {
   "data": Object {},
   "dataSchema": Object {
-    "confirmPassword": Object {
-      "validate": [Function],
-    },
     "credentials.passcode": Object {
       "validate": [Function],
     },

--- a/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
+++ b/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
@@ -154,22 +154,6 @@ export const transformEnrollPasswordAuthenticator: IdxStepTransformer = ({
   dataSchema.fieldsToValidate.push('confirmPassword');
   dataSchema.fieldsToValidate.push('passwordMatchesValidation');
 
-  // Controls live field change validation
-  dataSchema.confirmPassword = {
-    validate: (data: FormBag['data']) => {
-      const confirmPw = data.confirmPassword;
-      if (!confirmPw) {
-        return [{
-          name: 'confirmPassword',
-          class: 'ERROR',
-          message: loc('model.validation.field.blank', 'login'),
-          i18n: { key: 'model.validation.field.blank' },
-        }];
-      }
-      return undefined;
-    },
-  };
-
   // Controls form submission validation
   dataSchema[passwordFieldName] = {
     validate: (data: FormBag['data']) => {


### PR DESCRIPTION
## Description:
`confirmPassword` field is a custom field added by the client, however, it is bundled with the `credentials.passcode` field for validation. We do not need to define a validation function for the `confirmPassword` field since it is already defined in the original field from the server, doing so causes issues like the field relaying the incorrect message to screenreader upon validation.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-586845](https://oktainc.atlassian.net/browse/OKTA-586845)

### Reviewers:

### Screenshot/Video:

https://user-images.githubusercontent.com/97472729/227276896-1ec83d6b-f024-4703-b741-c757cd0ffaf8.mov


### Downstream Monolith Build:



