### PR TITLE
OKTA-595017 : MDM device terminal view

### DIFF
--- a/src/v3/src/transformer/terminal/__snapshots__/transformMdmTerminalView.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformMdmTerminalView.test.ts.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Terminal MDM enrollment transformer adds UI elements appropriately 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "enroll.title.mdm",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "enroll.explanation.mdm",
+        },
+        "type": "Description",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "items": Array [
+            Object {
+              "elements": Array [
+                Object {
+                  "noMargin": true,
+                  "options": Object {
+                    "content": "enroll.mdm.step.copyLink",
+                  },
+                  "type": "Description",
+                },
+                Object {
+                  "label": "enroll.mdm.copyLink",
+                  "options": Object {
+                    "onClick": [Function],
+                    "step": "",
+                    "type": "button",
+                    "variant": "secondary",
+                  },
+                  "type": "Button",
+                },
+              ],
+              "type": "VerticalLayout",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "noMargin": true,
+                  "options": Object {
+                    "content": "enroll.mdm.step.pasteLink",
+                  },
+                  "type": "Description",
+                },
+              ],
+              "type": "VerticalLayout",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "noMargin": true,
+                  "options": Object {
+                    "content": "enroll.mdm.step.followInstructions",
+                  },
+                  "type": "Description",
+                },
+              ],
+              "type": "VerticalLayout",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "noMargin": true,
+                  "options": Object {
+                    "content": "enroll.mdm.step.relogin",
+                  },
+                  "type": "Description",
+                },
+              ],
+              "type": "VerticalLayout",
+            },
+          ],
+          "type": "ol",
+        },
+        "type": "List",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/terminal/transformMdmTerminalView.test.ts
+++ b/src/v3/src/transformer/terminal/transformMdmTerminalView.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxContext, IdxStatus } from '@okta/okta-auth-js';
+
+import { getStubFormBag, getStubTransaction } from '../../mocks/utils/utils';
+import {
+  ButtonElement,
+  DescriptionElement,
+  ListElement,
+  TitleElement,
+  UISchemaLayout,
+  WidgetProps,
+} from '../../types';
+import { transformMdmTerminalView } from './transformMdmTerminalView';
+
+describe('Terminal MDM enrollment transformer', () => {
+  const transaction = getStubTransaction(IdxStatus.TERMINAL);
+  const formBag = getStubFormBag();
+  let widgetProps: WidgetProps;
+
+  beforeEach(() => {
+    transaction.messages = [];
+    widgetProps = {};
+  });
+
+  it('adds UI elements appropriately', () => {
+    transaction.context = {
+      deviceEnrollment: {
+        value: {
+          name: 'mdm',
+          enrollmentLink: 'https://okta.com',
+          vendor: 'Okta',
+        },
+      },
+    } as unknown as IdxContext;
+
+    const updatedFormBag = transformMdmTerminalView({
+      formBag,
+      transaction,
+      widgetProps,
+    });
+
+    expect(updatedFormBag).toMatchSnapshot();
+
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('enroll.title.mdm');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).type).toBe('Description');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('enroll.explanation.mdm');
+
+    const listElement = updatedFormBag.uischema.elements[2] as ListElement;
+    expect(listElement.type).toBe('List');
+    const listItems = listElement.options.items;
+
+    expect(listItems.length).toBe(4);
+
+    const listItemOne = listItems[0];
+    expect((listItemOne as UISchemaLayout).elements.length).toBe(2);
+    expect(((listItemOne as UISchemaLayout).elements[0] as DescriptionElement).options.content).toBe('enroll.mdm.step.copyLink');
+    expect(((listItemOne as UISchemaLayout).elements[1] as ButtonElement).label).toBe('enroll.mdm.copyLink');
+    expect(((listItemOne as UISchemaLayout).elements[1] as ButtonElement).type).toBe('Button');
+
+    const listItemTwo = listItems[1];
+    expect((listItemTwo as UISchemaLayout).elements.length).toBe(1);
+    expect(((listItemTwo as UISchemaLayout).elements[0] as DescriptionElement).options.content).toBe('enroll.mdm.step.pasteLink');
+
+    const listItemThree = listItems[2];
+    expect((listItemThree as UISchemaLayout).elements.length).toBe(1);
+    expect(((listItemThree as UISchemaLayout).elements[0] as DescriptionElement).options.content).toBe('enroll.mdm.step.followInstructions');
+
+    const listItemFour = listItems[3];
+    expect(((listItemFour as UISchemaLayout).elements[0] as DescriptionElement).options.content).toBe('enroll.mdm.step.relogin');
+  });
+});

