### PR TITLE
OKTA-603118: add symantecvip authenticator for g3

### DIFF
--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -49,6 +49,7 @@ import {
 import { transformWebAuthNAuthenticator } from '../webauthn';
 import { transformYubikeyOtpAuthenticator } from '../yubikey';
 import { transformDuoAuthenticator } from './duo';
+import { transformSymantecVipAuthenticator } from './symantecVip';
 import {
   transformEmailAuthenticatorEnroll,
   transformEmailAuthenticatorVerify,
@@ -136,6 +137,13 @@ const TransformerMap: {
     },
   },
   [IDX_STEP.CHALLENGE_AUTHENTICATOR]: {
+    [AUTHENTICATOR_KEY.SYMANTEC_VIP]: {
+      transform: transformSymantecVipAuthenticator,
+      buttonConfig: { 
+        showDefaultSubmit: false,
+        showVerifyWithOtherLink: true,
+      },
+    },
     [AUTHENTICATOR_KEY.DUO]: {
       transform: transformDuoAuthenticator,
       buttonConfig: { showDefaultSubmit: false },
@@ -239,6 +247,13 @@ const TransformerMap: {
     },
   },
   [IDX_STEP.ENROLL_AUTHENTICATOR]: {
+    [AUTHENTICATOR_KEY.SYMANTEC_VIP]: {
+      transform: transformSymantecVipAuthenticator,
+      buttonConfig: { 
+        showDefaultSubmit: false,
+        showReturnToAuthListLink: true,
+      },
+    },
     [AUTHENTICATOR_KEY.DUO]: {
       transform: transformDuoAuthenticator,
       buttonConfig: { showDefaultSubmit: false },

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -49,7 +49,6 @@ import {
 import { transformWebAuthNAuthenticator } from '../webauthn';
 import { transformYubikeyOtpAuthenticator } from '../yubikey';
 import { transformDuoAuthenticator } from './duo';
-import { transformSymantecVipAuthenticator } from './symantecVip';
 import {
   transformEmailAuthenticatorEnroll,
   transformEmailAuthenticatorVerify,
@@ -76,6 +75,7 @@ import {
   transformSecurityQuestionEnroll,
   transformSecurityQuestionVerify,
 } from './securityQuestion';
+import { transformSymantecVipAuthenticator } from './symantecVip';
 
 /**
  * TransformerMap
@@ -137,13 +137,6 @@ const TransformerMap: {
     },
   },
   [IDX_STEP.CHALLENGE_AUTHENTICATOR]: {
-    [AUTHENTICATOR_KEY.SYMANTEC_VIP]: {
-      transform: transformSymantecVipAuthenticator,
-      buttonConfig: { 
-        showDefaultSubmit: false,
-        showVerifyWithOtherLink: true,
-      },
-    },
     [AUTHENTICATOR_KEY.DUO]: {
       transform: transformDuoAuthenticator,
       buttonConfig: { showDefaultSubmit: false },
@@ -177,6 +170,12 @@ const TransformerMap: {
     [AUTHENTICATOR_KEY.SECURITY_QUESTION]: {
       transform: transformSecurityQuestionVerify,
       buttonConfig: { showDefaultSubmit: false },
+    },
+    [AUTHENTICATOR_KEY.SYMANTEC_VIP]: {
+      transform: transformSymantecVipAuthenticator,
+      buttonConfig: {
+        showDefaultSubmit: false,
+      },
     },
     [AUTHENTICATOR_KEY.WEBAUTHN]: {
       transform: transformWebAuthNAuthenticator,
@@ -247,13 +246,6 @@ const TransformerMap: {
     },
   },
   [IDX_STEP.ENROLL_AUTHENTICATOR]: {
-    [AUTHENTICATOR_KEY.SYMANTEC_VIP]: {
-      transform: transformSymantecVipAuthenticator,
-      buttonConfig: { 
-        showDefaultSubmit: false,
-        showReturnToAuthListLink: true,
-      },
-    },
     [AUTHENTICATOR_KEY.DUO]: {
       transform: transformDuoAuthenticator,
       buttonConfig: { showDefaultSubmit: false },
@@ -280,6 +272,12 @@ const TransformerMap: {
     [AUTHENTICATOR_KEY.SECURITY_QUESTION]: {
       transform: transformSecurityQuestionEnroll,
       buttonConfig: { showDefaultSubmit: false },
+    },
+    [AUTHENTICATOR_KEY.SYMANTEC_VIP]: {
+      transform: transformSymantecVipAuthenticator,
+      buttonConfig: {
+        showDefaultSubmit: false,
+      },
     },
     [AUTHENTICATOR_KEY.WEBAUTHN]: {
       transform: transformWebAuthNAuthenticator,

--- a/src/v3/src/transformer/layout/symantecVip/__snapshots__/transformSymantecVipAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/layout/symantecVip/__snapshots__/transformSymantecVipAuthenticator.test.ts.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SymantecVip Authenticator Transformer Tests should have correct elements in enroll flow 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.symantecVip.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.symantecVip.enroll.description",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "Fake Label 1",
+        "type": "Field",
+      },
+      Object {
+        "label": "Fake Label 2",
+        "type": "Field",
+      },
+      Object {
+        "label": "mfa.enroll",
+        "options": Object {
+          "step": "enroll-authenticator",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`SymantecVip Authenticator Transformer Tests should have correct elements in verify flow 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.symantecVip.challenge.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.symantecVip.challenge.description",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "Fake Label 1",
+        "type": "Field",
+      },
+      Object {
+        "label": "Fake Label 2",
+        "type": "Field",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "step": "challenge-authenticator",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/layout/symantecVip/index.ts
+++ b/src/v3/src/transformer/layout/symantecVip/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export * from './transformSymantecVipAuthenticator';

--- a/src/v3/src/transformer/layout/symantecVip/transformSymantecVipAuthenticator.test.ts
+++ b/src/v3/src/transformer/layout/symantecVip/transformSymantecVipAuthenticator.test.ts
@@ -35,7 +35,7 @@ describe('SymantecVip Authenticator Transformer Tests', () => {
       {
         type: 'Field',
         label: 'Fake Label 2',
-      }
+      },
     ];
     widgetProps = {};
   });

--- a/src/v3/src/transformer/layout/symantecVip/transformSymantecVipAuthenticator.test.ts
+++ b/src/v3/src/transformer/layout/symantecVip/transformSymantecVipAuthenticator.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IDX_STEP } from 'src/constants';
+import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
+import {
+  TitleElement,
+  WidgetProps,
+} from 'src/types';
+
+import { transformSymantecVipAuthenticator } from '.';
+
+describe('SymantecVip Authenticator Transformer Tests', () => {
+  let transaction = getStubTransactionWithNextStep();
+  let widgetProps: WidgetProps = {};
+  let formBag = getStubFormBag();
+
+  beforeEach(() => {
+    transaction = getStubTransactionWithNextStep();
+    formBag = getStubFormBag();
+    formBag.uischema.elements = [
+      {
+        type: 'Field',
+        label: 'Fake Label 1',
+      },
+      {
+        type: 'Field',
+        label: 'Fake Label 2',
+      }
+    ];
+    widgetProps = {};
+  });
+
+  it('should have correct elements in enroll flow', () => {
+    transaction.nextStep!.name = IDX_STEP.ENROLL_AUTHENTICATOR;
+    const updatedFormBag = transformSymantecVipAuthenticator({
+      transaction,
+      formBag,
+      widgetProps,
+    });
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    console.log(updatedFormBag.uischema.elements);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.symantecVip.enroll.title');
+  });
+
+  it('should have correct elements in verify flow', () => {
+    transaction.nextStep!.name = IDX_STEP.CHALLENGE_AUTHENTICATOR;
+    const updatedFormBag = transformSymantecVipAuthenticator({
+      transaction,
+      formBag,
+      widgetProps,
+    });
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    console.log(updatedFormBag.uischema.elements);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+      .toBe('oie.symantecVip.challenge.title');
+  });
+});

--- a/src/v3/src/transformer/layout/symantecVip/transformSymantecVipAuthenticator.ts
+++ b/src/v3/src/transformer/layout/symantecVip/transformSymantecVipAuthenticator.ts
@@ -14,13 +14,13 @@ import { NextStep } from '@okta/okta-auth-js';
 
 import { IDX_STEP } from '../../../constants';
 import {
-  IdxStepTransformer,
-  TitleElement,
-  DescriptionElement,
   ButtonElement,
   ButtonType,
+  DescriptionElement,
+  IdxStepTransformer,
+  TitleElement,
 } from '../../../types';
-import { loc, getDisplayName } from '../../../util';
+import { getDisplayName, loc } from '../../../util';
 
 export const transformSymantecVipAuthenticator: IdxStepTransformer = ({
   formBag,
@@ -37,8 +37,8 @@ export const transformSymantecVipAuthenticator: IdxStepTransformer = ({
     type: 'Title',
     options: {
       content: stepName === IDX_STEP.ENROLL_AUTHENTICATOR
-      ? loc('oie.symantecVip.enroll.title', 'login', [authenticatorVendorName])
-      : loc('oie.symantecVip.challenge.title', 'login', [authenticatorVendorName]),
+        ? loc('oie.symantecVip.enroll.title', 'login', [authenticatorVendorName])
+        : loc('oie.symantecVip.challenge.title', 'login', [authenticatorVendorName]),
     },
   };
 
@@ -47,8 +47,8 @@ export const transformSymantecVipAuthenticator: IdxStepTransformer = ({
     contentType: 'subtitle',
     options: {
       content: stepName === IDX_STEP.ENROLL_AUTHENTICATOR
-      ? loc('oie.symantecVip.enroll.description', 'login', [authenticatorVendorName])
-      : loc('oie.symantecVip.challenge.description', 'login', [authenticatorVendorName]),
+        ? loc('oie.symantecVip.enroll.description', 'login', [authenticatorVendorName])
+        : loc('oie.symantecVip.challenge.description', 'login', [authenticatorVendorName]),
     },
   };
 

--- a/src/v3/src/transformer/layout/symantecVip/transformSymantecVipAuthenticator.ts
+++ b/src/v3/src/transformer/layout/symantecVip/transformSymantecVipAuthenticator.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { NextStep } from '@okta/okta-auth-js';
+
+import { IDX_STEP } from '../../../constants';
+import {
+  IdxStepTransformer,
+  TitleElement,
+  DescriptionElement,
+  ButtonElement,
+  ButtonType,
+} from '../../../types';
+import { loc, getDisplayName } from '../../../util';
+
+export const transformSymantecVipAuthenticator: IdxStepTransformer = ({
+  formBag,
+  transaction,
+}) => {
+  const { uischema } = formBag;
+  const { nextStep = {} as NextStep } = transaction;
+  const stepName = nextStep.name;
+
+  const authenticatorVendorName = getDisplayName(transaction)
+    || loc('oie.on_prem.authenticator.default.vendorName', 'login');
+
+  const titleElement: TitleElement = {
+    type: 'Title',
+    options: {
+      content: stepName === IDX_STEP.ENROLL_AUTHENTICATOR
+      ? loc('oie.symantecVip.enroll.title', 'login', [authenticatorVendorName])
+      : loc('oie.symantecVip.challenge.title', 'login', [authenticatorVendorName]),
+    },
+  };
+
+  const subtitleElement: DescriptionElement = {
+    type: 'Description',
+    contentType: 'subtitle',
+    options: {
+      content: stepName === IDX_STEP.ENROLL_AUTHENTICATOR
+      ? loc('oie.symantecVip.enroll.description', 'login', [authenticatorVendorName])
+      : loc('oie.symantecVip.challenge.description', 'login', [authenticatorVendorName]),
+    },
+  };
+
+  const submitButtonControl: ButtonElement = {
+    type: 'Button',
+    label: stepName === IDX_STEP.ENROLL_AUTHENTICATOR
+      ? loc('mfa.enroll', 'login')
+      : loc('mfa.challenge.verify', 'login'),
+    options: {
+      type: ButtonType.SUBMIT,
+      step: transaction.nextStep!.name,
+    },
+  };
+
+  uischema.elements = [
+    titleElement,
+    subtitleElement,
+    ...uischema.elements,
+    submitButtonControl,
+  ];
+
+  return formBag;
+};

--- a/test/testcafe/framework/page-objects/SymantecAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/SymantecAuthenticatorPageObject.js
@@ -1,3 +1,4 @@
+import { userVariables } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 export default class SymantecAuthenticatorPageObject extends BasePageObject {
@@ -10,10 +11,16 @@ export default class SymantecAuthenticatorPageObject extends BasePageObject {
   }
 
   getPageSubtitle() {
+    if (userVariables.v3) {
+      return this.getFormSubtitle();
+    }
     return this.form.getElement('.okta-form-subtitle').textContent;
   }
 
-  submit() {
+  submit(buttonName) {
+    if (userVariables.v3) {
+      return this.form.clickButton(buttonName);
+    }
     return this.form.clickSaveButton();
   }
 }

--- a/test/testcafe/spec/AuthenticatorSymantecView_spec.js
+++ b/test/testcafe/spec/AuthenticatorSymantecView_spec.js
@@ -45,7 +45,7 @@ async function setup(t) {
   return pageObject;
 }
 
-fixture('Enroll Symantec VIP Authenticator');
+fixture('Enroll Symantec VIP Authenticator').meta('v3', true);
 test
   .requestHooks(logger, enrollMock)('enroll with Symantec VIP authenticator', async t => {
     const pageObject = await setup(t);
@@ -65,7 +65,7 @@ test
     await pageObject.verifyFactor('credentials.credentialId', '1234');
     await pageObject.verifyFactor('credentials.passcode', '1234');
     await pageObject.verifyFactor('credentials.nextPasscode', '1234');
-    await pageObject.submit();
+    await pageObject.submit('Enroll');
 
     const pageUrl = await pageObject.getPageUrl();
     await t.expect(pageUrl).eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
@@ -80,13 +80,13 @@ test
     
     // Fill out only first part of the form and submit
     await pageObject.verifyFactor('credentials.credentialId', '1234');
-    await pageObject.submit();
+    await pageObject.submit('Enroll');
 
     pageObject.form.waitForErrorBox();
     await t.expect(pageObject.form.getErrorBoxText()).eql('We found some errors. Please review the form and make corrections.');
   });
 
-fixture('Verify Symantec VIP Authenticator');
+fixture('Verify Symantec VIP Authenticator').meta('v3', true);
 test
   .requestHooks(logger, verifyMock)('verify with Symantec VIP authenticator', async t => {
     const pageObject = await setup(t);
@@ -104,7 +104,7 @@ test
     
     // Fill out form and submit
     await pageObject.verifyFactor('credentials.passcode', '1234');
-    await pageObject.submit();
+    await pageObject.submit('Verify');
 
     const pageUrl = await pageObject.getPageUrl();
     await t.expect(pageUrl).eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
@@ -117,7 +117,7 @@ test
 
     await t.expect(pageObject.getFormTitle()).eql('Verify with Symantec VIP');
     
-    await pageObject.submit();
+    await pageObject.submit('Verify');
 
     pageObject.form.waitForErrorBox();
     await t.expect(pageObject.form.getErrorBoxText()).eql('We found some errors. Please review the form and make corrections.');
@@ -133,13 +133,14 @@ test
     // Fill out form and submit
     const fieldName = 'credentials.passcode';
     await pageObject.verifyFactor(fieldName, 'somethingInvalid');
-    await pageObject.submit();
+    await pageObject.submit('Verify');
 
     await t.expect(pageObject.form.getTextBoxErrorMessage(fieldName))
       .eql('Your code doesn\'t match our records. Please try again.');
   });
 
-test.requestHooks(verifyMock)('should show custom factor page link', async t => {
+// Help links are not implemented in v3 - OKTA-609315
+test.meta('v3', false).requestHooks(verifyMock)('should show custom factor page link', async t => {
   const pageObject = await setup(t);
   await checkA11y(t);
 

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
@@ -207,7 +207,7 @@ test.requestHooks(requestLogger, mockChallengeOVTotpMethod)('should show switch 
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
 
-// Help links are not implemented in v3
+// Help links are not implemented in v3 - OKTA-609315
 test.meta('v3', false).requestHooks(mockChallengeOVTotpMethod)('should show custom factor page link', async t => {
   const selectAuthenticatorPage = await setup(t);
   await checkA11y(t);


### PR DESCRIPTION
## Description:

Support symantec vip authenticator for g3


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-603118](https://oktainc.atlassian.net/browse/OKTA-603118)

### Reviewers:

### Screenshot/Video:

Challenge

![Screen Shot 2023-05-09 at 2 53 22 PM](https://github.com/okta/okta-signin-widget/assets/60160041/2ae6865c-4e9b-4536-bdfd-4c2f6b3f72d4)

Enroll
![Screen Shot 2023-05-09 at 2 52 06 PM](https://github.com/okta/okta-signin-widget/assets/60160041/1e8123e8-9341-4554-abe2-fb171217f8b6)


### Downstream Monolith Build:



