### PR TITLE
Uses secrets from Vault for `e2e` suites

### DIFF
--- a/scripts/e2e-lang.sh
+++ b/scripts/e2e-lang.sh
@@ -13,7 +13,6 @@ export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/junit"
 echo $TEST_SUITE_TYPE > $TEST_SUITE_TYPE_FILE
 echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
 
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_TEST_SERVER WIDGET_TEST_SERVER
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER WIDGET_BASIC_USER
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD WIDGET_BASIC_PASSWORD
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_2 WIDGET_BASIC_USER_2
@@ -24,12 +23,6 @@ get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_4
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_4 WIDGET_BASIC_PASSWORD_4
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_5 WIDGET_BASIC_USER_5
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_5 WIDGET_BASIC_PASSWORD_5
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER WIDGET_FB_USER
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD WIDGET_FB_PASSWORD
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER_2 WIDGET_FB_USER_2
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD_2 WIDGET_FB_PASSWORD_2
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER_3 WIDGET_FB_USER_3
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD_3 WIDGET_FB_PASSWORD_3
 
 # We use the below OIE enabled org and clients for OIE tests
 export WIDGET_TEST_SERVER=https://oie-signin-widget.okta.com

--- a/scripts/e2e-lang.sh
+++ b/scripts/e2e-lang.sh
@@ -12,9 +12,23 @@ export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/junit"
 echo $TEST_SUITE_TYPE > $TEST_SUITE_TYPE_FILE
 echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
 
-# This file contains all the env vars we need for e2e tests
-aws s3 --quiet --region us-east-1 cp s3://ci-secret-stash/prod/signinwidget/export-test-credentials.sh $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
-source $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_TEST_SERVER WIDGET_TEST_SERVER
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER WIDGET_BASIC_USER
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD WIDGET_BASIC_PASSWORD
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_2 WIDGET_BASIC_USER_2
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_2 WIDGET_BASIC_PASSWORD_2
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_3 WIDGET_BASIC_USER_3
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_3 WIDGET_BASIC_PASSWORD_3
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_4 WIDGET_BASIC_USER_4
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_4 WIDGET_BASIC_PASSWORD_4
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_5 WIDGET_BASIC_USER_5
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_5 WIDGET_BASIC_PASSWORD_5
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER WIDGET_FB_USER
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD WIDGET_FB_PASSWORD
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER_2 WIDGET_FB_USER_2
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD_2 WIDGET_FB_PASSWORD_2
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER_3 WIDGET_FB_USER_3
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD_3 WIDGET_FB_PASSWORD_3
 
 # We use the below OIE enabled org and clients for OIE tests
 export WIDGET_TEST_SERVER=https://oie-signin-widget.okta.com

--- a/scripts/e2e-lang.sh
+++ b/scripts/e2e-lang.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exo pipefail
+set -eo pipefail
 export CI=true
 
 source $OKTA_HOME/$REPO/scripts/setup.sh

--- a/scripts/e2e-lang.sh
+++ b/scripts/e2e-lang.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -exo pipefail
 export CI=true
 
 source $OKTA_HOME/$REPO/scripts/setup.sh

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -15,6 +15,26 @@ echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
 aws s3 --quiet --region us-east-1 cp s3://ci-secret-stash/prod/signinwidget/export-test-credentials.sh $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
 source $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
 
+#get_vault_secret_key path/to/secret example_key SECRET1
+#repo_gh-{org}-{repo_name}/default
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_TEST_SERVER WIDGET_TEST_SERVER
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER WIDGET_BASIC_USER
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD WIDGET_BASIC_PASSWORD
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_2 WIDGET_BASIC_USER_2
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_2 WIDGET_BASIC_PASSWORD_2
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_3 WIDGET_BASIC_USER_3
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_3 WIDGET_BASIC_PASSWORD_3
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_4 WIDGET_BASIC_USER_4
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_4 WIDGET_BASIC_PASSWORD_4
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_5 WIDGET_BASIC_USER_5
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_5 WIDGET_BASIC_PASSWORD_5
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER WIDGET_FB_USER
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD WIDGET_FB_PASSWORD
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER_2 WIDGET_FB_USER_2
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD_2 WIDGET_FB_PASSWORD_2
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER_3 WIDGET_FB_USER_3
+get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD_3 WIDGET_FB_PASSWORD_3
+
 # We use the below OIE enabled org and clients for OIE tests
 export WIDGET_TEST_SERVER=https://oie-signin-widget.okta.com
 export WIDGET_SPA_CLIENT_ID=0oa8lrg7ojTsbJgRQ696

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -12,8 +12,8 @@ echo $TEST_SUITE_TYPE > $TEST_SUITE_TYPE_FILE
 echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
 
 # This file contains all the env vars we need for e2e tests
-aws s3 --quiet --region us-east-1 cp s3://ci-secret-stash/prod/signinwidget/export-test-credentials.sh $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
-source $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
+#aws s3 --quiet --region us-east-1 cp s3://ci-secret-stash/prod/signinwidget/export-test-credentials.sh $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
+#source $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
 
 #get_vault_secret_key path/to/secret example_key SECRET1
 #repo_gh-{org}-{repo_name}/default

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exo pipefail
+set -eo pipefail
 export CI=true
 
 source $OKTA_HOME/$REPO/scripts/setup.sh

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -12,13 +12,6 @@ export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/junit"
 echo $TEST_SUITE_TYPE > $TEST_SUITE_TYPE_FILE
 echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
 
-# This file contains all the env vars we need for e2e tests
-#aws s3 --quiet --region us-east-1 cp s3://ci-secret-stash/prod/signinwidget/export-test-credentials.sh $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
-#source $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
-
-#get_vault_secret_key path/to/secret example_key SECRET1
-#repo_gh-{org}-{repo_name}/default
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_TEST_SERVER WIDGET_TEST_SERVER
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER WIDGET_BASIC_USER
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD WIDGET_BASIC_PASSWORD
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_2 WIDGET_BASIC_USER_2
@@ -29,12 +22,6 @@ get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_4
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_4 WIDGET_BASIC_PASSWORD_4
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_USER_5 WIDGET_BASIC_USER_5
 get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_BASIC_PASSWORD_5 WIDGET_BASIC_PASSWORD_5
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER WIDGET_FB_USER
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD WIDGET_FB_PASSWORD
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER_2 WIDGET_FB_USER_2
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD_2 WIDGET_FB_PASSWORD_2
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_USER_3 WIDGET_FB_USER_3
-get_vault_secret_key repo_gh-okta-okta-signin-widget/default WIDGET_FB_PASSWORD_3 WIDGET_FB_PASSWORD_3
 
 # We use the below OIE enabled org and clients for OIE tests
 export WIDGET_TEST_SERVER=https://oie-signin-widget.okta.com

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -exo pipefail
 export CI=true
 
 source $OKTA_HOME/$REPO/scripts/setup.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -exo pipefail
 
 # Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exo pipefail
+set -eo pipefail
 
 # Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.


### PR DESCRIPTION
## Description:

Pulls secrets from Vault key/value store instead.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



