### PR TITLE
OKTA-598607: remove dockolith repo url

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -104,5 +104,5 @@ test_suites:
       sort_order: '1'
       timeout: '30'
       script_name: e2e-monolith
-      criteria: OPTIONAL
+      criteria: MERGE
       queue_name: ci-queue-prodJenga-Monolith-Build

--- a/.bacon.yml
+++ b/.bacon.yml
@@ -102,7 +102,7 @@ test_suites:
     - name: e2e-monolith
       script_path: ../okta-signin-widget/scripts
       sort_order: '1'
-      timeout: '30'
+      timeout: '60'
       script_name: e2e-monolith
       criteria: MERGE
       queue_name: ci-queue-prodJenga-Monolith-Build

--- a/scripts/downstream/create-downstream-for-dockolith.sh
+++ b/scripts/downstream/create-downstream-for-dockolith.sh
@@ -1,10 +1,20 @@
 #!/bin/bash -xe
-: "${upstream_artifact_branch?:"missing upstream_artifact_branch"}"
 
-local dockolith_branch="${upstream_artifact_branch}"
-local widget_home="$(readlink -f "$(dirname "$BASH_SOURCE")/../..")"
+# download dockolith artifact version if empty and assign to upstream_artifact_version
+if [[ -z "${upstream_artifact_version}" ]]; then
+  pushd ${OKTA_HOME}/dockolith > /dev/null
+    download_job_data global artifact_version upstream_artifact_version dockolith ${upstream_artifact_sha}
+  popd > /dev/null
+  echo "dockolith version that will be tested: ${upstream_artifact_version}"
+fi
 
-# Update script
-pushd ${widget_home}/scripts/monolith > /dev/null
-sed -i "s/\(DOCKOLITH_BRANCH\=\).*/\1\"${dockolith_branch}\"/g" install-dockolith.sh
+pushd ${OKTA_HOME}/okta-signin-widget/scripts > /dev/null
+
+# Get the dockolith version to use
+DOCKOLITH_VERSION="$(echo ${upstream_artifact_version} | cut -d'@' -f3)"
+
+# Update setup script
+echo "Update dockolith version in scripts/setup.sh to ${DOCKOLITH_VERSION}"
+sed -i "s/\(DOCKOLITH_VERSION\=\).*/\1\"${DOCKOLITH_VERSION}\"/g" setup.sh
+
 popd > /dev/null

--- a/scripts/e2e-monolith.sh
+++ b/scripts/e2e-monolith.sh
@@ -8,7 +8,6 @@ export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/junit"
 echo $TEST_SUITE_TYPE > $TEST_SUITE_TYPE_FILE
 echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
 export ORG_OIE_ENABLED=true
-export DOCKOLITH_BRANCH=${DOCKOLITH_BRANCH:-dockolith-1.6.0}
 
 set +e
 source $OKTA_HOME/$REPO/scripts/setup.sh

--- a/scripts/monolith/get-token.sh
+++ b/scripts/monolith/get-token.sh
@@ -3,5 +3,5 @@
 # Dockolith should be installed before running this script
 # Gets an API token from local monolith and exports to environment var: $OKTA_CLIENT_TOKEN
 
-source ./scripts/dockolith/scripts/api/get-token.sh
+source ${DOCKOLITH_HOME}/scripts/api/get-token.sh
 echo $OKTA_CLIENT_TOKEN

--- a/scripts/monolith/install-dockolith.sh
+++ b/scripts/monolith/install-dockolith.sh
@@ -1,24 +1,17 @@
 #!/bin/bash -xe
 
-if [[ -z ${DOCKOLITH_BRANCH} ]]; then
-  export DOCKOLITH_BRANCH=master
+if [[ -z ${DOCKOLITH_VERSION} ]]; then
+  export DOCKOLITH_VERSION=1.6.1
 fi
 
-pushd ./scripts
-  rm -rf dockolith
-  echo "Cloning dockolith from branch: ${DOCKOLITH_BRANCH}"
-  git clone --depth 1 -b $DOCKOLITH_BRANCH https://github.com/okta/dockolith.git
-  
-  # build dockolith target
-  pushd ./dockolith
-  yarn
-  yarn build
-  popd
-popd
 
-# Yarn "add" always modifies package.json https://github.com/yarnpkg/yarn/issues/1743
-# Make a backup of package.json and restore it after install
-cp package.json package.json.bak
-yarn add -DW --no-lockfile file:./scripts/dockolith
-mv package.json.bak package.json
-
+# only install if not triggered by upstream build
+if [[ -z "${upstream_artifact_version}" ]]; then
+  # Yarn "add" always modifies package.json https://github.com/yarnpkg/yarn/issues/1743
+  # Make a backup of package.json and restore it after install
+  # NOTE: export YARN_REGISTRY as env var when running locally
+  # YARN_REGISTRY={internalRegistry} yarn add @okta/dockolith@1.6.1 -WD --no-lockfile
+  cp package.json package.json.bak
+  yarn add -DW --no-lockfile @okta/dockolith@$DOCKOLITH_VERSION
+  mv package.json.bak package.json
+fi

--- a/scripts/monolith/install-dockolith.sh
+++ b/scripts/monolith/install-dockolith.sh
@@ -6,7 +6,7 @@ fi
 
 
 # only install if not triggered by upstream build
-if [[ -z "${upstream_artifact_version}" ]]; then
+if [[ -z ${DOCKOLITH_DOWNSTREAM} ]]; then
   # Yarn "add" always modifies package.json https://github.com/yarnpkg/yarn/issues/1743
   # Make a backup of package.json and restore it after install
   # NOTE: export YARN_REGISTRY as env var when running locally

--- a/scripts/monolith/lib/common-widget-setup.sh
+++ b/scripts/monolith/lib/common-widget-setup.sh
@@ -3,7 +3,7 @@
 export WIDGET_HOME=${WIDGET_HOME:-`(readlink -f "$(dirname "$0")/../../..")`}
 export WIDGET_VERSION="${WIDGET_VERSION:-$(cat ${WIDGET_HOME}/package.json | jq '.version' -r)}"
 export SYNTHETIC_WIDGET_VERSION=${SYNTHETIC_WIDGET_VERSION:-${WIDGET_VERSION}-local}
-export DOCKOLITH_HOME="${DOCKOLITH_HOME:-${WIDGET_HOME}/scripts/dockolith}"
+export DOCKOLITH_HOME="${DOCKOLITH_HOME:-${WIDGET_HOME}/node_modules/@okta/dockolith}"
 
 # Dockolith should be installed before running this script
 # Run `./scripts/monolith/install-dockolith.sh` to install latest dockolith version

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,7 @@
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
 export AUTHJS_VERSION=""
+export DOCKOLITH_VERSION=""
 
 # Install required node version
 export REGISTRY_REPO="npm-topic"
@@ -30,6 +31,24 @@ if [ ! -z "$AUTHJS_VERSION" ]; then
     exit ${FAILED_SETUP}
   fi
   echo "AUTHJS_VERSION installed: ${AUTHJS_VERSION}"
+fi
+
+if [ ! -z "$DOCKOLITH_VERSION" ]; then
+  echo "Installing DOCKOLITH_VERSION: ${DOCKOLITH_VERSION}"
+  npm config set strict-ssl false
+
+  if ! yarn add -W --force --no-lockfile https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/dockolith/-/@okta/dockolith-${DOCKOLITH_VERSION}.tgz ; then
+    echo "DOCKOLITH_VERSION could not be installed: ${DOCKOLITH_VERSION}"
+    exit ${FAILED_SETUP}
+  fi
+  
+  MATCH="$(yarn why @okta/dockolith | grep ${DOCKOLITH_VERSION})"
+  echo ${MATCH}
+  if [ -z "$MATCH" ]; then
+    echo "DOCKOLITH_VERSION was not installed: ${DOCKOLITH_VERSION}"
+    exit ${FAILED_SETUP}
+  fi
+  echo "DOCKOLITH_VERSION installed: ${DOCKOLITH_VERSION}"
 fi
 
 if ! yarn install ; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,6 +35,7 @@ fi
 
 if [ ! -z "$DOCKOLITH_VERSION" ]; then
   echo "Installing DOCKOLITH_VERSION: ${DOCKOLITH_VERSION}"
+  export DOCKOLITH_DOWNSTREAM=1
   npm config set strict-ssl false
 
   if ! yarn add -W --force --no-lockfile https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/dockolith/-/@okta/dockolith-${DOCKOLITH_VERSION}.tgz ; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,6 @@
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
 export AUTHJS_VERSION=""
-export DOCKOLITH_VERSION=""
 
 # Install required node version
 export REGISTRY_REPO="npm-topic"
@@ -31,25 +30,6 @@ if [ ! -z "$AUTHJS_VERSION" ]; then
     exit ${FAILED_SETUP}
   fi
   echo "AUTHJS_VERSION installed: ${AUTHJS_VERSION}"
-fi
-
-if [ ! -z "$DOCKOLITH_VERSION" ]; then
-  echo "Installing DOCKOLITH_VERSION: ${DOCKOLITH_VERSION}"
-  export DOCKOLITH_DOWNSTREAM=1
-  npm config set strict-ssl false
-
-  if ! yarn add -W --force --no-lockfile https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/dockolith/-/@okta/dockolith-${DOCKOLITH_VERSION}.tgz ; then
-    echo "DOCKOLITH_VERSION could not be installed: ${DOCKOLITH_VERSION}"
-    exit ${FAILED_SETUP}
-  fi
-  
-  MATCH="$(yarn why @okta/dockolith | grep ${DOCKOLITH_VERSION})"
-  echo ${MATCH}
-  if [ -z "$MATCH" ]; then
-    echo "DOCKOLITH_VERSION was not installed: ${DOCKOLITH_VERSION}"
-    exit ${FAILED_SETUP}
-  fi
-  echo "DOCKOLITH_VERSION installed: ${DOCKOLITH_VERSION}"
 fi
 
 if ! yarn install ; then


### PR DESCRIPTION
## Description:

* Installs @okta/dockolith npm package from internal registry instead of cloning dockolith repo for CI task.

* Replaces https://github.com/okta/okta-signin-widget/pull/3213


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-598607](https://oktainc.atlassian.net/browse/OKTA-598607)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:

Not required, changes only apply for CI test suite.


