### PR TITLE
V3 parity spec for enduser email consent view

### DIFF
--- a/test/testcafe/framework/page-objects/EnduserConsentPageObject.js
+++ b/test/testcafe/framework/page-objects/EnduserConsentPageObject.js
@@ -1,4 +1,5 @@
 import ConsentPageObject from './ConsentPageObject';
+import { userVariables } from 'testcafe';
 
 export default class EnduserConsentPageObject extends ConsentPageObject {
   constructor(t) {
@@ -13,15 +14,31 @@ export default class EnduserConsentPageObject extends ConsentPageObject {
     return this.form.clickCancelButton();
   }
 
-  getInfoItemTexts() {
+  getInfoItemTextBrowser() {
+    if(userVariables.v3) {
+      return this.form.getElement('[data-se="text-browser"]').innerText;
+    }
+    return this.form.getInnerTexts('.enduser-email-consent--info');
+  }
+
+  getInfoItemTextAppName() {
+    if(userVariables.v3) {
+      return this.form.getElement('[data-se="text-appName"]').innerText;
+    }
     return this.form.getInnerTexts('.enduser-email-consent--info');
   }
 
   getSaveButtonLabel() {
+    if (userVariables.v3) {
+      return this.form.getElement('[data-type="save"]').innerText; 
+    }
     return this.form.getElement('input[type="submit"]').value;
   }
 
   getCancelButtonLabel() {
+    if (userVariables.v3) {
+      return this.form.getElement('[data-type="cancel"]').innerText; 
+    }
     return this.form.getElement('input[data-type="cancel"]').value;
   }
 }

--- a/test/testcafe/framework/page-objects/EnduserConsentPageObject.js
+++ b/test/testcafe/framework/page-objects/EnduserConsentPageObject.js
@@ -28,13 +28,6 @@ export default class EnduserConsentPageObject extends ConsentPageObject {
     return this.form.getInnerTexts('.enduser-email-consent--info');
   }
 
-  getSaveButtonLabel() {
-    if (userVariables.v3) {
-      return this.form.getElement('[data-type="save"]').innerText; 
-    }
-    return this.form.getElement('input[type="submit"]').value;
-  }
-
   getCancelButtonLabel() {
     if (userVariables.v3) {
       return this.form.getElement('[data-type="cancel"]').innerText; 

--- a/test/testcafe/spec/EnduserEmailConsentView_spec.js
+++ b/test/testcafe/spec/EnduserEmailConsentView_spec.js
@@ -1,4 +1,5 @@
 import { RequestMock, RequestLogger } from 'testcafe';
+import { checkA11y } from '../framework/a11y';
 import EnduserConsentPageObject from '../framework/page-objects/EnduserConsentPageObject';
 import enduserEmailConsentChallengeResponse from '../../../playground/mocks/data/idp/idx/email-challenge-consent';
 import enduserEmailConsentChallengeSuccess from '../../../playground/mocks/data/idp/idx/terminal-return-email-consent';
@@ -34,6 +35,7 @@ async function setup(t) {
 test
   .requestHooks(enduserEmailConsentSuccess)('has the right title, info and button texts', async t => {
     const consentPage = await setup(t);
+    await checkA11y(t);
     const infoTextBrowser = await consentPage.getInfoItemTextBrowser();
     const infoTextAppName = await consentPage.getInfoItemTextAppName();
     const title = await consentPage.getFormTitle();
@@ -50,6 +52,7 @@ test
 test
   .requestHooks(requestLogger, enduserEmailConsentSuccess)('consent granted flow', async t => {
     const consentPage  = await setup(t);
+    await checkA11y(t);
     await consentPage.clickAllowButton();
 
     const {
@@ -75,6 +78,7 @@ test
 test
   .requestHooks(requestLogger, enduserEmailConsentFailure)('consent denied flow', async t => {
     const consentPage  = await setup(t);
+    await checkA11y(t);
     await consentPage.clickDontAllowButton();
 
     const {

--- a/test/testcafe/spec/EnduserEmailConsentView_spec.js
+++ b/test/testcafe/spec/EnduserEmailConsentView_spec.js
@@ -1,5 +1,4 @@
 import { RequestMock, RequestLogger } from 'testcafe';
-import { checkA11y } from '../framework/a11y';
 import EnduserConsentPageObject from '../framework/page-objects/EnduserConsentPageObject';
 import enduserEmailConsentChallengeResponse from '../../../playground/mocks/data/idp/idx/email-challenge-consent';
 import enduserEmailConsentChallengeSuccess from '../../../playground/mocks/data/idp/idx/terminal-return-email-consent';
@@ -23,7 +22,8 @@ const enduserEmailConsentFailure = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/consent')
   .respond(enduserEmailConsentChallengeDenied);
 
-fixture('Enduser Email Consent');
+fixture('Enduser Email Consent')
+  .meta('v3', true);
 
 async function setup(t) {
   const consentPageObject = new EnduserConsentPageObject(t);
@@ -34,13 +34,13 @@ async function setup(t) {
 test
   .requestHooks(enduserEmailConsentSuccess)('has the right title, info and button texts', async t => {
     const consentPage = await setup(t);
-    await checkA11y(t);
-    const infoTexts = await consentPage.getInfoItemTexts();
+    const infoTextBrowser = await consentPage.getInfoItemTextBrowser();
+    const infoTextAppName = await consentPage.getInfoItemTextAppName();
     const title = await consentPage.getFormTitle();
     const saveButtonText = await consentPage.getSaveButtonLabel();
     const cancelButtonText = await consentPage.getCancelButtonLabel();
-    await t.expect(infoTexts).contains('FIREFOX');
-    await t.expect(infoTexts).contains('Info DyneX');
+    await t.expect(infoTextBrowser).contains('FIREFOX');
+    await t.expect(infoTextAppName).contains('Info DyneX');
     await t.expect(title).eql('Did you just try to sign in?');
     await t.expect(saveButtonText).eql('Yes, it\'s me');
     await t.expect(cancelButtonText).eql('No, it\'s not me');
@@ -50,7 +50,6 @@ test
 test
   .requestHooks(requestLogger, enduserEmailConsentSuccess)('consent granted flow', async t => {
     const consentPage  = await setup(t);
-    await checkA11y(t);
     await consentPage.clickAllowButton();
 
     const {
@@ -69,14 +68,13 @@ test
     const terminalPage = new TerminalPageObject(t);
     await t.expect(terminalPage.getBeaconClass()).contains('mfa-okta-email');
     await t.expect(terminalPage.getFormTitle()).contains('Success! Return to the original tab or window');
-    await t.expect(terminalPage.getMessages()).contains('To continue, please return to the original browser tab or window you used to verify.');
-    await t.expect(terminalPage.getMessages()).contains('Close this window anytime.');
+    await t.expect(terminalPage.getMessages(0)).contains('To continue, please return to the original browser tab or window you used to verify.');
+    await t.expect(terminalPage.getMessages(1)).contains('Close this window anytime.');
   });
 
 test
   .requestHooks(requestLogger, enduserEmailConsentFailure)('consent denied flow', async t => {
     const consentPage  = await setup(t);
-    await checkA11y(t);
     await consentPage.clickDontAllowButton();
 
     const {


### PR DESCRIPTION
## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-594859](https://oktainc.atlassian.net/browse/OKTA-594859)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



