### PR TITLE
OKTA-566071 : SIW G3 : Adding translation for profile enrollment page

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -919,7 +919,6 @@ oie.challenge.answer.hideAnswer = Hide answer
 ## a non-required input field marked as "Optional" sublabel
 oie.form.field.optional = Optional
 oie.form.field.optional.description = Fields are required unless marked optional.
-
 ## Password
 oie.password.label = Password
 oie.password.newPasswordLabel = New password

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -918,6 +918,7 @@ oie.challenge.answer.hideAnswer = Hide answer
 
 ## a non-required input field marked as "Optional" sublabel
 oie.form.field.optional = Optional
+oie.form.field.optional.description = Fields are required unless marked optional.
 
 ## Password
 oie.password.label = Password

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -666,6 +666,7 @@ oie.auth.logo.aria.label = 》Åûţĥéñţîçåţöŕ ļöĝö 한Ӝฐโ⾼
 oie.challenge.answer.showAnswer = 》Šĥöŵ åñšŵéŕ ئ䀕ヸ€홝한Ӝฐโ《
 oie.challenge.answer.hideAnswer = 》Ĥîðé åñšŵéŕ ئ䀕ヸ€홝한Ӝฐโ《
 oie.form.field.optional = 》Öþţîöñåļ 䀕ヸ€홝한Ӝฐโ《
+oie.form.field.optional.description = 》Ƒîéļðš åŕé ŕéǫûîŕéð ûñļéšš ɱåŕķéð öþţîöñåļ· ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.password.label = 》Þåššŵöŕð 䀕ヸ€홝한Ӝฐโ《
 oie.password.newPasswordLabel = 》Ñéŵ þåššŵöŕð ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.password.authenticator.description = 》Çĥööšé å þåššŵöŕð ƒöŕ ýöûŕ åççöûñţ 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《


### PR DESCRIPTION
## Description:
The purpose of this PR is to add a new translation for the profile enrollment page for SIW G3. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-566071](https://oktainc.atlassian.net/browse/OKTA-566071)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



