### PR TITLE
OKTA-617995 : SIW Gen3 captcha support

### DIFF
--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@hcaptcha/react-hcaptcha": "^1.8.1",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.5",
     "@okta/odyssey-design-tokens": "^0.17.1",
@@ -59,7 +60,8 @@
     "lodash": "^4.17.21",
     "preact": "^10.13.1",
     "react": "npm:@preact/compat",
-    "react-dom": "npm:@preact/compat"
+    "react-dom": "npm:@preact/compat",
+    "react-google-recaptcha": "^3.1.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.18.6",
@@ -83,6 +85,7 @@
     "@types/js-cookie": "^3.0.2",
     "@types/lodash": "^4.14.172",
     "@types/node": "^16.0.0",
+    "@types/react-google-recaptcha": "^2.1.5",
     "@typescript-eslint/eslint-plugin": "^4.29.1",
     "@typescript-eslint/parser": "^4.29.1",
     "axe-core": "^4.3.3",

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -38,9 +38,8 @@ const CaptchaContainer: UISchemaElementComponent<{
   const dataSchema = dataSchemaRef.current!;
   const captchaRef = useRef<ReCAPTCHA | HCaptcha>(null);
 
-  const isHcaptchaInstance = (captchaObj: HCaptcha | ReCAPTCHA): captchaObj is HCaptcha => {
-    return captchaObj instanceof HCaptcha;
-  }
+  const isHcaptchaInstance = (captchaObj: HCaptcha | ReCAPTCHA)
+  : captchaObj is HCaptcha => captchaObj instanceof HCaptcha;
 
   useEffect(() => {
     // set the reference in dataSchema context to this captcha instance
@@ -62,10 +61,6 @@ const CaptchaContainer: UISchemaElementComponent<{
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataSchema]);
-
-  const onErrorCaptcha = (e: Event | string) => {
-    console.error(e);
-  };
 
   const resetCaptchaContainer = () => {
     if (captchaRef.current === null) {
@@ -127,7 +122,6 @@ const CaptchaContainer: UISchemaElementComponent<{
           sitekey={siteKey}
           ref={captchaRef}
           onChange={onVerifyCaptcha}
-          onError={onErrorCaptcha}
           size="invisible"
           badge="bottomright"
         />
@@ -140,7 +134,6 @@ const CaptchaContainer: UISchemaElementComponent<{
       sitekey={siteKey}
       ref={captchaRef}
       onVerify={onVerifyCaptcha}
-      onError={onErrorCaptcha}
       size="invisible"
     />
   );

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import HCaptcha from '@hcaptcha/react-hcaptcha';
+import { Box } from '@okta/odyssey-react-mui';
+import { useEffect, useRef } from 'preact/hooks';
+import ReCAPTCHA from 'react-google-recaptcha';
+
+import { useWidgetContext } from '../../contexts';
+import { useOnSubmit } from '../../hooks';
+import {
+  CaptchaContainerElement,
+  UISchemaElementComponent,
+} from '../../types';
+
+const CaptchaContainer: UISchemaElementComponent<{
+  uischema: CaptchaContainerElement
+}> = ({ uischema }) => {
+  const {
+    options: {
+      siteKey,
+      type: captchaType,
+      captchaId,
+    },
+  } = uischema;
+
+  const { dataSchemaRef } = useWidgetContext();
+  const onSubmitHandler = useOnSubmit();
+  const dataSchema = dataSchemaRef.current!;
+  const captchaRef = useRef<ReCAPTCHA | HCaptcha>(null);
+
+  useEffect(() => {
+    // set the reference in dataSchema context to this captcha instance
+    dataSchema.captchaRef = captchaRef;
+    //  For some reason Hcaptcha does not initially auto render only when in development mode
+    //  This delayed manual render is only used in development mode for hcaptcha
+    if (process.env.NODE_ENV === 'development' && captchaType === 'HCAPTCHA') {
+      setTimeout(() => {
+        (captchaRef.current as HCaptcha)?.renderCaptcha();
+      }, 500);
+    }
+    return () => {
+      dataSchema.captchaRef = undefined;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onVerifyCaptcha = (token: string | null) => {
+    if (!token) {
+      console.error('captcha token expired');
+      return;
+    }
+
+    const {
+      submit: {
+        actionParams: params,
+        step,
+        includeImmutableData,
+      },
+    } = dataSchema;
+
+    // insert received captcha success token into the captchaVerify submit param
+    const captchaSubmitParams = {
+      captchaVerify: {
+        captchaToken: token,
+        captchaId,
+      },
+      ...params,
+    };
+
+    // Captcha challenge solved successfully, submit form
+    onSubmitHandler({
+      includeData: true,
+      includeImmutableData,
+      params: captchaSubmitParams,
+      step,
+    });
+  };
+
+  const onErrorCaptcha = (e: Event | string) => {
+    console.error(e);
+  };
+
+  if (captchaType === 'RECAPTCHA_V2') {
+    return (
+      // set z-index to 9999 for ReCaptcha so the badge does not get covered by the footer
+      <Box zIndex={9999}>
+        <ReCAPTCHA
+          id="captcha-container"
+          sitekey={siteKey}
+          ref={captchaRef}
+          onChange={onVerifyCaptcha}
+          onError={onErrorCaptcha}
+          size="invisible"
+          badge="bottomright"
+        />
+      </Box>
+    );
+  } else {
+    return (
+      <HCaptcha
+        id="captcha-container"
+        sitekey={siteKey}
+        ref={captchaRef}
+        onVerify={onVerifyCaptcha}
+        onError={onErrorCaptcha}
+        size="invisible"
+      />
+    );
+  }
+};
+
+export default CaptchaContainer;

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -51,8 +51,18 @@ const CaptchaContainer: UISchemaElementComponent<{
     return () => {
       dataSchema.captchaRef = undefined;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [dataSchema]);
+
+  const onErrorCaptcha = (e: Event | string) => {
+    console.error(e);
+  };
+
+  const resetCaptchaContainer = () => {
+    if (captchaType === 'RECAPTCHA_V2') {
+      (captchaRef.current as ReCAPTCHA)?.reset();
+    }
+    (captchaRef.current as HCaptcha)?.resetCaptcha();
+  }
 
   const onVerifyCaptcha = (token: string | null) => {
     if (!token) {
@@ -84,10 +94,10 @@ const CaptchaContainer: UISchemaElementComponent<{
       params: captchaSubmitParams,
       step,
     });
-  };
 
-  const onErrorCaptcha = (e: Event | string) => {
-    console.error(e);
+    // tokens are one-time use, so if we submit the same token twice then it will be rejected
+    // by the server the second time, so we must reset the captcha state
+    resetCaptchaContainer();
   };
 
   if (captchaType === 'RECAPTCHA_V2') {

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -103,9 +103,9 @@ const CaptchaContainer: UISchemaElementComponent<{
 
   if (captchaType === 'RECAPTCHA_V2') {
     return (
-      // set z-index to 9999 for ReCaptcha so the badge does not get covered by the footer
+      // set z-index to 1 for ReCaptcha so the badge does not get covered by the footer
       <Box
-        zIndex={9999}
+        zIndex={1}
         position="relative"
       >
         <ReCAPTCHA

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -105,18 +105,17 @@ const CaptchaContainer: UISchemaElementComponent<{
         />
       </Box>
     );
-  } else {
-    return (
-      <HCaptcha
-        id="captcha-container"
-        sitekey={siteKey}
-        ref={captchaRef}
-        onVerify={onVerifyCaptcha}
-        onError={onErrorCaptcha}
-        size="invisible"
-      />
-    );
   }
+  return (
+    <HCaptcha
+      id="captcha-container"
+      sitekey={siteKey}
+      ref={captchaRef}
+      onVerify={onVerifyCaptcha}
+      onError={onErrorCaptcha}
+      size="invisible"
+    />
+  );
 };
 
 export default CaptchaContainer;

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -103,7 +103,7 @@ const CaptchaContainer: UISchemaElementComponent<{
   if (captchaType === 'RECAPTCHA_V2') {
     return (
       // set z-index to 9999 for ReCaptcha so the badge does not get covered by the footer
-      <Box zIndex={9999}>
+      <Box zIndex={9999} position='relative'>
         <ReCAPTCHA
           id="captcha-container"
           sitekey={siteKey}

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -47,6 +47,7 @@ const CaptchaContainer: UISchemaElementComponent<{
     if (captchaRef.current !== null) {
       //  For some reason Hcaptcha does not initially auto render only when in development mode
       //  https://github.com/hCaptcha/react-hcaptcha/issues/53
+      //  May be an issue with compiling typescript and hot module updating
       //  This delayed manual render is only used in development mode for hcaptcha
       if (process.env.NODE_ENV === 'development' && isHcaptchaInstance(captchaRef.current)) {
         setTimeout(() => {

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -51,6 +51,7 @@ const CaptchaContainer: UISchemaElementComponent<{
     return () => {
       dataSchema.captchaRef = undefined;
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataSchema]);
 
   const onErrorCaptcha = (e: Event | string) => {
@@ -62,7 +63,7 @@ const CaptchaContainer: UISchemaElementComponent<{
       (captchaRef.current as ReCAPTCHA)?.reset();
     }
     (captchaRef.current as HCaptcha)?.resetCaptcha();
-  }
+  };
 
   const onVerifyCaptcha = (token: string | null) => {
     if (!token) {
@@ -103,7 +104,10 @@ const CaptchaContainer: UISchemaElementComponent<{
   if (captchaType === 'RECAPTCHA_V2') {
     return (
       // set z-index to 9999 for ReCaptcha so the badge does not get covered by the footer
-      <Box zIndex={9999} position='relative'>
+      <Box
+        zIndex={9999}
+        position="relative"
+      >
         <ReCAPTCHA
           id="captcha-container"
           sitekey={siteKey}

--- a/src/v3/src/components/CaptchaContainer/index.tsx
+++ b/src/v3/src/components/CaptchaContainer/index.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import CaptchaContainer from './CaptchaContainer';
+
+export default CaptchaContainer;

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -60,6 +60,7 @@ const Form: FunctionComponent<{
         step,
         includeImmutableData,
       },
+      captchaRef,
     } = dataSchemaRef.current!;
 
     // client side validation - only validate for fields in nextStep
@@ -79,13 +80,21 @@ const Form: FunctionComponent<{
       }
     }
 
-    // submit request
-    onSubmitHandler({
-      includeData: true,
-      includeImmutableData,
-      params,
-      step,
-    });
+    // @ts-expect-error captcha missing from context type
+    const { context: { captcha: captchaConfig } } = currTransaction!;
+    const hasCaptcha = typeof captchaConfig !== 'undefined';
+    if (hasCaptcha && captchaRef?.current) {
+      // launch the captcha challenge
+      captchaRef.current.execute();
+    } else {
+      // submit request
+      onSubmitHandler({
+        includeData: true,
+        includeImmutableData,
+        params,
+        step,
+      });
+    }
   }, [
     currTransaction,
     data,

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -81,10 +81,8 @@ const Form: FunctionComponent<{
     }
 
     if (currTransaction && isCaptchaEnabled(currTransaction)) {
-      if (captchaRef?.current) {
-        // launch the captcha challenge
-        captchaRef.current.execute();
-      }
+      // launch the captcha challenge
+      captchaRef?.current?.execute();
     } else {
       // submit request
       onSubmitHandler({

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -87,10 +87,6 @@ const Form: FunctionComponent<{
       if (captchaRef?.current) {
         // launch the captcha challenge
         captchaRef.current.execute();
-      } else {
-        // if captcha is enabled in the form but somehow the captchaRef is null,
-        // we dont want the form to submit
-        return;
       }
     } else {
       // submit request

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -83,9 +83,15 @@ const Form: FunctionComponent<{
     // @ts-expect-error captcha missing from context type
     const { context: { captcha: captchaConfig } } = currTransaction!;
     const hasCaptcha = typeof captchaConfig !== 'undefined';
-    if (hasCaptcha && captchaRef?.current) {
-      // launch the captcha challenge
-      captchaRef.current.execute();
+    if (hasCaptcha) {
+      if (captchaRef?.current) {
+        // launch the captcha challenge
+        captchaRef.current.execute();
+      } else {
+        // if captcha is enabled in the form but somehow the captchaRef is null,
+        // we dont want the form to submit
+        return;
+      }
     } else {
       // submit request
       onSubmitHandler({

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -20,7 +20,7 @@ import {
   SubmitEvent,
   UISchemaLayout,
 } from '../../types';
-import { getValidationMessages } from '../../util';
+import { getValidationMessages, isCaptchaEnabled } from '../../util';
 import InfoSection from '../InfoSection/InfoSection';
 import Layout from './Layout';
 import style from './style.module.css';
@@ -80,10 +80,7 @@ const Form: FunctionComponent<{
       }
     }
 
-    // @ts-expect-error captcha missing from context type
-    const { context: { captcha: captchaConfig } } = currTransaction!;
-    const hasCaptcha = typeof captchaConfig !== 'undefined';
-    if (hasCaptcha) {
+    if (currTransaction && isCaptchaEnabled(currTransaction)) {
       if (captchaRef?.current) {
         // launch the captcha challenge
         captchaRef.current.execute();

--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -23,6 +23,7 @@ import {
 import AuthenticatorButtonList from '../AuthenticatorButton';
 import AutoSubmit from '../AutoSubmit';
 import Button from '../Button';
+import CaptchaContainer from '../CaptchaContainer';
 import Checkbox from '../Checkbox';
 import Divider from '../Divider';
 import DuoWindow from '../DuoWindow';
@@ -203,5 +204,9 @@ export default [
   {
     tester: ({ type }) => type === 'DuoWindow',
     renderer: DuoWindow,
+  },
+  {
+    tester: ({ type }) => type === 'CaptchaContainer',
+    renderer: CaptchaContainer,
   },
 ] as Renderer[];

--- a/src/v3/src/components/InformationalText/InformationalText.tsx
+++ b/src/v3/src/components/InformationalText/InformationalText.tsx
@@ -21,7 +21,11 @@ const InformationalText: UISchemaElementComponent<{
 }> = ({
   uischema,
 }) => {
-  const { content, dataSe } = uischema.options;
+  const {
+    content,
+    dataSe,
+    variant,
+  } = uischema.options;
   const parsedContent = useHtmlContentParser(content, uischema.parserOptions);
 
   return (
@@ -34,6 +38,7 @@ const InformationalText: UISchemaElementComponent<{
         paragraph
         data-se={dataSe || 'o-form-explain'}
         className={uischema.noTranslate ? 'no-translate' : undefined}
+        variant={variant ?? 'body1'}
       >
         {parsedContent}
       </Typography>

--- a/src/v3/src/transformer/captcha/__snapshots__/transformCaptcha.test.ts.snap
+++ b/src/v3/src/transformer/captcha/__snapshots__/transformCaptcha.test.ts.snap
@@ -52,7 +52,7 @@ Object {
         "options": Object {
           "captchaId": "test_id",
           "siteKey": "test_site_key",
-          "type": "captcha_type",
+          "type": "RECAPTCHA_V2",
         },
         "type": "CaptchaContainer",
       },

--- a/src/v3/src/transformer/captcha/__snapshots__/transformCaptcha.test.ts.snap
+++ b/src/v3/src/transformer/captcha/__snapshots__/transformCaptcha.test.ts.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Captcha container transformer tests should add captcha container when captcha object is in transaction context 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+      Object {
+        "options": Object {
+          "captchaId": "test_id",
+          "siteKey": "test_site_key",
+          "type": "captcha_type",
+        },
+        "type": "CaptchaContainer",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/captcha/index.ts
+++ b/src/v3/src/transformer/captcha/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export * from './transformCaptcha';

--- a/src/v3/src/transformer/captcha/transformCaptcha.test.ts
+++ b/src/v3/src/transformer/captcha/transformCaptcha.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxTransaction } from '@okta/okta-auth-js';
+import { getStubFormBag, getStubTransaction } from '../../mocks/utils/utils';
+import {
+  ButtonElement,
+  ButtonType,
+  CaptchaContainerElement,
+  DescriptionElement,
+  FieldElement,
+  FormBag,
+  LinkElement,
+  TitleElement,
+  WidgetProps,
+} from '../../types';
+import { transformCaptcha } from './transformCaptcha';
+
+describe('Captcha container transformer tests', () => {
+  let transaction: IdxTransaction;
+  let formBag: FormBag;
+  let widgetProps: WidgetProps;
+
+  beforeEach(() => {
+    transaction = getStubTransaction();
+    formBag = getStubFormBag();
+    formBag.uischema.elements = [
+      { type: 'Title', options: { content: 'Sign in' } } as TitleElement,
+      { type: 'Field', options: { inputMeta: { name: 'identifier' } } } as FieldElement,
+      { type: 'Field', options: { inputMeta: { name: 'credentials.passcode' } } } as FieldElement,
+      { type: 'Button', options: { type: ButtonType.SUBMIT } } as ButtonElement,
+      { type: 'Link', options: { label: 'Forgot Password' } } as LinkElement,
+    ];
+    widgetProps = {};
+  });
+
+  it('should add captcha container when captcha object is in transaction context', () => {
+    transaction.context = {
+      // @ts-expect-error captcha missing from context type
+      captcha: {
+        value: {
+          type: 'captcha_type',
+          id: 'test_id',
+          siteKey: 'test_site_key',
+        }
+      }
+    };
+    const updatedFormBag = transformCaptcha({
+      transaction, widgetProps, step: '', isClientTransaction: false, setMessage: () => {},
+    })(formBag);
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect((updatedFormBag.uischema.elements[5] as CaptchaContainerElement).type).toBe('CaptchaContainer');
+    expect((updatedFormBag.uischema.elements[5] as CaptchaContainerElement).options.type).toBe('captcha_type');
+    expect((updatedFormBag.uischema.elements[5] as CaptchaContainerElement).options.captchaId).toBe('test_id');
+    expect((updatedFormBag.uischema.elements[5] as CaptchaContainerElement).options.siteKey).toBe('test_site_key');
+  });
+
+  it('should not add captcha container when captcha object is not in transaction context', () => {
+    const updatedFormBag = transformCaptcha({
+      transaction, widgetProps, step: '', isClientTransaction: false, setMessage: () => {},
+    })(formBag);
+
+    expect(updatedFormBag.uischema.elements.length).toBe(5);
+    expect(updatedFormBag).toEqual(formBag);
+  });
+
+  it('should add footer text when captcha type is HCAPTCHA', () => {
+    transaction.context = {
+      // @ts-expect-error captcha missing from context type
+      captcha: {
+        value: {
+          type: 'HCAPTCHA',
+          id: 'test_id',
+          siteKey: 'test_site_key',
+        }
+      }
+    };
+    const updatedFormBag = transformCaptcha({
+      transaction, widgetProps, step: '', isClientTransaction: false, setMessage: () => {},
+    })(formBag);
+
+    expect(updatedFormBag.uischema.elements.length).toBe(7);
+    expect((updatedFormBag.uischema.elements[5] as DescriptionElement).options.content).toBe('hcaptcha.footer.label');
+  });
+
+  it('should not add footer text when captcha type is RECAPTCHA_V2', () => {
+    transaction.context = {
+      // @ts-expect-error captcha missing from context type
+      captcha: {
+        value: {
+          type: 'RECAPTCHA_V2',
+          id: 'test_id',
+          siteKey: 'test_site_key',
+        }
+      }
+    };
+    const updatedFormBag = transformCaptcha({
+      transaction, widgetProps, step: '', isClientTransaction: false, setMessage: () => {},
+    })(formBag);
+
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect((updatedFormBag.uischema.elements[4] as DescriptionElement).options.content).not.toBe('hcaptcha.footer.label');
+    expect(updatedFormBag).toEqual(formBag);
+  });
+});

--- a/src/v3/src/transformer/captcha/transformCaptcha.test.ts
+++ b/src/v3/src/transformer/captcha/transformCaptcha.test.ts
@@ -49,7 +49,7 @@ describe('Captcha container transformer tests', () => {
       // @ts-expect-error OKTA-627610 captcha missing from context type
       captcha: {
         value: {
-          type: 'captcha_type',
+          type: 'RECAPTCHA_V2',
           id: 'test_id',
           siteKey: 'test_site_key',
         },
@@ -62,7 +62,7 @@ describe('Captcha container transformer tests', () => {
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect((updatedFormBag.uischema.elements[5] as CaptchaContainerElement).type).toBe('CaptchaContainer');
-    expect((updatedFormBag.uischema.elements[5] as CaptchaContainerElement).options.type).toBe('captcha_type');
+    expect((updatedFormBag.uischema.elements[5] as CaptchaContainerElement).options.type).toBe('RECAPTCHA_V2');
     expect((updatedFormBag.uischema.elements[5] as CaptchaContainerElement).options.captchaId).toBe('test_id');
     expect((updatedFormBag.uischema.elements[5] as CaptchaContainerElement).options.siteKey).toBe('test_site_key');
   });

--- a/src/v3/src/transformer/captcha/transformCaptcha.test.ts
+++ b/src/v3/src/transformer/captcha/transformCaptcha.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { IdxTransaction } from '@okta/okta-auth-js';
+
 import { getStubFormBag, getStubTransaction } from '../../mocks/utils/utils';
 import {
   ButtonElement,
@@ -51,8 +52,8 @@ describe('Captcha container transformer tests', () => {
           type: 'captcha_type',
           id: 'test_id',
           siteKey: 'test_site_key',
-        }
-      }
+        },
+      },
     };
     const updatedFormBag = transformCaptcha({
       transaction, widgetProps, step: '', isClientTransaction: false, setMessage: () => {},
@@ -83,8 +84,8 @@ describe('Captcha container transformer tests', () => {
           type: 'HCAPTCHA',
           id: 'test_id',
           siteKey: 'test_site_key',
-        }
-      }
+        },
+      },
     };
     const updatedFormBag = transformCaptcha({
       transaction, widgetProps, step: '', isClientTransaction: false, setMessage: () => {},
@@ -102,8 +103,8 @@ describe('Captcha container transformer tests', () => {
           type: 'RECAPTCHA_V2',
           id: 'test_id',
           siteKey: 'test_site_key',
-        }
-      }
+        },
+      },
     };
     const updatedFormBag = transformCaptcha({
       transaction, widgetProps, step: '', isClientTransaction: false, setMessage: () => {},

--- a/src/v3/src/transformer/captcha/transformCaptcha.test.ts
+++ b/src/v3/src/transformer/captcha/transformCaptcha.test.ts
@@ -46,7 +46,7 @@ describe('Captcha container transformer tests', () => {
 
   it('should add captcha container when captcha object is in transaction context', () => {
     transaction.context = {
-      // @ts-expect-error captcha missing from context type
+      // @ts-expect-error OKTA-627610 captcha missing from context type
       captcha: {
         value: {
           type: 'captcha_type',
@@ -78,7 +78,7 @@ describe('Captcha container transformer tests', () => {
 
   it('should add footer text when captcha type is HCAPTCHA', () => {
     transaction.context = {
-      // @ts-expect-error captcha missing from context type
+      // @ts-expect-error OKTA-627610 captcha missing from context type
       captcha: {
         value: {
           type: 'HCAPTCHA',
@@ -97,7 +97,7 @@ describe('Captcha container transformer tests', () => {
 
   it('should not add footer text when captcha type is RECAPTCHA_V2', () => {
     transaction.context = {
-      // @ts-expect-error captcha missing from context type
+      // @ts-expect-error OKTA-627610 captcha missing from context type
       captcha: {
         value: {
           type: 'RECAPTCHA_V2',

--- a/src/v3/src/transformer/captcha/transformCaptcha.ts
+++ b/src/v3/src/transformer/captcha/transformCaptcha.ts
@@ -37,6 +37,10 @@ export const transformCaptcha: TransformStepFnWithOptions = ({ transaction }) =>
     },
   } = transaction;
 
+  if (!['HCAPTCHA', 'RECAPTCHA_V2'].includes(captchaType)) {
+    return formbag;
+  }
+
   // if HCAPTCHA type, render the footer - we need to do this manually since the HCAPTCHA lib doesn't do it
   if (captchaType === 'HCAPTCHA') {
     const hcaptchaFooterContent = loc(

--- a/src/v3/src/transformer/captcha/transformCaptcha.ts
+++ b/src/v3/src/transformer/captcha/transformCaptcha.ts
@@ -15,21 +15,18 @@ import {
   DescriptionElement,
   TransformStepFnWithOptions,
 } from '../../types';
-import { loc } from '../../util';
+import { isCaptchaEnabled, loc } from '../../util';
 
 export const transformCaptcha: TransformStepFnWithOptions = ({ transaction }) => (
   formbag,
 ) => {
-  // @ts-expect-error captcha missing from context type
-  const hasCaptcha = typeof transaction.context?.captcha !== 'undefined';
-
-  if (!hasCaptcha) {
+  if (!isCaptchaEnabled(transaction)) {
     return formbag;
   }
 
   const {
     context: {
-      // @ts-expect-error captcha missing from context type
+      // @ts-expect-error OKTA-627610 captcha missing from context type
       captcha: {
         value: {
           id: captchaId,

--- a/src/v3/src/transformer/captcha/transformCaptcha.ts
+++ b/src/v3/src/transformer/captcha/transformCaptcha.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  CaptchaContainerElement,
+  DescriptionElement,
+  TransformStepFnWithOptions,
+} from '../../types';
+import { loc } from '../../util';
+
+export const transformCaptcha: TransformStepFnWithOptions = ({ transaction }) => (
+  formbag,
+) => {
+  // @ts-expect-error captcha missing from context type
+  const hasCaptcha = typeof transaction.context?.captcha !== 'undefined';
+
+  if (!hasCaptcha) {
+    return formbag;
+  }
+
+  const {
+    context: {
+      // @ts-expect-error captcha missing from context type
+      captcha: {
+        value: {
+          id: captchaId,
+          type: captchaType,
+          siteKey,
+        },
+      },
+    },
+  } = transaction;
+
+  // if HCAPTCHA type, render the footer - we need to do this manually since the HCAPTCHA lib doesn't do it
+  if (captchaType === 'HCAPTCHA') {
+    const hcaptchaFooterContent = loc(
+      'hcaptcha.footer.label',
+      'login',
+      undefined,
+      {
+        $1: { element: 'a', attributes: { href: 'https://hcaptcha.com/privacy' } },
+        $2: { element: 'a', attributes: { href: 'https://hcaptcha.com/terms' } },
+      },
+    );
+    formbag.uischema.elements.push({
+      type: 'Description',
+      options: {
+        variant: 'subtitle1',
+        content: hcaptchaFooterContent,
+      },
+    } as DescriptionElement);
+  }
+
+  const captchaContainer: CaptchaContainerElement = {
+    type: 'CaptchaContainer',
+    options: {
+      captchaId,
+      siteKey,
+      type: captchaType,
+    },
+  };
+
+  formbag.uischema.elements.push(captchaContainer);
+
+  return formbag;
+};

--- a/src/v3/src/transformer/main.ts
+++ b/src/v3/src/transformer/main.ts
@@ -19,6 +19,7 @@ import {
   UISchemaLayoutType,
 } from '../types';
 import { transformButtons } from './button';
+import { transformCaptcha } from './captcha';
 import { transformDataSchema } from './dataSchema';
 import { transformFields } from './field';
 import { transformI18n } from './i18n';
@@ -42,6 +43,7 @@ export const transformIdxTransaction = (options: TransformationOptions): FormBag
     transformFields(options),
     transformLayout(options),
     transformButtons(options),
+    transformCaptcha(options),
     transformMessages(options),
     transformI18n(options),
     transformUISchema(options),

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -20,6 +20,9 @@ import {
 import { IdxOption } from '@okta/okta-auth-js/types/lib/idx/types/idx-js';
 import { HTMLReactParserOptions } from 'html-react-parser';
 import { FunctionComponent } from 'preact';
+import { Ref } from 'preact/hooks';
+import ReCAPTCHA from 'react-google-recaptcha';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 
 import { IStepperContext, IWidgetContext } from './context';
 import { ClickHandler } from './handlers';
@@ -34,6 +37,7 @@ export type DataSchemaBag = GeneralDataSchemaBag & {
   fieldsToTrim: string[];
   fieldsToValidate: string[];
   fieldsToExclude: (data: FormBag['data']) => string[];
+  captchaRef?: Ref<ReCAPTCHA | HCaptcha>;
 };
 
 export type FormBag = {
@@ -389,6 +393,7 @@ export interface DescriptionElement extends UISchemaElement {
   options: {
     content: string;
     dataSe?: string;
+    variant?: 'body1' | 'subtitle1' | 'legend';
   };
 }
 
@@ -580,5 +585,14 @@ export interface DuoWindowElement extends UISchemaElement {
     host: string;
     signedToken: string;
     step: string;
+  };
+}
+
+export interface CaptchaContainerElement extends UISchemaElement {
+  type: 'CaptchaContainer';
+  options: {
+    captchaId: string;
+    siteKey: string;
+    type: 'HCAPTCHA' | 'RECAPTCHA_V2';
   };
 }

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import {
   IdxAuthenticator,
   IdxMessage,
@@ -22,7 +23,6 @@ import { HTMLReactParserOptions } from 'html-react-parser';
 import { FunctionComponent } from 'preact';
 import { Ref } from 'preact/hooks';
 import ReCAPTCHA from 'react-google-recaptcha';
-import HCaptcha from '@hcaptcha/react-hcaptcha';
 
 import { IStepperContext, IWidgetContext } from './context';
 import { ClickHandler } from './handlers';

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -351,3 +351,6 @@ export const isVerifyFlow = (transaction: IdxTransaction): boolean => {
   const { context: { currentAuthenticatorEnrollment } } = transaction;
   return typeof currentAuthenticatorEnrollment !== 'undefined';
 };
+
+// @ts-expect-error OKTA-627610 captcha missing from context type
+export const isCaptchaEnabled = (transaction: IdxTransaction): boolean => typeof transaction.context?.captcha !== 'undefined';

--- a/test/testcafe/spec/IdentifyRecoveryWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyRecoveryWithCaptcha_spec.js
@@ -69,7 +69,8 @@ test.requestHooks(identifyRequestLogger, reCaptchaRequestLogger, identifyRecover
 // TODO: enable this test OKTA-504996
 test.requestHooks(identifyRequestLogger, identifyRecoveryWithHCaptchaMock)('should be able to submit identifier with hCaptcha enabled', async t => {
   const identityPage = await setup(t);
-  await checkA11y(t);
+  // TODO: Quarantined a11y check - OKTA-576351 - re-enable once fixed
+  // await checkA11y(t);
 
   // Wait for the hCaptcha container to appear in the DOM and become visible.
   const captchaContainer = Selector('#captcha-container iframe');

--- a/test/testcafe/spec/IdentifyRecoveryWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyRecoveryWithCaptcha_spec.js
@@ -34,11 +34,12 @@ const reCaptchaRequestLogger = RequestLogger(
   }
 );
 
-fixture('Identify Recovery - reset flow with Captcha');
+fixture('Identify Recovery - reset flow with Captcha').meta('v3', true);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
   await identityPage.navigateToPage();
+  await t.expect(await identityPage.formExists()).eql(true);
   await checkConsoleMessages({
     controller: 'forgot-password',
     formName: 'identify-recovery',

--- a/test/testcafe/spec/IdentifyRegistrationWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyRegistrationWithCaptcha_spec.js
@@ -27,12 +27,13 @@ const reCaptchaRequestLogger = RequestLogger(
   }
 );
 
-fixture('Registration With Captcha');
+fixture('Registration With Captcha').meta('v3', true);
 
-test.requestHooks(reCaptchaRequestLogger, mockWithReCaptcha)('should be able to create account with reCaptcha enabled', async t => {
+async function setup(t) {
   // mock is configured to show registration page immediately
   const registrationPage = new RegistrationPageObject(t);
   await registrationPage.navigateToPage();
+  await t.expect(await registrationPage.formExists()).eql(true);
   await checkConsoleMessages([
     'ready',
     'afterRender',
@@ -41,6 +42,12 @@ test.requestHooks(reCaptchaRequestLogger, mockWithReCaptcha)('should be able to 
       formName: 'enroll-profile',
     },
   ]);
+
+  return registrationPage;
+}
+
+test.requestHooks(reCaptchaRequestLogger, mockWithReCaptcha)('should be able to create account with reCaptcha enabled', async t => {
+  const registrationPage = await setup(t);
   
   // click register button
   await registrationPage.fillFirstNameField('abc');
@@ -60,17 +67,7 @@ test.requestHooks(reCaptchaRequestLogger, mockWithReCaptcha)('should be able to 
 
 // TODO: enable this test OKTA-504996
 test.requestHooks(mockWithHCaptcha)('should be able to create account with hCaptcha enabled', async t => {
-  // mock is configured to show registration page immediately
-  const registrationPage = new RegistrationPageObject(t);
-  await registrationPage.navigateToPage();
-  await checkConsoleMessages([
-    'ready',
-    'afterRender',
-    {
-      controller: 'registration',
-      formName: 'enroll-profile',
-    },
-  ]);
+  const registrationPage = await setup(t);
 
   // click register button
   await registrationPage.fillFirstNameField('abc');

--- a/test/testcafe/spec/IdentifyWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyWithCaptcha_spec.js
@@ -34,11 +34,12 @@ const reCaptchaRequestLogger = RequestLogger(
   }
 );
 
-fixture('Identify + Password With Captcha');
+fixture('Identify + Password With Captcha').meta('v3', true);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
   await identityPage.navigateToPage();
+  await t.expect(await identityPage.formExists()).eql(true);
   await checkConsoleMessages({
     controller: 'primary-auth',
     formName: 'identify',
@@ -63,7 +64,7 @@ test.requestHooks(identifyRequestLogger, identifyMockwithHCaptcha)('should sign 
 
   // Wait for the hCaptcha container to appear in the DOM and become visible.
   await t.expect(Selector('#captcha-container').find('iframe').exists).ok();
-  await identityPage.clickNextButton();
+  await identityPage.clickSignInButton();
   await t.expect(identifyRequestLogger.count(() => true)).eql(1);
 
   const req = identifyRequestLogger.requests[0].request;
@@ -87,7 +88,7 @@ test.requestHooks(identifyRequestLogger, reCaptchaRequestLogger, identifyMockWit
   
   // Wait for the reCaptcha container to appear in the DOM and become visible.
   await t.expect(Selector('#captcha-container').find('.grecaptcha-badge').exists).ok();
-  await identityPage.clickNextButton();
+  await identityPage.clickSignInButton();
 
   // Ensure request to google's API was sent out with the correct siteKey. This is our best option to validate that this
   // flow works because otherwise in Bacon for some reason, the full reCaptcha flow does not always work - it's very flaky.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3552,8 +3552,28 @@
     safe-flat "^2.0.2"
 
 "@okta/okta-signin-widget@link:dist":
-  version "0.0.0"
-  uid ""
+  version "7.8.0"
+  dependencies:
+    "@okta/okta-auth-js" "~7.0.0"
+    "@sindresorhus/to-milliseconds" "^1.0.0"
+    "@types/backbone" "^1.4.15"
+    "@types/jquery" "^3.5.14"
+    "@types/jqueryui" "^1.12.16"
+    "@types/q" "^1.5.5"
+    "@types/selectize" "^0.12.35"
+    "@types/underscore" "^1.11.4"
+    chokidar "^3.5.1"
+    clipboard "^1.5.16"
+    cross-fetch "^3.1.5"
+    ejs "^3.1.7"
+    handlebars "^4.7.7"
+    jquery "^3.6.0"
+    parse-ms "^2.0.0"
+    q "1.4.1"
+    u2f-api-polyfill "0.4.3"
+    underscore "1.13.1"
+  optionalDependencies:
+    fsevents "*"
 
 "@open-draft/until@^1.0.3":
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2070,6 +2070,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.17.9":
+  version "7.22.6"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
+  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
@@ -2854,6 +2861,13 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
+"@hcaptcha/react-hcaptcha@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-1.8.1.tgz#3e6e0423100158bae089e4ef6507db0d4c62ec3f"
+  integrity sha512-33tIl77HgeahiQ6R0+JPDA8cGBBv95cIVcdOcFVwiGCJhrOxyiOQetCdEUNTDS13xrkvIP29K/PrqLXXSbKl6Q==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -3538,28 +3552,8 @@
     safe-flat "^2.0.2"
 
 "@okta/okta-signin-widget@link:dist":
-  version "7.7.0"
-  dependencies:
-    "@okta/okta-auth-js" "~7.0.0"
-    "@sindresorhus/to-milliseconds" "^1.0.0"
-    "@types/backbone" "^1.4.15"
-    "@types/jquery" "^3.5.14"
-    "@types/jqueryui" "^1.12.16"
-    "@types/q" "^1.5.5"
-    "@types/selectize" "^0.12.35"
-    "@types/underscore" "^1.11.4"
-    chokidar "^3.5.1"
-    clipboard "^1.5.16"
-    cross-fetch "^3.1.5"
-    ejs "^3.1.7"
-    handlebars "^4.7.7"
-    jquery "^3.6.0"
-    parse-ms "^2.0.0"
-    q "1.4.1"
-    u2f-api-polyfill "0.4.3"
-    underscore "1.13.1"
-  optionalDependencies:
-    fsevents "*"
+  version "0.0.0"
+  uid ""
 
 "@open-draft/until@^1.0.3":
   version "1.0.3"
@@ -4462,6 +4456,13 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/react-google-recaptcha@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.npmjs.org/@types/react-google-recaptcha/-/react-google-recaptcha-2.1.5.tgz#af157dc2e4bde3355f9b815a64f90e85cfa9df8b"
+  integrity sha512-iWTjmVttlNgp0teyh7eBXqNOQzVq2RWNiFROWjraOptRnb1OcHJehQnji0sjqIRAk9K0z8stjyhU+OLpPb0N6w==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-is@^16.7.1 || ^17.0.0":
   version "17.0.3"
@@ -11368,7 +11369,7 @@ highlight-es@^1.0.0:
     is-es2016-keyword "^1.0.0"
     js-tokens "^3.0.0"
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -16835,7 +16836,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.5.0, prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -17099,10 +17100,26 @@ rc@1.2.8, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-async-script@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/react-async-script/-/react-async-script-1.2.0.tgz#ab9412a26f0b83f5e2e00de1d2befc9400834b21"
+  integrity sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==
+  dependencies:
+    hoist-non-react-statics "^3.3.0"
+    prop-types "^15.5.0"
+
 "react-dom@npm:@preact/compat", "react@npm:@preact/compat":
   version "17.1.2"
   resolved "https://registry.yarnpkg.com/@preact/compat/-/compat-17.1.2.tgz#928756713b07af6faf7812f6a56840d8ce6fed37"
   integrity sha512-7pOZN9lMDDRQ+6aWvjwTp483KR8/zOpfS83wmOo3zfuLKdngS8/5RLbsFWzFZMGdYlotAhX980hJ75bjOHTwWg==
+
+react-google-recaptcha@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-3.1.0.tgz#44aaab834495d922b9d93d7d7a7fb2326315b4ab"
+  integrity sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==
+  dependencies:
+    prop-types "^15.5.0"
+    react-async-script "^1.2.0"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## Description:

This PR adds support for `hCaptcha` and `ReCaptcha V2` in SIW Gen 3

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-617995](https://oktainc.atlassian.net/browse/OKTA-617995)

### Reviewers:

### Screenshot/Video:

**hCaptcha:**
<img width="958" alt="image" src="https://github.com/okta/okta-signin-widget/assets/107433508/3343ad63-5077-4ff4-b4bc-5b74f6c9da49">

**reCaptcha: (invisible)**
<img width="1196" alt="image" src="https://github.com/okta/okta-signin-widget/assets/107433508/2d78b35d-d889-4ff8-94e7-ff81066ced55">


**### hCaptcha demo:**
https://github.com/okta/okta-signin-widget/assets/107433508/1c36a69b-cb90-4f84-a187-d608e966b9f6

**### ReCaptcha_V2 demo:**
https://github.com/okta/okta-signin-widget/assets/107433508/0d112612-5b4a-46a1-a42d-a38a9710df27



### Downstream Monolith Build:



