### PR TITLE
Add rel attribute to anchors for EndUserRemediationTerminalMessage

### DIFF
--- a/src/v2/view-builder/views/end-user-remediation/EndUserRemediationTerminalMessage.js
+++ b/src/v2/view-builder/views/end-user-remediation/EndUserRemediationTerminalMessage.js
@@ -39,7 +39,7 @@ export default View.extend({
       {{#each remediationOptions}}
         <div class="{{className}}">
         {{#if link}}
-          <a href="{{link}}" target="_blank">{{message}}</a>
+          <a href="{{link}}" target="_blank" rel="noopener noreferrer">{{message}}</a>
         {{else}}
           {{message}}
         {{/if}}
@@ -52,13 +52,13 @@ export default View.extend({
       {{i18n
         code="idx.error.code.access_denied.device_assurance.remediation.additional_help_custom"
         bundle="login"
-        $1="<a href='#' target='_blank' class='additional-help'>$1</a>"
+        $1="<a href='#' target='_blank' rel='noopener noreferrer' class='additional-help'>$1</a>"
       }}
     {{else}}
       {{i18n
         code="idx.error.code.access_denied.device_assurance.remediation.additional_help_default"
         bundle="login"
-        $1="<a href='#' target='_blank' class='additional-help'>$1</a>"
+        $1="<a href='#' target='_blank' rel='noopener noreferrer' class='additional-help'>$1</a>"
       }}
     {{/if}}
     </div>

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -124,6 +124,10 @@ export default class BaseFormObject {
     return this.el.find(FORM_INFOBOX_ERROR).innerText;
   }
 
+  getErrorBox() {
+    return Selector(CALLOUT);
+  }
+
   getErrorBoxHtml() {
     return this.getCallout(CALLOUT).innerHTML;
   }

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -195,44 +195,68 @@ test.requestHooks(terminalCustomAccessDeniedErrorMessageMock)('should render cus
   await t.expect(terminalViewPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><ul class="custom-links"><li><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a></li><li><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></li></ul></div>');
 });
 
+const assertAnchorWithBlankTargetHaveCorrectRelAttribute = async (t, selector) => {
+  await t.expect(
+    selector
+      .find('a[target="_blank"]')
+      .filter((node) => {
+        const relValues = (node.getAttribute('rel') || '').split(' ');
+        return relValues.indexOf('noopener') < 0 || relValues.indexOf('noreferrer') < 0;
+      })
+      .exists).eql(false);
+};
+
+const assertSIWEndUserRemediationHeaders = async (t, terminalViewPage, explanationExists) => {
+  await t.expect(terminalViewPage.form.getErrorBox().find('.end-user-remediation-title').withExactText('Your device doesn\'t meet the security requirements').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBox().find('.end-user-remediation-explanation').withExactText('To sign in, make the following updates. Then, access the app again.').exists).eql(explanationExists);
+};
+
+const endUserRemediationActionFound = async (t, terminalViewPage, url, text, optionIndex) => {
+  await t.expect(
+    terminalViewPage.form.getErrorBox()
+      .find('.end-user-remediation-options')
+      .child((node) => {
+        let currentOptionIndex = 0;
+        let prevNode = node.previousSibling;
+
+        // Count the number of "Option N" siblings before the current node, to figure out what position are in
+        while (prevNode) {
+          if (prevNode.classList.contains('end-user-remediation-option')) {
+            currentOptionIndex += 1;
+          }
+          prevNode = prevNode.previousSibling;
+        }
+
+        return currentOptionIndex === optionIndex;
+      }, {optionIndex})
+      .filter('.end-user-remediation-action')
+      .child(`a[href="${url}"]`)
+      .withExactText(text).exists
+  ).eql(true);
+};
+
 test.requestHooks(endUserRemediationOneOptionMock)('should render end user remediation error message when there is one option', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
 
-  await t.expect(terminalViewPage.form.getErrorBoxHtml()).eql([
-    '<span data-se="icon" class="icon error-16"></span>',
-    '<div class="end-user-remediation-terminal-view">',
-    '<div class="end-user-remediation-title">Your device doesn\'t meet the security requirements</div>',
-    '<div class="end-user-remediation-explanation">To sign in, make the following updates. Then, access the app again.</div>',
-    '<div class="end-user-remediation-options">',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/android-upgrade-os" target="_blank">Update to Android 100</a></div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/android-biometric-lock" target="_blank">Enable lock screen and biometrics</a></div>',
-    '</div>',
-    '<div class="end-user-remediation-help-and-contact">For more information, follow the instructions on <a href="https://okta.com/help" target="_blank" class="additional-help">the help page</a> or contact your administrator for help</div>',
-    '</div>'
-  ].join(''));
+  assertSIWEndUserRemediationHeaders(t, terminalViewPage, true);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/android-upgrade-os', 'Update to Android 100', 0);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/android-biometric-lock', 'Enable lock screen and biometrics', 0);
+  await t.expect(terminalViewPage.form.getErrorBox().find('div.end-user-remediation-help-and-contact').withText('follow the instructions on the help page').child('a[href="https://okta.com/help"]').exists).eql(true);
+  await assertAnchorWithBlankTargetHaveCorrectRelAttribute(t, terminalViewPage.form.getErrorBox());
 });
 
 test.requestHooks(endUserRemediationMultipleOptionsMock)('should render end user remediation error message when there are multiple options', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
 
-  await t.expect(terminalViewPage.form.getErrorBoxHtml()).eql([
-    '<span data-se="icon" class="icon error-16"></span>',
-    '<div class="end-user-remediation-terminal-view">',
-    '<div class="end-user-remediation-title">Your device doesn\'t meet the security requirements</div>',
-    '<div class="end-user-remediation-explanation">To sign in, make the following updates. Then, access the app again.</div>',
-    '<div class="end-user-remediation-options">',
-    '<div class="end-user-remediation-option">Option 1:</div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/android-upgrade-os" target="_blank">Update to Android 100</a></div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/android-biometric-lock" target="_blank">Enable lock screen and biometrics</a></div>',
-    '<div class="end-user-remediation-option">Option 2:</div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/android-lock-screen" target="_blank">Enable lock screen</a></div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/android-disk-encrypted" target="_blank">Encrypt your device</a></div>',
-    '</div>',
-    '<div class="end-user-remediation-help-and-contact">For more information, follow the instructions on <a href="https://okta.com/help" target="_blank" class="additional-help">the help page</a> or contact your administrator for help</div>',
-    '</div>'
-  ].join(''));
+  assertSIWEndUserRemediationHeaders(t, terminalViewPage, true);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/android-upgrade-os', 'Update to Android 100', 1);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/android-biometric-lock', 'Enable lock screen and biometrics', 1);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/android-lock-screen', 'Enable lock screen', 2);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/android-disk-encrypted', 'Encrypt your device', 2);
+  await t.expect(terminalViewPage.form.getErrorBox().find('div.end-user-remediation-help-and-contact').withText('follow the instructions on the help page').child('a[href="https://okta.com/help"]').exists).eql(true);
+  await assertAnchorWithBlankTargetHaveCorrectRelAttribute(t, terminalViewPage.form.getErrorBox());
 });
 
 test.requestHooks(endUserRemediationMultipleOptionsWithCustomHelpUrlMock)('should render end user remediation error message when there are multiple options and a custom URL is set for the organization help page', async t => {
@@ -242,40 +266,27 @@ test.requestHooks(endUserRemediationMultipleOptionsWithCustomHelpUrlMock)('shoul
   // The body of the API response is not normally returned for multiple different
   // platforms. The test exists to ensure all of the expected keys can be
   // localized
-  await t.expect(terminalViewPage.form.getErrorBoxHtml()).eql([
-    '<span data-se="icon" class="icon error-16"></span>',
-    '<div class="end-user-remediation-terminal-view">',
-    '<div class="end-user-remediation-title">Your device doesn\'t meet the security requirements</div>',
-    '<div class="end-user-remediation-explanation">To sign in, make the following updates. Then, access the app again.</div>',
-    '<div class="end-user-remediation-options">',
-    '<div class="end-user-remediation-option">Option 1:</div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/ios-upgrade-os" target="_blank">Update to iOS 12.0.1</a></div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/ios-lock-screen" target="_blank">Set a passcode for the lock screen</a></div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/ios-biometric-lock" target="_blank">Set a passcode for the lock screen and enable Touch ID or Face ID</a></div>',
-    '<div class="end-user-remediation-option">Option 2:</div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/macos-upgrade-os" target="_blank">Update to macOS 13.2</a></div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/macos-lock-screen" target="_blank">Set a passcode for the lock screen</a></div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/macos-disk-encrypted" target="_blank">Turn on FileVault</a></div>',
-    '<div class="end-user-remediation-option">Option 3:</div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/windows-upgrade-os" target="_blank">Update to Windows 10.0.25530.123</a></div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/windows-disk-encrypted" target="_blank">Encrypt all internal disks with BitLocker</a></div>',
-    '<div class="end-user-remediation-option">Option 4:</div>',
-    '<div class="end-user-remediation-action"><a href="https://okta.com/windows-biometric-lock" target="_blank">Enable Windows Hello for the lock screen</a></div>',
-    '</div>',
-    '<div class="end-user-remediation-help-and-contact">For more information, follow the instructions on <a href="https://okta1.com/custom-help-me" target="_blank" class="additional-help">your organization\'s help page</a> or contact your administrator for help</div>',
-    '</div>'
-  ].join(''));
+  assertSIWEndUserRemediationHeaders(t, terminalViewPage, true);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/ios-upgrade-os', 'Update to iOS 12.0.1', 1);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/ios-lock-screen', 'Set a passcode for the lock screen', 1);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/ios-biometric-lock', 'Set a passcode for the lock screen and enable Touch ID or Face ID', 1);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/macos-upgrade-os', 'Update to macOS 13.2', 2);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/macos-lock-screen', 'Set a passcode for the lock screen', 2);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/macos-disk-encrypted', 'Turn on FileVault', 2);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/windows-upgrade-os', 'Update to Windows 10.0.25530.123', 3);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/windows-disk-encrypted', 'Encrypt all internal disks with BitLocker', 3);
+  await endUserRemediationActionFound(t, terminalViewPage, 'https://okta.com/windows-biometric-lock', 'Enable Windows Hello for the lock screen', 4);
+  await t.expect(terminalViewPage.form.getErrorBox().find('div.end-user-remediation-help-and-contact').withText('follow the instructions on your organization\'s help page').child('a[href="https://okta1.com/custom-help-me"]').exists).eql(true);
+  await assertAnchorWithBlankTargetHaveCorrectRelAttribute(t, terminalViewPage.form.getErrorBox());
 });
 
 test.requestHooks(endUserRemediationNoOptionsMock)('should render end user remediation error message when there are no options', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
 
-  await t.expect(terminalViewPage.form.getErrorBoxHtml()).eql([
-    '<span data-se="icon" class="icon error-16"></span>',
-    '<div class="end-user-remediation-terminal-view">',
-    '<div class="end-user-remediation-title">Your device doesn\'t meet the security requirements</div>',
-    '<div class="end-user-remediation-help-and-contact">For more information, follow the instructions on <a href="https://okta1.com/custom-help-me" target="_blank" class="additional-help">your organization\'s help page</a> or contact your administrator for help</div>',
-    '</div>'
-  ].join(''));
+  assertSIWEndUserRemediationHeaders(t, terminalViewPage, false);
+  await t.expect(terminalViewPage.form.getErrorBox().find('.end-user-remediation-options').count).eql(0);
+  await t.expect(terminalViewPage.form.getErrorBox().find('.end-user-remediation-action').count).eql(0);
+  await t.expect(terminalViewPage.form.getErrorBox().find('div.end-user-remediation-help-and-contact').withText('follow the instructions on your organization\'s help page').child('a[href="https://okta1.com/custom-help-me"]').exists).eql(true);
+  await assertAnchorWithBlankTargetHaveCorrectRelAttribute(t, terminalViewPage.form.getErrorBox());
 });


### PR DESCRIPTION
## Description:

Updated EndUserRemediationTerminalMessage to have rel attributes added to all anchors with the correct values.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-606968](https://oktainc.atlassian.net/browse/OKTA-606968)

### Reviewers:

- @okta/device-platform 

### Screenshot/Video:



### Downstream Monolith Build:



