### PR TITLE
Bumps yarn and removes ca cert

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "engines": {
     "node": ">=14.18",
-    "yarn": "^1.7.0"
+    "yarn": "^1.22.19"
   },
   "types": "./types/src/exports/default.d.ts",
   "main": "./target/js/okta-sign-in.js",

--- a/scripts/downstream/create-downstream-for-courage.sh
+++ b/scripts/downstream/create-downstream-for-courage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 setup_service node v14.18.2
-setup_service yarn 1.21.1
+setup_service yarn 1.22.19
 
 # download okta-ui artifact version if empty and assign to upstream_artifact_version
 if [[ -z "${upstream_artifact_version}" ]]; then
@@ -31,9 +31,6 @@ popd > /dev/null
 
 # Install top-level (public) dependencies, also needed for a build
 echo "installing top-level dependencies"
-
-# Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
-setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
 
 pushd ${OKTA_HOME}/okta-signin-widget > /dev/null
   yarn install

--- a/scripts/downstream/create-downstream-for-monolith.sh
+++ b/scripts/downstream/create-downstream-for-monolith.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -xe
 
 setup_service node v14.18.2
-# Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
-setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
+setup_service yarn 1.22.19
 
 # install dockolith based on upstream branch
 export DOCKOLITH_BRANCH=${upstream_artifact_branch}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,8 +15,7 @@ if ! setup_service node v16.19.1 &> /dev/null; then
   exit ${FAILED_SETUP}
 fi
 
-# Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
-if ! setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt &> /dev/null; then
+if ! setup_service yarn 1.22.19 &> /dev/null; then
   echo "Failed to install yarn"
   exit ${FAILED_SETUP}
 fi

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -158,8 +158,7 @@ if [ -n "${TEST_SUITE_ID}" ]; then
   setup_service node v14.18.2
 
   # Verify minimum supported version of yarn
-  # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
-  setup_service yarn 1.7.0 /etc/pki/tls/certs/ca-bundle.crt
+  setup_service yarn 1.22.19
   export PATH="${PATH}:$(yarn global bin)"
   set -e
 fi

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -6,7 +6,7 @@ cd ${OKTA_HOME}/${REPO}
 
 # Install required node version
 setup_service node v14.18.2
-setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
+setup_service yarn 1.22.19
 
 # Install required dependencies
 yarn global add @okta/ci-append-sha
@@ -29,9 +29,6 @@ git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/
 pushd test/package/angular-sample/custom-login
 
 yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.5.0
-
-# NOTE: setup_service sets the registry to internal mirror, add certs to chain
-export NODE_EXTRA_CA_CERTS="/etc/pki/tls/certs/ca-bundle.crt"
 
 # use npm instead of yarn to test as a community dev
 if ! npm i; then


### PR DESCRIPTION
## Description:

- [X] Bumps yarn to 1.22.19 as required by the CI/CD.
- [X] Removes the ca cert requirement since it is no longer necessary

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



