### PR TITLE
Set flow to authClient if passed as instance

### DIFF
--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -404,7 +404,7 @@ export default class Settings extends Model {
 
   initialize(options) {
     options = options || {};
-    const { colors, authClient } = options;
+    const { colors, authClient, flow } = options;
     let { baseUrl } = options;
 
     if (!baseUrl) {
@@ -420,6 +420,11 @@ export default class Settings extends Model {
         baseUrl = issuer?.split('/oauth2/')[0];
       }
       this.set('baseUrl', baseUrl);
+    }
+
+    // If `flow` and `authClient` instance are passed to settings, set flow in auth client
+    if (authClient && flow) {
+      authClient.idx.setFlow(flow);
     }
 
     if (!baseUrl) {

--- a/test/unit/spec/Settings_spec.js
+++ b/test/unit/spec/Settings_spec.js
@@ -12,12 +12,19 @@ describe('models/Settings', () => {
   });
   
   function mockAuthClient(baseUrl) {
+    let flow;
     const authClient = {
       options: {},
       http: {
         setRequestHeader: () => {}
       },
-      getIssuerOrigin: () => baseUrl
+      getIssuerOrigin: () => baseUrl,
+      idx: {
+        getFlow: () => flow,
+        setFlow: jest.fn().mockImplementation((newFlow) => {
+          flow = newFlow;
+        }),
+      }
     };
     return authClient;
   }
@@ -78,6 +85,22 @@ describe('models/Settings', () => {
       settings.setAuthClient(authClient);
       expect(settings.getAuthClient()).toBe(authClient);
       expect(settings.get('authClient')).toBe(authClient);
+    });
+  });
+
+  describe('flow', () => {
+    it('sets flow in authClient if authClient is passed to settings', () => {
+      const { baseUrl } = testContext;
+      const authClient = mockAuthClient(baseUrl);
+      const flow = 'register';
+      const settings = new Settings({
+        baseUrl,
+        flow,
+        authClient,
+      });
+      expect(settings.getAuthClient()).toBe(authClient);
+      expect(settings.getAuthClient().idx.setFlow).toHaveBeenCalledWith(flow);
+      expect(settings.getAuthClient().idx.getFlow()).toBe(flow);
     });
   });
 

--- a/test/unit/spec/widget/getAuthClient_spec.js
+++ b/test/unit/spec/widget/getAuthClient_spec.js
@@ -10,6 +10,14 @@ describe('widget/getAuthClient', () => {
     expect(authClient instanceof OktaAuth).toBe(true);
   });
 
+  it('creates auth client with predefined flow', () => {
+    const authClient = getAuthClient(OktaAuth, {
+      issuer: 'https://foo.bar',
+      flow: 'register'
+    });
+    expect(authClient.idx.getFlow()).toEqual('register');
+  });
+
   it('returns auth client passed via widget options', () => {
     const mockAuthClient = {
       options: {


### PR DESCRIPTION
## Description:

The [flow](https://github.com/okta/okta-signin-widget#flow) option works only if `authClient` is not passed to `OktaSignIn` constructor params and being constructed in [getAuthClientInstance](https://github.com/okta/okta-signin-widget/blob/master/src/widget/getAuthClient.ts#L45).
This PR fixes this be adding `authClient.setFlow(flow)` for passed instance

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-595063](https://oktainc.atlassian.net/browse/OKTA-595063)

### Reviewers:

### Screenshot/Video:

Configure SIW with
```js
  const authClient: OktaAuth = new OktaAuth({
    issuer: 'https://dev-xxxxxx.okta.com',
    clientId: 'xxxxx',
  });
  const signIn = new OktaSignIn({
    authClient,
    flow: 'resetPassword',
  });
```

Before:
<img width="428" alt="Screenshot 2023-04-05 at 00 07 28" src="https://user-images.githubusercontent.com/72614880/229923125-6784d0b8-827b-4c4e-bc39-a48ab1e6cde4.png">

After:
<img width="441" alt="Screenshot 2023-04-05 at 00 05 59" src="https://user-images.githubusercontent.com/72614880/229923160-49b41717-dcb7-4cf9-a64c-cb812f12bae2.png">



### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=f84c451af9aefc3a3518554261c2ca2f8d4c1590&tab=main

