### PR TITLE
fix courage downstream

### DIFF
--- a/packages/@okta/courage-for-signin-widget/package.json
+++ b/packages/@okta/courage-for-signin-widget/package.json
@@ -22,11 +22,7 @@
     "build:esm": "rollup -c",
     "build": "yarn clean && yarn build:types && yarn build:esm && yarn lint && yarn copy",
     "build:babel": "rm -rf target/babel && yarn babel src -x .ts,.js --out-dir target/babel",
-    "patch": "yarn patch:hbs && yarn patch:hbs2 && yarn patch:qtip && yarn patch:i18n",
-    "patch:hbs": "find ./node_modules/@okta/courage/src -type f | xargs sed -i '' -e \"s/import hbs from 'handlebars-inline-precompile'/import hbs from '@okta\\/handlebars-inline-precompile'/g\"",
-    "patch:hbs2": "find ./node_modules/@okta/babel-plugin-handlebars-inline-precompile -type f | xargs sed -i '' -e \"s/'handlebars-inline-precompile'/'@okta\\/handlebars-inline-precompile'/g\"",
-    "patch:qtip": "find ./node_modules/@okta/courage/src -type f | xargs sed -i '' -e \"s/import 'qtip'/import '@okta\\/qtip'/g\"",
-    "patch:i18n": "find ./node_modules/@okta/courage/src -type f | xargs sed -i '' -e \"s/from 'okta-i18n-bundles'/from '@okta\\/okta-i18n-bundles'/g\""
+    "patch": "./scripts/patch.sh"
   },
   "engines": {
     "node": ">=12.22.0",

--- a/packages/@okta/courage-for-signin-widget/scripts/patch.sh
+++ b/packages/@okta/courage-for-signin-widget/scripts/patch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -xe
+
+SEDOPTION="-i"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SEDOPTION="-i ''"
+fi
+
+# HBS
+find ./node_modules/@okta/courage/src -type f | xargs sed ${SEDOPTION} -e "s/import hbs from 'handlebars-inline-precompile'/import hbs from '@okta\\/handlebars-inline-precompile'/g"
+
+# HBS2
+find ./node_modules/@okta/babel-plugin-handlebars-inline-precompile -type f | xargs sed ${SEDOPTION} -e "s/'handlebars-inline-precompile'/'@okta\\/handlebars-inline-precompile'/g"
+
+# QTIP
+find ./node_modules/@okta/courage/src -type f | xargs sed ${SEDOPTION} -e "s/import 'qtip'/import '@okta\\/qtip'/g"
+
+# I18N
+find ./node_modules/@okta/courage/src -type f | xargs sed ${SEDOPTION} -e "s/from 'okta-i18n-bundles'/from '@okta\\/okta-i18n-bundles'/g"

--- a/packages/@okta/courage-for-signin-widget/scripts/patch.sh
+++ b/packages/@okta/courage-for-signin-widget/scripts/patch.sh
@@ -1,18 +1,19 @@
 #!/bin/bash -xe
 
-SEDOPTION="-i"
+# MacOS has a slightly different implementation of sed
+SED_OPTIONS=("-i")
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  SEDOPTION="-i ''"
+  SED_OPTIONS=("-i" "") # we need to pass an empty parameter after -i
 fi
 
 # HBS
-find ./node_modules/@okta/courage/src -type f | xargs sed ${SEDOPTION} -e "s/import hbs from 'handlebars-inline-precompile'/import hbs from '@okta\\/handlebars-inline-precompile'/g"
+find ./node_modules/@okta/courage/src -type f | xargs sed "${SED_OPTIONS[@]}" -e "s/import hbs from 'handlebars-inline-precompile'/import hbs from '@okta\\/handlebars-inline-precompile'/g"
 
 # HBS2
-find ./node_modules/@okta/babel-plugin-handlebars-inline-precompile -type f | xargs sed ${SEDOPTION} -e "s/'handlebars-inline-precompile'/'@okta\\/handlebars-inline-precompile'/g"
+find ./node_modules/@okta/babel-plugin-handlebars-inline-precompile -type f | xargs sed "${SED_OPTIONS[@]}" -e "s/'handlebars-inline-precompile'/'@okta\\/handlebars-inline-precompile'/g"
 
 # QTIP
-find ./node_modules/@okta/courage/src -type f | xargs sed ${SEDOPTION} -e "s/import 'qtip'/import '@okta\\/qtip'/g"
+find ./node_modules/@okta/courage/src -type f | xargs sed "${SED_OPTIONS[@]}" -e "s/import 'qtip'/import '@okta\\/qtip'/g"
 
 # I18N
-find ./node_modules/@okta/courage/src -type f | xargs sed ${SEDOPTION} -e "s/from 'okta-i18n-bundles'/from '@okta\\/okta-i18n-bundles'/g"
+find ./node_modules/@okta/courage/src -type f | xargs sed "${SED_OPTIONS[@]}" -e "s/from 'okta-i18n-bundles'/from '@okta\\/okta-i18n-bundles'/g"


### PR DESCRIPTION
## Description:
- fixes a courage build error that occurs in CI, but not on local Mac
- specifically, sed behaves differently on Mac than on Posix. Mac wants an empty string '' after the -i command
- move all patch commands into a script

Example output from running downstream against this branch (on previous courage version)

https://github.com/okta/okta-signin-widget/commit/0ae82f7023c5e710b68e329ec120b956528997a5

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-586604](https://oktainc.atlassian.net/browse/OKTA-586604)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



