### PR TITLE
OKTA-612385 : Adding process.env property to vite config

### DIFF
--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -26,6 +26,7 @@
     "lint:styles": "stylelint **/*.css",
     "lint:styles:report": "stylelint **/*.css --custom-formatter ../../node_modules/stylelint-checkstyle-formatter -o build2/reports/lint/OSW-stylelint-checkstyle-result.xml --quiet",
     "serve": "vite preview --port 3000",
+    "preview": "yarn build && cp public/index.html ../../dist/dist && yarn serve",
     "test": "yarn codegen && jest",
     "test:dev": "NODE_ENV=development jest",
     "test:e2e": "NODE_ENV=test testcafe test/e2e/tests/**/*.js --config-file test/e2e/.testcaferc.js",

--- a/src/v3/public/index.html
+++ b/src/v3/public/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Okta</title>
+  <script src="/js/okta-sign-in.next.js"></script>
+  <link rel="stylesheet" href="/css/okta-sign-in.next.css">
+</head>
+
+<body>
+  <div id="okta-login-container"></div>
+  <script>
+    new OktaSignIn({
+      el: '#okta-login-container',
+      // base url for building issuer, localhost:3030 is dyson mock server
+      issuer: 'http://localhost:3030/oauth2/default',
+      logo: '/img/widgico.png',
+      logoText: 'widgico',
+      redirectUri: `http://localhost:3030/login/callback`,
+      features: {},
+      assets: {
+        baseUrl: 'http://localhost:3030/mocks',
+      },
+      authParams: {
+        pkce: false, // pkce enabled by default in okta-auth-js@3.0
+      },
+    })
+  </script>
+</body>
+
+</html>

--- a/src/v3/vite.config.ts
+++ b/src/v3/vite.config.ts
@@ -38,6 +38,8 @@ export default defineConfig(({ mode, command }) => {
       OKTA_SIW_VERSION: '"0.0.0"',
       OKTA_SIW_COMMIT_HASH: '"local"',
       DEBUG: env.VITE_DEBUG,
+      // required for env variables like: NODE_ENV
+      'process.env': `(${JSON.stringify(process.env)})`,
     },
     resolve: {
       alias: {

--- a/src/v3/vite.config.ts
+++ b/src/v3/vite.config.ts
@@ -38,8 +38,7 @@ export default defineConfig(({ mode, command }) => {
       OKTA_SIW_VERSION: '"0.0.0"',
       OKTA_SIW_COMMIT_HASH: '"local"',
       DEBUG: env.VITE_DEBUG,
-      // required for env variables like: NODE_ENV
-      'process.env': `(${JSON.stringify(process.env)})`,
+      'process.env.NODE_ENV': `"${process.env.NODE_ENV}"`,
     },
     resolve: {
       alias: {


### PR DESCRIPTION
## Description:

SIW G3 fails to load when `process.env` is not defined in vite config. Adding this option. 

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-612385](https://oktainc.atlassian.net/browse/OKTA-612385)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



