### PR TITLE
OKTA-588958 : Email magic link mobile browser icon fix

### DIFF
--- a/src/v3/src/img/16pxApp.svg
+++ b/src/v3/src/img/16pxApp.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="application-icon">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="application-icon" aria-hidden="true">
 <title id="application-icon">Application</title>
 <rect x="1.5" y="1.5" width="5" height="5" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <rect x="1.5" y="9.5" width="5" height="5" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxApp.svg
+++ b/src/v3/src/img/16pxApp.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="application">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="application-icon">
 <title id="application-icon">Application</title>
 <rect x="1.5" y="1.5" width="5" height="5" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <rect x="1.5" y="9.5" width="5" height="5" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxApp.svg
+++ b/src/v3/src/img/16pxApp.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="application">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="application" aria-hidden="true">
 <title id="application-icon">Application</title>
 <rect x="1.5" y="1.5" width="5" height="5" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <rect x="1.5" y="9.5" width="5" height="5" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxApp.svg
+++ b/src/v3/src/img/16pxApp.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="application" aria-hidden="true">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="application">
 <title id="application-icon">Application</title>
 <rect x="1.5" y="1.5" width="5" height="5" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <rect x="1.5" y="9.5" width="5" height="5" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxDevice.svg
+++ b/src/v3/src/img/16pxDevice.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="desktop" role="img">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="desktop" role="img" aria-hidden="true">
 <title id="desktop-icon">Desktop browser</title>
 <path d="M4.5 14.5H8M11.5 14.5H8M8 14.5V13" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <path d="M3 1.5H13C13.8284 1.5 14.5 2.17157 14.5 3V10C14.5 10.8284 13.8284 11.5 13 11.5H3C2.17157 11.5 1.5 10.8284 1.5 10V3C1.5 2.17157 2.17157 1.5 3 1.5Z" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxDevice.svg
+++ b/src/v3/src/img/16pxDevice.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="desktop" role="img">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="desktop-icon" role="img">
 <title id="desktop-icon">Desktop browser</title>
 <path d="M4.5 14.5H8M11.5 14.5H8M8 14.5V13" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <path d="M3 1.5H13C13.8284 1.5 14.5 2.17157 14.5 3V10C14.5 10.8284 13.8284 11.5 13 11.5H3C2.17157 11.5 1.5 10.8284 1.5 10V3C1.5 2.17157 2.17157 1.5 3 1.5Z" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxDevice.svg
+++ b/src/v3/src/img/16pxDevice.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="desktop-icon" role="img">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="desktop-icon" role="img" aria-hidden="true">
 <title id="desktop-icon">Desktop browser</title>
 <path d="M4.5 14.5H8M11.5 14.5H8M8 14.5V13" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <path d="M3 1.5H13C13.8284 1.5 14.5 2.17157 14.5 3V10C14.5 10.8284 13.8284 11.5 13 11.5H3C2.17157 11.5 1.5 10.8284 1.5 10V3C1.5 2.17157 2.17157 1.5 3 1.5Z" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxDevice.svg
+++ b/src/v3/src/img/16pxDevice.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="desktop" role="img" aria-hidden="true">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="desktop" role="img">
 <title id="desktop-icon">Desktop browser</title>
 <path d="M4.5 14.5H8M11.5 14.5H8M8 14.5V13" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <path d="M3 1.5H13C13.8284 1.5 14.5 2.17157 14.5 3V10C14.5 10.8284 13.8284 11.5 13 11.5H3C2.17157 11.5 1.5 10.8284 1.5 10V3C1.5 2.17157 2.17157 1.5 3 1.5Z" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxDevice.svg
+++ b/src/v3/src/img/16pxDevice.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="desktop" role="img">
-<title id="desktop-icon">Browser</title>
+<title id="desktop-icon">Desktop browser</title>
 <path d="M4.5 14.5H8M11.5 14.5H8M8 14.5V13" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <path d="M3 1.5H13C13.8284 1.5 14.5 2.17157 14.5 3V10C14.5 10.8284 13.8284 11.5 13 11.5H3C2.17157 11.5 1.5 10.8284 1.5 10V3C1.5 2.17157 2.17157 1.5 3 1.5Z" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <rect x="2" y="9" width="12" height="1" fill="#1662DD" class="siwIconFillPrimary"/>

--- a/src/v3/src/img/16pxLocation.svg
+++ b/src/v3/src/img/16pxLocation.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="location" role="img">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="location" role="img" aria-hidden="true">
 <title id="location-icon">Location</title>
 <path d="M2.5 6C2.5 2.88969 4.95673 0.5 8 0.5C11.0433 0.5 13.5 2.88969 13.5 6C13.5 8.17828 12.3122 10.408 10.9484 12.2145C9.81608 13.7144 8.61136 14.859 8.0028 15.3649C7.39633 14.8508 6.1897 13.6812 5.05432 12.1652C3.68717 10.3398 2.5 8.11236 2.5 6Z" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <circle cx="8" cy="6" r="2.5" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxLocation.svg
+++ b/src/v3/src/img/16pxLocation.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="location" role="img" aria-hidden="true">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="location" role="img">
 <title id="location-icon">Location</title>
 <path d="M2.5 6C2.5 2.88969 4.95673 0.5 8 0.5C11.0433 0.5 13.5 2.88969 13.5 6C13.5 8.17828 12.3122 10.408 10.9484 12.2145C9.81608 13.7144 8.61136 14.859 8.0028 15.3649C7.39633 14.8508 6.1897 13.6812 5.05432 12.1652C3.68717 10.3398 2.5 8.11236 2.5 6Z" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <circle cx="8" cy="6" r="2.5" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxLocation.svg
+++ b/src/v3/src/img/16pxLocation.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="location" role="img">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="location-icon" role="img">
 <title id="location-icon">Location</title>
 <path d="M2.5 6C2.5 2.88969 4.95673 0.5 8 0.5C11.0433 0.5 13.5 2.88969 13.5 6C13.5 8.17828 12.3122 10.408 10.9484 12.2145C9.81608 13.7144 8.61136 14.859 8.0028 15.3649C7.39633 14.8508 6.1897 13.6812 5.05432 12.1652C3.68717 10.3398 2.5 8.11236 2.5 6Z" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <circle cx="8" cy="6" r="2.5" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxLocation.svg
+++ b/src/v3/src/img/16pxLocation.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="location-icon" role="img">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="location-icon" role="img" aria-hidden="true">
 <title id="location-icon">Location</title>
 <path d="M2.5 6C2.5 2.88969 4.95673 0.5 8 0.5C11.0433 0.5 13.5 2.88969 13.5 6C13.5 8.17828 12.3122 10.408 10.9484 12.2145C9.81608 13.7144 8.61136 14.859 8.0028 15.3649C7.39633 14.8508 6.1897 13.6812 5.05432 12.1652C3.68717 10.3398 2.5 8.11236 2.5 6Z" stroke="#1662DD" class="siwIconStrokePrimary"/>
 <circle cx="8" cy="6" r="2.5" stroke="#1662DD" class="siwIconStrokePrimary"/>

--- a/src/v3/src/img/16pxMobileDevice.svg
+++ b/src/v3/src/img/16pxMobileDevice.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mobile" role="img">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mobile" role="img" aria-hidden="true">
 <title id="mobile-icon">Mobile browser</title>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M11.5 1H5.5C4.94772 1 4.5 1.44772 4.5 2V14C4.5 14.5523 4.94772 15 5.5 15H11.5C12.0523 15 12.5 14.5523 12.5 14V2C12.5 1.44772 12.0523 1 11.5 1ZM5.5 0C4.39543 0 3.5 0.895431 3.5 2V14C3.5 15.1046 4.39543 16 5.5 16H11.5C12.6046 16 13.5 15.1046 13.5 14V2C13.5 0.895431 12.6046 0 11.5 0H5.5ZM10 13V14H7V13H10ZM8.5 3C8.77614 3 9 2.77614 9 2.5C9 2.22386 8.77614 2 8.5 2C8.22386 2 8 2.22386 8 2.5C8 2.77614 8.22386 3 8.5 3Z" fill="#1662DD" class="siwIconFillPrimary"/>
 </svg>

--- a/src/v3/src/img/16pxMobileDevice.svg
+++ b/src/v3/src/img/16pxMobileDevice.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mobile" role="img" aria-hidden="true">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mobile" role="img">
 <title id="mobile-icon">Mobile browser</title>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M11.5 1H5.5C4.94772 1 4.5 1.44772 4.5 2V14C4.5 14.5523 4.94772 15 5.5 15H11.5C12.0523 15 12.5 14.5523 12.5 14V2C12.5 1.44772 12.0523 1 11.5 1ZM5.5 0C4.39543 0 3.5 0.895431 3.5 2V14C3.5 15.1046 4.39543 16 5.5 16H11.5C12.6046 16 13.5 15.1046 13.5 14V2C13.5 0.895431 12.6046 0 11.5 0H5.5ZM10 13V14H7V13H10ZM8.5 3C8.77614 3 9 2.77614 9 2.5C9 2.22386 8.77614 2 8.5 2C8.22386 2 8 2.22386 8 2.5C8 2.77614 8.22386 3 8.5 3Z" fill="#1662DD" class="siwIconFillPrimary"/>
 </svg>

--- a/src/v3/src/img/16pxMobileDevice.svg
+++ b/src/v3/src/img/16pxMobileDevice.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mobile-icon" role="img">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mobile-icon" role="img" aria-hidden="true">
 <title id="mobile-icon">Mobile browser</title>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M11.5 1H5.5C4.94772 1 4.5 1.44772 4.5 2V14C4.5 14.5523 4.94772 15 5.5 15H11.5C12.0523 15 12.5 14.5523 12.5 14V2C12.5 1.44772 12.0523 1 11.5 1ZM5.5 0C4.39543 0 3.5 0.895431 3.5 2V14C3.5 15.1046 4.39543 16 5.5 16H11.5C12.6046 16 13.5 15.1046 13.5 14V2C13.5 0.895431 12.6046 0 11.5 0H5.5ZM10 13V14H7V13H10ZM8.5 3C8.77614 3 9 2.77614 9 2.5C9 2.22386 8.77614 2 8.5 2C8.22386 2 8 2.22386 8 2.5C8 2.77614 8.22386 3 8.5 3Z" fill="#1662DD" class="siwIconFillPrimary"/>
 </svg>

--- a/src/v3/src/img/16pxMobileDevice.svg
+++ b/src/v3/src/img/16pxMobileDevice.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mobile" role="img">
+<title id="mobile-icon">Mobile browser</title>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.5 1H5.5C4.94772 1 4.5 1.44772 4.5 2V14C4.5 14.5523 4.94772 15 5.5 15H11.5C12.0523 15 12.5 14.5523 12.5 14V2C12.5 1.44772 12.0523 1 11.5 1ZM5.5 0C4.39543 0 3.5 0.895431 3.5 2V14C3.5 15.1046 4.39543 16 5.5 16H11.5C12.6046 16 13.5 15.1046 13.5 14V2C13.5 0.895431 12.6046 0 11.5 0H5.5ZM10 13V14H7V13H10ZM8.5 3C8.77614 3 9 2.77614 9 2.5C9 2.22386 8.77614 2 8.5 2C8.22386 2 8 2.22386 8 2.5C8 2.77614 8.22386 3 8.5 3Z" fill="#1662DD" class="siwIconFillPrimary"/>
+</svg>

--- a/src/v3/src/img/16pxMobileDevice.svg
+++ b/src/v3/src/img/16pxMobileDevice.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mobile" role="img">
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-labelledby="mobile-icon" role="img">
 <title id="mobile-icon">Mobile browser</title>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M11.5 1H5.5C4.94772 1 4.5 1.44772 4.5 2V14C4.5 14.5523 4.94772 15 5.5 15H11.5C12.0523 15 12.5 14.5523 12.5 14V2C12.5 1.44772 12.0523 1 11.5 1ZM5.5 0C4.39543 0 3.5 0.895431 3.5 2V14C3.5 15.1046 4.39543 16 5.5 16H11.5C12.6046 16 13.5 15.1046 13.5 14V2C13.5 0.895431 12.6046 0 11.5 0H5.5ZM10 13V14H7V13H10ZM8.5 3C8.77614 3 9 2.77614 9 2.5C9 2.22386 8.77614 2 8.5 2C8.22386 2 8 2.22386 8 2.5C8 2.77614 8.22386 3 8.5 3Z" fill="#1662DD" class="siwIconFillPrimary"/>
 </svg>

--- a/src/v3/src/transformer/terminal/transformEmailMagicLinkOTPOnlyElements.ts
+++ b/src/v3/src/transformer/terminal/transformEmailMagicLinkOTPOnlyElements.ts
@@ -12,8 +12,9 @@
 
 import { CHALLENGE_INTENT_TO_I18KEY } from '../../constants';
 import AppSvg from '../../img/16pxApp.svg';
-import BrowserSvg from '../../img/16pxDevice.svg';
+import DesktopBrowserSvg from '../../img/16pxDevice.svg';
 import LocationSvg from '../../img/16pxLocation.svg';
+import MobileBrowserSvg from '../../img/16pxMobileDevice.svg';
 import {
   DescriptionElement,
   HeadingElement,
@@ -85,16 +86,19 @@ export const transformEmailMagicLinkOTPOnly: TerminalKeyTransformer = (transacti
     };
   }
 
