### PR TITLE
OKTA-594871 : removing success* mock files from v3 ignore list

### DIFF
--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -58,10 +58,6 @@ const v3IgnoredMocks = [
   'terminal-return-otp-only-no-location.json',
   'terminal-return-otp-only-partial-location.json',
   /** END of "page" issue **/
-  /** The below are erroring due to the user identifier, but it has the no-translate class on the element and doesn't fail in other mocks, must investigate TODO: OKTA-594871 */
-  'success-with-app-user.json',
-  'success.json',
-  /** END user identifier issue */
 ];
 
 const optionsForInteractionCodeFlow = {


### PR DESCRIPTION
## Description:
The purpose of this PR is to remove the success* mock files from the **ignore** list for english leak detection. 

Context, these were added because they were failing locally, however, after some additional testing, it looks like because of the redirect, it failed to detect the `no-translate` class on the element because the app navigated away from the view. These are passing for v2 so my conclusion is that it is occurring fast enough to detect the content before redirection.  

My theory was correct, not an issue on bacon because of the speed at which the test executes (prior to redirection).
Bacon Link: https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&page=1&pageSize=6&sha=9a8f5004c5cedf2d8e99510a7387360857887907&tab=main

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-594871](https://oktainc.atlassian.net/browse/OKTA-594871)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



