### PR TITLE
V1: Allow localisation of UserNotAssignedError with `error.access_denied` translation key

### DIFF
--- a/src/util/OAuthErrors.ts
+++ b/src/util/OAuthErrors.ts
@@ -2,6 +2,7 @@ import { loc } from '@okta/courage';
 
 import { AuthSdkError, OAuthError as SdkOAuthError} from '@okta/okta-auth-js';
 import { OAuthError } from './Errors';
+import Bundles from './Bundles';
 import { ErrorDetails } from 'types/errors';
 
 type ErrorTraits = 'inline' | 'terminal';
@@ -65,6 +66,9 @@ class ClockDriftError extends RecoverableError<TerminalErrorType> {
 class UserNotAssignedError extends RecoverableError<InlineErrorType> {
   constructor(error) {
     super(error, InlineErrorType);
+  }
+  getErrorSummary(): string {
+    return Bundles.login['error.access_denied'] ? loc('error.access_denied', 'login') : super.getErrorSummary();
   }
 }
 


### PR DESCRIPTION

## Description:

Resolves #2690

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-595567](https://oktainc.atlassian.net/browse/OKTA-595567)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



