### PR TITLE
fix the issue where policy unsatisfiable error doesn't render expecte…

### DIFF
--- a/src/v2/models/AppState.ts
+++ b/src/v2/models/AppState.ts
@@ -198,7 +198,10 @@ export default class AppState extends Model {
   }
 
   shouldReRenderView(transformedResponse) {
-    if (transformedResponse?.idx?.hasFormError) {
+    const isWebAuthnTerminalError = this._isWebAuthnTerminalErrorResponse(transformedResponse);
+
+    // if it is webauthn terminal error, always re-render the view.
+    if (!isWebAuthnTerminalError && transformedResponse?.idx?.hasFormError) {
       return false;
     }
 
@@ -393,4 +396,17 @@ export default class AppState extends Model {
 
     return isSameExceptMessages && isChallengeAuthenticator && isCurrentAuthenticatorEmail;
   }
+
+   /**
+   * Check if the response is due to policy non-satisfiable error which is terminal error.
+   * In this case, we should re-render the view to display the error page to user.
+   * @returns {boolean}
+   */ 
+    _isWebAuthnTerminalErrorResponse(transformedResponse) {
+      const enrollmentAuthenticator =  this.get('enrollmentAuthenticator')?.key;
+      const remediationName = transformedResponse?.remediations?.[0]?.name;
+      const errorI18NKey = transformedResponse?.messages?.value?.[0]?.i18n?.key;
+      return (enrollmentAuthenticator && enrollmentAuthenticator === AUTHENTICATOR_KEY.WEBAUTHN && remediationName && remediationName === FORMS.IDENTIFY && 
+      errorI18NKey && errorI18NKey === 'errors.E0000004');
+    }
 }

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -234,7 +234,68 @@ describe('v2/models/AppState', function() {
       expect(this.appState.shouldReRenderView(transformedResponse)).toBe(true);
     });
 
+    it.each([['errors.E0000004', 'webauthn', 'identify', true],
+      ['errors.E0000003', 'webauthn','identify', false],
+      ['errors.E0000004', 'okta_verify', 'identify', false],
+      ['errors.E0000004', 'webauthn', 'challenge-poll', false],
+    ])('rerender view should be true if webauthn got terminal error', (errorCode, authenticatorKey, remediationFormName, expectedResult) => {
+      const idxObj = {
+        'idx': {
+          'enabledFeatures': [],
+          'messages': [
+            {
+              'message': 'Unable to sign in',
+              'i18n': {
+                'key': errorCode
+              },
+              'class': 'ERROR'
+            }
+          ],
+          'actions': {},
+          'rawIdxState': {
+            'version':'1.0.0',
+            'stateHandle':'abcdf',
+            'intent':'LOGIN',
+            'remediation':{
+              'type':'array',
+              'value':[]
+            },
+            'messages': {
+              'type': 'array',
+              'value': [
+                {
+                  'message': 'Unable to sign in',
+                  'i18n': { 'key': errorCode, 'params': [] },
+                  'class': 'ERROR'
+                }
+              ]
+            },
+          },
+          'requestDidSucceed': false,
+          'hasFormError': true
+        },
+        'messages': {'value': [
+          {
+            'message': 'Unable to sign in',
+            'i18n': {
+              'key': errorCode,
+              'params': []
+            },
+            'class': 'ERROR'
+          }
+        ]},
+        'remediations': [
+          {
+            'name': remediationFormName,
+            'refresh': 2000,
+          }
+        ],
+      };
 
+      const transformedResponse = JSON.parse(JSON.stringify(idxObj));
+      this.initAppState({'enrollmentAuthenticator': {'key': authenticatorKey}}, remediationFormName);
+      expect(this.appState.shouldReRenderView(transformedResponse)).toBe(expectedResult);
+    });
   });
 
   describe('hasRemediationObject', () => {


### PR DESCRIPTION
## Description:
* Currently whenever we have policy evaluation fails during WebAuthn enrollment, based on the response we expect the user to be redirected to username/password form(identify) with signin error.
* But as we don't re-render the view, user was still on WebAuthn view and if user tries to setup or return to authenticators will result in console errors.
* So the fix is to fix the re-render logic to handle this scenario.

## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-598411](https://oktainc.atlassian.net/browse/OKTA-598411)

### Reviewers:
@okta/passwordless-okta 

### Screenshot/Video:

## WITH FIX
https://github.com/okta/okta-signin-widget/assets/100623681/d4188a44-5c7d-4355-8a97-200bbaf7de42

## WITHOUT FIX
https://okta.app.box.com/file/1185144730737?s=idfq17vognwaw3h1rbqldlipncxlnnqb


### Downstream Monolith Build:



