### PR TITLE
G3 : Enable custom label to be displayed in enroll profile form

### DIFF
--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -309,9 +309,6 @@ const doesI18NKeyExist = (i18nKey) => {
  */
 const getI18NValue = (i18nPath, defaultValue, params = []) => {
   const i18nKey = getI18nKey(i18nPath);
-  // TODO : OKTA-397225
-  // here defaultValue is uiSchema label or placeholders, some lables may be customized by 
-  // admin to anything string. We should not localize and replace these customized labels even if i18nkey exists
   if (i18nKey) {
     return loc(i18nKey, 'login', params);
   } else {

--- a/src/v3/src/transformer/i18n/__snapshots__/transformField.test.ts.snap
+++ b/src/v3/src/transformer/i18n/__snapshots__/transformField.test.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Field transformer tests should use provided custom labels instead of translations 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "label": "Please enter your first name",
+        "options": Object {
+          "inputMeta": Object {
+            "customLabel": true,
+            "name": "userProfile.firstName",
+          },
+        },
+        "translations": Array [
+          Object {
+            "i18nKey": "oie.user.profile.firstname",
+            "name": "label",
+            "noTranslate": true,
+            "value": "Please enter your first name",
+          },
+        ],
+        "type": "Field",
+      },
+      Object {
+        "label": "Please enter your last name",
+        "options": Object {
+          "inputMeta": Object {
+            "customLabel": true,
+            "name": "userProfile.lastName",
+          },
+        },
+        "translations": Array [
+          Object {
+            "i18nKey": "oie.user.profile.lastname",
+            "name": "label",
+            "noTranslate": true,
+            "value": "Please enter your last name",
+          },
+        ],
+        "type": "Field",
+      },
+      Object {
+        "label": "Please enter your email",
+        "options": Object {
+          "inputMeta": Object {
+            "customLabel": false,
+            "name": "userProfile.email",
+          },
+        },
+        "translations": Array [
+          Object {
+            "i18nKey": "oie.user.profile.primary.email",
+            "name": "label",
+            "noTranslate": false,
+            "value": "oie.user.profile.primary.email",
+          },
+        ],
+        "type": "Field",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/i18n/transformField.test.ts
+++ b/src/v3/src/transformer/i18n/transformField.test.ts
@@ -10,15 +10,15 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxTransaction, Input } from '@okta/okta-auth-js';
+import { IdxTransaction } from '@okta/okta-auth-js';
 
 import { IDX_STEP } from '../../constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from '../../mocks/utils/utils';
 import {
-  FormBag,
-  WidgetProps,
   FieldElement,
+  FormBag,
   TranslationInfo,
+  WidgetProps,
 } from '../../types';
 import { transformField } from './transformField';
 
@@ -34,26 +34,32 @@ describe('Field transformer tests', () => {
       {
         type: 'Field',
         label: 'Please enter your first name',
-        options: { inputMeta: {
-          name: 'userProfile.firstName',
-          customLabel: true,
-        } }
+        options: {
+          inputMeta: {
+            name: 'userProfile.firstName',
+            customLabel: true,
+          },
+        },
       } as FieldElement,
       {
         type: 'Field',
         label: 'Please enter your last name',
-        options: { inputMeta: {
-          name: 'userProfile.lastName',
-          customLabel: true,
-        } }
+        options: {
+          inputMeta: {
+            name: 'userProfile.lastName',
+            customLabel: true,
+          },
+        },
       } as FieldElement,
       {
         type: 'Field',
         label: 'Please enter your email',
-        options: { inputMeta: {
-          name: 'userProfile.email',
-          customLabel: false,
-        } }
+        options: {
+          inputMeta: {
+            name: 'userProfile.email',
+            customLabel: false,
+          },
+        },
       } as FieldElement,
     ];
     widgetProps = {};

--- a/src/v3/src/transformer/i18n/transformField.test.ts
+++ b/src/v3/src/transformer/i18n/transformField.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxTransaction, Input } from '@okta/okta-auth-js';
+
+import { IDX_STEP } from '../../constants';
+import { getStubFormBag, getStubTransactionWithNextStep } from '../../mocks/utils/utils';
+import {
+  FormBag,
+  WidgetProps,
+  FieldElement,
+  TranslationInfo,
+} from '../../types';
+import { transformField } from './transformField';
+
+describe('Field transformer tests', () => {
+  let transaction: IdxTransaction;
+  let formBag: FormBag;
+  let widgetProps: WidgetProps;
+
+  beforeEach(() => {
+    transaction = getStubTransactionWithNextStep();
+    formBag = getStubFormBag();
+    formBag.uischema.elements = [
+      {
+        type: 'Field',
+        label: 'Please enter your first name',
+        options: { inputMeta: {
+          name: 'userProfile.firstName',
+          customLabel: true,
+        } }
+      } as FieldElement,
+      {
+        type: 'Field',
+        label: 'Please enter your last name',
+        options: { inputMeta: {
+          name: 'userProfile.lastName',
+          customLabel: true,
+        } }
+      } as FieldElement,
+      {
+        type: 'Field',
+        label: 'Please enter your email',
+        options: { inputMeta: {
+          name: 'userProfile.email',
+          customLabel: false,
+        } }
+      } as FieldElement,
+    ];
+    widgetProps = {};
+  });
+
+  it('should use provided custom labels instead of translations', () => {
+    transaction.nextStep = {
+      name: IDX_STEP.ENROLL_PROFILE,
+    };
+    const options = {
+      transaction,
+      widgetProps,
+      step: IDX_STEP.IDENTIFY,
+      isClientTransaction: false,
+      setMessage: () => {},
+    };
+    const updatedFormBag = transformField(options)(formBag);
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect((updatedFormBag.uischema.elements[0] as FieldElement).translations)
+      .toEqual([{
+        name: 'label',
+        i18nKey: 'oie.user.profile.firstname',
+        value: 'Please enter your first name',
+        noTranslate: true,
+      } as TranslationInfo]);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).translations)
+      .toEqual([{
+        name: 'label',
+        i18nKey: 'oie.user.profile.lastname',
+        value: 'Please enter your last name',
+        noTranslate: true,
+      } as TranslationInfo]);
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).translations)
+      .toEqual([{
+        name: 'label',
+        i18nKey: 'oie.user.profile.primary.email',
+        value: 'oie.user.profile.primary.email',
+        noTranslate: false,
+      } as TranslationInfo]);
+  });
+});

--- a/src/v3/src/transformer/i18n/util.ts
+++ b/src/v3/src/transformer/i18n/util.ts
@@ -41,7 +41,7 @@ export const addTranslation = ({
   // TODO: change translations to required field with default value
   // eslint-disable-next-line no-param-reassign
   element.translations = element.translations || [];
-  const useDefault = !i18nKey || noTranslate && defaultValue;
+  const useDefault = !i18nKey || noTranslate && !!defaultValue;
   element.translations.push({
     name,
     i18nKey,

--- a/src/v3/src/transformer/i18n/util.ts
+++ b/src/v3/src/transformer/i18n/util.ts
@@ -41,7 +41,7 @@ export const addTranslation = ({
   // TODO: change translations to required field with default value
   // eslint-disable-next-line no-param-reassign
   element.translations = element.translations || [];
-  const useDefault = !i18nKey || noTranslate && !!defaultValue;
+  const useDefault = !i18nKey || (noTranslate && !!defaultValue);
   element.translations.push({
     name,
     i18nKey,

--- a/src/v3/src/transformer/i18n/util.ts
+++ b/src/v3/src/transformer/i18n/util.ts
@@ -41,10 +41,11 @@ export const addTranslation = ({
   // TODO: change translations to required field with default value
   // eslint-disable-next-line no-param-reassign
   element.translations = element.translations || [];
+  const useDefault = !i18nKey || noTranslate && defaultValue;
   element.translations.push({
     name,
     i18nKey,
-    value: i18nKey ? loc(i18nKey, 'login', params, tokenReplacement) : defaultValue,
+    value: useDefault ? defaultValue : loc(i18nKey, 'login', params, tokenReplacement),
     noTranslate,
   });
 };
@@ -63,8 +64,9 @@ export const addLabelTranslationToFieldElement = (
   const i18nKey = getI18nKey(path);
   const params = getI18NParams(nextStep, authenticatorKey);
   if (i18nKey || element.label) {
+    const noTranslate = element.options.inputMeta.customLabel;
     addTranslation({
-      element, name: 'label', i18nKey, params, defaultValue: element.label,
+      element, name: 'label', i18nKey, params, defaultValue: element.label, noTranslate,
     });
   }
 };

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -258,7 +258,10 @@ export interface FieldElement extends UISchemaElement {
    */
   showAsterisk?: boolean;
   options: {
-    inputMeta: Input;
+    // TODO: remove customLabel after https://github.com/okta/okta-auth-js/pull/1422
+    inputMeta: Input & {
+      customLabel?: boolean;
+    };
     format?: 'select' | 'radio';
     attributes?: InputAttributes;
     type?: string;

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -258,7 +258,7 @@ export interface FieldElement extends UISchemaElement {
    */
   showAsterisk?: boolean;
   options: {
-    // TODO: remove customLabel after https://github.com/okta/okta-auth-js/pull/1422
+    // TODO: remove customLabel after updating okta-auth-js (OKTA-626602)
     inputMeta: Input & {
       customLabel?: boolean;
     };

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -435,11 +435,18 @@ export default class BaseFormObject {
   }
 
   findFormFieldInputLabel(fieldName) {
-    return this.el
-      .find(`[data-se="o-form-input-${fieldName}"]`)
-      .parent('[data-se="o-form-input-container"]')
-      .sibling('[data-se="o-form-label"]')
-      .child('label');
+    if (userVariables.v3) {
+      return this.el
+        .find(`label[for="${fieldName}"]`)
+        // get first text node
+        .find((_node, index) => index === 0);
+    } else {
+      return this.el
+        .find(`[data-se="o-form-input-${fieldName}"]`)
+        .parent('[data-se="o-form-input-container"]')
+        .sibling('[data-se="o-form-label"]')
+        .child('label');
+    }
   }
 
   getFormFieldSubLabel(fieldName) {

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -117,8 +117,7 @@ test.requestHooks(requestLogger, EnrollProfileSubmitMock)('should show submit bu
   await t.expect(await enrollProfilePage.submitButtonExists()).eql(true);
 });
 
-// TODO: OKTA-616638 - enable custom label in v3
-test.meta('v3', false).requestHooks(requestLogger, EnrollProfileSignUpWithCustomLabelsMock)('should show custom label when provided in response', async t => {
+test.requestHooks(requestLogger, EnrollProfileSignUpWithCustomLabelsMock)('should show custom label when provided in response', async t => {
   const enrollProfilePage = new EnrollProfileViewPageObject(t);
   const identityPage = await setup(t);
   await checkA11y(t);

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -326,14 +326,3 @@ test.requestHooks(mock)('should call settings.registration.click on "Sign Up" cl
   await t.expect(identityPage.getFormTitle()).eql('Sign In');
 });
 
-// TODO : OKTA-397225
-// Uncomment once we support custom labels
-// test.requestHooks(enrollProfileNewCustomLabelMock)('should show custom labels', async t => {
-//   const registrationPage = await setup(t);
-//   await checkA11y(t);
-
-//   await t.expect(await registrationPage.getFormFieldLabel('userProfile.email')).eql('This is your awesome email address');
-//   await t.expect(await registrationPage.getFormFieldLabel('userProfile.firstName')).eql('Please enter your first name');
-//   await t.expect(await registrationPage.getFormFieldLabel('userProfile.lastName')).eql('Please enter your last name');
-
-// });


### PR DESCRIPTION
## Description:

Follow-up for #3262 for G3

Respect `customLabel: true` in IDX response to display label from response instead of using i18n translation.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-616638](https://oktainc.atlassian.net/browse/OKTA-616638)

### Reviewers:

### Screenshot/Video:

after:
<img width="444" alt="Screenshot 2023-06-27 at 12 09 06" src="https://github.com/okta/okta-signin-widget/assets/72614880/39cf8dc2-0572-4f33-8568-cf2e01754cc0">

before:
<img width="447" alt="Screenshot 2023-06-27 at 12 09 29" src="https://github.com/okta/okta-signin-widget/assets/72614880/335b0a64-ef41-4688-99d7-91de0e704385">


### Downstream Monolith Build:



