### PR TITLE
OKTA-616191 : SIW Gen 3 support remember me when launch OV

### DIFF
--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -65,6 +65,11 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
     }
     onSubmitHandler({
       step,
+      isActionStep: true,
+      // pass the rememberMe checkbox value into the request params
+      params: {
+        rememberMe: data['rememberMe'],
+      }
     });
   };
 

--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -65,7 +65,7 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
     }
     onSubmitHandler({
       step,
-      isActionStep: true,
+      isActionStep: !!data.rememberMe,
       // pass the rememberMe checkbox value into the request params
       params: {
         rememberMe: data.rememberMe,

--- a/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchAuthenticatorButton/LaunchAuthenticatorButton.tsx
@@ -68,8 +68,8 @@ const LaunchAuthenticatorButton: UISchemaElementComponent<{
       isActionStep: true,
       // pass the rememberMe checkbox value into the request params
       params: {
-        rememberMe: data['rememberMe'],
-      }
+        rememberMe: data.rememberMe,
+      },
     });
   };
 

--- a/test/testcafe/spec/LaunchOVWithRememberMe_spec.js
+++ b/test/testcafe/spec/LaunchOVWithRememberMe_spec.js
@@ -11,9 +11,8 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/authenticators/okta-verify/launch')
   .respond('');
 
-// TODO: OKTA-616191 - enable in G3
 fixture('Launch OV with rememberMe')
-  .meta('v3', false)
+  .meta('v3', true)
   .requestHooks(logger, mock);
 
 


### PR DESCRIPTION
## Description:

This PR adds support for the "remember me" functionality when pressing the `Sign in with fastpass` button, and to meet parity with the Gen 2 implementation here: https://github.com/okta/okta-signin-widget/pull/3163

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-616191](https://oktainc.atlassian.net/browse/OKTA-616191)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



