### PR TITLE
OKTA-612385 : Add process.env property to vite config

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "copy:types": "grunt copy:types",
     "build:types": "yarn clean:types && yarn generate:types && yarn copy:types",
     "start:mock-server": "MOCK_SERVER_PORT=3030 nodemon --delay 500ms -e js,json --watch playground --exec 'node playground/mocks/server.js'",
-    "test:parity-setup": "mkdir -p test-reports/testcafe && yarn generate-config && mockDuo=true yarn workspace v3 build --mode testcafe && yarn workspace v3 serve --mode testcafe",
+    "test:parity-setup": "mkdir -p test-reports/testcafe && yarn generate-config && yarn workspace v3 build --mode testcafe && yarn workspace v3 serve --mode testcafe",
     "test:parity-run": "OKTA_SIW_V3=TRUE yarn testcafe -c 2 chrome:headless --reporter spec,xunit:build2/reports/junit/testcafe-results.xml",
     "test:parity-ci": "OKTA_SIW_SKIP_FLAKY=true yarn codegen && run-p -r start:mock-server test:parity-setup test:parity-run",
     "test:testcafe-ci-flaky": "OKTA_SIW_V3= OKTA_SIW_ONLY_FLAKY=TRUE yarn test:testcafe-ci",

--- a/src/v3/.env.production
+++ b/src/v3/.env.production
@@ -1,0 +1,2 @@
+VITE_MOCK_DUO=false
+VITE_DEBUG=false

--- a/src/v3/.env.testcafe
+++ b/src/v3/.env.testcafe
@@ -1,0 +1,2 @@
+VITE_MOCK_DUO=true
+VITE_DEBUG=true

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -20,7 +20,7 @@
     "build": "vite build",
     "clean-svg": "svgo -f src/img/authCoinIcons",
     "codegen": "yarn workspace @okta/okta-signin-widget codegen",
-    "dev": "yarn codegen && mockDuo=true vite",
+    "dev": "yarn codegen && VITE_MOCK_DUO=true vite",
     "lint": "yarn codegen && eslint .",
     "lint:report": "scripts/buildtools/lint-report.sh",
     "lint:styles": "stylelint **/*.css",

