### PR TITLE
OKTA-566071 : SIW G3 : Applying optional label to fields

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -916,6 +916,7 @@ oie.challenge.answer.hideAnswer = Hide answer
 
 ## a non-required input field marked as "Optional" sublabel
 oie.form.field.optional = Optional
+oie.form.field.optional.description = Fields are required unless marked optional.
 
 ## Password
 oie.password.label = Password

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -664,6 +664,7 @@ oie.auth.logo.aria.label = 》Åûţĥéñţîçåţöŕ ļöĝö 한Ӝฐโ⾼
 oie.challenge.answer.showAnswer = 》Šĥöŵ åñšŵéŕ ئ䀕ヸ€홝한Ӝฐโ《
 oie.challenge.answer.hideAnswer = 》Ĥîðé åñšŵéŕ ئ䀕ヸ€홝한Ӝฐโ《
 oie.form.field.optional = 》Öþţîöñåļ 䀕ヸ€홝한Ӝฐโ《
+oie.form.field.optional.description = 》Ƒîéļðš åŕé ŕéǫûîŕéð ûñļéšš ɱåŕķéð öþţîöñåļ· ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.password.label = 》Þåššŵöŕð 䀕ヸ€홝한Ӝฐโ《
 oie.password.newPasswordLabel = 》Ñéŵ þåššŵöŕð ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.password.authenticator.description = 》Çĥööšé å þåššŵöŕð ƒöŕ ýöûŕ åççöûñţ 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《

--- a/src/v3/src/components/Checkbox/Checkbox.tsx
+++ b/src/v3/src/components/Checkbox/Checkbox.tsx
@@ -11,11 +11,12 @@
  */
 
 import {
+  Box,
   Checkbox as CheckboxMui,
   FormControl,
   FormControlLabel,
 } from '@okta/odyssey-react-mui';
-import { h } from 'preact';
+import { Fragment, h } from 'preact';
 
 import { useWidgetContext } from '../../contexts';
 import { useAutoFocus, useValue } from '../../hooks';
@@ -38,15 +39,16 @@ const Checkbox: UISchemaElementComponent<UISchemaElementComponentWithValidationP
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
 
-  const { options: { inputMeta: { name } }, focus, required } = uischema;
-  const label = getTranslation(uischema.translations!, 'label');
+  const {
+    options: { inputMeta: { name } }, focus, translations = [], showAsterisk,
+  } = uischema;
+  const label = getTranslation(translations, 'label');
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
   const hasErrors = typeof errors !== 'undefined';
 
   return (
     <FormControl
       component="fieldset"
-      required={required}
       error={hasErrors}
       aria-describedby={describedByIds}
     >
@@ -71,7 +73,20 @@ const Checkbox: UISchemaElementComponent<UISchemaElementComponentWithValidationP
             }}
           />
         )}
