### PR TITLE
OKTA-585921 : SIW Gen 3 custom access denied error support

### DIFF
--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -44,6 +44,27 @@ const InfoBox: UISchemaElementComponent<{
   } = uischema;
 
   const { links = [] } = message;
+  const renderLinks = () => (
+    <List
+      className="custom-links"
+      disablePadding
+    >
+      {links.map((link) => (
+        <ListItem
+          sx={{ paddingLeft: 0 }}
+          key={link.label}
+        >
+          <Link
+            href={link.url}
+            target="_blank"
+            variant="monochrome"
+          >
+            {link.label}
+          </Link>
+        </ListItem>
+      ))}
+    </List>
+  );
 
   return loading ? null : (
     <Box
@@ -66,25 +87,7 @@ const InfoBox: UISchemaElementComponent<{
           </Typography>
         )}
         <WidgetMessageContainer message={message} />
-        <List
-          className="custom-links"
-          disablePadding
-        >
-          {links.length > 0 && links.map((link) => (
-            <ListItem
-              sx={{ paddingLeft: 0 }}
-              key={link.label}
-            >
-              <Link
-                href={link.url}
-                target="_blank"
-                variant="monochrome"
-              >
-                {link.label}
-              </Link>
-            </ListItem>
-          ))}
-        </List>
+        {links.length > 0 && renderLinks()}
       </Alert>
     </Box>
   );

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -20,11 +20,14 @@ import { h } from 'preact';
 import { useWidgetContext } from '../../contexts';
 import {
   InfoboxElement,
+  LinkElement,
   MessageType,
   MessageTypeVariant,
   UISchemaElementComponent,
 } from '../../types';
 import WidgetMessageContainer from '../WidgetMessageContainer';
+import Link from '../Link';
+import { List, ListItem } from '@mui/material';
 
 const InfoBox: UISchemaElementComponent<{
   uischema: InfoboxElement
@@ -40,6 +43,8 @@ const InfoBox: UISchemaElementComponent<{
       dataSe,
     },
   } = uischema;
+
+  const { links = [] } = message;
 
   return loading ? null : (
     <Box
@@ -62,6 +67,20 @@ const InfoBox: UISchemaElementComponent<{
           </Typography>
         )}
         <WidgetMessageContainer message={message} />
+        <List className="custom-links" disablePadding>
+        {links.length > 0 && links.map(link => (
+            <ListItem sx={{ paddingLeft: 0 }}>
+            <Link uischema={
+              {
+                type: 'Link',
+                options: {
+                  label: link.label,
+                  href: link.url,
+                }
+              } as LinkElement} />
+            </ListItem>)
+        )}
+        </List>
       </Alert>
     </Box>
   );

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -75,7 +75,7 @@ const InfoBox: UISchemaElementComponent<{
               sx={{ paddingLeft: 0 }}
               key={link.label}
             >
-              <Link href={link.url}>
+              <Link href={link.url} target = "_blank" variant='monochrome'>
                 {link.label}
               </Link>
             </ListItem>

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -10,9 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { List, ListItem } from '@mui/material';
 import {
   Alert,
   Box,
+  Link,
   Typography,
 } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
@@ -20,14 +22,11 @@ import { h } from 'preact';
 import { useWidgetContext } from '../../contexts';
 import {
   InfoboxElement,
-  LinkElement,
   MessageType,
   MessageTypeVariant,
   UISchemaElementComponent,
 } from '../../types';
 import WidgetMessageContainer from '../WidgetMessageContainer';
-import Link from '../Link';
-import { List, ListItem } from '@mui/material';
 
 const InfoBox: UISchemaElementComponent<{
   uischema: InfoboxElement
@@ -67,19 +66,20 @@ const InfoBox: UISchemaElementComponent<{
           </Typography>
         )}
         <WidgetMessageContainer message={message} />
-        <List className="custom-links" disablePadding>
-        {links.length > 0 && links.map(link => (
-            <ListItem sx={{ paddingLeft: 0 }}>
-            <Link uischema={
-              {
-                type: 'Link',
-                options: {
-                  label: link.label,
-                  href: link.url,
-                }
-              } as LinkElement} />
-            </ListItem>)
-        )}
+        <List
+          className="custom-links"
+          disablePadding
+        >
+          {links.length > 0 && links.map((link) => (
+            <ListItem
+              sx={{ paddingLeft: 0 }}
+              key={link.label}
+            >
+              <Link href={link.url}>
+                {link.label}
+              </Link>
+            </ListItem>
+          ))}
         </List>
       </Alert>
     </Box>

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -75,7 +75,11 @@ const InfoBox: UISchemaElementComponent<{
               sx={{ paddingLeft: 0 }}
               key={link.label}
             >
-              <Link href={link.url} target = "_blank" variant='monochrome'>
+              <Link
+                href={link.url}
+                target="_blank"
+                variant="monochrome"
+              >
                 {link.label}
               </Link>
             </ListItem>

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -54,6 +54,10 @@ export type WidgetMessage = Modify<IdxMessage, {
   title?: string;
   name?: string;
   description?: string;
+  links?: {
+    label: string,
+    url: string,
+  }[];
 }>;
 
 export type AutoCompleteValue = 'username'
@@ -493,6 +497,7 @@ export interface InfoboxElement extends UISchemaElement {
     message: WidgetMessage;
     class: string;
     dataSe?: string;
+    links?: LinkElement[]
   }
 }
 

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -497,7 +497,6 @@ export interface InfoboxElement extends UISchemaElement {
     message: WidgetMessage;
     class: string;
     dataSe?: string;
-    links?: LinkElement[]
   }
 }
 

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -171,7 +171,6 @@ test.requestHooks(identifyWithPasswordErrorMock)('should show custom access deni
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.fillPasswordField('adasdas');
   await identityPage.clickSignInButton();
-  await identityPage.waitForErrorBox();
 
   const errorBox = identityPage.form.getErrorBox();
   await t.expect(errorBox.innerText).contains('You do not have permission to perform the requested action.');

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -6,6 +6,7 @@ import xhrIdentifyWithPassword from '../../../playground/mocks/data/idp/idx/iden
 import xhrIdentifyRecover from '../../../playground/mocks/data/idp/idx/identify-recovery';
 import xhrErrorIdentify from '../../../playground/mocks/data/idp/idx/error-identify-access-denied';
 import xhrErrorIdentifyAccessDeniedCustomMessage from '../../../playground/mocks/data/idp/idx/error-identify-access-denied-custom-message';
+import { within } from '@testing-library/testcafe';
 
 const identifyWithPasswordMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -163,8 +164,7 @@ test.requestHooks(identifyWithPasswordMock)('should add sub labels for Username 
   await t.expect(identityPage.getPasswordSubLabelValue()).eql('Your password goes here');
 });
 
-// OKTA-585921 - custom error message links not supported in gen3 widget
-test.meta('v3', false).requestHooks(identifyWithPasswordErrorMock)('should show custom access denied error message', async t => {
+test.requestHooks(identifyWithPasswordErrorMock)('should show custom access denied error message', async t => {
   const identityPage = await setup(t);
   await checkA11y(t);
 
@@ -172,8 +172,18 @@ test.meta('v3', false).requestHooks(identifyWithPasswordErrorMock)('should show 
   await identityPage.fillPasswordField('adasdas');
   await identityPage.clickSignInButton();
   await identityPage.waitForErrorBox();
-  await t.expect(identityPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><ul class="custom-links"><li><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a></li><li><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></li></ul></div>');
-});
+
+  const errorBox = identityPage.form.getErrorBox();
+  await t.expect(errorBox.innerText).contains('You do not have permission to perform the requested action.');
+
+  const errorLink1 = within(errorBox).getByRole('link', {name: 'Help link 1'});
+  const errorLink2 = within(errorBox).getByRole('link', {name: 'Help link 2'});
+
+  await t.expect(errorLink1.exists).eql(true);
+  await t.expect(errorLink1.getAttribute('href')).eql('https://www.okta.com/');
+
+  await t.expect(errorLink2.exists).eql(true);
+  await t.expect(errorLink2.getAttribute('href')).eql('https://www.okta.com/help?page=1');});
 
 test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not trim whitespace characters from password when password field is in plain text view', async t => {
   const identityPage = await setup(t);

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -194,7 +194,7 @@ test.requestHooks(terminalMultipleErrorsMock)('should render each error message 
 test.requestHooks(terminalCustomAccessDeniedErrorMessageMock)('should render custom access denied error message', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
-  const errorBox = terminalViewPage.form.getAlertBox();
+  const errorBox = userVariables.v3 ? terminalViewPage.form.getErrorBox() : terminalViewPage.form.getErrorBoxCallout();
   await t.expect(errorBox.innerText).contains('You do not have permission to perform the requested action.');
 
   const errorLink1 = within(errorBox).getByRole('link', {name: 'Help link 1'});

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -194,7 +194,7 @@ test.requestHooks(terminalMultipleErrorsMock)('should render each error message 
 test.requestHooks(terminalCustomAccessDeniedErrorMessageMock)('should render custom access denied error message', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
-  const errorBox = terminalViewPage.form.getErrorBox();
+  const errorBox = terminalViewPage.form.getAlertBox();
   await t.expect(errorBox.innerText).contains('You do not have permission to perform the requested action.');
 
   const errorLink1 = within(errorBox).getByRole('link', {name: 'Help link 1'});

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -19,6 +19,7 @@ import endUserRemediationOneOption from '../../../playground/mocks/data/idp/idx/
 import endUserRemediationMultipleOptions from '../../../playground/mocks/data/idp/idx/end-user-remediation-multiple-options.json';
 import endUserRemediationMultipleOptionsWithCustomHelpUrl from '../../../playground/mocks/data/idp/idx/end-user-remediation-multiple-options-with-custom-help-url.json';
 import endUserRemediationNoOptions from '../../../playground/mocks/data/idp/idx/end-user-remediation-no-options.json';
+import { within } from '@testing-library/testcafe';
 
 const terminalTransferredEmailMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -190,12 +191,20 @@ test.requestHooks(terminalMultipleErrorsMock)('should render each error message 
   await t.expect(await terminalViewPage.form.getErrorBoxTextByIndex(2)).eql('Your session has expired. Please try to sign in again.');
 });
 
-// OKTA-585921 - custom error message not supported in gen3 widget
-test.meta('v3', false).requestHooks(terminalCustomAccessDeniedErrorMessageMock)('should render custom access denied error message', async t => {
+test.requestHooks(terminalCustomAccessDeniedErrorMessageMock)('should render custom access denied error message', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
+  const errorBox = terminalViewPage.form.getErrorBox();
+  await t.expect(errorBox.innerText).contains('You do not have permission to perform the requested action.');
 
-  await t.expect(terminalViewPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><ul class="custom-links"><li><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a></li><li><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></li></ul></div>');
+  const errorLink1 = within(errorBox).getByRole('link', {name: 'Help link 1'});
+  const errorLink2 = within(errorBox).getByRole('link', {name: 'Help link 2'});
+
+  await t.expect(errorLink1.exists).eql(true);
+  await t.expect(errorLink1.getAttribute('href')).eql('https://www.okta.com/');
+
+  await t.expect(errorLink2.exists).eql(true);
+  await t.expect(errorLink2.getAttribute('href')).eql('https://www.okta.com/help?page=1');
 });
 
 // TODO: OKTA-616188 - add end user remediation changes in v3


### PR DESCRIPTION
## Description:

This PR adds support for the custom Access denied error with links, to SIW Gen 3.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-585921](https://oktainc.atlassian.net/browse/OKTA-585921)

### Reviewers:

### Screenshot/Video:
<img width="678" alt="Screenshot 2023-06-23 at 1 44 41 PM" src="https://github.com/okta/okta-signin-widget/assets/107433508/ebc399fe-cd4f-411b-a477-87c39bc83b9b">

### Downstream Monolith Build:



