### PR TITLE
OKTA-599817 : SIW Gen 2 : Correctly extract scopes when sending Granular Consent payload

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -104,5 +104,5 @@ test_suites:
       sort_order: '1'
       timeout: '60'
       script_name: e2e-monolith
-      criteria: MERGE
+      criteria: OPTIONAL
       queue_name: ci-queue-prodJenga-Monolith-Build

--- a/playground/mocks/data/idp/idx/consent-granular.json
+++ b/playground/mocks/data/idp/idx/consent-granular.json
@@ -53,6 +53,16 @@
                 "mutable": true
               },
               {
+                "name": "custom3.custom4.custom5",
+                "label": "View your mobile phone call history.",
+                "desc": "This allows the app to view your mobile phone call history.",
+                "type": "boolean",
+                "required": true,
+                "value": true,
+                "visible": true,
+                "mutable": true
+              },
+              {
                 "name": "email",
                 "label": "View your email address.",
                 "desc": "This allows the app to view your email address.",

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -14,7 +14,7 @@ import ViewFactory from '../view-builder/ViewFactory';
 import IonResponseHelper from '../ion/IonResponseHelper';
 import { getV1ClassName } from '../ion/ViewClassNamesFactory';
 import { FORMS, TERMINAL_FORMS, FORM_NAME_TO_OPERATION_MAP } from '../ion/RemediationConstants';
-import payloadTransformer from '../ion/payloadTransformer';
+import transformPayload from '../ion/payloadTransformer';
 import Util from 'util/Util';
 import sessionStorageHelper from '../client/sessionStorageHelper';
 import { HttpResponse, IdxStatus, ProceedOptions } from '@okta/okta-auth-js';
@@ -247,9 +247,9 @@ export default Controller.extend({
       return;
     }
 
-    let values = payloadTransformer(formName, model);
+    const payload = transformPayload(formName, model);
     // Run hook: transform the user name (a.k.a identifier)
-    values = this.transformIdentifier(formName, values);
+    const values = this.transformIdentifier(formName, payload);
 
     // widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
     if (this.options.settings.get('features.rememberMe') && this.options.settings.get('features.rememberMyUsernameOnOIE')) {

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -14,6 +14,7 @@ import ViewFactory from '../view-builder/ViewFactory';
 import IonResponseHelper from '../ion/IonResponseHelper';
 import { getV1ClassName } from '../ion/ViewClassNamesFactory';
 import { FORMS, TERMINAL_FORMS, FORM_NAME_TO_OPERATION_MAP } from '../ion/RemediationConstants';
+import payloadTransformer from '../ion/payloadTransformer';
 import Util from 'util/Util';
 import sessionStorageHelper from '../client/sessionStorageHelper';
 import { HttpResponse, IdxStatus, ProceedOptions } from '@okta/okta-auth-js';
@@ -246,8 +247,9 @@ export default Controller.extend({
       return;
     }
 
+    let values = payloadTransformer(formName, model);
     // Run hook: transform the user name (a.k.a identifier)
-    const values = this.transformIdentifier(formName, model);
+    values = this.transformIdentifier(formName, values);
 
     // widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
     if (this.options.settings.get('features.rememberMe') && this.options.settings.get('features.rememberMyUsernameOnOIE')) {
@@ -328,8 +330,7 @@ export default Controller.extend({
     }
   },
 
-  transformIdentifier(formName, model) {
-    const modelJSON = model.toJSON();
+  transformIdentifier(formName, modelJSON) {
     if (Object.prototype.hasOwnProperty.call(modelJSON, 'identifier')) {
       // The callback function is passed two arguments:
       // 1) username: The name entered by the user

--- a/src/v2/ion/payloadTransformer.js
+++ b/src/v2/ion/payloadTransformer.js
@@ -29,6 +29,19 @@ const flattenObj = (obj) => {
   return result;
 };
 
+/**
+ * This function is for the Granular Consent remediation, scopes within the optedScopes
+ * property can include a singular value or n values delimited by a "."
+ * When they are delimited, BackBone's toJSON function will create a nested object, however,
+ * these should not be nested and the delimited key names should stay as is. So this function will
+ * flatten those nested proeprties to format it how the backend expects it. 
+ * i.e. { optedScopes: { some: { scope: true }}} = { optedScopes: { 'some.scope': true }}
+ * 
+ * @param {JSON} modelJSON JSON Equivalent of the Backbone Model's attributes/fields
+ * @returns If the JSON contains the optedScopes Property, we will flatten the fields from
+ * a nested object into K/V pair with dot notation for nested key names. Otherwise, we will return
+ * the JSON as is.
+ */
 const transformOptedScopes = (modelJSON) => {
   if (modelJSON.optedScopes && typeof modelJSON.optedScopes !== 'string') {
     const data = {
@@ -44,6 +57,15 @@ const FormNameToTransformerHandler = {
   [RemediationForms.CONSENT_GRANULAR]: transformOptedScopes,
 };
 
+/**
+ * The purpose of this function is the transform the
+ * Backbone Model's attributes/fields into a JSON equivalent before sending to IDX,
+ * since the Model fields are all flattend when the UI Schema is transformed on consumption.
+ * 
+ * @param {string} formName Form name of the current remediation
+ * @param {Model} model Backbone Model Class
+ * @returns JSON equivalent of the Model
+ */
 const transformPayload = (formName, model) => {
   const modelJSON = model.toJSON();
   const transformHandler = FormNameToTransformerHandler[formName];

--- a/src/v2/ion/payloadTransformer.js
+++ b/src/v2/ion/payloadTransformer.js
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) 2020, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { FORMS as RemediationForms } from './RemediationConstants';
+
+const flattenObj = (obj) => {
+  let result = {};
+
+  Object.keys(obj).forEach((key) => {
+    if (typeof obj[key] !== 'object' || Array.isArray(obj[key])) {
+      result[key] = obj[key];
+      return;
+    }
+
+    const tempObj = flattenObj(obj[key]);
+    Object.keys(tempObj).forEach((j) => {
+      result[key + '.' + j] = tempObj[j];
+    });
+  });
+  return result;
+};
+
+const transformOptedScopes = (modelJSON) => {
+  if (modelJSON.optedScopes && typeof modelJSON.optedScopes !== 'string') {
+    const data = {
+      ...modelJSON,
+      optedScopes: flattenObj(modelJSON.optedScopes),
+    };
+    return data;
+  }
+  return modelJSON;
+};
+
+const FormNameToTransformerHandler = {
+  [RemediationForms.CONSENT_GRANULAR]: transformOptedScopes,
+};
+
+const transformPayload = (formName, model) => {
+  const modelJSON = model.toJSON();
+  const transformHandler = FormNameToTransformerHandler[formName];
+  if (typeof transformHandler === 'undefined') {
+    return modelJSON;
+  }
+  return transformHandler(modelJSON);
+};
+
+export default transformPayload;

--- a/src/v2/ion/payloadTransformer.js
+++ b/src/v2/ion/payloadTransformer.js
@@ -36,6 +36,8 @@ const flattenObj = (obj) => {
  * these should not be nested and the delimited key names should stay as is. So this function will
  * flatten those nested proeprties to format it how the backend expects it. 
  * i.e. { optedScopes: { some: { scope: true }}} = { optedScopes: { 'some.scope': true }}
+ * Currently, this is only used when the Granular Consent view form is saved see:
+ * src/v2/view-builder/views/consent/GranularConsentView.js
  * 
  * @param {JSON} modelJSON JSON Equivalent of the Backbone Model's attributes/fields
  * @returns If the JSON contains the optedScopes Property, we will flatten the fields from

--- a/src/v2/ion/payloadTransformer.js
+++ b/src/v2/ion/payloadTransformer.js
@@ -16,7 +16,7 @@ const flattenObj = (obj) => {
   let result = {};
 
   Object.keys(obj).forEach((key) => {
-    if (typeof obj[key] !== 'object' || Array.isArray(obj[key])) {
+    if (typeof obj[key] !== 'object') {
       result[key] = obj[key];
       return;
     }

--- a/test/testcafe/spec/GranularConsentView_spec.js
+++ b/test/testcafe/spec/GranularConsentView_spec.js
@@ -103,6 +103,7 @@ test.requestHooks(requestLogger, consentGranularMock)('should send correct paylo
   await t.expect(jsonBody.optedScopes.openid).eql(true);
   await t.expect(jsonBody.optedScopes.custom1).eql(false);
   await t.expect(jsonBody.optedScopes.custom2).eql(true);
+  await t.expect(jsonBody.optedScopes['custom3.custom4.custom5']).eql(true);
   await t.expect(jsonBody.optedScopes.email).eql(false);
   await t.expect(jsonBody.optedScopes.profile).eql(true);
   await t.expect(method).eql('post');

--- a/test/testcafe/spec/GranularConsentView_spec.js
+++ b/test/testcafe/spec/GranularConsentView_spec.js
@@ -48,6 +48,8 @@ test.requestHooks(requestLogger, consentGranularMock)('should show scopes list',
     'View your mobile phone data plan.\n\n' +
         'This allows the app to view your mobile phone data plan.',
     'View your internet search history.',
+    'View your mobile phone call history.\n\n' +
+      'This allows the app to view your mobile phone call history.',
     'View your email address.\n\n' +
         'This allows the app to view your email address.',
     'openid\n\n' +


### PR DESCRIPTION
## Description:

The SIW transforms the current SIW model into JSON body to send to the corresponding API request. This happens [here](https://github.com/okta/okta-signin-widget/blob/okta-signin-widget-7.6.0/src/v2/controllers/FormController.ts#LL332C15-L332C15)

However, in case of granular consent view, the model could contain fields with periods in the name, like so,
![scopewithperiods](https://github.com/okta/okta-signin-widget/assets/64189176/0cca9e6b-bf77-4ece-bec1-5196602dde20)

The scope name `test.scope` is wrongly being transformed to `"optedScopes":{"test":{"scope":true}}` in the request body, resulting in a 400 error on the API call.

The culprit is the `model.toJSON()` call mentioned above. This method unflattens the model (which was flattened before sending to courage) [here](https://github.com/okta/okta-signin-widget/blob/okta-signin-widget-7.6.0/packages/%40okta/courage-dist/esm/src/courage/framework/Model.js#L634). While doing so, it nests any values that have periods in the value [here](https://github.com/okta/okta-signin-widget/blob/okta-signin-widget-7.6.0/packages/@okta/courage-dist/esm/src/courage/framework/Model.js#L93-L99).

To fix this, we special case the `granular-consent` formName when transforming the model to JSON in the FormController - https://github.com/okta/okta-signin-widget/pull/3222/files#diff-72a0e868d27f4dfd26d36bcba1d860aa25999401fa00788f3ac694304043dd4dR333. This handles the case for nested scope names.

More discussion on the bug can be found in this [slack thread](https://okta.slack.com/archives/CAZH2MWEL/p1682095746440499). 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-599817](https://oktainc.atlassian.net/browse/OKTA-599817)

### Reviewers:
cc: @shantanusardal-okta 

### Screenshot/Video:


### Downstream Monolith Build:

SIW Bacon build: https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&page=1&pageSize=6&sha=52017b0c7da33b7d1a6e04c7e113d7272aaa174d&tab=main

Downstream Monolith build: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=1c25061b34d40e068aaf750e126419e50497fe6e&tab=main

Fully green downstream: 
![image](https://github.com/okta/okta-signin-widget/assets/97472729/bcd44c53-9965-4391-8e9f-d3e6e2fc10c1)


