### PR TITLE
OKTA-594754 : SIW Gen 3 custom buttons support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,7 +56,7 @@
           "--page-load-timeout",
           "1000000",
           "--config-file",
-          ".testcaferc-parity.js"
+          ".testcaferc.js"
       ],
       "console": "integratedTerminal",
       "cwd": "${workspaceRoot}"

--- a/src/v3/src/transformer/button/transformIDPButtons.ts
+++ b/src/v3/src/transformer/button/transformIDPButtons.ts
@@ -15,7 +15,9 @@ import {
   DividerElement,
   TransformStepFnWithOptions,
 } from '../../types';
-import { getFastPassButtonElement, getIdpButtonElements, loc } from '../../util';
+import {
+  getCustomButtonElements, getFastPassButtonElement, getIdpButtonElements, loc,
+} from '../../util';
 
 export const transformIDPButtons: TransformStepFnWithOptions = ({
   transaction,
@@ -36,9 +38,17 @@ export const transformIDPButtons: TransformStepFnWithOptions = ({
     return formbag;
   }
 
-  const fastPassButtonElement = getFastPassButtonElement(transaction);
+  // only include fastpass button in identify flow
+  const fastPassButtonElement = containsIdentifyStep ? getFastPassButtonElement(transaction) : [];
   const idpButtonElements = getIdpButtonElements(transaction, widgetProps);
-  const buttonsToAdd = [...fastPassButtonElement, ...idpButtonElements];
+  // Only identify step contains custom buttons
+  const customButtonElements = containsIdentifyStep ? getCustomButtonElements(widgetProps) : [];
+  const buttonsToAdd = [
+    ...fastPassButtonElement,
+    ...idpButtonElements,
+    ...customButtonElements,
+  ];
+
   if (buttonsToAdd.length < 1) {
     return formbag;
   }

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -276,6 +276,8 @@ interface ProxyIdxResponse {
 type CustomButton = {
   title: string;
   className: string;
+  i18nKey: string;
+  dataAttr?: string;
   click: { (): void }
 };
 

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -234,12 +234,19 @@ export default class IdentityPageObject extends BasePageObject {
     return Selector(FOOTER_INFO_SELECTOR).textContent;
   }
 
-  async clickCustomButtonLink(index) {
-    await this.t.click(Selector(CUSTOM_BUTTON).nth(index));
+  getCustomButton(index) {
+    if(userVariables.v3) {
+      return Selector('.default-custom-button').nth(index);
+    }
+    return Selector(CUSTOM_BUTTON).nth(index);
   }
 
+  async clickCustomButtonLink(index) {
+    await this.t.click(this.getCustomButton(index));
+  }
+  
   getCustomButtonText(index) {
-    return Selector(CUSTOM_BUTTON).nth(index).textContent;
+    return this.getCustomButton(index).textContent;
   }
 
   async clickSignUpLink() {

--- a/test/testcafe/spec/WidgetCustomization_spec.js
+++ b/test/testcafe/spec/WidgetCustomization_spec.js
@@ -117,8 +117,7 @@ test.requestHooks(xhrSelectAuthenticatorMock)('can customize back to signin link
   await t.expect(selectAuthenticatorPageObject.getSignoutLinkText()).eql('Back to sign in');
 });
 
-// OKTA-594754 Custom buttons are not supported in v3
-test.meta('v3', false).requestHooks(identifyMock)('should show custom buttons links', async t => {
+test.requestHooks(identifyMock)('should show custom buttons links', async t => {
   const identityPage = await setup(t);
   await checkA11y(t);
   await rerenderWidget({


### PR DESCRIPTION
## Description:

This PR adds support for custom buttons in SIW gen 3.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-594754](https://oktainc.atlassian.net/browse/OKTA-594754)

### Reviewers:

### Screenshot/Video:

![image](https://github.com/okta/okta-signin-widget/assets/107433508/17c603ec-f9a4-4ba8-840a-1adcf0ecb972)

### Downstream Monolith Build:



