### PR TITLE
sb - BUG - consolidate rememberMyUsername features - OKTA - 593912

### DIFF
--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -37,7 +37,7 @@ const local: Record<string, ModelProperty> = {
   username: ['string', false],
   relayState: ['string', false],
 
-  // These two settings are aliases. Setting either value will set `backToSignInUri` 
+  // These two settings are aliases. Setting either value will set `backToSignInUri`
   signOutLink: ['string', false], // for backward compatibility
   backToSignInLink: ['string', false], // preferred setting
 
@@ -107,9 +107,8 @@ const local: Record<string, ModelProperty> = {
   'features.showKeepMeSignedIn': ['boolean', false, true],
   'features.showIdentifier': ['boolean', false, true],
   'features.autoFocus': ['boolean', false, true],
-  'features.rememberMyUsernameOnOIE': ['boolean', false, false],
   'features.showSessionRevocation': ['boolean', false, false],
-  
+
   defaultCountryCode: ['string', false, 'US'],
 
   // I18N
@@ -222,8 +221,8 @@ const derived: Record<string, ModelProperty>  = {
       // Developers can also provide a list of languages with hosted assets, these replace the default list
       const supportedLanguages = hostedLanguages || config.supportedLanguages;
       return _.union(
-        supportedLanguages, 
-        _.keys(i18n), 
+        supportedLanguages,
+        _.keys(i18n),
         _.isString(language) ? [language] : []
       );
     },
@@ -243,7 +242,7 @@ const derived: Record<string, ModelProperty>  = {
           userLanguages[idx] = 'pt-BR';
         }
       });
-      
+
       const preferred = _.clone(userLanguages);
 
       const supportedLowerCase = Util.toLower(supportedLanguages);

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -250,7 +250,7 @@ export default Controller.extend({
     const values = this.transformIdentifier(formName, model);
 
     // widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
-    if (this.options.settings.get('features.rememberMe') && this.options.settings.get('features.rememberMyUsernameOnOIE')) {
+    if (this.options.settings.get('features.rememberMe')) {
       if (values.identifier) {
         CookieUtil.setUsernameCookie(values.identifier);
       }

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -36,7 +36,7 @@ const Body = BaseForm.extend({
 
     // Precedence for pre-filling identifier field:
     // 1. Use username/identifier from the config.
-    // 2. Use identifier value returned in remediation response (model will have this attr set if it's there) 
+    // 2. Use identifier value returned in remediation response (model will have this attr set if it's there)
     // 3. Use value from the "remember my username" cookie.
     if(this._shouldAddUsername(uiSchema)) {
       // Set username/identifier from the config (i.e. config.username)
@@ -205,7 +205,7 @@ const Body = BaseForm.extend({
   },
 
   _addIdpView(idpButtons) {
-    // We check the 'idpDisplay' option config to determine whether to render the idp buttons 
+    // We check the 'idpDisplay' option config to determine whether to render the idp buttons
     // above or below the login fields
     const idpDisplay = this.options.settings.get('idpDisplay');
     const isPrimaryIdpDisplay = idpDisplay && idpDisplay.toUpperCase() === 'PRIMARY';
@@ -224,12 +224,11 @@ const Body = BaseForm.extend({
     // We pre-populate the identifier/username field only if we're in an identifier
     // form and if the option is passed in.
     return (uiSchema.find(schema => schema.name === 'identifier') && this.settings.get('username'));
-  }, 
-   
+  },
+
   _shouldApplyRememberMyUsername(uiSchema) {
-    return (uiSchema.find(schema => schema.name === 'identifier') 
-        && this.settings.get('features.rememberMe')
-        && this.settings.get('features.rememberMyUsernameOnOIE'));
+    return (uiSchema.find(schema => schema.name === 'identifier')
+        && this.settings.get('features.rememberMe'));
   },
 
   /**
@@ -250,7 +249,7 @@ export default BaseView.extend({
 
   createModelClass() {
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
-    
+
     // customize pre-submit form validation inline error messages
     const identifierRequiredi18nKey = 'error.username.required';
     const passwordRequiredi18nKey = 'error.password.required';

--- a/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
+++ b/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
@@ -21,7 +21,7 @@ const identifyMock = RequestMock()
 
 const identifyWithUsernameMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(xhrIdentifyWithUsername);  
+  .respond(xhrIdentifyWithUsername);
 
 const identifyWithPasswordMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -48,8 +48,7 @@ const identifyRequestLogger = RequestLogger(
 
 const baseConfig = {
   features: {
-    rememberMe: true,
-    rememberMyUsernameOnOIE: true
+    rememberMe: true
   }
 };
 
@@ -70,7 +69,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('identifer first flow - s
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();  
+  await identityPage.clickNextButton();
 
   await t.expect(identifyRequestLogger.count(() => true)).eql(2);
   const req = identifyRequestLogger.requests[0].request;
@@ -93,7 +92,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('identifer wi
 
   await identityPage.fillIdentifierField('testUser@okta.com');
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();  
+  await identityPage.clickNextButton();
 
   await t.expect(identifyRequestLogger.count(() => true)).eql(1);
   const req = identifyRequestLogger.requests[0].request;
@@ -108,7 +107,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('identifer wi
 
   // Ensure identifier field is pre-filled with saved username cookie
   await identityPage.navigateToPage();
-  await rerenderWidget(baseConfig);  
+  await rerenderWidget(baseConfig);
   const identifier = identityPage.getIdentifierValue();
   await t.expect(identifier).eql('testUser@okta.com');
 });
@@ -116,8 +115,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('identifer wi
 test.requestHooks(identifyRequestLogger, identifyWithEmailAuthenticator)('identifer with email challenge - should remember username after successful authentication', async t => {
   const options = {
     features: {
-      rememberMe: true,
-      rememberMyUsernameOnOIE: true
+      rememberMe: true
     },
   };
 
@@ -159,7 +157,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should pre-fill identifi
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();  
+  await identityPage.clickNextButton();
 
   await t.expect(identifyRequestLogger.count(() => true)).eql(2);
   const req = identifyRequestLogger.requests[0].request;
@@ -173,8 +171,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should pre-fill identifi
   await rerenderWidget({
     username: 'configUsername@okta.com',
     features: {
-      rememberMe: true,
-      rememberMyUsernameOnOIE: true
+      rememberMe: true
     }
   });
 
@@ -192,7 +189,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should pre-fill identifi
   await identityPage.clickNextButton();
 
   await identityPage.fillPasswordField('testPassword');
-  await identityPage.clickNextButton();  
+  await identityPage.clickNextButton();
 
   await t.expect(identifyRequestLogger.count(() => true)).eql(2);
   const req = identifyRequestLogger.requests[0].request;
@@ -208,8 +205,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should pre-fill identifi
   await identityPage.navigateToPage({ 'login_hint': 'testUsername@okta.com' });
   await rerenderWidget({
     features: {
-      rememberMe: true,
-      rememberMyUsernameOnOIE: true
+      rememberMe: true
     }
   });
 
@@ -226,8 +222,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should store identifier 
 
   await rerenderWidget({
     features: {
-      rememberMe: true,
-      rememberMyUsernameOnOIE: true
+      rememberMe: true
     }
   });
 

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -28,7 +28,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     originalLoginEnBundle = null;
   });
 
-  beforeEach(function() { 
+  beforeEach(function() {
     testContext = {};
     testContext.init = (remediations = XHRIdentifyWithThirdPartyIdps.remediation.value) => {
       const appState = new AppState({}, {});
@@ -62,7 +62,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
     testContext.init(XHRIdentifyWithPassword.remediation.value);
-    
+
     // The forgot password link should be in the siw-main-footer
     expect(testContext.view.$el.find('.siw-main-footer .js-forgot-password').length).toEqual(1);
     expect(testContext.view.$el.find('.links-primary .js-forgot-password').length).toEqual(0);
@@ -98,7 +98,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
     testContext.init(XHRIdentifyWithPassword.remediation.value);
-    
+
     // No IDP buttons should be rendered.
     expect(testContext.view.$el.find('.o-form-fieldset-container .sign-in-with-idp').length).toEqual(0);
     expect(testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp').length).toEqual(0);
@@ -115,7 +115,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
 
     // Get the idp buttons
     let buttons = testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp .social-auth-button.link-button');
-    
+
     buttons.each(function(){
       // Ensure there is no tooltip when text is short.
       expect($(this).attr('title')).toEqual(undefined);
@@ -128,7 +128,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
 
     // Get the idp buttons
     buttons = testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp .social-auth-button.link-button');
-    
+
     buttons.each(function(){
       // Ensure the button tooltip is equal to the button title when it is long
       expect($(this).attr('title')).toEqual($(this).text());
@@ -145,7 +145,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
     testContext.init(XHRIdentifyWithPassword.remediation.value);
-    
+
     const $customButton = testContext.view.$el.find('.o-form-button-bar .custom-buttons .btn-customAuth');
     expect($customButton.text()).toEqual('Click Me');
   });
@@ -167,7 +167,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
     testContext.init(XHRIdentifyWithPassword.remediation.value);
-    
+
     const $customButton = testContext.view.$el.find('.o-form-button-bar .custom-buttons .btn-customAuth');
     expect($customButton.text()).toEqual('Custom Button Title');
   });
@@ -179,7 +179,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
 
-    currentViewState = { 
+    currentViewState = {
       uiSchema: [{
         'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
@@ -194,19 +194,18 @@ describe('v2/view-builder/views/IdentifierView', function() {
     testContext.init(XHRIdentifyWithPassword.remediation.value);
     expect(testContext.view.model.get('identifier')).toEqual('testUsername');
     expect(testContext.view.$el.find('.o-form-input-name-identifier input').val()).toEqual('testUsername');
-  });  
+  });
 
   it('pre-fill identifier form with username from cookie when rememberMe feature is enabled', function() {
     settings.set('username', '');
     settings.set('features.rememberMe', true);
-    settings.set('features.rememberMyUsernameOnOIE', true);
 
     jest.spyOn(AppState.prototype, 'hasRemediationObject').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
     jest.spyOn(CookieUtil, 'getCookieUsername').mockReturnValue('testUsername');
 
-    currentViewState = { 
+    currentViewState = {
       uiSchema: [{
         'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
@@ -226,7 +225,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
 
   it('does not pre-fill identifier form with username from cookie when rememberMe feature is disabled', function() {
     settings.set('username', '');
-   
+
     jest.spyOn(AppState.prototype, 'hasRemediationObject').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
@@ -234,7 +233,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     jest.spyOn(IdentifierView.prototype.Body.prototype, '_shouldApplyRememberMyUsername').mockReturnValue(false);
     jest.spyOn(CookieUtil, 'getCookieUsername').mockReturnValue('testUsername');
 
-    currentViewState = { 
+    currentViewState = {
       uiSchema: [{
         'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
@@ -249,7 +248,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     testContext.init(XHRIdentifyWithPassword.remediation.value);
     expect(testContext.view.model.get('identifier')).not.toEqual('testUsername');
     expect(testContext.view.$el.find('.o-form-input-name-identifier input').val()).toEqual('');
-    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('username');    
+    expect(testContext.view.$el.find('.o-form-input-name-identifier input').attr('autocomplete')).toEqual('username');
   });
 
   it('should customize username/password required messages', function() {
@@ -268,8 +267,8 @@ describe('v2/view-builder/views/IdentifierView', function() {
     jest.spyOn(AppState.prototype, 'hasRemediationObject').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
-    
-    currentViewState = { 
+
+    currentViewState = {
       uiSchema: [{
         'autoComplete': 'username',
         'data-se': 'o-form-fieldset-identifier',
@@ -306,7 +305,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(true);
     testContext.init(XHRIdentifyWithWebAuthn.remediation.value);
-    
+
     expect(testContext.view.$el.find('.sign-in-with-webauthn-option').length).toEqual(1);
   });
 });


### PR DESCRIPTION
## Description:
Removed `rememberMyUsernameOnOIE` feature since it's redundant. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-593912](https://oktainc.atlassian.net/browse/OKTA-593912)

### Reviewers:
@okta/authx @kamaldeepcheema-okta @brentschaus-okta 

### Screenshot/Video:

Before video:
https://okta.box.com/s/nzmnujry32ko2uy3hn6bujnay1nsznkt

after video:
https://okta.box.com/s/pq9eih9elb2u5gng3orosdjkvzdhc004

### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=sb-BUG-rememberLastUsername-features-dummy

### Bacon:
https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=sb-BUG-rememberMyUsername-consolidate-features-OKTA-593912