-        label={label as string}
+        label={(
+          <Fragment>
+            {label}
+            {showAsterisk && (
+              <Box
+                component="span"
+                className="no-translate"
+                aria-hidden
+              >
+                &nbsp;&#42;
+              </Box>
+            )}
+          </Fragment>
+        )}
       />
       {hasErrors && (
         <FieldLevelMessageContainer

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -20,6 +20,7 @@ import {
   InputBase,
   InputLabel,
   Tooltip,
+  Typography,
 } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 import { useState } from 'preact/hooks';
@@ -50,15 +51,16 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
   const {
-    translations = [], focus, required, parserOptions, noTranslate,
+    translations = [], focus, parserOptions, noTranslate, showAsterisk,
   } = uischema;
   const {
     attributes,
-    inputMeta: { name },
+    inputMeta: { name, required },
   } = uischema.options;
   const label = getTranslation(translations, 'label');
   const hint = getTranslation(translations, 'hint');
   const explain = getTranslation(translations, 'bottomExplain');
+  const optionalLabel = getTranslation(translations, 'optionalLabel');
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
   const parsedExplainContent = useHtmlContentParser(explain, parserOptions);
   const hasErrors = typeof errors !== 'undefined';
@@ -81,9 +83,22 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
     <Box>
       <InputLabel
         htmlFor={name}
-        required={required}
+        // To prevent asterisk from shifting far right
+        sx={{ justifyContent: showAsterisk ? 'flex-start' : undefined }}
       >
         {label}
+        {showAsterisk && (
+          <Box
+            component="span"
+            className="no-translate"
+            aria-hidden
+          >
+            &nbsp;&#42;
+          </Box>
+        )}
+        {required === false && (
+          <Typography variant="subtitle1">{optionalLabel}</Typography>
+        )}
       </InputLabel>
       {hint && (
         <FormHelperText

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -15,6 +15,7 @@ import {
   FormHelperText,
   InputBase,
   InputLabel,
+  Typography,
 } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 
@@ -43,14 +44,15 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
   const {
-    translations = [], focus, required, parserOptions,
+    translations = [], focus, parserOptions, showAsterisk,
   } = uischema;
   const label = getTranslation(translations, 'label');
   const hint = getTranslation(translations, 'hint');
   const explain = getTranslation(translations, 'bottomExplain');
+  const optionalLabel = getTranslation(translations, 'optionalLabel');
   const {
     attributes,
-    inputMeta: { name },
+    inputMeta: { name, required },
     dataSe,
   } = uischema.options;
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
@@ -66,9 +68,22 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
     <Box>
       <InputLabel
         htmlFor={name}
-        required={required}
+        // To prevent asterisk from shifting far right
+        sx={{ justifyContent: showAsterisk ? 'flex-start' : undefined }}
       >
         {label}
+        {showAsterisk && (
+          <Box
+            component="span"
+            className="no-translate"
+            aria-hidden
+          >
+            &nbsp;&#42;
+          </Box>
+        )}
+        {required === false && (
+          <Typography variant="subtitle1">{optionalLabel}</Typography>
+        )}
       </InputLabel>
       {
         hint && (

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -17,6 +17,7 @@ import {
   InputBase,
   InputLabel,
   Select,
+  Typography,
 } from '@okta/odyssey-react-mui';
 import { IdxMessage } from '@okta/okta-auth-js';
 import { h } from 'preact';
@@ -52,13 +53,14 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
   const {
     translations = [],
     focus,
-    required,
     ariaDescribedBy,
+    showAsterisk,
     options: {
       inputMeta: {
         name: fieldName,
         // @ts-ignore TODO: OKTA-539834 - messages missing from type
         messages = {},
+        required,
       },
       attributes,
     },
@@ -66,6 +68,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
   const mainLabel = getTranslation(translations, 'label');
   const extensionLabel = getTranslation(translations, 'extension');
   const countryLabel = getTranslation(translations, 'country');
+  const optionalLabel = getTranslation(translations, 'optionalLabel');
 
   const countries = CountryUtil.getCountries() as Record<string, string>;
   const [phone, setPhone] = useState<string>('');
@@ -145,10 +148,23 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
     <Box marginBlockEnd={4}>
       <InputLabel
         id="countryLabel"
-        required={required}
         htmlFor="country"
+        // To prevent asterisk from shifting far right
+        sx={{ justifyContent: showAsterisk ? 'flex-start' : undefined }}
       >
         {countryLabel}
+        {showAsterisk && (
+          <Box
+            component="span"
+            className="no-translate"
+            aria-hidden
+          >
+            &nbsp;&#42;
+          </Box>
+        )}
+        {required === false && (
+          <Typography variant="subtitle1">{optionalLabel}</Typography>
+        )}
       </InputLabel>
       <Select
         id="country"
@@ -197,9 +213,22 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
         >
           <InputLabel
             htmlFor={fieldName}
-            required={required}
+            // To prevent asterisk from shifting far right
+            sx={{ justifyContent: showAsterisk ? 'flex-start' : undefined }}
           >
             {mainLabel}
+            {showAsterisk && (
+              <Box
+                component="span"
+                className="no-translate"
+                aria-hidden
+              >
+                &nbsp;&#42;
+              </Box>
+            )}
+            {required === false && (
+              <Typography variant="subtitle1">{optionalLabel}</Typography>
+            )}
           </InputLabel>
           <InputBase
             type="tel"

--- a/src/v3/src/components/Radio/Radio.tsx
+++ b/src/v3/src/components/Radio/Radio.tsx
@@ -11,11 +11,13 @@
  */
 
 import {
+  Box,
   FormControl,
   FormControlLabel,
   FormLabel,
   Radio as RadioMui,
   RadioGroup,
+  Typography,
 } from '@okta/odyssey-react-mui';
 import { IdxOption } from '@okta/okta-auth-js/types/lib/idx/types/idx-js';
 import { h } from 'preact';
@@ -41,28 +43,48 @@ const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProp
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
   const {
-    required,
     translations = [],
     options: {
       inputMeta: {
         name,
         options,
+        required,
       },
       customOptions,
     },
     focus,
+    showAsterisk,
   } = uischema;
   const label = getTranslation(translations, 'label');
+  const optionalLabel = getTranslation(translations, 'optionalLabel');
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
   const hasErrors = typeof errors !== 'undefined';
 
   return (
     <FormControl
       component="fieldset"
-      required={required}
       error={hasErrors}
     >
-      {label && (<FormLabel>{label}</FormLabel>)}
+      {label && (
+        <FormLabel
+          // To prevent asterisk from shifting far right
+          sx={{ display: 'flex', justifyContent: showAsterisk ? 'flex-start' : 'space-between' }}
+        >
+          {label}
+          {showAsterisk && (
+            <Box
+              component="span"
+              className="no-translate"
+              aria-hidden
+            >
+              &nbsp;&#42;
+            </Box>
+          )}
+          {required === false && (
+            <Typography variant="subtitle1">{optionalLabel}</Typography>
+          )}
+        </FormLabel>
+      )}
       <RadioGroup
         name={name}
         id={name}

--- a/src/v3/src/components/Select/Select.tsx
+++ b/src/v3/src/components/Select/Select.tsx
@@ -11,7 +11,9 @@
  */
 
 import { SelectChangeEvent } from '@mui/material';
-import { FormControl, InputLabel, Select as MuiSelect } from '@okta/odyssey-react-mui';
+import {
+  Box, FormControl, InputLabel, Select as MuiSelect, Typography,
+} from '@okta/odyssey-react-mui';
 import { IdxOption } from '@okta/okta-auth-js/types/lib/idx/types/idx-js';
 import { h } from 'preact';
 
@@ -34,14 +36,17 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
 }) => {
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
-  const { focus, required, translations = [] } = uischema;
+  const { focus, translations = [], showAsterisk } = uischema;
   const label = getTranslation(translations, 'label');
   const emptyOptionLabel = getTranslation(translations, 'empty-option-label');
+  const optionalLabel = getTranslation(translations, 'optionalLabel');
+
   const {
     attributes,
     inputMeta: {
       name,
       options,
+      required,
     },
     customOptions,
   } = uischema.options;
@@ -65,9 +70,26 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
     <FormControl
       disabled={loading}
       error={hasErrors}
-      required={required}
     >
-      <InputLabel htmlFor={name}>{label}</InputLabel>
+      <InputLabel
+        htmlFor={name}
+        // To prevent asterisk from shifting far right
+        sx={{ justifyContent: showAsterisk ? 'flex-start' : undefined }}
+      >
+        {label}
+        {showAsterisk && (
+          <Box
+            component="span"
+            className="no-translate"
+            aria-hidden
+          >
+            &nbsp;&#42;
+          </Box>
+        )}
+        {required === false && (
+          <Typography variant="subtitle1">{optionalLabel}</Typography>
+        )}
+      </InputLabel>
       <MuiSelect
         native
         variant="standard"

--- a/src/v3/src/transformer/i18n/transformField.ts
+++ b/src/v3/src/transformer/i18n/transformField.ts
@@ -15,7 +15,9 @@ import {
   TransformStepFnWithOptions,
 } from '../../types';
 import { traverseLayout } from '../util';
-import { addLabelTranslationToFieldElement } from './util';
+import {
+  addLabelTranslationToFieldElement, addOptionalLabelTranslationToFieldElement,
+} from './util';
 
 export const transformField: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
   traverseLayout({
@@ -23,6 +25,7 @@ export const transformField: TransformStepFnWithOptions = ({ transaction }) => (
     predicate: (element) => element.type === 'Field',
     callback: (element) => {
       addLabelTranslationToFieldElement(transaction, element as FieldElement);
+      addOptionalLabelTranslationToFieldElement(element as FieldElement);
     },
   });
   return formbag;

--- a/src/v3/src/transformer/i18n/util.ts
+++ b/src/v3/src/transformer/i18n/util.ts
@@ -65,3 +65,13 @@ export const addLabelTranslationToFieldElement = (
     });
   }
 };
+
+export const addOptionalLabelTranslationToFieldElement = (
+  element: FieldElement,
+): void => {
+  if (element.options.inputMeta.required === false) {
+    addTranslation({
+      element, name: 'optionalLabel', i18nKey: 'oie.form.field.optional',
+    });
+  }
+};

--- a/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
+++ b/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
@@ -24,6 +24,13 @@ Object {
         "type": "Title",
       },
       Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.form.field.optional.description",
+        },
+        "type": "Description",
+      },
+      Object {
         "options": Object {
           "inputMeta": Object {
             "name": "userProfile.firstName",
@@ -106,6 +113,13 @@ Object {
           "content": "oie.registration.form.title",
         },
         "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.form.field.optional.description",
+        },
+        "type": "Description",
       },
       Object {
         "options": Object {
@@ -213,6 +227,13 @@ Object {
         "type": "Title",
       },
       Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.form.field.optional.description",
+        },
+        "type": "Description",
+      },
+      Object {
         "options": Object {
           "inputMeta": Object {
             "name": "userProfile.firstName",
@@ -282,6 +303,13 @@ Object {
           "content": "oie.registration.form.title",
         },
         "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.form.field.optional.description",
+        },
+        "type": "Description",
       },
       Object {
         "options": Object {

--- a/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfileUpdate.test.ts.snap
+++ b/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfileUpdate.test.ts.snap
@@ -21,6 +21,13 @@ Object {
         "type": "Title",
       },
       Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.form.field.optional.description",
+        },
+        "type": "Description",
+      },
+      Object {
         "options": Object {
           "inputMeta": Object {
             "name": "userProfile.firstName",
@@ -94,6 +101,13 @@ Object {
         "type": "Title",
       },
       Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.form.field.optional.description",
+        },
+        "type": "Description",
+      },
+      Object {
         "options": Object {
           "inputMeta": Object {
             "name": "userProfile.firstName",
@@ -165,6 +179,13 @@ Object {
         "type": "Title",
       },
       Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.form.field.optional.description",
+        },
+        "type": "Description",
+      },
+      Object {
         "options": Object {
           "inputMeta": Object {
             "name": "userProfile.firstName",
@@ -224,6 +245,13 @@ Object {
           "content": "oie.profile.additional.title",
         },
         "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.form.field.optional.description",
+        },
+        "type": "Description",
       },
       Object {
         "options": Object {

--- a/src/v3/src/transformer/profile/transformEnrollProfile.test.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfile.test.ts
@@ -48,20 +48,22 @@ describe('Enroll Profile Transformer Tests', () => {
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.registration.form.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.form.field.optional.description');
     expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.lastName');
+      .toBe('userProfile.firstName');
     expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.lastName');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
       .toBe('userProfile.email');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label)
       .toBe('oie.registration.form.submit');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options?.type)
       .toBe(ButtonType.SUBMIT);
   });
 
@@ -85,24 +87,26 @@ describe('Enroll Profile Transformer Tests', () => {
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.registration.form.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.form.field.optional.description');
     expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.lastName');
+      .toBe('userProfile.firstName');
     expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.email');
+      .toBe('userProfile.lastName');
     expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.email');
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options?.inputMeta.name)
       .toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.attributes?.autocomplete)
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options?.attributes?.autocomplete)
       .toBe('new-password');
-    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label)
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).label)
       .toBe('oie.registration.form.submit');
-    expect((updatedFormBag.uischema.elements[5] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options?.type)
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options?.type)
       .toBe(ButtonType.SUBMIT);
   });
 
@@ -142,35 +146,37 @@ describe('Enroll Profile Transformer Tests', () => {
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
-    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect(updatedFormBag.uischema.elements.length).toBe(8);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.registration.form.title');
-    expect(updatedFormBag.uischema.elements[1].type).toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.id)
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.form.field.optional.description');
+    expect(updatedFormBag.uischema.elements[2].type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.id)
       .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.header)
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.header)
       .toBe('password.complexity.requirements.header');
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.userInfo)
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.userInfo)
       .toEqual(mockUserInfo);
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement).options?.settings)
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.settings)
       .toEqual({ complexity: { minNumber: 1, minSymbol: 1 } });
-    expect((updatedFormBag.uischema.elements[1] as PasswordRequirementsElement)
+    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
       .options?.validationDelayMs).toBe(PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS);
-    expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.firstName');
     expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.lastName');
+      .toBe('userProfile.firstName');
     expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.email');
+      .toBe('userProfile.lastName');
     expect((updatedFormBag.uischema.elements[5] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.email');
+    expect((updatedFormBag.uischema.elements[6] as FieldElement).options?.inputMeta.name)
       .toBe('credentials.passcode');
-    expect((updatedFormBag.uischema.elements[5] as FieldElement).options?.attributes?.autocomplete)
+    expect((updatedFormBag.uischema.elements[6] as FieldElement).options?.attributes?.autocomplete)
       .toBe('new-password');
-    expect((updatedFormBag.uischema.elements[6] as ButtonElement).label)
+    expect((updatedFormBag.uischema.elements[7] as ButtonElement).label)
       .toBe('oie.registration.form.submit');
-    expect((updatedFormBag.uischema.elements[6] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options?.type)
+    expect((updatedFormBag.uischema.elements[7] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[7] as ButtonElement).options?.type)
       .toBe(ButtonType.SUBMIT);
   });
 
@@ -183,25 +189,27 @@ describe('Enroll Profile Transformer Tests', () => {
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
     expect(updatedFormBag).toMatchSnapshot();
-    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect(updatedFormBag.uischema.elements.length).toBe(8);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.registration.form.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.form.field.optional.description');
     expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.lastName');
+      .toBe('userProfile.firstName');
     expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.lastName');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
       .toBe('userProfile.email');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label)
       .toBe('oie.registration.form.submit');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options?.type)
       .toBe(ButtonType.SUBMIT);
-    expect(updatedFormBag.uischema.elements[5].type).toBe('Divider');
-    expect(updatedFormBag.uischema.elements[6].type).toBe('HorizontalLayout');
-    expect(((updatedFormBag.uischema.elements[6] as UISchemaLayout)
+    expect(updatedFormBag.uischema.elements[6].type).toBe('Divider');
+    expect(updatedFormBag.uischema.elements[7].type).toBe('HorizontalLayout');
+    expect(((updatedFormBag.uischema.elements[7] as UISchemaLayout)
       .elements[0] as DescriptionElement).options.content).toBe('haveaccount');
-    expect(((updatedFormBag.uischema.elements[6] as UISchemaLayout)
+    expect(((updatedFormBag.uischema.elements[7] as UISchemaLayout)
       .elements[1] as LinkElement).options.label).toBe('signin');
   });
 });

--- a/src/v3/src/transformer/profile/transformEnrollProfile.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfile.ts
@@ -123,6 +123,12 @@ export const transformEnrollProfile: IdxStepTransformer = ({ transaction, formBa
     options: { content: loc('oie.registration.form.title', 'login') },
   };
 
+  const subtitleElement: DescriptionElement = {
+    type: 'Description',
+    contentType: 'subtitle',
+    options: { content: loc('oie.form.field.optional.description', 'login') },
+  };
+
   const submitBtnElement: ButtonElement = {
     type: 'Button',
     label: loc('oie.registration.form.submit', 'login'),
@@ -146,6 +152,7 @@ export const transformEnrollProfile: IdxStepTransformer = ({ transaction, formBa
     }
   }
 
+  uischema.elements.unshift(subtitleElement);
   uischema.elements.unshift(titleElement);
   uischema.elements.push(submitBtnElement);
 

--- a/src/v3/src/transformer/profile/transformEnrollProfileUpdate.test.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfileUpdate.test.ts
@@ -14,6 +14,7 @@ import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/
 import {
   ButtonElement,
   ButtonType,
+  DescriptionElement,
   FieldElement,
   LinkElement,
   TitleElement,
@@ -44,25 +45,27 @@ describe('Enroll Profile Update Transformer Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.data['userProfile.secondEmail']).toBeUndefined();
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.profile.additional.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.form.field.optional.description');
     expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.lastName');
+      .toBe('userProfile.firstName');
     expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.lastName');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
       .toBe('userProfile.email');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label)
       .toBe('enroll.choices.submit.finish');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options?.type)
       .toBe(ButtonType.SUBMIT);
-    expect(updatedFormBag.uischema.elements[5].type).toBe('Link');
-    expect((updatedFormBag.uischema.elements[5] as LinkElement).options.label)
+    expect(updatedFormBag.uischema.elements[6].type).toBe('Link');
+    expect((updatedFormBag.uischema.elements[6] as LinkElement).options.label)
       .toBe('oie.enroll.skip.profile');
-    expect((updatedFormBag.uischema.elements[5] as LinkElement).options.isActionStep).toBe(false);
+    expect((updatedFormBag.uischema.elements[6] as LinkElement).options.isActionStep).toBe(false);
   });
 
   it('should add title, button and input elements from remediation with all optional fields when skip is missing from remediation', () => {
@@ -72,20 +75,22 @@ describe('Enroll Profile Update Transformer Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.data['userProfile.secondEmail']).toBeUndefined();
-    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.profile.additional.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.form.field.optional.description');
     expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.lastName');
+      .toBe('userProfile.firstName');
     expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.lastName');
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
       .toBe('userProfile.email');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).label)
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label)
       .toBe('enroll.choices.submit.finish');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[4] as ButtonElement).options?.type)
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options?.type)
       .toBe(ButtonType.SUBMIT);
   });
 
@@ -102,22 +107,24 @@ describe('Enroll Profile Update Transformer Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.data['userProfile.secondEmail']).toBeUndefined();
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.profile.additional.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.form.field.optional.description');
     expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.lastName');
+      .toBe('userProfile.firstName');
     expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.email');
+      .toBe('userProfile.lastName');
     expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.email');
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options?.inputMeta.name)
       .toBe('userProfile.anotherField');
-    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label)
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).label)
       .toBe('enroll.choices.submit.finish');
-    expect((updatedFormBag.uischema.elements[5] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options?.type)
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options?.type)
       .toBe(ButtonType.SUBMIT);
   });
 
@@ -134,22 +141,24 @@ describe('Enroll Profile Update Transformer Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.data['userProfile.secondEmail']).toBe('');
-    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.profile.additional.title');
-    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.firstName');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      .toBe('oie.form.field.optional.description');
     expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.lastName');
+      .toBe('userProfile.firstName');
     expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
-      .toBe('userProfile.email');
+      .toBe('userProfile.lastName');
     expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
+      .toBe('userProfile.email');
+    expect((updatedFormBag.uischema.elements[5] as FieldElement).options?.inputMeta.name)
       .toBe('userProfile.secondEmail');
-    expect((updatedFormBag.uischema.elements[5] as ButtonElement).label)
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).label)
       .toBe('enroll.choices.submit.finish');
-    expect((updatedFormBag.uischema.elements[5] as ButtonElement).type).toBe('Button');
-    expect((updatedFormBag.uischema.elements[5] as ButtonElement).options?.type)
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[6] as ButtonElement).options?.type)
       .toBe(ButtonType.SUBMIT);
   });
 });

