### PR TITLE
OKTA-594852 : SIW G2 : Update translation keys used on OTP only terminal view

### DIFF
--- a/src/v2/view-builder/views/consent/EmailMagicLinkOTPTerminalView.js
+++ b/src/v2/view-builder/views/consent/EmailMagicLinkOTPTerminalView.js
@@ -14,21 +14,21 @@ const generateGeolocationString = (location = {}) => {
 };
 
 // A map from FactorTransactionIntent in okta-core to customer-facing flow name
-const challengeIntentToFlowMap = {
-  'AUTHENTICATION': loc('idx.return.link.otponly.enter.code.on.page.sign.in', 'login'),
-  'RECOVERY': loc('idx.return.link.otponly.enter.code.on.page.password.reset', 'login'),
-  'UNLOCK_ACCOUNT': loc('idx.return.link.otponly.enter.code.on.page.account.unlock', 'login'),
-  'ENROLLMENT': loc('idx.return.link.otponly.enter.code.on.page.registration', 'login')
+const challengeIntentToI18nKeyMap = {
+  'AUTHENTICATION': 'idx.return.link.otponly.enter.code.on.sign.in.page',
+  'RECOVERY': 'idx.return.link.otponly.enter.code.on.password.reset.page',
+  'UNLOCK_ACCOUNT': 'idx.return.link.otponly.enter.code.on.account.unlock.page',
+  'ENROLLMENT': 'idx.return.link.otponly.enter.code.on.sign.up.page'
 };
 
 const getTerminalOtpEmailMagicLinkContext = (settings, appState) => {
   const app = appState.get('app');
   const client = appState.get('client');
-  const challengeIntent = challengeIntentToFlowMap[appState.get('idx').context.intent];
-  let enterCodeOnFlowPage, appName, browserOnOsString, isMobileDevice, geolocation;
-  enterCodeOnFlowPage = challengeIntent
-    ? loc('idx.return.link.otponly.enter.code.on.page', 'login', [challengeIntent])
+  const challengeIntentContentKey = challengeIntentToI18nKeyMap[appState.get('idx').context.intent];
+  const enterCodeOnFlowPage = challengeIntentContentKey
+    ? loc(challengeIntentContentKey, 'login')
     : loc('idx.enter.otp.in.original.tab', 'login');
+  let appName, browserOnOsString, isMobileDevice, geolocation;
   if (app) {
     appName = loc('idx.return.link.otponly.app', 'login', [app.label]);
   }


### PR DESCRIPTION
## Description:
The purpose of this PR is to utilize the newly created translated keys on the OTP only terminal view. These new keys allow for better translation between various languages and this fix also resolves a hidden english leak that was previously uncaught. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-594852](https://oktainc.atlassian.net/browse/OKTA-594852)

### Reviewers:

### Screenshot/Video:
**Before the fix:**
<img width="504" alt="Screen Shot 2023-06-06 at 4 31 47 PM" src="https://github.com/okta/okta-signin-widget/assets/97472729/d02f123c-02e9-4b29-b30b-776aaeb1f33c">

**After the fix:**
<img width="543" alt="Screen Shot 2023-06-06 at 4 33 13 PM" src="https://github.com/okta/okta-signin-widget/assets/97472729/c2a91510-2c97-4dd2-ae2e-23bfebd35d59">


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=210a994bda0383a1de27bf1ae6d6ca5a3e508114&tab=main