-  if (client?.value?.browser && client?.value?.os) {
+  const clientOs = client?.value?.os;
+  const clientBrowser = client?.value?.browser;
+  if (clientBrowser && clientOs) {
+    const isMobileDevice = clientOs === 'Android' || clientOs === 'iOS';
     browserImageElement = {
       type: 'ImageWithText',
       options: {
         id: 'browser',
-        SVGIcon: BrowserSvg,
+        SVGIcon: isMobileDevice ? MobileBrowserSvg : DesktopBrowserSvg,
         textContent: loc(
           'idx.return.link.otponly.browser.on.os',
           'login',
-          [client.value.browser, client.value.os],
+          [clientBrowser, clientOs],
         ),
       },
     };

--- a/test/testcafe/framework/page-objects/TerminalOtpOnlyPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalOtpOnlyPageObject.js
@@ -44,6 +44,9 @@ export default class TerminalOtpOnlyPageObject extends TerminalPageObject {
   }
 
   doesBrowserOsSmartphoneIconExist() {
+    if(userVariables.v3) {
+      return this.form.getImageByTitle('Mobile browser').exists;
+    }
     return this.form.elementExist(BROWSER_OS_SMARTPHONE_ICON_SELECTOR);
   }
 

--- a/test/testcafe/framework/page-objects/TerminalOtpOnlyPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalOtpOnlyPageObject.js
@@ -1,3 +1,4 @@
+import { within } from '@testing-library/testcafe';
 import { Selector, userVariables } from 'testcafe';
 import TerminalPageObject from './TerminalPageObject';
 
@@ -45,7 +46,9 @@ export default class TerminalOtpOnlyPageObject extends TerminalPageObject {
 
   doesBrowserOsSmartphoneIconExist() {
     if(userVariables.v3) {
-      return this.form.getImageByTitle('Mobile browser').exists;
+      const iconSelector = getOtpOnlyIconSelector('browser');
+      return within(this.form.getElement(iconSelector))
+        .findByTitle('Mobile browser').exists;
     }
     return this.form.elementExist(BROWSER_OS_SMARTPHONE_ICON_SELECTOR);
   }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -462,6 +462,9 @@ export default class BaseFormObject {
     return within(this.getButton(buttonName)).getByRole('img');
   }
 
+  getImageByTitle(title) {
+    return within(this.el).findByRole('img', {name: title});
+  }
   /**
    * Queries for all elements matching the selector
    * and returns a list of inner texts of the matching elements.

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -461,10 +461,6 @@ export default class BaseFormObject {
   getButtonIcon(buttonName) {
     return within(this.getButton(buttonName)).getByRole('img');
   }
-
-  getImageByTitle(title) {
-    return within(this.el).findByRole('img', {name: title});
-  }
   /**
    * Queries for all elements matching the selector
    * and returns a list of inner texts of the matching elements.

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -461,7 +461,7 @@ export default class BaseFormObject {
   getButtonIcon(buttonName) {
     return within(this.getButton(buttonName)).getByRole('img');
   }
-  
+
   /**
    * Queries for all elements matching the selector
    * and returns a list of inner texts of the matching elements.

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -461,6 +461,7 @@ export default class BaseFormObject {
   getButtonIcon(buttonName) {
     return within(this.getButton(buttonName)).getByRole('img');
   }
+  
   /**
    * Queries for all elements matching the selector
    * and returns a list of inner texts of the matching elements.

--- a/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
+++ b/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, userVariables } from 'testcafe';
+import { RequestMock } from 'testcafe';
 import terminalReturnOtpOnlyFullLocation from '../../../playground/mocks/data/idp/idx/terminal-return-otp-only-full-location.json';
 import terminalReturnOtpOnlyPartialLocation from '../../../playground/mocks/data/idp/idx/terminal-return-otp-only-partial-location.json';
 import terminalReturnOtpOnlyNoLocation from '../../../playground/mocks/data/idp/idx/terminal-return-otp-only-no-location.json';
@@ -120,10 +120,7 @@ async function setupOtpOnly(t) {
       await t.expect(await terminalOtpOnlyPage.doesFormTitleExist()).ok();
       await t.expect(await terminalOtpOnlyPage.doesUserEmailExist()).ok();
       await t.expect(await terminalOtpOnlyPage.doesEnterCodeOnPageExist()).ok();
-      // TODO: Enable in v3 after OKTA-588958 is fixed
-      if (!userVariables.v3) {
-        await t.expect(await terminalOtpOnlyPage.doesBrowserOsSmartphoneIconExist()).ok();
-      }
+      await t.expect(await terminalOtpOnlyPage.doesBrowserOsSmartphoneIconExist()).ok();
       await t.expect(terminalOtpOnlyPage.getFormTitleElement().innerText).eql('Your verification code');
       await t.expect(terminalOtpOnlyPage.getUserEmailElement().innerText).eql('test@okta.com');
       await t.expect(terminalOtpOnlyPage.getEnterCodeOnPageElement().innerText).eql(intent);


### PR DESCRIPTION
## Description:

This PR adds the mobile browser icon to the email magic link flow

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-588958](https://oktainc.atlassian.net/browse/OKTA-588958)

### Reviewers:

### Screenshot/Video:
![image](https://user-images.githubusercontent.com/107433508/228077806-eb2c1e63-222f-4119-b66a-a9df7759b658.png)
### Downstream Monolith Build:



