### PR TITLE
Install siw-platform-scripts globally

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,9 +31,9 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0
+  yarn global add @okta/siw-platform-scripts@0.7.0
 
-  if ! yarn run siw-platform install-artifact -n @okta/okta-auth-js -v ${AUTHJS_VERSION} ; then
+  if ! siw-platform install-artifact -n @okta/okta-auth-js -v ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"
     exit ${FAILED_SETUP}
   fi

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -2,6 +2,8 @@
 
 # NOTE: MUST BE RAN *AFTER* THE PUBLISH SUITE
 
+export REGISTRY="${ARTIFACTORY_URL}/npm-topic"
+
 cd ${OKTA_HOME}/${REPO}
 
 # Install required node version
@@ -22,13 +24,12 @@ if ! ci-append-sha; then
 fi
 
 # NOTE: hyphen rather than '@'
-artifact_version="$(ci-pkginfo -t pkgsemver)"
+artifact_version="$(ci-pkginfo -t pkgname)-$(ci-pkginfo -t pkgsemver)"
+published_tarball=${REGISTRY}/@okta/okta-signin-widget/-/${artifact_version}.tgz
 
 # clone angular sample, using angular sample because angular toolchain is *very* opinionated about modules
 git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/angular-sample
 pushd test/package/angular-sample/custom-login
-
-yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0
 
 # use npm instead of yarn to test as a community dev
 if ! npm i; then
@@ -37,8 +38,8 @@ if ! npm i; then
 fi
 
 # install the version of @okta/okta-signin-widget from artifactory that was published during the `publish` suite
-if ! yarn run siw-platform install-artifact -n @okta/okta-signin-widget -v ${artifact_version}; then
-  echo "install @okta/okta-signin-widget@${artifact_version} failed! Exiting..."
+if ! npm i ${published_tarball}; then
+  echo "install ${published_tarball} failed! Exiting..."
   exit ${FAILED_SETUP}
 fi
 


### PR DESCRIPTION
## Description:

To prevent leaking of internal package into `package.json`, install `@okta/siw-platform-scripts` with `yarn global add` rather than `yarn add -W --force --no-lockfile`


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-626176](https://oktainc.atlassian.net/browse/OKTA-626176)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