--- a/src/v3/src/transformer/terminal/transformMdmTerminalView.ts
+++ b/src/v3/src/transformer/terminal/transformMdmTerminalView.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  ButtonElement,
+  ButtonType,
+  DescriptionElement,
+  IdxStepTransformer,
+  ListElement,
+  TitleElement,
+  UISchemaLayout,
+  UISchemaLayoutType,
+} from '../../types';
+import { copyToClipboard, loc } from '../../util';
+
+export const transformMdmTerminalView: IdxStepTransformer = ({ formBag, transaction }) => {
+  // @ts-expect-error Property 'deviceEnrollment' does not exist on type 'IdxContext' ts(2339)
+  const deviceEnrollment = transaction.context?.deviceEnrollment?.value;
+
+  formBag.uischema.elements.push({
+    type: 'Title',
+    options: { content: loc('enroll.title.mdm', 'login') },
+  } as TitleElement);
+
+  formBag.uischema.elements.push({
+    type: 'Description',
+    contentType: 'subtitle',
+    options: { content: loc('enroll.explanation.mdm', 'login') },
+  } as DescriptionElement);
+
+  const listItems: (string | UISchemaLayout)[] = [];
+  listItems.push({
+    type: UISchemaLayoutType.VERTICAL,
+    elements: [
+      {
+        type: 'Description',
+        noMargin: true,
+        options: {
+          content: loc('enroll.mdm.step.copyLink', 'login'),
+        },
+      } as DescriptionElement,
+      {
+        type: 'Button',
+        label: loc('enroll.mdm.copyLink'),
+        options: {
+          step: '',
+          type: ButtonType.BUTTON,
+          variant: 'secondary',
+          onClick: () => copyToClipboard(deviceEnrollment?.enrollmentLink),
+        },
+      } as ButtonElement,
+    ],
+  } as UISchemaLayout,
+  {
+    type: UISchemaLayoutType.VERTICAL,
+    elements: [
+      {
+        type: 'Description',
+        noMargin: true,
+        options: {
+          content: loc('enroll.mdm.step.pasteLink', 'login'),
+        },
+      } as DescriptionElement,
+    ],
+  } as UISchemaLayout,
+  {
+    type: UISchemaLayoutType.VERTICAL,
+    elements: [
+      {
+        type: 'Description',
+        noMargin: true,
+        options: {
+          content: loc(
+            'enroll.mdm.step.followInstructions',
+            'login',
+            [deviceEnrollment?.vendor],
+            { $1: { element: 'span', attributes: { class: 'strong no-translate' } } },
+          ),
+        },
+      } as DescriptionElement,
+    ],
+  } as UISchemaLayout,
+  {
+    type: UISchemaLayoutType.VERTICAL,
+    elements: [
+      {
+        type: 'Description',
+        noMargin: true,
+        options: {
+          content: loc('enroll.mdm.step.relogin', 'login'),
+        },
+      } as DescriptionElement,
+    ],
+  } as UISchemaLayout);
+
+  formBag.uischema.elements.push({
+    type: 'List',
+    noMargin: true,
+    options: {
+      type: 'ol',
+      items: listItems,
+    },
+  } as ListElement);
+
+  return formBag;
+};

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -49,6 +49,7 @@ import { redirectTransformer } from '../redirect';
 import { setFocusOnFirstElement } from '../uischema';
 import { createForm } from '../utils';
 import { transformOdaEnrollment } from './odaEnrollment';
+import { transformMdmTerminalView } from './transformMdmTerminalView';
 import { transformTerminalMessages } from './transformTerminalMessages';
 
 const getTitleKey = (messages?: IdxMessage[]): string | undefined => {
@@ -268,6 +269,8 @@ export const transformTerminalTransaction = (
   if (typeof deviceEnrollment !== 'undefined') {
     if (deviceEnrollment.name === DEVICE_ENROLLMENT_TYPE.ODA) {
       return transformOdaEnrollment({ transaction, formBag, widgetProps });
+    } if (deviceEnrollment.name === DEVICE_ENROLLMENT_TYPE.MDM) {
+      return transformMdmTerminalView({ transaction, formBag, widgetProps });
     }
   }
 

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -65,7 +65,7 @@ test
     await t.expect(content).contains('Finish setting up your account in Okta Verify, then try accessing this app again.');
   });
 
-test.meta('v3', false) // mdm not enabled in v3
+test
   .requestHooks(logger, mdmMock)('shows the correct content in MDM terminal view', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await checkA11y(t);
@@ -78,7 +78,9 @@ test.meta('v3', false) // mdm not enabled in v3
     await t.expect(content).contains('Follow the instructions in your browser to set up Airwatch.');
     await t.expect(content).contains('Logout and re-login and then try accessing the app again.');
     await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
-    await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://sampleEnrollmentlink.com');
+    if (!userVariables.v3) {
+      await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://sampleEnrollmentlink.com');
+    }
   });
 
 // Below two tests are covering special use cases in ODA Universal Link/App Link flow
@@ -123,7 +125,7 @@ test
     await t.expect(content).contains('Finish setting up your account in Okta Verify, then try accessing this app again.');
   });
 
-test.meta('v3', false) // mdm not enabled in v3
+test
   .requestHooks()('shows the correct content in iOS MDM terminal view when Okta Verify is not set up in Universal Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -150,7 +152,9 @@ test.meta('v3', false) // mdm not enabled in v3
     await t.expect(content).contains('Follow the instructions in your browser to set up MobileIron.');
     await t.expect(content).contains('Logout and re-login and then try accessing the app again.');
     await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
-    await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://anotherSampleEnrollmentlink.com');
+    if (!userVariables.v3) {
+      await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://anotherSampleEnrollmentlink.com');
+    }
   });
 
 test
@@ -268,7 +272,7 @@ test
     await t.expect(deviceEnrollmentTerminalPage.getBackLinkText()).eql('Back');
   });
 
-test.meta('v3', false) // mdm not enabled in v3
+test
   .requestHooks()('shows the correct content in ANDROID MDM terminal view when Okta Verify is not installed in App Link flow', async t => {
     const deviceEnrollmentTerminalPage = await setup(t);
     await rerenderWidget({
@@ -296,5 +300,7 @@ test.meta('v3', false) // mdm not enabled in v3
     await t.expect(content).contains('Follow the instructions in your browser to set up MobileIron.');
     await t.expect(content).contains('Logout and re-login and then try accessing the app again.');
     await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
-    await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://anotherSampleEnrollmentlink.com');
+    if (!userVariables.v3) {
+      await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://anotherSampleEnrollmentlink.com');
+    }
   });


### PR DESCRIPTION
## Description:

This PR implements the MDM device enrollment terminal view in SIW Gen 3.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-595017](https://oktainc.atlassian.net/browse/OKTA-595017)

### Reviewers:

### Screenshot/Video:
![Screenshot 2023-04-21 at 3 08 54 PM](https://user-images.githubusercontent.com/107433508/234383776-45b32ac6-b318-47f3-94e1-f3eae056dd5b.png)

### Downstream Monolith Build:



