### PR TITLE
[G2] Fix position of email resend view

### DIFF
--- a/src/v2/view-builder/views/email/AuthenticatorEmailViewUtil.js
+++ b/src/v2/view-builder/views/email/AuthenticatorEmailViewUtil.js
@@ -39,7 +39,17 @@ const CheckYourEmailTitle = View.extend({
     return this.options;
   },
 });
-  
+
+const CheckYourEmailEnrollTitle = View.extend({
+  className: 'okta-form-subtitle',
+  attributes: {
+    'data-se': 'o-form-explain',
+  },
+  template: hbs`
+    {{i18n code="oie.email.enroll.subtitle" bundle="login"}}
+  `,
+});
+
 const EnterCodeLink = View.extend({
   template: hbs`
       <button 
@@ -52,6 +62,10 @@ const EnterCodeLink = View.extend({
 
 export function getCheckYourEmailTitle() {
   return CheckYourEmailTitle;
+}
+
+export function getCheckYourEmailEnrollTitle() {
+  return CheckYourEmailEnrollTitle;
 }
 
 export function getEnterCodeLink() {

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -38,14 +38,22 @@ const Body = BaseFormWithPolling.extend(Object.assign(
     },
     initialize() {
       BaseFormWithPolling.prototype.initialize.apply(this, arguments);
-
-      this.add(ResendView, {
-        selector: '.o-form-error-container',
-        options: {
-          resendEmailAction: this.resendEmailAction,
-        }
-      });
       this.startPolling();
+    },
+
+    postRender() {
+      BaseForm.prototype.postRender.apply(this, arguments);
+
+      // Add 1 instance of resend view
+      if (!this.$el.find('.resend-email-view').length) {
+        this.add(ResendView, {
+          selector: '.o-form-error-container',
+          prepend: true,
+          options: {
+            resendEmailAction: this.resendEmailAction,
+          }
+        });
+      }
     },
 
     saveForm() {

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -1,6 +1,6 @@
 import { loc } from '@okta/courage';
 import BaseAuthenticatorEmailView from './BaseAuthenticatorEmailView';
-import { getCheckYourEmailTitle, getEnterCodeLink } from './AuthenticatorEmailViewUtil';
+import { getCheckYourEmailTitle, getEnterCodeLink, getCheckYourEmailEnrollTitle } from './AuthenticatorEmailViewUtil';
 
 const BaseAuthenticatorEmailForm = BaseAuthenticatorEmailView.prototype.Body;
 
@@ -33,13 +33,16 @@ const Body = BaseAuthenticatorEmailForm.extend(
           options: { email, useEmailMagicLinkValue },
         });
       } else {
-        this.subtitle = loc('oie.email.enroll.subtitle', 'login');
+        this.add(getCheckYourEmailEnrollTitle(), {
+          prepend: true,
+          selector: '.o-form-error-container',
+        });
       }
     },
 
     postRender() {
+      BaseAuthenticatorEmailForm.prototype.postRender.apply(this, arguments);
       if (this.isUseEmailMagicLink() !== undefined) {
-        BaseAuthenticatorEmailForm.prototype.postRender.apply(this, arguments);
         if (this.isUseEmailMagicLink()) {
           this.showCodeEntryField(false);
         } else {

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -1,4 +1,3 @@
-import { loc } from '@okta/courage';
 import BaseAuthenticatorEmailView from './BaseAuthenticatorEmailView';
 import { getCheckYourEmailTitle, getEnterCodeLink, getCheckYourEmailEnrollTitle } from './AuthenticatorEmailViewUtil';
 

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -556,6 +556,16 @@ test
     const resendEmailView = challengeEmailPageObject.resendEmailView();
     await t.expect(resendEmailView.innerText).eql('Haven\'t received an email? Send again');
 
+    await t.expect(challengeEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Click the verification link in your email to continue or enter the code below',
+      'Enter Code'
+    ].join('.+'), 'si'));
+
     // 8 poll requests in 32 seconds and 1 resend request after click.
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&
@@ -606,6 +616,16 @@ test
     await t.expect(challengeEmailPageObject.resendEmailView().hasClass('hide')).notOk();
     const resendEmailView = challengeEmailPageObject.resendEmailView();
     await t.expect(resendEmailView.innerText).eql('Haven\'t received an email? Send again');
+
+    await t.expect(challengeEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Click the verification link in your email to continue or enter the code below',
+      'Enter Code'
+    ].join('.+'), 'si'));
   });
 
 test
@@ -620,6 +640,16 @@ test
     const resendEmailView = challengeEmailPageObject.resendEmailView();
     await t.expect(resendEmailView.innerText).eql('Haven\'t received an email? Send again');
 
+    await t.expect(challengeEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Click the verification link in your email to continue or enter the code below',
+      'Enter Code'
+    ].join('.+'), 'si'));
+
     // Navigate away from the view
     await challengeEmailPageObject.clickSignOutLink();
     challengeEmailPageObject.navigateToPage();
@@ -629,6 +659,16 @@ test
     await t.wait(30500);
     await t.expect(challengeEmailPageObject.resendEmailView().hasClass('hide')).notOk();
     await t.expect(resendEmailView.innerText).eql('Haven\'t received an email? Send again');
+
+    await t.expect(challengeEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Click the verification link in your email to continue or enter the code below',
+      'Enter Code'
+    ].join('.+'), 'si'));
   });
 
 test

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -308,6 +308,16 @@ test
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
     await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
 
+    await t.expect(enrollEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Please check your email and enter the code below',
+      'Enter Code'
+    ].join('.+'), 'si'));
+
     // 8 poll requests in 31 seconds and 1 resend request after click.
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&
@@ -354,6 +364,16 @@ test
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
     await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
 
+    await t.expect(enrollEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Click the verification link in your email to continue or enter the code below',
+      'Enter a verification code instead'
+    ].join('.+'), 'si'));
+
     // 8 poll requests in 31 seconds and 1 resend request after click.
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&
@@ -399,6 +419,16 @@ test
     await t.wait(31000);
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
     await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
+
+    await t.expect(enrollEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Enter the verification code in the text box',
+      'Enter Code'
+    ].join('.+'), 'si'));
 
     // 8 poll requests in 31 seconds and 1 resend request after click.
     await t.expect(logger.count(
@@ -447,6 +477,16 @@ test
     await t.wait(15500);
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
     await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
+
+    await t.expect(enrollEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Please check your email and enter the code below',
+      'Enter Code'
+    ].join('.+'), 'si'));
   });
 
 test
@@ -459,6 +499,16 @@ test
     await t.wait(15500);
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
     await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
+
+    await t.expect(enrollEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Click the verification link in your email to continue or enter the code below',
+      'Enter a verification code instead'
+    ].join('.+'), 'si'));
   });
 
 test
@@ -471,4 +521,14 @@ test
     await t.wait(15500);
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
     await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
+
+    await t.expect(enrollEmailPageObject.form.el.innerText).match(new RegExp([
+      // title
+      'Verify with your email',
+      // resend prompt
+      'Haven\'t received an email\\? Send again',
+      // instructions and form imputs
+      'Enter the verification code in the text box',
+      'Enter Code'
+    ].join('.+'), 'si'));
   });


### PR DESCRIPTION
## Description:

The prompt "Haven't received an email? [Send again]" should be displayed immediately below the form title/header (as in G3).

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-578954](https://oktainc.atlassian.net/browse/OKTA-578954)

### Reviewers:

@glenfannin-okta 
@shawyu-okta 

### Screenshot/Video:

`authenticator-enroll-email`

Before:
<img width="417" alt="authenticator-enroll-email (before)" src="https://user-images.githubusercontent.com/72614880/231180354-b6f11ac1-3457-4274-b455-064ec8331957.png">
After:
<img width="425" alt="authenticator-enroll-email (after)" src="https://user-images.githubusercontent.com/72614880/231180470-3dbef2da-2b9c-4ca6-9ad6-ceb47359cd92.png">

`authenticator-verification-email`

Before:
<img width="423" alt="authenticator-verification-email (before)" src="https://user-images.githubusercontent.com/72614880/231180671-cbf3f7ef-41a2-4436-8952-ca6c373b238b.png">
After:
<img width="417" alt="authenticator-verification-email (after)" src="https://user-images.githubusercontent.com/72614880/231180697-a11fb0c1-f424-4597-ad76-45e89e8305d8.png">


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=25bdaa527444013a89f028f4272b4297228ab8ab&tab=main
