### PR TITLE
OKTA-621759 test courage build

### DIFF
--- a/packages/@okta/courage-dist/esm/src/courage/models/SchemaProperty.js
+++ b/packages/@okta/courage-dist/esm/src/courage/models/SchemaProperty.js
@@ -252,13 +252,13 @@ const SchemaPropertySchemaProperty = BaseModel.extend({
 
     if (!minVal) {
       return {
-        __minVal__: 'Min value is required'
+        __minVal__: loc('schema.validation.field.enter.minimum.number', 'courage')
       };
     }
 
     if (!maxVal) {
       return {
-        __maxVal__: 'Max value is required'
+        __maxVal__: loc('schema.validation.field.enter.maximum.number', 'courage')
       };
     }
 
@@ -276,7 +276,7 @@ const SchemaPropertySchemaProperty = BaseModel.extend({
 
     if (+minVal >= +maxVal) {
       return {
-        __maxVal__: 'Max val must be greater than min val'
+        __maxVal__: loc('schema.validation.field.maximum.must.be.greater.than.minimum', 'courage')
       };
     }
   },
@@ -287,7 +287,7 @@ const SchemaPropertySchemaProperty = BaseModel.extend({
       return;
     }
 
-    const val = this._checkIntegerConstraints('__minVal__', 'Min value');
+    const val = this._checkIntegerConstraints('__minVal__', 'Constraint');
 
     if (val) {
       return val;
@@ -300,7 +300,7 @@ const SchemaPropertySchemaProperty = BaseModel.extend({
       return;
     }
 
-    const val = this._checkIntegerConstraints('__maxVal__', 'Max value');
+    const val = this._checkIntegerConstraints('__maxVal__', 'Constraint');
 
     if (val) {
       return val;
@@ -324,12 +324,26 @@ const SchemaPropertySchemaProperty = BaseModel.extend({
     const error = {}; // eslint-disable-next-line no-restricted-globals
 
     if (isNaN(val)) {
-      error[field] = name + ' must be a number';
+      if (name === 'Min value') {
+        error[field] = loc('schema.validation.field.minimum.value.must.be.number', 'courage');
+      } else if (name === 'Max value') {
+        error[field] = loc('schema.validation.field.maximum.value.must.be.number', 'courage');
+      } else if (name === 'Constraint') {
+        error[field] = loc('schema.validation.field.constraint.must.be.number', 'courage');
+      }
+
       return error;
     }
 
     if (+val < 0) {
-      error[field] = name + ' must be greater than 0';
+      if (name === 'Min value') {
+        error[field] = loc('schema.validation.field.minimum.number.must.be.greater.than.zero', 'courage');
+      } else if (name === 'Max value') {
+        error[field] = loc('schema.validation.field.maximum.number.must.be.greater.than.zero', 'courage');
+      } else if (name === 'Constraint') {
+        error[field] = loc('schema.validation.field.number.must.be.greater.than.zero', 'courage');
+      }
+
       return error;
     }
   },

--- a/packages/@okta/courage-dist/esm/src/courage/util/BaseController.js
+++ b/packages/@okta/courage-dist/esm/src/courage/util/BaseController.js
@@ -134,7 +134,7 @@ const proto =
  *
  * See:
  * [Hello World Tutorial](https://github.com/okta/courage/wiki/Hello-World),
- * [Test Spec](https://github.com/okta/okta-ui/blob/master/packages/courage/test/spec/util/BaseController_spec.js)
+ * [Test Spec](https://github.com/atko-eng/okta-ui/blob/master/packages/courage/test/spec/util/BaseController_spec.js)
  *
  * @class module:Okta.Controller
  * @param {Object} options Options Hash

--- a/packages/@okta/courage-dist/esm/src/courage/views/forms/inputs/DeletableBox.js
+++ b/packages/@okta/courage-dist/esm/src/courage/views/forms/inputs/DeletableBox.js
@@ -5,14 +5,6 @@ import StringUtil from '../../../util/StringUtil.js';
 import Time from '../../../util/Time.js';
 import BaseView from '../../BaseView.js';
 
-const isVowel = function (string) {
-  return /^[aeiou]/.test(string);
-};
-
-const getArticle = function (string) {
-  return isVowel(string) ? 'an' : 'a';
-};
-
 const template = _Handlebars2.template({
   "compiler": [8, ">= 4.3.0"],
   "main": function (container, depth0, helpers, partials, data) {
@@ -163,16 +155,50 @@ var DeletableBox = BaseView.extend({
     this.$el.removeClass(errorClass);
   },
   getPlaceholderText: function () {
-    const text = ['Enter'];
-    text.push(getArticle(this.options.itemType));
-    text.push(this.options.itemType.toLowerCase());
-    return text.join(' ');
+    let placeholderText;
+
+    switch (this.options.itemType.toLowerCase()) {
+      // TODO fix lint and add the spaces/indent
+      case 'string':
+        placeholderText = StringUtil.localize('placeholder.text.string', 'courage');
+        break;
+
+      case 'number':
+        placeholderText = StringUtil.localize('placeholder.text.number', 'courage');
+        break;
+
+      case 'integer':
+        placeholderText = StringUtil.localize('placeholder.text.integer', 'courage');
+        break;
+
+      default:
+        placeholderText = '';
+    }
+
+    return placeholderText;
   },
   getErrorExplainText: function () {
-    const text = ['Value must be'];
-    text.push(getArticle(this.options.itemType));
-    text.push(this.options.itemType.toLowerCase());
-    return text.join(' ');
+    let itemTypeMismatchMessages;
+
+    switch (this.options.itemType.toLowerCase()) {
+      // TODO fix lint and add the spaces/indent
+      case 'string':
+        itemTypeMismatchMessages = StringUtil.localize('string.item.type.error.message', 'courage');
+        break;
+
+      case 'number':
+        itemTypeMismatchMessages = StringUtil.localize('number.item.type.error.message', 'courage');
+        break;
+
+      case 'integer':
+        itemTypeMismatchMessages = StringUtil.localize('integer.item.type.error.message', 'courage');
+        break;
+
+      default:
+        itemTypeMismatchMessages = '';
+    }
+
+    return itemTypeMismatchMessages;
   },
   parseInt: function (string) {
     // native javascript parseInt is aggressive

--- a/packages/@okta/courage-dist/esm/src/courage/views/forms/inputs/TextBox.js
+++ b/packages/@okta/courage-dist/esm/src/courage/views/forms/inputs/TextBox.js
@@ -283,6 +283,7 @@ var TextBox = BaseInput.extend({
    */
   readMode: function () {
     BaseInput.prototype.readMode.apply(this, arguments);
+    this.$el.addClass('no-translate');
 
     if (this.options.type === 'password') {
       this.$el.text('********');

--- a/packages/@okta/courage-dist/types/courage/util/BaseController.d.ts
+++ b/packages/@okta/courage-dist/types/courage/util/BaseController.d.ts
@@ -33,7 +33,7 @@ declare const _default: typeof BaseControllerClass;
  *
  * See:
  * [Hello World Tutorial](https://github.com/okta/courage/wiki/Hello-World),
- * [Test Spec](https://github.com/okta/okta-ui/blob/master/packages/courage/test/spec/util/BaseController_spec.js)
+ * [Test Spec](https://github.com/atko-eng/okta-ui/blob/master/packages/courage/test/spec/util/BaseController_spec.js)
  *
  * @class module:Okta.Controller
  * @param {Object} options Options Hash

--- a/packages/@okta/courage-for-signin-widget/package.json
+++ b/packages/@okta/courage-for-signin-widget/package.json
@@ -38,7 +38,7 @@
     "@babel/plugin-transform-shorthand-properties": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@okta/babel-plugin-handlebars-inline-precompile": "3.1.0-beta.4200.gf3d0a27",
-    "@okta/courage": "4.5.0-7729-gdf1c695",
+    "@okta/courage": "4.5.0-8098-g7a3d025",
     "@okta/eslint-plugin-okta-ui": "0.1.0-beta.4181.g1f38f27",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.1",

--- a/packages/@okta/courage-for-signin-widget/yarn.lock
+++ b/packages/@okta/courage-for-signin-widget/yarn.lock
@@ -487,10 +487,10 @@
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
 
-"@okta/courage@4.5.0-7729-gdf1c695":
-  version "4.5.0-7729-gdf1c695"
-  resolved "https://artifacts.aue1e.internal:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-7729-gdf1c695.tgz#88730483fa4a028a503977ea5c7dbe47d910edea"
-  integrity sha1-iHMEg/pKAopQOXfqXH2+R9kQ7eo=
+"@okta/courage@4.5.0-8098-g7a3d025":
+  version "4.5.0-8098-g7a3d025"
+  resolved "https://artifacts.aue1e.internal:443/artifactory/api/npm/npm-okta-all/@okta/courage/-/@okta/courage-4.5.0-8098-g7a3d025.tgz#0428358c3c28c315b02d0f8a063312b3e518b218"
+  integrity sha512-StK9psVz9kVKdzaFKi6ad4iGgJ5M6k5n22Mwic4qXgvda52vjsLsd0z1FFepRc0I30nC+/ycOSRaDVXkxgV3Bg==
   dependencies:
     "@okta/jquery.simplemodal" "1.4.19-g8b711ea"
     "@types/backbone" "^1.4.10"


### PR DESCRIPTION
## Description:

OKTA-621759 test courage build

Changes from https://github.com/atko-eng/okta-ui/pull/6618

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