--- a/src/v3/src/transformer/profile/transformEnrollProfileUpdate.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfileUpdate.ts
@@ -13,6 +13,7 @@
 import {
   ButtonElement,
   ButtonType,
+  DescriptionElement,
   FieldElement,
   IdxStepTransformer,
   LinkElement,
@@ -49,6 +50,12 @@ export const transformEnrollProfileUpdate: IdxStepTransformer = ({ transaction, 
     options: { content: loc('oie.profile.additional.title', 'login') },
   };
 
+  const subtitleElement: DescriptionElement = {
+    type: 'Description',
+    contentType: 'subtitle',
+    options: { content: loc('oie.form.field.optional.description', 'login') },
+  };
+
   const submitBtnElement: ButtonElement = {
     type: 'Button',
     label: loc('enroll.choices.submit.finish', 'login'),
@@ -58,6 +65,7 @@ export const transformEnrollProfileUpdate: IdxStepTransformer = ({ transaction, 
     },
   };
 
+  uischema.elements.unshift(subtitleElement);
   uischema.elements.unshift(titleElement);
   uischema.elements.push(submitBtnElement);
 

--- a/src/v3/src/transformer/uischema/applyAsteriskToFieldElements.ts
+++ b/src/v3/src/transformer/uischema/applyAsteriskToFieldElements.ts
@@ -17,8 +17,9 @@ import {
 } from '../../types';
 import { traverseLayout } from '../util';
 
-// TODO: OKTA-524769 - temporary solution for custom fields in profile enrollment
-export const updateRequiredFields: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
+export const applyAsteriskToFieldElements: TransformStepFnWithOptions = ({
+  transaction,
+}) => (formbag) => {
   const { nextStep: { name = '' } = {} } = transaction;
   if (![IDX_STEP.ENROLL_PROFILE, IDX_STEP.ENROLL_PROFILE_UPDATE].includes(name)) {
     return formbag;
@@ -29,7 +30,7 @@ export const updateRequiredFields: TransformStepFnWithOptions = ({ transaction }
     callback: (el) => {
       const fieldElement = (el as FieldElement);
       const { options: { inputMeta: { required } } } = fieldElement;
-      fieldElement.required = required;
+      fieldElement.showAsterisk = required;
     },
   });
   return formbag;

--- a/src/v3/src/transformer/uischema/transform.test.ts
+++ b/src/v3/src/transformer/uischema/transform.test.ts
@@ -30,8 +30,8 @@ jest.mock('./updateCustomFields', () => ({
 jest.mock('./setFocusOnFirstElement', () => ({
   setFocusOnFirstElement: () => ({}),
 }));
-jest.mock('./updateRequiredFields', () => ({
-  updateRequiredFields: () => () => ({}),
+jest.mock('./applyAsteriskToFieldElements', () => ({
+  applyAsteriskToFieldElements: () => () => ({}),
 }));
 jest.mock('./updatePasswordDescribedByValue', () => ({
   updatePasswordDescribedByValue: () => ({}),
@@ -44,7 +44,7 @@ const mocked = {
   addIdToEle: require('./addIdToElements'),
   updateCustomField: require('./updateCustomFields'),
   setFocus: require('./setFocusOnFirstElement'),
-  updateRequiredField: require('./updateRequiredFields'),
+  applyAsterisk: require('./applyAsteriskToFieldElements'),
   updatePasswordEle: require('./updatePasswordDescribedByValue'),
 };
 /* eslint-enable global-require */
@@ -56,7 +56,7 @@ describe('UISchema transformer', () => {
     jest.spyOn(mocked.addIdToEle, 'addIdToElements');
     jest.spyOn(mocked.updateCustomField, 'updateCustomFields');
     jest.spyOn(mocked.setFocus, 'setFocusOnFirstElement');
-    jest.spyOn(mocked.updateRequiredField, 'updateRequiredFields');
+    jest.spyOn(mocked.applyAsterisk, 'applyAsteriskToFieldElements');
     jest.spyOn(mocked.updatePasswordEle, 'updatePasswordDescribedByValue');
 
     const formBag = getStubFormBag();
@@ -78,7 +78,7 @@ describe('UISchema transformer', () => {
     expect(mocked.addIdToEle.addIdToElements).toHaveBeenCalled();
     expect(mocked.updateCustomField.updateCustomFields).toHaveBeenCalled();
     expect(mocked.setFocus.setFocusOnFirstElement).toHaveBeenCalled();
-    expect(mocked.updateRequiredField.updateRequiredFields).toHaveBeenCalled();
+    expect(mocked.applyAsterisk.applyAsteriskToFieldElements).toHaveBeenCalled();
     expect(mocked.updatePasswordEle.updatePasswordDescribedByValue).toHaveBeenCalled();
   });
 });

--- a/src/v3/src/transformer/uischema/transform.ts
+++ b/src/v3/src/transformer/uischema/transform.ts
@@ -16,20 +16,19 @@ import {
   TransformStepFnWithOptions,
 } from '../../types';
 import { addIdToElements } from './addIdToElements';
+import { applyAsteriskToFieldElements } from './applyAsteriskToFieldElements';
 import { createTextElementKeys } from './createTextElementKeys';
 import { setFocusOnFirstElement } from './setFocusOnFirstElement';
 import { updateCustomFields } from './updateCustomFields';
 import { updateElementKeys } from './updateElementKeys';
 import { updatePasswordDescribedByValue } from './updatePasswordDescribedByValue';
-import { updateRequiredFields } from './updateRequiredFields';
 
 export const transformUISchema: TransformStepFnWithOptions = (
   options,
 ) => (formbag) => flow(
   updateCustomFields,
   setFocusOnFirstElement,
-  // TODO: OKTA-524769 - temporary solution for custom fields in profile enrollment
-  updateRequiredFields(options),
+  applyAsteriskToFieldElements(options),
   createTextElementKeys,
   updateElementKeys(options),
   addIdToElements,

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -242,9 +242,10 @@ export interface FieldElement extends UISchemaElement {
   type: 'Field';
   key: string;
   /**
-   * @description TODO: OKTA-524769 - temporary solution for custom fields in profile enrollment
+   * @description Determines if the app should display an asterisk next to the field label
+   * This only applies for profile enrollment view.
    */
-  required?: boolean | undefined;
+  showAsterisk?: boolean;
   options: {
     inputMeta: Input;
     format?: 'select' | 'radio';

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -87,30 +87,44 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.firstName-error  "
                       aria-invalid="true"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -119,10 +133,10 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.firstName-error"
                       id="userProfile.firstName-error"
                       role="alert"
@@ -136,30 +150,29 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.lastName-error  "
                       aria-invalid="true"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -168,10 +181,10 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.lastName-error"
                       id="userProfile.lastName-error"
                       role="alert"
@@ -185,30 +198,29 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.email-error  "
                       aria-invalid="true"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -218,10 +230,10 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.email-error"
                       id="userProfile.email-error"
                       role="alert"
@@ -235,29 +247,28 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-40"
+                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-43"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-41"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-44"
                     for="userProfile.country"
                   >
                     Country
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk Mui-error emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-43"
+                    class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-46"
                     required="true"
                   >
                     <select
                       aria-describedby=" userProfile.country-error  "
                       aria-invalid="true"
-                      class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-44"
+                      class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-47"
                       data-se="userProfile.country"
                       id="userProfile.country"
                       name="userProfile.country"
@@ -1476,7 +1487,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     </select>
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-45"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-48"
                       data-testid="ArrowDropDownIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1487,10 +1498,10 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     </svg>
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-required emotion-22"
+                      class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-25"
                       data-se="userProfile.country-error"
                       id="userProfile.country-error"
                       role="alert"
@@ -1504,29 +1515,28 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.countryCode"
                   >
                     Country code
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.countryCode-error  "
                       aria-invalid="true"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.countryCode"
                       id="userProfile.countryCode"
                       name="userProfile.countryCode"
@@ -1535,10 +1545,10 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.countryCode-error"
                       id="userProfile.countryCode-error"
                       role="alert"
@@ -1552,29 +1562,28 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-40"
+                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-43"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-41"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-44"
                     for="userProfile.timezone"
                   >
                     Time zone
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk Mui-error emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-43"
+                    class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-46"
                     required="true"
                   >
                     <select
                       aria-describedby=" userProfile.timezone-error  "
                       aria-invalid="true"
-                      class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-44"
+                      class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-47"
                       data-se="userProfile.timezone"
                       id="userProfile.timezone"
                       name="userProfile.timezone"
@@ -1753,7 +1762,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     </select>
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-45"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-48"
                       data-testid="ArrowDropDownIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1764,10 +1773,10 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     </svg>
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-required emotion-22"
+                      class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-25"
                       data-se="userProfile.timezone-error"
                       id="userProfile.timezone-error"
                       role="alert"
@@ -1781,7 +1790,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-66"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-69"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1793,11 +1802,11 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                 class="MuiBox-root emotion-12"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-68"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-71"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-69"
+                class="MuiBox-root emotion-72"
               >
                 <div
                   class="MuiBox-root emotion-12"
@@ -1806,9 +1815,9 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiBox-root emotion-13"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-72"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_11"
+                      id="enroll-profile_Description_Already_have_an_account_12"
                     >
                       Already have an account?
                     </p>
@@ -1818,7 +1827,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                   class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-74"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-77"
                     data-se="back"
                     role="link"
                   >
@@ -1889,29 +1898,43 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-8"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-12"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-7"
+              >
+                <div
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -1925,29 +1948,28 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -1961,29 +1983,28 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -1998,28 +2019,27 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-29"
+                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-32"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-30"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-33"
                     for="userProfile.country"
                   >
                     Country
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-32"
+                    class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-35"
                     required="true"
                   >
                     <select
                       aria-invalid="false"
-                      class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-33"
+                      class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-36"
                       data-se="userProfile.country"
                       id="userProfile.country"
                       name="userProfile.country"
@@ -3238,7 +3258,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     </select>
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-34"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-37"
                       data-testid="ArrowDropDownIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -3254,28 +3274,27 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.countryCode"
                   >
                     Country code
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.countryCode"
                       id="userProfile.countryCode"
                       name="userProfile.countryCode"
@@ -3289,28 +3308,27 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-29"
+                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-32"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-30"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-33"
                     for="userProfile.timezone"
                   >
                     Time zone
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-32"
+                    class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-35"
                     required="true"
                   >
                     <select
                       aria-invalid="false"
-                      class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-33"
+                      class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-36"
                       data-se="userProfile.timezone"
                       id="userProfile.timezone"
                       name="userProfile.timezone"
@@ -3489,7 +3507,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     </select>
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-34"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-37"
                       data-testid="ArrowDropDownIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -3505,7 +3523,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-49"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-52"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -3517,11 +3535,11 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-51"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-54"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-52"
+                class="MuiBox-root emotion-55"
               >
                 <div
                   class="MuiBox-root emotion-7"
@@ -3530,9 +3548,9 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     class="MuiBox-root emotion-8"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-55"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-12"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_11"
+                      id="enroll-profile_Description_Already_have_an_account_12"
                     >
                       Already have an account?
                     </p>
@@ -3542,7 +3560,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                   class="MuiBox-root emotion-7"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                     data-se="back"
                     role="link"
                   >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -54,29 +54,43 @@ exports[`enroll-profile-new should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-8"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-12"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-7"
+              >
+                <div
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -90,29 +104,28 @@ exports[`enroll-profile-new should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -126,29 +139,28 @@ exports[`enroll-profile-new should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -163,7 +175,7 @@ exports[`enroll-profile-new should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-29"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-32"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -175,11 +187,11 @@ exports[`enroll-profile-new should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-31"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-34"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-32"
+                class="MuiBox-root emotion-35"
               >
                 <div
                   class="MuiBox-root emotion-7"
@@ -188,9 +200,9 @@ exports[`enroll-profile-new should render form 1`] = `
                     class="MuiBox-root emotion-8"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-35"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-12"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_8"
+                      id="enroll-profile_Description_Already_have_an_account_9"
                     >
                       Already have an account?
                     </p>
@@ -200,7 +212,7 @@ exports[`enroll-profile-new should render form 1`] = `
                   class="MuiBox-root emotion-7"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                     data-se="back"
                     role="link"
                   >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -54,29 +54,43 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-8"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-12"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-7"
+              >
+                <div
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -90,29 +104,28 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -126,29 +139,28 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -163,28 +175,27 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-14"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-12"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
                     for="userProfile.address"
                   >
                     Street Address
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-13"
+                      class="no-translate MuiBox-root emotion-14"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-14"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-15"
+                      class="MuiInputBase-input emotion-18"
                       data-se="userProfile.address"
                       id="userProfile.address"
                       name="userProfile.address"
@@ -198,7 +209,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                 class="MuiBox-root emotion-7"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-35"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-38"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -210,11 +221,11 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                 class="MuiBox-root emotion-7"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-37"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-40"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-38"
+                class="MuiBox-root emotion-41"
               >
                 <div
                   class="MuiBox-root emotion-7"
@@ -223,9 +234,9 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     class="MuiBox-root emotion-8"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-41"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-12"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_9"
+                      id="enroll-profile_Description_Already_have_an_account_10"
                     >
                       Already have an account?
                     </p>
@@ -235,7 +246,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                   class="MuiBox-root emotion-7"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-46"
                     data-se="back"
                     role="link"
                   >
@@ -339,30 +350,44 @@ exports[`enroll-profile-with-password should show custom error message and preve
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.lastName-error  "
                       aria-invalid="true"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -371,10 +396,10 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.lastName-error"
                       id="userProfile.lastName-error"
                       role="alert"
@@ -388,29 +413,28 @@ exports[`enroll-profile-with-password should show custom error message and preve
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -424,29 +448,28 @@ exports[`enroll-profile-with-password should show custom error message and preve
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -461,7 +484,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-36"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-39"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -473,11 +496,11 @@ exports[`enroll-profile-with-password should show custom error message and preve
                 class="MuiBox-root emotion-12"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-38"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-41"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-39"
+                class="MuiBox-root emotion-42"
               >
                 <div
                   class="MuiBox-root emotion-12"
@@ -486,9 +509,9 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     class="MuiBox-root emotion-13"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-42"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_8"
+                      id="enroll-profile_Description_Already_have_an_account_9"
                     >
                       Already have an account?
                     </p>
@@ -498,7 +521,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                   class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-47"
                     data-se="back"
                     role="link"
                   >
@@ -602,30 +625,44 @@ exports[`enroll-profile-with-password should show custom field level error messa
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.lastName-error  "
                       aria-invalid="true"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -634,10 +671,10 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.lastName-error"
                       id="userProfile.lastName-error"
                       role="alert"
@@ -651,29 +688,28 @@ exports[`enroll-profile-with-password should show custom field level error messa
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -687,29 +723,28 @@ exports[`enroll-profile-with-password should show custom field level error messa
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -724,7 +759,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-36"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-39"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -736,11 +771,11 @@ exports[`enroll-profile-with-password should show custom field level error messa
                 class="MuiBox-root emotion-12"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-38"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-41"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-39"
+                class="MuiBox-root emotion-42"
               >
                 <div
                   class="MuiBox-root emotion-12"
@@ -749,9 +784,9 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     class="MuiBox-root emotion-13"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-42"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_8"
+                      id="enroll-profile_Description_Already_have_an_account_9"
                     >
                       Already have an account?
                     </p>
@@ -761,7 +796,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                   class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-47"
                     data-se="back"
                     role="link"
                   >
@@ -865,29 +900,43 @@ exports[`enroll-profile-with-password should show generic error message and prev
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -901,29 +950,28 @@ exports[`enroll-profile-with-password should show generic error message and prev
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -937,29 +985,28 @@ exports[`enroll-profile-with-password should show generic error message and prev
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -974,7 +1021,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-37"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -986,11 +1033,11 @@ exports[`enroll-profile-with-password should show generic error message and prev
                 class="MuiBox-root emotion-12"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-36"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-39"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-37"
+                class="MuiBox-root emotion-40"
               >
                 <div
                   class="MuiBox-root emotion-12"
@@ -999,9 +1046,9 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     class="MuiBox-root emotion-13"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-40"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_8"
+                      id="enroll-profile_Description_Already_have_an_account_9"
                     >
                       Already have an account?
                     </p>
@@ -1011,7 +1058,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                   class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-45"
                     data-se="back"
                     role="link"
                   >
@@ -1115,30 +1162,44 @@ exports[`enroll-profile-with-password should show validation error messages on a
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.lastName-error  "
                       aria-invalid="true"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -1147,10 +1208,10 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.lastName-error"
                       id="userProfile.lastName-error"
                       role="alert"
@@ -1164,30 +1225,29 @@ exports[`enroll-profile-with-password should show validation error messages on a
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.firstName-error  "
                       aria-invalid="true"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -1196,10 +1256,10 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.firstName-error"
                       id="userProfile.firstName-error"
                       role="alert"
@@ -1213,30 +1273,29 @@ exports[`enroll-profile-with-password should show validation error messages on a
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.email-error  "
                       aria-invalid="true"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -1246,10 +1305,10 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.email-error"
                       id="userProfile.email-error"
                       role="alert"
@@ -1263,29 +1322,28 @@ exports[`enroll-profile-with-password should show validation error messages on a
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.address"
                   >
                     Street Address
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-19"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.address-error  "
                       aria-invalid="true"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.address"
                       id="userProfile.address"
                       name="userProfile.address"
@@ -1294,10 +1352,10 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-16"
+                    class="MuiBox-root emotion-19"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-22"
+                      class="MuiFormHelperText-root Mui-error emotion-25"
                       data-se="userProfile.address-error"
                       id="userProfile.address-error"
                       role="alert"
@@ -1311,7 +1369,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-48"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1323,11 +1381,11 @@ exports[`enroll-profile-with-password should show validation error messages on a
                 class="MuiBox-root emotion-12"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-50"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-53"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-51"
+                class="MuiBox-root emotion-54"
               >
                 <div
                   class="MuiBox-root emotion-12"
@@ -1336,9 +1394,9 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     class="MuiBox-root emotion-13"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-54"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_9"
+                      id="enroll-profile_Description_Already_have_an_account_10"
                     >
                       Already have an account?
                     </p>
@@ -1348,7 +1406,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                   class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
                     data-se="back"
                     role="link"
                   >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -91,21 +91,41 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                 class="MuiBox-root emotion-12"
               >
                 <div
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="profile-update_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.newAttribute"
                   >
                     Some custom attribute
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-21"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-18"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-19"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.newAttribute"
                       id="userProfile.newAttribute"
                       name="userProfile.newAttribute"
@@ -122,19 +142,24 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.secondEmail"
                   >
                     Secondary email
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-21"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-18"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby="userProfile.secondEmail-explain"
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-19"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.secondEmail"
                       id="userProfile.secondEmail"
                       name="userProfile.secondEmail"
@@ -143,7 +168,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     />
                   </div>
                   <p
-                    class="MuiFormHelperText-root o-form-explain emotion-25"
+                    class="MuiFormHelperText-root o-form-explain emotion-30"
                     data-se="userProfile.secondEmail-explain"
                     id="userProfile.secondEmail-explain"
                   >
@@ -164,18 +189,23 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.newAttribute2"
                   >
                     Some custom attribute 2
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-21"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-18"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-19"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.newAttribute2"
                       id="userProfile.newAttribute2"
                       name="userProfile.newAttribute2"
@@ -189,7 +219,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-32"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-38"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -201,7 +231,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                   data-se="skip"
                   role="link"
                 >
@@ -212,7 +242,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                   data-se="cancel"
                   role="link"
                 >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -124,21 +124,41 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                 class="MuiBox-root emotion-17"
               >
                 <div
+                  class="MuiBox-root emotion-18"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-22"
+                    data-se="o-form-explain"
+                    id="profile-update_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-17"
+              >
+                <div
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
                     for="userProfile.newAttribute"
                   >
                     Some custom attribute
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-24"
+                      class="MuiInputBase-input emotion-28"
                       data-se="userProfile.newAttribute"
                       id="userProfile.newAttribute"
                       name="userProfile.newAttribute"
@@ -155,19 +175,24 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
                     for="userProfile.secondEmail"
                   >
                     Secondary email
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
                     required="true"
                   >
                     <input
                       aria-describedby="userProfile.secondEmail-explain"
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-24"
+                      class="MuiInputBase-input emotion-28"
                       data-se="userProfile.secondEmail"
                       id="userProfile.secondEmail"
                       name="userProfile.secondEmail"
@@ -176,7 +201,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                     />
                   </div>
                   <p
-                    class="MuiFormHelperText-root o-form-explain emotion-30"
+                    class="MuiFormHelperText-root o-form-explain emotion-35"
                     data-se="userProfile.secondEmail-explain"
                     id="userProfile.secondEmail-explain"
                   >
@@ -197,26 +222,25 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-22"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-38"
                     for="userProfile.newAttribute2"
                   >
                     Some custom attribute 2
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-34"
+                      class="no-translate MuiBox-root emotion-8"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-23"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.newAttribute2-error  "
                       aria-invalid="true"
-                      class="MuiInputBase-input emotion-24"
+                      class="MuiInputBase-input emotion-28"
                       data-se="userProfile.newAttribute2"
                       id="userProfile.newAttribute2"
                       name="userProfile.newAttribute2"
@@ -228,7 +252,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                     class="MuiBox-root emotion-8"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-30"
+                      class="MuiFormHelperText-root Mui-error emotion-35"
                       data-se="userProfile.newAttribute2-error"
                       id="userProfile.newAttribute2-error"
                       role="alert"
@@ -242,7 +266,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                 class="MuiBox-root emotion-17"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-40"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-45"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -254,7 +278,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                 class="MuiBox-root emotion-17"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-47"
                   data-se="cancel"
                   role="link"
                 >
@@ -361,21 +385,41 @@ exports[`enroll-profile-update-required-field should render form with one requir
                 class="MuiBox-root emotion-12"
               >
                 <div
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="profile-update_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.newAttribute"
                   >
                     Some custom attribute
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-21"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-18"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-19"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.newAttribute"
                       id="userProfile.newAttribute"
                       name="userProfile.newAttribute"
@@ -392,19 +436,24 @@ exports[`enroll-profile-update-required-field should render form with one requir
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.secondEmail"
                   >
                     Secondary email
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-21"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-18"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-describedby="userProfile.secondEmail-explain"
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-19"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.secondEmail"
                       id="userProfile.secondEmail"
                       name="userProfile.secondEmail"
@@ -413,7 +462,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     />
                   </div>
                   <p
-                    class="MuiFormHelperText-root o-form-explain emotion-25"
+                    class="MuiFormHelperText-root o-form-explain emotion-30"
                     data-se="userProfile.secondEmail-explain"
                     id="userProfile.secondEmail-explain"
                   >
@@ -434,25 +483,24 @@ exports[`enroll-profile-update-required-field should render form with one requir
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-33"
                     for="userProfile.newAttribute2"
                   >
                     Some custom attribute 2
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-29"
+                      class="no-translate MuiBox-root emotion-8"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-18"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-19"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.newAttribute2"
                       id="userProfile.newAttribute2"
                       name="userProfile.newAttribute2"
@@ -466,7 +514,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-38"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -478,7 +526,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                   data-se="cancel"
                   role="link"
                 >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -124,29 +124,43 @@ exports[`enroll-profile-update fails client side validation with empty required 
                 class="MuiBox-root emotion-17"
               >
                 <div
+                  class="MuiBox-root emotion-18"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-22"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-17"
+              >
+                <div
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-22"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
                     for="userProfile.favoriteSport"
                   >
                     Favorite sport
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-23"
+                      class="no-translate MuiBox-root emotion-8"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-24"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-27"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.favoriteSport-error  "
                       aria-invalid="true"
-                      class="MuiInputBase-input emotion-25"
+                      class="MuiInputBase-input emotion-28"
                       data-se="userProfile.favoriteSport"
                       id="userProfile.favoriteSport"
                       name="userProfile.favoriteSport"
@@ -158,7 +172,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
                     class="MuiBox-root emotion-8"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-27"
+                      class="MuiFormHelperText-root Mui-error emotion-30"
                       data-se="userProfile.favoriteSport-error"
                       id="userProfile.favoriteSport-error"
                       role="alert"
@@ -175,26 +189,25 @@ exports[`enroll-profile-update fails client side validation with empty required 
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-22"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
                     for="userProfile.newAttribute"
                   >
                     Custom attribute
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-23"
+                      class="no-translate MuiBox-root emotion-8"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-24"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
                     required="true"
                   >
                     <input
                       aria-describedby=" userProfile.newAttribute-error  "
                       aria-invalid="true"
-                      class="MuiInputBase-input emotion-25"
+                      class="MuiInputBase-input emotion-28"
                       data-se="userProfile.newAttribute"
                       id="userProfile.newAttribute"
                       name="userProfile.newAttribute"
@@ -206,7 +219,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
                     class="MuiBox-root emotion-8"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-27"
+                      class="MuiFormHelperText-root Mui-error emotion-30"
                       data-se="userProfile.newAttribute-error"
                       id="userProfile.newAttribute-error"
                       role="alert"
@@ -220,7 +233,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
                 class="MuiBox-root emotion-17"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-37"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-40"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -328,28 +341,42 @@ exports[`enroll-profile-update should render form 1`] = `
                 class="MuiBox-root emotion-12"
               >
                 <div
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
+                <div
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.favoriteSport"
                   >
                     Favorite sport
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-8"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.favoriteSport"
                       id="userProfile.favoriteSport"
                       name="userProfile.favoriteSport"
@@ -366,25 +393,24 @@ exports[`enroll-profile-update should render form 1`] = `
                   class="MuiBox-root emotion-8"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-17"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                     for="userProfile.newAttribute"
                   >
                     Custom attribute
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-18"
+                      class="no-translate MuiBox-root emotion-8"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input emotion-20"
+                      class="MuiInputBase-input emotion-23"
                       data-se="userProfile.newAttribute"
                       id="userProfile.newAttribute"
                       name="userProfile.newAttribute"
@@ -398,7 +424,7 @@ exports[`enroll-profile-update should render form 1`] = `
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-28"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
                   data-type="save"
                   tabindex="0"
                   type="submit"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -86,35 +86,50 @@ exports[`enroll-profile-with-password should display field level error when pass
               <div
                 class="MuiBox-root emotion-12"
               >
+                <div
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_NON_NULL_VALUE_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
                 <figure
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                   data-se="password-authenticator--rules"
-                  id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_2"
+                  id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
                 >
                   <figcaption
-                    class="password-authenticator--heading MuiBox-root emotion-17"
+                    class="password-authenticator--heading MuiBox-root emotion-20"
                   >
                     Password requirements:
                   </figcaption>
                   <ul
-                    class="MuiBox-root emotion-18"
+                    class="MuiBox-root emotion-21"
                     id="password-authenticator--list"
                   >
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -134,10 +149,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             At least 8 characters
                           </p>
@@ -145,20 +160,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -178,10 +193,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             A lowercase letter
                           </p>
@@ -189,20 +204,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -222,10 +237,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             An uppercase letter
                           </p>
@@ -233,20 +248,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -266,10 +281,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             A number
                           </p>
@@ -277,20 +292,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -310,10 +325,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             No parts of your username
                           </p>
@@ -327,29 +342,28 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-17"
+                  class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-56"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-57"
+                      class="no-translate MuiBox-root emotion-20"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-58"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-59"
+                      class="MuiInputBase-input emotion-62"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -364,29 +378,28 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-17"
+                  class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-56"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-57"
+                      class="no-translate MuiBox-root emotion-20"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-58"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-59"
+                      class="MuiInputBase-input emotion-62"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -400,29 +413,28 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-17"
+                  class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-56"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-57"
+                      class="no-translate MuiBox-root emotion-20"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-58"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-59"
+                      class="MuiInputBase-input emotion-62"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -436,30 +448,29 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-17"
+                  class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-56"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
                     for="credentials.passcode"
                   >
                     Password
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-57"
+                      class="no-translate MuiBox-root emotion-20"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-58"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-61"
                     required="true"
                   >
                     <input
-                      aria-describedby=" credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_2 "
+                      aria-describedby=" credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_3 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-59"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -467,13 +478,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-78"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-81"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-79"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-82"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -497,32 +508,32 @@ exports[`enroll-profile-with-password should display field level error when pass
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-17"
+                    class="MuiBox-root emotion-20"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-82"
+                      class="MuiFormHelperText-root Mui-error emotion-85"
                       data-se="credentials.passcode-error"
                       id="credentials.passcode-error"
                       role="alert"
                     >
                       <div
-                        class="MuiBox-root emotion-83"
+                        class="MuiBox-root emotion-86"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-84"
+                          class="MuiTypography-root MuiTypography-body1 emotion-87"
                         >
                           Password requirements were not met:
                         </p>
                         <ul
-                          class="MuiList-root MuiList-dense emotion-85"
+                          class="MuiList-root MuiList-dense emotion-88"
                         >
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-86"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-89"
                           >
                             At least 8 characters
                           </li>
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-86"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-89"
                           >
                             An uppercase letter
                           </li>
@@ -536,7 +547,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-89"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-92"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -548,11 +559,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-91"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-94"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-92"
+                class="MuiBox-root emotion-95"
               >
                 <div
                   class="MuiBox-root emotion-12"
@@ -561,9 +572,9 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-13"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-95"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_NON_NULL_VALUE_10"
+                      id="enroll-profile_Description_Already_have_an_account_NON_NULL_VALUE_11"
                     >
                       Already have an account?
                     </p>
@@ -573,7 +584,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-97"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
                     data-se="back"
                     role="link"
                   >
@@ -676,35 +687,50 @@ exports[`enroll-profile-with-password should display field level error when pass
               <div
                 class="MuiBox-root emotion-12"
               >
+                <div
+                  class="MuiBox-root emotion-13"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_NON_NULL_VALUE_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-12"
+              >
                 <figure
-                  class="MuiBox-root emotion-16"
+                  class="MuiBox-root emotion-19"
                   data-se="password-authenticator--rules"
-                  id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_2"
+                  id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
                 >
                   <figcaption
-                    class="password-authenticator--heading MuiBox-root emotion-17"
+                    class="password-authenticator--heading MuiBox-root emotion-20"
                   >
                     Password requirements:
                   </figcaption>
                   <ul
-                    class="MuiBox-root emotion-18"
+                    class="MuiBox-root emotion-21"
                     id="password-authenticator--list"
                   >
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -724,10 +750,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             At least 8 characters
                           </p>
@@ -735,20 +761,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -768,10 +794,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             A lowercase letter
                           </p>
@@ -779,20 +805,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -812,10 +838,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             An uppercase letter
                           </p>
@@ -823,20 +849,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -856,10 +882,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             A number
                           </p>
@@ -867,20 +893,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-22"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-21"
+                          class="MuiBox-root emotion-24"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-22"
+                            class="passwordRequirementIcon MuiBox-root emotion-25"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -900,10 +926,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-17"
+                          class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             No parts of your username
                           </p>
@@ -917,29 +943,28 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-17"
+                  class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-56"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-57"
+                      class="no-translate MuiBox-root emotion-20"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-58"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-59"
+                      class="MuiInputBase-input emotion-62"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -954,29 +979,28 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-17"
+                  class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-56"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-57"
+                      class="no-translate MuiBox-root emotion-20"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-58"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-59"
+                      class="MuiInputBase-input emotion-62"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -990,29 +1014,28 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-17"
+                  class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-56"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-57"
+                      class="no-translate MuiBox-root emotion-20"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-58"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-59"
+                      class="MuiInputBase-input emotion-62"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -1026,30 +1049,29 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <div
-                  class="MuiBox-root emotion-17"
+                  class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-56"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
                     for="credentials.passcode"
                   >
                     Password
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-57"
+                      class="no-translate MuiBox-root emotion-20"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-58"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-61"
                     required="true"
                   >
                     <input
-                      aria-describedby=" credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_2 "
+                      aria-describedby=" credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_3 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-59"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -1057,13 +1079,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-78"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-81"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-79"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-82"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -1087,10 +1109,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-17"
+                    class="MuiBox-root emotion-20"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-82"
+                      class="MuiFormHelperText-root Mui-error emotion-85"
                       data-se="credentials.passcode-error"
                       id="credentials.passcode-error"
                       role="alert"
@@ -1104,7 +1126,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-84"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-87"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1116,11 +1138,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-86"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-89"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-87"
+                class="MuiBox-root emotion-90"
               >
                 <div
                   class="MuiBox-root emotion-12"
@@ -1129,9 +1151,9 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-13"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-90"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-17"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_NON_NULL_VALUE_10"
+                      id="enroll-profile_Description_Already_have_an_account_NON_NULL_VALUE_11"
                     >
                       Already have an account?
                     </p>
@@ -1141,7 +1163,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-92"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-95"
                     data-se="back"
                     role="link"
                   >
@@ -1211,35 +1233,50 @@ exports[`enroll-profile-with-password should render form 1`] = `
               <div
                 class="MuiBox-root emotion-7"
               >
+                <div
+                  class="MuiBox-root emotion-8"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-12"
+                    data-se="o-form-explain"
+                    id="enroll-profile_Description_Fields_are_required_unless_marked_optional_NON_NULL_VALUE_2"
+                  >
+                    Fields are required unless marked optional.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-7"
+              >
                 <figure
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-14"
                   data-se="password-authenticator--rules"
-                  id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_2"
+                  id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
                 >
                   <figcaption
-                    class="password-authenticator--heading MuiBox-root emotion-12"
+                    class="password-authenticator--heading MuiBox-root emotion-15"
                   >
                     Password requirements:
                   </figcaption>
                   <ul
-                    class="MuiBox-root emotion-13"
+                    class="MuiBox-root emotion-16"
                     id="password-authenticator--list"
                   >
                     <li
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-17"
                     >
                       <div
-                        class="MuiBox-root emotion-15"
+                        class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-16"
+                          class="MuiBox-root emotion-19"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-17"
+                            class="passwordRequirementIcon MuiBox-root emotion-20"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-18"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -1259,10 +1296,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-12"
+                          class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-20"
+                            class="MuiTypography-root MuiTypography-body1 emotion-23"
                           >
                             At least 8 characters
                           </p>
@@ -1270,20 +1307,20 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-17"
                     >
                       <div
-                        class="MuiBox-root emotion-15"
+                        class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-16"
+                          class="MuiBox-root emotion-19"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-17"
+                            class="passwordRequirementIcon MuiBox-root emotion-20"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-18"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -1303,10 +1340,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-12"
+                          class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-20"
+                            class="MuiTypography-root MuiTypography-body1 emotion-23"
                           >
                             A lowercase letter
                           </p>
@@ -1314,20 +1351,20 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-17"
                     >
                       <div
-                        class="MuiBox-root emotion-15"
+                        class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-16"
+                          class="MuiBox-root emotion-19"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-17"
+                            class="passwordRequirementIcon MuiBox-root emotion-20"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-18"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -1347,10 +1384,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-12"
+                          class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-20"
+                            class="MuiTypography-root MuiTypography-body1 emotion-23"
                           >
                             An uppercase letter
                           </p>
@@ -1358,20 +1395,20 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-17"
                     >
                       <div
-                        class="MuiBox-root emotion-15"
+                        class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-16"
+                          class="MuiBox-root emotion-19"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-17"
+                            class="passwordRequirementIcon MuiBox-root emotion-20"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-18"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -1391,10 +1428,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-12"
+                          class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-20"
+                            class="MuiTypography-root MuiTypography-body1 emotion-23"
                           >
                             A number
                           </p>
@@ -1402,20 +1439,20 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </div>
                     </li>
                     <li
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-17"
                     >
                       <div
-                        class="MuiBox-root emotion-15"
+                        class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-16"
+                          class="MuiBox-root emotion-19"
                         >
                           <div
                             aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-17"
+                            class="passwordRequirementIcon MuiBox-root emotion-20"
                           >
                             <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-18"
+                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
                               fill="none"
                               focusable="false"
                               role="img"
@@ -1435,10 +1472,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </div>
                         </div>
                         <div
-                          class="MuiBox-root emotion-12"
+                          class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-20"
+                            class="MuiTypography-root MuiTypography-body1 emotion-23"
                           >
                             No parts of your username
                           </p>
@@ -1452,29 +1489,28 @@ exports[`enroll-profile-with-password should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-15"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-51"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-52"
+                      class="no-translate MuiBox-root emotion-15"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-53"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-54"
+                      class="MuiInputBase-input emotion-57"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -1489,29 +1525,28 @@ exports[`enroll-profile-with-password should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-15"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-51"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-52"
+                      class="no-translate MuiBox-root emotion-15"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-53"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-54"
+                      class="MuiInputBase-input emotion-57"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -1525,29 +1560,28 @@ exports[`enroll-profile-with-password should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-15"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-51"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-52"
+                      class="no-translate MuiBox-root emotion-15"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-53"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-54"
+                      class="MuiInputBase-input emotion-57"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -1561,30 +1595,29 @@ exports[`enroll-profile-with-password should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-15"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root emotion-51"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     for="credentials.passcode"
                   >
                     Password
                     <span
                       aria-hidden="true"
-                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-52"
+                      class="no-translate MuiBox-root emotion-15"
                     >
-                       
-                      *
+                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-53"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-56"
                     required="true"
                   >
                     <input
-                      aria-describedby="enroll-profile_PasswordRequirements_NON_NULL_VALUE_2"
+                      aria-describedby="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-54"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-57"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -1592,20 +1625,20 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-73"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-76"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-74"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-77"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-75"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-78"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1627,7 +1660,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-77"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-80"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1639,11 +1672,11 @@ exports[`enroll-profile-with-password should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-79"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-82"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-80"
+                class="MuiBox-root emotion-83"
               >
                 <div
                   class="MuiBox-root emotion-7"
@@ -1652,9 +1685,9 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-8"
                   >
                     <p
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-83"
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-12"
                       data-se="haveaccount"
-                      id="enroll-profile_Description_Already_have_an_account_NON_NULL_VALUE_10"
+                      id="enroll-profile_Description_Already_have_an_account_NON_NULL_VALUE_11"
                     >
                       Already have an account?
                     </p>
@@ -1664,7 +1697,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   class="MuiBox-root emotion-7"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-88"
                     data-se="back"
                     role="link"
                   >

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -339,31 +339,36 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
                   >
                     Which option do you want to try?
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-19"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiFormGroup-root emotion-19"
+                    class="MuiFormGroup-root emotion-20"
                     data-se="authenticator.channel"
                     id="authenticator.channel"
                     role="radiogroup"
                   >
                     <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                     >
                       <span
-                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary emotion-21"
+                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary emotion-22"
                       >
                         <input
-                          class="PrivateSwitchBase-input emotion-22"
+                          class="PrivateSwitchBase-input emotion-23"
                           name="authenticator.channel"
                           type="radio"
                           value="email"
                         />
                         <span
-                          class="emotion-23"
+                          class="emotion-24"
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
                             data-testid="RadioButtonUncheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -374,7 +379,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-26"
                             data-testid="RadioButtonCheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -386,29 +391,29 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                         </span>
                       </span>
                       <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-27"
                       >
                         Email me a setup link
                       </span>
                     </label>
                     <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                     >
                       <span
-                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary emotion-21"
+                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary emotion-22"
                       >
                         <input
-                          class="PrivateSwitchBase-input emotion-22"
+                          class="PrivateSwitchBase-input emotion-23"
                           name="authenticator.channel"
                           type="radio"
                           value="sms"
                         />
                         <span
-                          class="emotion-23"
+                          class="emotion-24"
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
                             data-testid="RadioButtonUncheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -419,7 +424,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-32"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-33"
                             data-testid="RadioButtonCheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -431,7 +436,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                         </span>
                       </span>
                       <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-27"
                       >
                         Text me a setup link
                       </span>
@@ -443,7 +448,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-35"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-36"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -459,7 +464,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 >
                   Or 
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways switch-channel-link emotion-38"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways switch-channel-link emotion-39"
                     href="#"
                   >
                     try a different way
@@ -471,7 +476,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                   data-se="switchAuthenticator"
                   role="link"
                 >
@@ -482,7 +487,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                   data-se="cancel"
                   role="link"
                 >
@@ -1094,31 +1099,36 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
                   >
                     Which option do you want to try?
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-19"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiFormGroup-root emotion-19"
+                    class="MuiFormGroup-root emotion-20"
                     data-se="authenticator.channel"
                     id="authenticator.channel"
                     role="radiogroup"
                   >
                     <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                     >
                       <span
-                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary emotion-21"
+                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary emotion-22"
                       >
                         <input
-                          class="PrivateSwitchBase-input emotion-22"
+                          class="PrivateSwitchBase-input emotion-23"
                           name="authenticator.channel"
                           type="radio"
                           value="qrcode"
                         />
                         <span
-                          class="emotion-23"
+                          class="emotion-24"
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
                             data-testid="RadioButtonUncheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1129,7 +1139,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-26"
                             data-testid="RadioButtonCheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1141,29 +1151,29 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                         </span>
                       </span>
                       <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-27"
                       >
                         Scan a QR code
                       </span>
                     </label>
                     <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                     >
                       <span
-                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary emotion-21"
+                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary emotion-22"
                       >
                         <input
-                          class="PrivateSwitchBase-input emotion-22"
+                          class="PrivateSwitchBase-input emotion-23"
                           name="authenticator.channel"
                           type="radio"
                           value="sms"
                         />
                         <span
-                          class="emotion-23"
+                          class="emotion-24"
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
                             data-testid="RadioButtonUncheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1174,7 +1184,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-32"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-33"
                             data-testid="RadioButtonCheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1186,7 +1196,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                         </span>
                       </span>
                       <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-27"
                       >
                         Text me a setup link
                       </span>
@@ -1198,7 +1208,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-35"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-36"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1210,7 +1220,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                   data-se="switchAuthenticator"
                   role="link"
                 >
@@ -1221,7 +1231,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                   data-se="cancel"
                   role="link"
                 >
@@ -1784,31 +1794,36 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
                   >
                     Which option do you want to try?
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-19"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiFormGroup-root emotion-19"
+                    class="MuiFormGroup-root emotion-20"
                     data-se="authenticator.channel"
                     id="authenticator.channel"
                     role="radiogroup"
                   >
                     <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                     >
                       <span
-                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary emotion-21"
+                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary emotion-22"
                       >
                         <input
-                          class="PrivateSwitchBase-input emotion-22"
+                          class="PrivateSwitchBase-input emotion-23"
                           name="authenticator.channel"
                           type="radio"
                           value="email"
                         />
                         <span
-                          class="emotion-23"
+                          class="emotion-24"
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
                             data-testid="RadioButtonUncheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1819,7 +1834,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-26"
                             data-testid="RadioButtonCheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1831,29 +1846,29 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                         </span>
                       </span>
                       <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-27"
                       >
                         Email me a setup link
                       </span>
                     </label>
                     <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                     >
                       <span
-                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary emotion-21"
+                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary emotion-22"
                       >
                         <input
-                          class="PrivateSwitchBase-input emotion-22"
+                          class="PrivateSwitchBase-input emotion-23"
                           name="authenticator.channel"
                           type="radio"
                           value="sms"
                         />
                         <span
-                          class="emotion-23"
+                          class="emotion-24"
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
                             data-testid="RadioButtonUncheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1864,7 +1879,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-32"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-33"
                             data-testid="RadioButtonCheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1876,7 +1891,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                         </span>
                       </span>
                       <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-27"
                       >
                         Text me a setup link
                       </span>
@@ -1888,7 +1903,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-35"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-36"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1904,7 +1919,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 >
                   Or 
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways switch-channel-link emotion-38"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways switch-channel-link emotion-39"
                     href="#"
                   >
                     try a different way
@@ -1916,7 +1931,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                   data-se="switchAuthenticator"
                   role="link"
                 >
@@ -1927,7 +1942,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                   data-se="cancel"
                   role="link"
                 >
@@ -3796,31 +3811,36 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
                   >
                     Which option do you want to try?
+                    <p
+                      class="MuiTypography-root MuiTypography-subtitle1 emotion-19"
+                    >
+                      Optional
+                    </p>
                   </label>
                   <div
-                    class="MuiFormGroup-root emotion-19"
+                    class="MuiFormGroup-root emotion-20"
                     data-se="authenticator.channel"
                     id="authenticator.channel"
                     role="radiogroup"
                   >
                     <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                     >
                       <span
-                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary emotion-21"
+                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary emotion-22"
                       >
                         <input
-                          class="PrivateSwitchBase-input emotion-22"
+                          class="PrivateSwitchBase-input emotion-23"
                           name="authenticator.channel"
                           type="radio"
                           value="qrcode"
                         />
                         <span
-                          class="emotion-23"
+                          class="emotion-24"
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
                             data-testid="RadioButtonUncheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -3831,7 +3851,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-26"
                             data-testid="RadioButtonCheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -3843,29 +3863,29 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                         </span>
                       </span>
                       <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-27"
                       >
                         Scan a QR code
                       </span>
                     </label>
                     <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                     >
                       <span
-                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary emotion-21"
+                        class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary emotion-22"
                       >
                         <input
-                          class="PrivateSwitchBase-input emotion-22"
+                          class="PrivateSwitchBase-input emotion-23"
                           name="authenticator.channel"
                           type="radio"
                           value="email"
                         />
                         <span
-                          class="emotion-23"
+                          class="emotion-24"
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
                             data-testid="RadioButtonUncheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -3876,7 +3896,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                           </svg>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-32"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-33"
                             data-testid="RadioButtonCheckedIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -3888,7 +3908,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                         </span>
                       </span>
                       <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-27"
                       >
                         Email me a setup link
                       </span>
@@ -3900,7 +3920,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-35"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-36"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -3912,7 +3932,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                   data-se="switchAuthenticator"
                   role="link"
                 >
@@ -3923,7 +3943,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                   data-se="cancel"
                   role="link"
                 >

--- a/test/testcafe/framework/page-objects/EnrollProfileUpdateViewPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollProfileUpdateViewPageObject.js
@@ -1,3 +1,4 @@
+import { userVariables } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 export default class EnrollProfileUpdateViewPageObject extends BasePageObject {
@@ -14,6 +15,9 @@ export default class EnrollProfileUpdateViewPageObject extends BasePageObject {
   }
 
   getFormFieldSubLabel(fieldName) {
+    if (userVariables.v3) {
+      return this.form.getElement(`label[for="${fieldName}"] > p`).innerText;
+    }
     return this.form.getFormFieldSubLabel(fieldName);
   }
 

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -32,20 +32,6 @@ const ignoredMocks = [
 
 const v3IgnoredMocks = [
   'consent-granular.json', // TODO: Not yet implemented OKTA-594847
-  /** The below are all erroring due to the asterisk next to labels, OKTA-566071 will resolve this **/
-  'enroll-profile-new-checkbox.json',
-  'enroll-profile-new-custom-labels.json',
-  'enroll-profile-new-with-hcaptcha.json',
-  'enroll-profile-new-with-recaptcha-v2.json',
-  'enroll-profile-new.json',
-  'enroll-profile-with-idps.json',
-  'enroll-profile-with-password-returns-error.json',
-  'enroll-profile-with-password-returns-multiple-errors.json',
-  'enroll-profile-with-password.json',
-  'enroll-profile.json',
-  'error-new-signup-email-exists.json',
-  'error-new-signup-email.json',
-  /** END of asterisk issue */
   'success-with-interaction-code.json', // Receiving error regarding codeVerifier from auth-js, must investigate TODO: OKTA-594851
   /** The below mocks are all complaining about the "page" text in the description but it IS localized. Need to investigate TODO: OKTA-594852 **/ 
   'terminal-return-otp-only-full-location-mobile-icon-authentication.json',

--- a/test/testcafe/spec/EnrollProfileUpdateView_spec.js
+++ b/test/testcafe/spec/EnrollProfileUpdateView_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, RequestLogger, userVariables } from 'testcafe';
+import { RequestMock, RequestLogger } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import EnrollProfileUpdateViewPageObject from '../framework/page-objects/EnrollProfileUpdateViewPageObject';
@@ -55,10 +55,7 @@ test.requestHooks(xhrEnrollProfileUpdateMock)('should have correct form title, f
   await t.expect(enrollProfileUpdatePage.getFormTitle()).eql('Additional Profile information');
   await t.expect(await enrollProfileUpdatePage.skipProfileLinkExists()).eql(false);
   await t.expect(await enrollProfileUpdatePage.formFieldExistsByLabel('Secondary email')).eql(true);
-  // TODO: OKTA-524769 - awaitng ODY team to create wrapped components to enable optional sub label in v3
-  if (!userVariables.v3) {
-    await t.expect(enrollProfileUpdatePage.getFormFieldSubLabel('userProfile.secondEmail')).eql('Optional');
-  }
+  await t.expect(enrollProfileUpdatePage.getFormFieldSubLabel('userProfile.secondEmail')).eql('Optional');
 
   // show error when field is required
   await enrollProfileUpdatePage.clickFinishButton();

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -187,10 +187,8 @@ test.requestHooks(requestLogger, EnrollProfileSignUpAllBaseAttributesMock)('All 
   };
 
   Object.keys(formFieldToLabel).forEach(async (formField) => {
-    // const selector = `userProfile.${formField}`;
     // verify all base attributes map to correct translation
     // all 'label' fields for base attributes in json are appended with a '1'
-    // await t.expect(await enrollProfilePage.getFormFieldLabel(selector)).eql(formFieldToLabel[formField]);
     await t.expect(await enrollProfilePage.form.fieldByLabelExists(formFieldToLabel[formField])).eql(true);
   });
 });

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -146,8 +146,7 @@ test.requestHooks(requestLogger, EnrollProfileSignUpWithBooleanFieldsMock)('shou
   await enrollProfilePage.setCheckbox('userProfile.optional');
 });
 
-// TODO: OKTA-524769 - Enable this for v3 once ODY Team enables optional sub label in field elements
-test.meta('v3', false).requestHooks(requestLogger, EnrollProfileSignUpAllBaseAttributesMock)('All Base Attributes are rendered based on their i18n translation, not the label in the json file', async t => {
+test.requestHooks(requestLogger, EnrollProfileSignUpAllBaseAttributesMock)('All Base Attributes are rendered based on their i18n translation, not the label in the json file', async t => {
   const enrollProfilePage = new EnrollProfileViewPageObject(t);
   const identityPage = await setup(t);
   await checkA11y(t);
@@ -188,10 +187,11 @@ test.meta('v3', false).requestHooks(requestLogger, EnrollProfileSignUpAllBaseAtt
   };
 
   Object.keys(formFieldToLabel).forEach(async (formField) => {
-    const selector = `userProfile.${formField}`;
+    // const selector = `userProfile.${formField}`;
     // verify all base attributes map to correct translation
     // all 'label' fields for base attributes in json are appended with a '1'
-    await t.expect(await enrollProfilePage.getFormFieldLabel(selector)).eql(formFieldToLabel[formField]);
+    // await t.expect(await enrollProfilePage.getFormFieldLabel(selector)).eql(formFieldToLabel[formField]);
+    await t.expect(await enrollProfilePage.form.fieldByLabelExists(formFieldToLabel[formField])).eql(true);
   });
 });
 


### PR DESCRIPTION
## Description:
The purpose of this PR is to apply the `Optional` label for optional field elements throughout the SIW. Additionally, for required fields displayed on the profile enrollment page, the ask is to display an asterisk next to the label of required fields along with the sub title denoting that all fields are required unless otherwise stated.

PR for the added translation: https://github.com/okta/okta-signin-widget/pull/3207

Bacon link: https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&page=1&pageSize=6&sha=35b17a53dd2fff85ade3163b56c07d2701adc218&tab=main

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-566071](https://oktainc.atlassian.net/browse/OKTA-566071)

### Reviewers:

### Screenshot/Video:
<img width="528" alt="Screen Shot 2023-04-12 at 6 49 27 PM" src="https://user-images.githubusercontent.com/97472729/231603116-3e4ae5d1-71df-4069-8a1f-151f0a7557f8.png">
<img width="532" alt="Screen Shot 2023-04-12 at 6 49 36 PM" src="https://user-images.githubusercontent.com/97472729/231603118-867d8182-31f2-40df-b14c-bd555a01dcf5.png">
<img width="510" alt="Screen Shot 2023-04-12 at 6 49 52 PM" src="https://user-images.githubusercontent.com/97472729/231603120-6f259928-eb49-4b41-97fd-e11057d342ed.png">


### Downstream Monolith Build:



