### PR TITLE
OKTA-623397 : SIW G3 : Remove the unnecessary afterRender event trigger

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -58,6 +58,7 @@ import {
   isOauth2Enabled,
   loadLanguage,
   SessionStorage,
+  shouldSkipAfterRender,
 } from '../../util';
 import { getEventContext } from '../../util/getEventContext';
 import { mapMuiThemeFromBrand } from '../../util/theme';
@@ -344,7 +345,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     if (isClientTransaction) {
       return;
     }
-    if (widgetRendered && typeof idxTransaction !== 'undefined') {
+    if (widgetRendered && typeof idxTransaction !== 'undefined'
+      && !shouldSkipAfterRender(idxTransaction)) {
       events?.afterRender?.(getEventContext(idxTransaction));
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -58,7 +58,6 @@ import {
   isOauth2Enabled,
   loadLanguage,
   SessionStorage,
-  shouldSkipAfterRender,
 } from '../../util';
 import { getEventContext } from '../../util/getEventContext';
 import { mapMuiThemeFromBrand } from '../../util/theme';
@@ -156,7 +155,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
         });
         return;
       }
-      const transaction = await authClient.idx.start({
+      const transaction: IdxTransaction = await authClient.idx.start({
         stateHandle,
         // Required to prevent auth-js from clearing sessionStorage and breaking interaction code flow
         exchangeCodeForTokens: false,
@@ -346,7 +345,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       return;
     }
     if (widgetRendered && typeof idxTransaction !== 'undefined'
-      && !shouldSkipAfterRender(idxTransaction)) {
+      && uischema.elements.length > 0) {
       events?.afterRender?.(getEventContext(idxTransaction));
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -15,7 +15,6 @@ import {
   FieldError,
   IdxMessage,
   IdxRemediation,
-  IdxStatus,
   IdxTransaction,
   Input,
   NextStep,
@@ -355,19 +354,3 @@ export const isVerifyFlow = (transaction: IdxTransaction): boolean => {
 
 // @ts-expect-error OKTA-627610 captcha missing from context type
 export const isCaptchaEnabled = (transaction: IdxTransaction): boolean => typeof transaction.context?.captcha !== 'undefined';
-
-export const shouldSkipAfterRender = (idxTransaction: IdxTransaction): boolean => {
-  const {
-    nextStep: { name: stepName } = {},
-    neededToProceed,
-    messages,
-    context,
-  } = idxTransaction;
-  // When a transaction is in this scenario, it usually indicates a successful
-  // interaction code flow token response which means we should not trigger the afterRender event.
-  return idxTransaction.status === IdxStatus.SUCCESS
-    && stepName === 'cancel'
-    && neededToProceed.length === 0
-    && !messages?.length
-    && !context.messages;
-};

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -15,6 +15,7 @@ import {
   FieldError,
   IdxMessage,
   IdxRemediation,
+  IdxStatus,
   IdxTransaction,
   Input,
   NextStep,
@@ -354,3 +355,19 @@ export const isVerifyFlow = (transaction: IdxTransaction): boolean => {
 
 // @ts-expect-error OKTA-627610 captcha missing from context type
 export const isCaptchaEnabled = (transaction: IdxTransaction): boolean => typeof transaction.context?.captcha !== 'undefined';
+
+export const shouldSkipAfterRender = (idxTransaction: IdxTransaction): boolean => {
+  const {
+    nextStep: { name: stepName } = {},
+    neededToProceed,
+    messages,
+    context,
+  } = idxTransaction;
+  // When a transaction is in this scenario, it usually indicates a successful
+  // interaction code flow token response which means we should not trigger the afterRender event.
+  return idxTransaction.status === IdxStatus.SUCCESS
+    && stepName === 'cancel'
+    && neededToProceed.length === 0
+    && !messages?.length
+    && !context.messages;
+};

--- a/test/testcafe/spec/SessionStorage_spec.js
+++ b/test/testcafe/spec/SessionStorage_spec.js
@@ -246,6 +246,7 @@ test.requestHooks(identifyChallengeMockWithError)('shall clear when session.stat
 
   // Identify page
   await identityPage.navigateToPage();
+  await t.expect(identityPage.formExists()).eql(true);
   await t.expect(getStateHandleFromSessionStorage()).eql(null);
   await identityPage.fillIdentifierField('foo@test.com');
   await identityPage.clickNextButton();
@@ -263,6 +264,9 @@ test.requestHooks(identifyChallengeMockWithError)('shall clear when session.stat
 
   // Refresh
   await challengeEmailPageObject.refresh();
+  // wait for refresh to complete
+  await t.wait(1000);
+  await t.expect(challengeEmailPageObject.formExists()).eql(true);
 
   // Verify introspect requests
   // introspect with session.stateHandle
@@ -367,6 +371,7 @@ test.requestHooks(identifyChallengeMock)('shall back to sign-in and authenticate
   await renderWidget(optionsForInteractionCodeFlow);
 
   // Identify page
+  await t.expect(identityPage.formExists()).eql(true);
   await identityPage.fillIdentifierField('foo@test.com');
   await identityPage.clickNextButton();
 
@@ -421,14 +426,5 @@ test.requestHooks(identifyChallengeMock)('shall back to sign-in and authenticate
       idToken: xhrSuccessTokens.id_token
     }
   ];
-  if (userVariables.v3) {
-    expectedMessages.push(...[
-      'afterRender',
-      {
-        controller: null,
-        formName: 'cancel'
-      },
-    ]);
-  }
   await checkConsoleMessages(expectedMessages);
 });

--- a/test/testcafe/spec/SessionStorage_spec.js
+++ b/test/testcafe/spec/SessionStorage_spec.js
@@ -264,8 +264,6 @@ test.requestHooks(identifyChallengeMockWithError)('shall clear when session.stat
 
   // Refresh
   await challengeEmailPageObject.refresh();
-  // wait for refresh to complete
-  await t.wait(1000);
   await t.expect(challengeEmailPageObject.formExists()).eql(true);
 
   // Verify introspect requests


### PR DESCRIPTION
## Description:
SessionStorage_spec.js was flaky in SIW Gen 3 due to an extra (unnecessary) event being triggered. This PR prevents the unnecessary event from being triggered. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-623397](https://oktainc.atlassian.net/browse/OKTA-623397)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