--- a/src/v3/vite.config.ts
+++ b/src/v3/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig(({ mode, command }) => ({
     OKTA_SIW_VERSION: '"0.0.0"',
     OKTA_SIW_COMMIT_HASH: '"local"',
     DEBUG: true,
+    'process.env': `(${JSON.stringify(process.env)})`,
   },
   resolve: {
     alias: {

--- a/src/v3/vite.config.ts
+++ b/src/v3/vite.config.ts
@@ -13,118 +13,125 @@
 /// <reference types="vite/client" />
 import preact from '@preact/preset-vite';
 import { resolve } from 'path';
-import { BuildOptions, defineConfig, splitVendorChunkPlugin } from 'vite';
+import {
+  BuildOptions,
+  defineConfig,
+  loadEnv,
+  splitVendorChunkPlugin,
+} from 'vite';
 
 const outDir = resolve(__dirname, '../../dist/dist');
 const mockServerBaseUrl = 'http://localhost:3030';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode, command }) => ({
-  root: command === 'serve' && mode === 'testcafe'
-    ? outDir
-    : process.cwd(),
-  plugins: [
-    preact(),
-    splitVendorChunkPlugin(),
-  ],
-  define: {
-    OKTA_SIW_VERSION: '"0.0.0"',
-    OKTA_SIW_COMMIT_HASH: '"local"',
-    DEBUG: true,
-    'process.env': `(${JSON.stringify(process.env)})`,
-  },
-  resolve: {
-    alias: {
-      '@okta/courage': resolve(__dirname, '../../packages/@okta/courage-dist'),
-      '@okta/mocks': resolve(__dirname, '../../playground/mocks'),
-      '@okta/okta-i18n-bundles': resolve(__dirname, '../util/Bundles.ts'),
-      '@okta/qtip': resolve(__dirname, '../../packages/@okta/qtip2/dist/jquery.qtip.js'),
-      config: resolve(__dirname, '../config'),
-      nls: resolve(__dirname, '../../packages/@okta/i18n/src/json'),
-      okta: resolve(__dirname, '../../packages/@okta/courage-dist'),
-      src: resolve(__dirname, './src'), // FIXME use relative imports
-      'util/BrowserFeatures': resolve(__dirname, '../util/BrowserFeatures'),
-      'util/Bundles': resolve(__dirname, '../util/Bundles'),
-      'util/Enums': resolve(__dirname, '../util/Enums'),
-      'util/FactorUtil': resolve(__dirname, '../util/FactorUtil'),
-      'util/Logger': resolve(__dirname, '../util/Logger'),
-      'util/TimeUtil': resolve(__dirname, '../util/TimeUtil'),
-      v1: resolve(__dirname, '../v1'),
-      v2: resolve(__dirname, '../v2'),
-
-      duo_web_sdk: process.env.mockDuo
-        ? resolve(__dirname, 'src/__mocks__/duo_web_sdk') // mock
-        : 'duo_web_sdk', // real
-
-      // react -> preact alias
-      react: 'preact/compat',
-      'react-dom/test-utils': 'preact/test-utils',
-      'react-dom': 'preact/compat',
-      'react/jsx-runtime': 'preact/jsx-runtime',
+export default defineConfig(({ mode, command }) => {
+  const env = loadEnv(mode, process.cwd());
+  return {
+    root: command === 'serve' && mode === 'testcafe'
+      ? outDir
+      : process.cwd(),
+    plugins: [
+      preact(),
+      splitVendorChunkPlugin(),
+    ],
+    define: {
+      OKTA_SIW_VERSION: '"0.0.0"',
+      OKTA_SIW_COMMIT_HASH: '"local"',
+      DEBUG: env.VITE_DEBUG,
     },
-  },
+    resolve: {
+      alias: {
+        '@okta/courage': resolve(__dirname, '../../packages/@okta/courage-dist'),
+        '@okta/mocks': resolve(__dirname, '../../playground/mocks'),
+        '@okta/okta-i18n-bundles': resolve(__dirname, '../util/Bundles.ts'),
+        '@okta/qtip': resolve(__dirname, '../../packages/@okta/qtip2/dist/jquery.qtip.js'),
+        config: resolve(__dirname, '../config'),
+        nls: resolve(__dirname, '../../packages/@okta/i18n/src/json'),
+        okta: resolve(__dirname, '../../packages/@okta/courage-dist'),
+        src: resolve(__dirname, './src'), // FIXME use relative imports
+        'util/BrowserFeatures': resolve(__dirname, '../util/BrowserFeatures'),
+        'util/Bundles': resolve(__dirname, '../util/Bundles'),
+        'util/Enums': resolve(__dirname, '../util/Enums'),
+        'util/FactorUtil': resolve(__dirname, '../util/FactorUtil'),
+        'util/Logger': resolve(__dirname, '../util/Logger'),
+        'util/TimeUtil': resolve(__dirname, '../util/TimeUtil'),
+        v1: resolve(__dirname, '../v1'),
+        v2: resolve(__dirname, '../v2'),
 
-  // not used in "dev" mode, i.e., when `command === 'serve'`
-  build: ((): BuildOptions => {
-    const base: BuildOptions = {
-      // send output to ../../dist/dist
-      outDir,
+        duo_web_sdk: env.VITE_MOCK_DUO
+          ? resolve(__dirname, 'src/__mocks__/duo_web_sdk') // mock
+          : 'duo_web_sdk', // real
 
-      // for debugging
-      sourcemap: 'inline',
-
-      // chained with g1,g2 in `yarn build:release`
-      emptyOutDir: false,
-
-      // playground assets, e.g., logo, favicon
-      copyPublicDir: true,
-    };
-
-    if (mode === 'testcafe') {
-      return base;
-    }
-
-    // default mode for build is "production"
-    return {
-      ...base,
-
-      // hide sourcemaps
-      sourcemap: false, // boolean | 'inline' | 'hidden'
-
-      // set to library mode with "umd" format to expose `OktaSignIn` on the
-      // `window`
-      // https://vitejs.dev/guide/build.html#library-mode
-      lib: {
-        entry: resolve(__dirname, 'src/index.ts'),
-        name: 'OktaSignIn',
-        formats: ['umd'],
-        fileName: () => 'js/okta-sign-in.next.js',
+        // react -> preact alias
+        react: 'preact/compat',
+        'react-dom/test-utils': 'preact/test-utils',
+        'react-dom': 'preact/compat',
+        'react/jsx-runtime': 'preact/jsx-runtime',
       },
-      rollupOptions: {
-        output: {
-          assetFileNames: ({ name }) => (
-            name === 'style.css'
-              ? 'css/okta-sign-in.next.css'
-              : '[name][hash][extname]'
-          ),
+    },
+
+    // not used in "dev" mode, i.e., when `command === 'serve'`
+    build: ((): BuildOptions => {
+      const base: BuildOptions = {
+        // send output to ../../dist/dist
+        outDir,
+
+        // for debugging
+        sourcemap: 'inline',
+
+        // chained with g1,g2 in `yarn build:release`
+        emptyOutDir: false,
+
+        // playground assets, e.g., logo, favicon
+        copyPublicDir: true,
+      };
+
+      if (mode === 'testcafe') {
+        return base;
+      }
+
+      // default mode for build is "production"
+      return {
+        ...base,
+
+        // hide sourcemaps
+        sourcemap: false, // boolean | 'inline' | 'hidden'
+
+        // set to library mode with "umd" format to expose `OktaSignIn` on the
+        // `window`
+        // https://vitejs.dev/guide/build.html#library-mode
+        lib: {
+          entry: resolve(__dirname, 'src/index.ts'),
+          name: 'OktaSignIn',
+          formats: ['umd'],
+          fileName: () => 'js/okta-sign-in.next.js',
         },
-      },
-    };
-  })(),
+        rollupOptions: {
+          output: {
+            assetFileNames: ({ name }) => (
+              name === 'style.css'
+                ? 'css/okta-sign-in.next.css'
+                : '[name][hash][extname]'
+            ),
+          },
+        },
+      };
+    })(),
 
-  server: {
-    host: 'localhost',
-    proxy: {
-      '/oauth2/': mockServerBaseUrl,
-      '/api/v1/': mockServerBaseUrl,
-      '/idp/idx/': mockServerBaseUrl,
-      '/login/getimage': mockServerBaseUrl,
-      '/sso/idps/': mockServerBaseUrl,
-      '/app/UserHome': mockServerBaseUrl,
-      '/oauth2/v1/authorize': mockServerBaseUrl,
-      '/auth/services/': mockServerBaseUrl,
-      '/.well-known/webfinger': mockServerBaseUrl,
+    server: {
+      host: 'localhost',
+      proxy: {
+        '/oauth2/': mockServerBaseUrl,
+        '/api/v1/': mockServerBaseUrl,
+        '/idp/idx/': mockServerBaseUrl,
+        '/login/getimage': mockServerBaseUrl,
+        '/sso/idps/': mockServerBaseUrl,
+        '/app/UserHome': mockServerBaseUrl,
+        '/oauth2/v1/authorize': mockServerBaseUrl,
+        '/auth/services/': mockServerBaseUrl,
+        '/.well-known/webfinger': mockServerBaseUrl,
+      },
+      port: 3000,
     },
-    port: 3000,
-  },
-}));
+  };
+});


### PR DESCRIPTION
## Description:
Vite config cannot read `process.env` property, we must add to `define` object of vite config to expose properties. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-612385](https://oktainc.atlassian.net/browse/OKTA-612385)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



