### PR TITLE
Added i18n keys for Chrome DTC DA remediation

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1530,7 +1530,7 @@ idx.error.code.access_denied.device_assurance.remediation.additional_help_custom
 idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted = Turn on disk encryption
 idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = Turn on your device’s firewall
 idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured = Turn on automatic screen saver and screen locking when idle
-idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.upgrade_browser_version = Update Chrome browser to {0}
+idx.error.code.access_denied.device_assurance.remediation.chrome.upgrade_browser_version = Update Chrome browser to {0}
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.upgrade_os_version = Update to ChromeOS {0}
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.verified_mode = Switch your device to verified mode
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.developer_mode = Switch your device to developer mode

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1528,7 +1528,7 @@ idx.error.code.access_denied.device_assurance.remediation.additional_help_defaul
 idx.error.code.access_denied.device_assurance.remediation.additional_help_custom = For more information, follow the instructions on <$1>your organization's help page</$1> or contact your administrator for help
 # end user remediation for Chrome DTC signals
 idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted = Turn on disk encryption
-idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = Turn on your device’s firewall
+idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = Turn on your device's firewall
 idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured = Turn on automatic screen saver and screen locking when idle
 idx.error.code.access_denied.device_assurance.remediation.chrome.upgrade_browser_version = Update Chrome browser to {0}
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.upgrade_os_version = Update to ChromeOS {0}

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1530,7 +1530,7 @@ idx.error.code.access_denied.device_assurance.remediation.additional_help_custom
 idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted = Turn on disk encryption
 idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = Turn on your device’s firewall
 idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured = Turn on automatic screen saver and screen locking when idle
-idx.error.code.access_denied.device_assurance.remediation.chrome.browser_version = Update your Chrome browser
+idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.upgrade_browser_version = Update Chrome browser to {0}
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.upgrade_os_version = Update to ChromeOS {0}
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.verified_mode = Switch your device to verified mode
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.developer_mode = Switch your device to developer mode

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1526,3 +1526,11 @@ idx.error.code.access_denied.device_assurance.remediation.windows.device_disk_en
 idx.error.code.access_denied.device_assurance.remediation.windows.use_biometric_lock_screen = Enable Windows Hello for the lock screen
 idx.error.code.access_denied.device_assurance.remediation.additional_help_default = For more information, follow the instructions on <$1>the help page</$1> or contact your administrator for help
 idx.error.code.access_denied.device_assurance.remediation.additional_help_custom = For more information, follow the instructions on <$1>your organization's help page</$1> or contact your administrator for help
+# end user remediation for Chrome DTC signals
+idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted = Turn on disk encryption
+idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = Turn on your device’s firewall
+idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured = Turn on automatic screen saver and screen locking when idle
+idx.error.code.access_denied.device_assurance.remediation.chrome.browser_version = Update your Chrome browser
+idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.upgrade_os_version = Update to ChromeOS {0}
+idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.verified_mode = Switch your device to verified mode
+idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.developer_mode = Switch your device to developer mode

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1530,7 +1530,9 @@ idx.error.code.access_denied.device_assurance.remediation.additional_help_custom
 idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted = Turn on disk encryption
 idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = Turn on your device's firewall
 idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured = Turn on automatic screen saver and screen locking when idle
+# {0} is the version for Chrome browser, i.e. Update Chrome browser to 114.0.5735.198
 idx.error.code.access_denied.device_assurance.remediation.chrome.upgrade_browser_version = Update Chrome browser to {0}
+# {0} is the version for this OS, i.e. Update to ChromeOS 15134.0.0
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.upgrade_os_version = Update to ChromeOS {0}
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.verified_mode = Switch your device to verified mode
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.developer_mode = Switch your device to developer mode

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -1143,3 +1143,10 @@ idx.error.code.access_denied.device_assurance.remediation.windows.device_disk_en
 idx.error.code.access_denied.device_assurance.remediation.windows.use_biometric_lock_screen = 》Éñåƀļé Ŵîñðöŵš Ĥéļļö ƒöŕ ţĥé ļöçķ šçŕééñ €홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 idx.error.code.access_denied.device_assurance.remediation.additional_help_default = 》Ƒöŕ ɱöŕé îñƒöŕɱåţîöñ، ƒöļļöŵ ţĥé îñšţŕûçţîöñš öñ <$1>ţĥé ĥéļþ þåĝé</$1> öŕ çöñţåçţ ýöûŕ åðɱîñîšţŕåţöŕ ƒöŕ ĥéļþ ฐโ⾼ئ䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 idx.error.code.access_denied.device_assurance.remediation.additional_help_custom = 》Ƒöŕ ɱöŕé îñƒöŕɱåţîöñ، ƒöļļöŵ ţĥé îñšţŕûçţîöñš öñ <$1>ýöûŕ öŕĝåñîžåţîöñ´š ĥéļþ þåĝé</$1> öŕ çöñţåçţ ýöûŕ åðɱîñîšţŕåţöŕ ƒöŕ ĥéļþ 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted = 》Ţûŕñ öñ ðîšķ éñçŕýþţîöñ 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = 》Ţûŕñ öñ ýöûŕ ðéṽîçé´š ƒîŕéŵåļļ 䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured = 》Ţûŕñ öñ åûţöɱåţîç šçŕééñ šåṽéŕ åñð šçŕééñ ļöçķîñĝ ŵĥéñ îðļé 䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+idx.error.code.access_denied.device_assurance.remediation.chrome.upgrade_browser_version = 》Ûþðåţé Çĥŕöɱé ƀŕöŵšéŕ ţö 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ {0}《
+idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.upgrade_os_version = 》Ûþðåţé ţö ÇĥŕöɱéÖŠ โ⾼ئ䀕ヸ€홝한Ӝฐโ {0}《
+idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.verified_mode = 》Šŵîţçĥ ýöûŕ ðéṽîçé ţö ṽéŕîƒîéð ɱöðé 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.developer_mode = 》Šŵîţçĥ ýöûŕ ðéṽîçé ţö ðéṽéļöþéŕ ɱöðé 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《


### PR DESCRIPTION
## Description:
- Added i18n keys for Chrome DTC DA remediation
- okta-core pr (WIP) https://github.com/atko-eng/okta-core/pull/81866


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-626335](https://oktainc.atlassian.net/browse/OKTA-626335)

### Reviewers:
@shuowu 

### Screenshot/Video:


### Downstream Monolith Build:



