### PR TITLE
SIW Next | Translate default Security Questions during enrollment

### DIFF
--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -50,7 +50,7 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
   const {
-    translations = [], focus, required, parserOptions,
+    translations = [], focus, required, parserOptions, noTranslate,
   } = uischema;
   const {
     attributes,
@@ -116,6 +116,7 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
           'aria-describedby': ariaDescribedByIds,
           ...attributes,
         }}
+        className={noTranslate ? 'no-translate' : undefined}
         endAdornment={(
           <InputAdornment position="end">
             <Tooltip title={showPassword ? getTranslation(translations, 'hide') : getTranslation(translations, 'show')}>

--- a/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionEnroll.test.ts.snap
+++ b/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionEnroll.test.ts.snap
@@ -85,6 +85,7 @@ Object {
               },
               Object {
                 "key": "credentials.answer_predefined",
+                "noTranslate": true,
                 "options": Object {
                   "inputMeta": Object {
                     "name": "credentials.answer",
@@ -139,6 +140,7 @@ Object {
               },
               Object {
                 "label": "oie.security.question.createQuestion.label",
+                "noTranslate": true,
                 "options": Object {
                   "inputMeta": Object {
                     "name": "credentials.question",
@@ -150,6 +152,7 @@ Object {
               Object {
                 "key": "credentials.answer_custom",
                 "label": "Answer",
+                "noTranslate": true,
                 "options": Object {
                   "inputMeta": Object {
                     "label": "Answer",

--- a/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionVerify.test.ts.snap
+++ b/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionVerify.test.ts.snap
@@ -21,6 +21,7 @@ Object {
         "type": "Title",
       },
       Object {
+        "noTranslate": true,
         "options": Object {
           "inputMeta": Object {
             "name": "credentials.answer",
@@ -71,6 +72,7 @@ Object {
         "type": "Title",
       },
       Object {
+        "noTranslate": true,
         "options": Object {
           "inputMeta": Object {
             "name": "credentials.answer",

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.test.ts
@@ -132,6 +132,8 @@ describe('SecurityQuestionEnroll Tests', () => {
       .toBe('credentials.answer');
     expect((layoutOne.elements[3] as FieldElement).options.inputMeta.secret)
       .toBe(true);
+    expect((layoutOne.elements[3] as FieldElement).noTranslate)
+      .toBe(true);
     expect((layoutOne.elements[4] as ButtonElement).label)
       .toBe('mfa.challenge.verify');
     expect((layoutOne.elements[4] as ButtonElement).options.includeImmutableData)
@@ -156,6 +158,8 @@ describe('SecurityQuestionEnroll Tests', () => {
     expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.name)
       .toBe('credentials.answer');
     expect((layoutTwo.elements[3] as FieldElement).options.inputMeta.secret)
+      .toBe(true);
+    expect((layoutOne.elements[3] as FieldElement).noTranslate)
       .toBe(true);
     expect((layoutTwo.elements[4] as ButtonElement).label)
       .toBe('mfa.challenge.verify');

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.ts
@@ -56,12 +56,14 @@ export const transformSecurityQuestionEnroll: IdxStepTransformer = ({ transactio
   ) as FieldElement;
   predefinedAnswerElement.options.inputMeta.secret = true;
   predefinedAnswerElement.key = `${ANSWER_INPUT_NAME}_predefined`;
+  predefinedAnswerElement.noTranslate = true;
 
   const customAnswerInput = (customQuestionOptions?.[0].value as Input[]).find(({ name }) => name === 'answer');
   const customAnswerElement: FieldElement = {
     type: 'Field',
     key: `${ANSWER_INPUT_NAME}_custom`,
     label: customAnswerInput?.label ?? customAnswerInput?.name,
+    noTranslate: true,
     options: {
       inputMeta: {
         ...customAnswerInput,
@@ -119,6 +121,7 @@ export const transformSecurityQuestionEnroll: IdxStepTransformer = ({ transactio
     uischema.elements,
   ) as FieldElement;
   customQuestionElement.label = loc('oie.security.question.createQuestion.label', 'login');
+  customQuestionElement.noTranslate = true;
 
   // Add the title to the top
   const titleElement: TitleElement = {

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
@@ -58,6 +58,8 @@ describe('SecurityQuestionVerify Tests', () => {
       .toBe('credentials.answer');
     expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.secret)
       .toBe(true);
+      expect((updatedFormBag.uischema.elements[1] as FieldElement).noTranslate)
+      .toBe(true);
     expect((updatedFormBag.uischema.elements[1] as FieldElement).translations?.[0])
       .toEqual({
         i18nKey: '',
@@ -95,6 +97,8 @@ describe('SecurityQuestionVerify Tests', () => {
     expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
       .toBe('credentials.answer');
     expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.secret)
+      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).noTranslate)
       .toBe(true);
     expect((updatedFormBag.uischema.elements[1] as FieldElement).translations?.[0])
       .toEqual({

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
@@ -58,7 +58,7 @@ describe('SecurityQuestionVerify Tests', () => {
       .toBe('credentials.answer');
     expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.secret)
       .toBe(true);
-      expect((updatedFormBag.uischema.elements[1] as FieldElement).noTranslate)
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).noTranslate)
       .toBe(true);
     expect((updatedFormBag.uischema.elements[1] as FieldElement).translations?.[0])
       .toEqual({

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
@@ -45,6 +45,8 @@ export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transactio
       ? relatesTo?.value?.profile?.question as string
       : loc(`security.${relatesTo?.value?.profile?.questionKey}`, 'login'),
   }];
+
+  // TODO: this should be cleaned up once backend API was fixed.
   answerElement.options.inputMeta.secret = true;
   answerElement.noTranslate = true;
 

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
@@ -45,6 +45,8 @@ export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transactio
       ? relatesTo?.value?.profile?.question as string
       : loc(`security.${relatesTo?.value?.profile?.questionKey}`, 'login'),
   }];
+  answerElement.options.inputMeta.secret = true;
+  answerElement.noTranslate = true;
 
   const submitButton: ButtonElement = {
     type: 'Button',

--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
@@ -142,7 +142,7 @@ const appendFooterAccordion = (uischema: UISchemaLayout, app: IdxContext['app'])
         options: {
           id: 'cant-verify',
           summary: loc('oie.verify.webauthn.cant.verify', 'login'),
-          content: app.value?.name === OKTA_AUTHENTICATOR
+          content: app?.value?.name === OKTA_AUTHENTICATOR
             ? getCantVerifyEnrollContent()
             : getCantVerifyChallengeContent(),
         },

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -825,7 +825,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       Answer
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
+                      class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-48"
                       required="true"
                     >
                       <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -307,7 +307,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                       Answer
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-42"
+                      class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-42"
                       required="true"
                     >
                       <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -1318,7 +1318,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       Answer
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-43"
+                      class="MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-43"
                       required="true"
                     >
                       <input
@@ -1868,7 +1868,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       Answer
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
+                      class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-48"
                       required="true"
                     >
                       <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -320,7 +320,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                       Answer
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-42"
+                      class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-42"
                       required="true"
                     >
                       <input
@@ -682,7 +682,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       Answer
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
+                      class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-37"
                       required="true"
                     >
                       <input
@@ -1154,7 +1154,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                       Answer
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-43"
+                      class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-43"
                       required="true"
                     >
                       <input
@@ -1627,7 +1627,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                       Answer
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-43"
+                      class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-43"
                       required="true"
                     >
                       <input

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -138,7 +138,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                     What is the food you least liked as a child?
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-19"
                     required="true"
                   >
                     <input


### PR DESCRIPTION
## Description:
* Fix the localization issue with security question verify and enroll screens

## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-589125](https://oktainc.atlassian.net/browse/OKTA-589125)

### Reviewers:

### Screenshot/Video:

WebAuthn console error
![Screen Shot 2023-03-29 at 3 20 43 PM](https://user-images.githubusercontent.com/100623681/229403098-4b093355-4d7d-4af4-b079-20d1446f70dd.png)

![image](https://user-images.githubusercontent.com/100623681/229408410-ff9234e1-320b-480b-aa6a-42ce4c31de7f.png)

![image](https://user-images.githubusercontent.com/100623681/229408831-f7fdbade-06d8-4da8-be94-c8f1ceee9d78.png)

![image](https://user-images.githubusercontent.com/100623681/229418896-1f8eaec7-87f6-4a2f-8af9-c1315a42b2e0.png)


### Downstream Monolith Build:



