### PR TITLE
Correctly extract scope name with periods when transforming model to JSON

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -104,7 +104,8 @@ const idx = {
     // 'oda-enrollment-android',
     // 'mdm-enrollment',
     // 'authenticator-verification-custom-app-push',
-    // 'authenticator-enroll-custom-app-push'    
+    // 'authenticator-enroll-custom-app-push',
+    // 'consent-granular',
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',

--- a/playground/mocks/data/idp/idx/consent-granular.json
+++ b/playground/mocks/data/idp/idx/consent-granular.json
@@ -34,7 +34,7 @@
                 "mutable": false
               },
               {
-                "name": "custom1",
+                "name": "level1.level2.level3.level4",
                 "label": "View your mobile phone data plan.",
                 "desc": "This allows the app to view your mobile phone data plan.",
                 "type": "boolean",

--- a/test/testcafe/spec/GranularConsentView_spec.js
+++ b/test/testcafe/spec/GranularConsentView_spec.js
@@ -92,7 +92,7 @@ test.requestHooks(requestLogger, consentGranularMock)('should send correct paylo
   const consentPage  = await setup(t);
   await checkA11y(t);
 
-  await consentPage.setScopeCheckBox('optedScopes.custom1', false);
+  await consentPage.setScopeCheckBox('optedScopes.level1.level2.level3.level4', false);
   await consentPage.setScopeCheckBox('optedScopes.email', false);
 
   await consentPage.clickAllowButton();
@@ -101,7 +101,7 @@ test.requestHooks(requestLogger, consentGranularMock)('should send correct paylo
 
   await t.expect(jsonBody.consent).eql(true);
   await t.expect(jsonBody.optedScopes.openid).eql(true);
-  await t.expect(jsonBody.optedScopes.custom1).eql(false);
+  await t.expect(jsonBody.optedScopes['level1.level2.level3.level4']).eql(false);
   await t.expect(jsonBody.optedScopes.custom2).eql(true);
   await t.expect(jsonBody.optedScopes.email).eql(false);
   await t.expect(jsonBody.optedScopes.profile).eql(true);


### PR DESCRIPTION
## Description:

The SIW transforms the current SIW model into JSON body to send to the corresponding API request. This happens [here](https://github.com/okta/okta-signin-widget/blob/okta-signin-widget-7.6.0/src/v2/controllers/FormController.ts#LL332C15-L332C15)

However, in case of granular consent view, the model could contain fields with periods in the name, like so,
![scopewithperiods](https://github.com/okta/okta-signin-widget/assets/64189176/eca814a0-6708-4991-a45d-5d641e9dbc75)

The scope name test.scope is wrongly being transformed to "optedScopes":{"test":{"scope":true}} in the request body, resulting in a 400 error on the API call.

The culprit is the model.toJSON() call mentioned above. This method unflattens the model (which was flattened before sending to courage) [here](https://github.com/okta/okta-signin-widget/blob/okta-signin-widget-7.6.0/packages/%40okta/courage-dist/esm/src/courage/framework/Model.js#L634). While doing so, it nests any values that have periods in the value [here](https://github.com/okta/okta-signin-widget/blob/okta-signin-widget-7.6.0/packages/@okta/courage-dist/esm/src/courage/framework/Model.js#L93-L99).

To fix this, we special case the granular-consent formName when transforming the model to JSON in the FormController - https://github.com/okta/okta-signin-widget/pull/3222/files#diff-72a0e868d27f4dfd26d36bcba1d860aa25999401fa00788f3ac694304043dd4dR333. This handles the case for nested scope names.

More discussion on the bug can be found in this [slack thread](https://okta.slack.com/archives/CAZH2MWEL/p1682095746440499).

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-599817](https://oktainc.atlassian.net/browse/OKTA-599817)

### Reviewers:
@glenfannin-okta @conorhanrahan-okta

### Screenshot/Video:
https://github.com/okta/okta-signin-widget/assets/64189176/0cb9e3c9-b4fa-4440-95bb-89eb336ba2b6

### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=ss-siw-consent-nesting-issue&page=1&pageSize=6&sha=9fa9233cafbb56f7a1b1bf8bf26fbeca658ba6b0&tab=main

### Downstream Monolith PR:
https://github.com/okta/okta-core/pull/79844

