### PR TITLE
fix: O365 login screen app banner disappear issue

### DIFF
--- a/assets/sass/modules/_app-login-banner.scss
+++ b/assets/sass/modules/_app-login-banner.scss
@@ -41,12 +41,6 @@
       font-weight: lighter;
       line-height: 26px;
     }
-
-    p {
-      @include max-height-mq(660px) {
-        display: none;
-      }
-    }
   }
 
   .applogin-app-logo {


### PR DESCRIPTION
## Description:

Always show app login banner description no matter of the viewport size.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-594775](https://oktainc.atlassian.net/browse/OKTA-594775)

### Reviewers:

### Screenshot/Video:

Before: 
Description is hidden when viewport height is less than 660px
![Screen Shot 2023-04-12 at 11 12 07 AM](https://user-images.githubusercontent.com/60160041/231501978-cfec2ffc-9aea-4b9e-ab97-03c1ea76397e.png)

After:
Description will always be displayed no matter of what the viewport height is
![Screen Shot 2023-04-12 at 11 08 57 AM](https://user-images.githubusercontent.com/60160041/231501514-9d136484-dacd-409d-b747-28efc3670c27.png)


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=58c5a7a148c1c21c9249730b24c045ddec4d4e23&tab=main



