### PR TITLE
OKTA-628622 : verify-registry-install failing test fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "engines": {
     "node": ">=14.18",
-    "yarn": "^1.22.19"
+    "yarn": "^1.7.0"
   },
   "types": "./types/src/exports/default.d.ts",
   "main": "./target/js/okta-sign-in.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "engines": {
     "node": ">=14.18",
-    "yarn": "^1.7.0"
+    "yarn": "^1.22.19"
   },
   "types": "./types/src/exports/default.d.ts",
   "main": "./target/js/okta-sign-in.js",

--- a/scripts/downstream/create-downstream-for-courage.sh
+++ b/scripts/downstream/create-downstream-for-courage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 setup_service node v14.18.2
-setup_service yarn 1.21.1
+setup_service yarn 1.22.19
 
 # download okta-ui artifact version if empty and assign to upstream_artifact_version
 if [[ -z "${upstream_artifact_version}" ]]; then
@@ -31,9 +31,6 @@ popd > /dev/null
 
 # Install top-level (public) dependencies, also needed for a build
 echo "installing top-level dependencies"
-
-# Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
-setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
 
 pushd ${OKTA_HOME}/okta-signin-widget > /dev/null
   yarn install

--- a/scripts/downstream/create-downstream-for-monolith.sh
+++ b/scripts/downstream/create-downstream-for-monolith.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -xe
 
 setup_service node v14.18.2
-# Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
-setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
+setup_service yarn 1.22.19
 
 # install dockolith based on upstream branch
 export DOCKOLITH_BRANCH=${upstream_artifact_branch}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,7 +31,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.5.0
+  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0
 
   if ! yarn run siw-platform install-artifact -n @okta/okta-auth-js -v ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,7 +31,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0
+  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0-gd2f5715
 
   if ! yarn run siw-platform install-artifact -n @okta/okta-auth-js -v ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,7 +31,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0-gd2f5715
+  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0#gd2f5715
 
   if ! yarn run siw-platform install-artifact -n @okta/okta-auth-js -v ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,7 +31,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.8.0
+  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0
 
   if ! yarn run siw-platform install-artifact -n @okta/okta-auth-js -v ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,8 +15,7 @@ if ! setup_service node v16.19.1 &> /dev/null; then
   exit ${FAILED_SETUP}
 fi
 
-# Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
-if ! setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt &> /dev/null; then
+if ! setup_service yarn 1.22.19 &> /dev/null; then
   echo "Failed to install yarn"
   exit ${FAILED_SETUP}
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,7 +31,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0#gd2f5715
+  yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.8.0
 
   if ! yarn run siw-platform install-artifact -n @okta/okta-auth-js -v ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -158,8 +158,7 @@ if [ -n "${TEST_SUITE_ID}" ]; then
   setup_service node v14.18.2
 
   # Verify minimum supported version of yarn
-  # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
-  setup_service yarn 1.7.0 /etc/pki/tls/certs/ca-bundle.crt
+  setup_service yarn 1.22.19
   export PATH="${PATH}:$(yarn global bin)"
   set -e
 fi

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -28,7 +28,7 @@ artifact_version="$(ci-pkginfo -t pkgsemver)"
 git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/angular-sample
 pushd test/package/angular-sample/custom-login
 
-yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.8.0
+yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0
 
 # use npm instead of yarn to test as a community dev
 if ! npm i; then

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -6,7 +6,7 @@ cd ${OKTA_HOME}/${REPO}
 
 # Install required node version
 setup_service node v14.18.2
-setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
+setup_service yarn 1.22.19
 
 # Install required dependencies
 yarn global add @okta/ci-append-sha
@@ -29,9 +29,6 @@ git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/
 pushd test/package/angular-sample/custom-login
 
 yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.5.0
-
-# NOTE: setup_service sets the registry to internal mirror, add certs to chain
-export NODE_EXTRA_CA_CERTS="/etc/pki/tls/certs/ca-bundle.crt"
 
 # use npm instead of yarn to test as a community dev
 if ! npm i; then

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -28,7 +28,7 @@ artifact_version="$(ci-pkginfo -t pkgsemver)"
 git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/angular-sample
 pushd test/package/angular-sample/custom-login
 
-yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.5.0
+yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0
 
 # use npm instead of yarn to test as a community dev
 if ! npm i; then

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -38,7 +38,7 @@ fi
 
 # install the version of @okta/okta-signin-widget from artifactory that was published during the `publish` suite
 if ! yarn run siw-platform install-artifact -n @okta/okta-signin-widget -v ${artifact_version}; then
-  echo "install @okta/okta-signin-wdiget@${artifact_version} failed! Exiting..."
+  echo "install @okta/okta-signin-widget@${artifact_version} failed! Exiting..."
   exit ${FAILED_SETUP}
 fi
 

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -28,7 +28,7 @@ artifact_version="$(ci-pkginfo -t pkgsemver)"
 git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/angular-sample
 pushd test/package/angular-sample/custom-login
 
-yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0#gd2f5715
+yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.8.0
 
 # use npm instead of yarn to test as a community dev
 if ! npm i; then

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -28,7 +28,7 @@ artifact_version="$(ci-pkginfo -t pkgsemver)"
 git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/angular-sample
 pushd test/package/angular-sample/custom-login
 
-yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0-gd2f5715
+yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0#gd2f5715
 
 # use npm instead of yarn to test as a community dev
 if ! npm i; then

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -28,7 +28,7 @@ artifact_version="$(ci-pkginfo -t pkgsemver)"
 git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/angular-sample
 pushd test/package/angular-sample/custom-login
 
-yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0
+yarn add -W --force --no-lockfile @okta/siw-platform-scripts@0.7.0-gd2f5715
 
 # use npm instead of yarn to test as a community dev
 if ! npm i; then

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -309,9 +309,6 @@ const doesI18NKeyExist = (i18nKey) => {
  */
 const getI18NValue = (i18nPath, defaultValue, params = []) => {
   const i18nKey = getI18nKey(i18nPath);
-  // TODO : OKTA-397225
-  // here defaultValue is uiSchema label or placeholders, some lables may be customized by 
-  // admin to anything string. We should not localize and replace these customized labels even if i18nkey exists
   if (i18nKey) {
     return loc(i18nKey, 'login', params);
   } else {

--- a/src/v3/src/transformer/i18n/__snapshots__/transformField.test.ts.snap
+++ b/src/v3/src/transformer/i18n/__snapshots__/transformField.test.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Field transformer tests should use provided custom labels instead of translations 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "label": "Please enter your first name",
+        "options": Object {
+          "inputMeta": Object {
+            "customLabel": true,
+            "name": "userProfile.firstName",
+          },
+        },
+        "translations": Array [
+          Object {
+            "i18nKey": "oie.user.profile.firstname",
+            "name": "label",
+            "noTranslate": true,
+            "value": "Please enter your first name",
+          },
+        ],
+        "type": "Field",
+      },
+      Object {
+        "label": "Please enter your last name",
+        "options": Object {
+          "inputMeta": Object {
+            "customLabel": true,
+            "name": "userProfile.lastName",
+          },
+        },
+        "translations": Array [
+          Object {
+            "i18nKey": "oie.user.profile.lastname",
+            "name": "label",
+            "noTranslate": true,
+            "value": "Please enter your last name",
+          },
+        ],
+        "type": "Field",
+      },
+      Object {
+        "label": "Please enter your email",
+        "options": Object {
+          "inputMeta": Object {
+            "customLabel": false,
+            "name": "userProfile.email",
+          },
+        },
+        "translations": Array [
+          Object {
+            "i18nKey": "oie.user.profile.primary.email",
+            "name": "label",
+            "noTranslate": false,
+            "value": "oie.user.profile.primary.email",
+          },
+        ],
+        "type": "Field",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/i18n/transformField.test.ts
+++ b/src/v3/src/transformer/i18n/transformField.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxTransaction } from '@okta/okta-auth-js';
+
+import { IDX_STEP } from '../../constants';
+import { getStubFormBag, getStubTransactionWithNextStep } from '../../mocks/utils/utils';
+import {
+  FieldElement,
+  FormBag,
+  TranslationInfo,
+  WidgetProps,
+} from '../../types';
+import { transformField } from './transformField';
+
+describe('Field transformer tests', () => {
+  let transaction: IdxTransaction;
+  let formBag: FormBag;
+  let widgetProps: WidgetProps;
+
+  beforeEach(() => {
+    transaction = getStubTransactionWithNextStep();
+    formBag = getStubFormBag();
+    formBag.uischema.elements = [
+      {
+        type: 'Field',
+        label: 'Please enter your first name',
+        options: {
+          inputMeta: {
+            name: 'userProfile.firstName',
+            customLabel: true,
+          },
+        },
+      } as FieldElement,
+      {
+        type: 'Field',
+        label: 'Please enter your last name',
+        options: {
+          inputMeta: {
+            name: 'userProfile.lastName',
+            customLabel: true,
+          },
+        },
+      } as FieldElement,
+      {
+        type: 'Field',
+        label: 'Please enter your email',
+        options: {
+          inputMeta: {
+            name: 'userProfile.email',
+            customLabel: false,
+          },
+        },
+      } as FieldElement,
+    ];
+    widgetProps = {};
+  });
+
+  it('should use provided custom labels instead of translations', () => {
+    transaction.nextStep = {
+      name: IDX_STEP.ENROLL_PROFILE,
+    };
+    const options = {
+      transaction,
+      widgetProps,
+      step: IDX_STEP.IDENTIFY,
+      isClientTransaction: false,
+      setMessage: () => {},
+    };
+    const updatedFormBag = transformField(options)(formBag);
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect((updatedFormBag.uischema.elements[0] as FieldElement).translations)
+      .toEqual([{
+        name: 'label',
+        i18nKey: 'oie.user.profile.firstname',
+        value: 'Please enter your first name',
+        noTranslate: true,
+      } as TranslationInfo]);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).translations)
+      .toEqual([{
+        name: 'label',
+        i18nKey: 'oie.user.profile.lastname',
+        value: 'Please enter your last name',
+        noTranslate: true,
+      } as TranslationInfo]);
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).translations)
+      .toEqual([{
+        name: 'label',
+        i18nKey: 'oie.user.profile.primary.email',
+        value: 'oie.user.profile.primary.email',
+        noTranslate: false,
+      } as TranslationInfo]);
+  });
+});

--- a/src/v3/src/transformer/i18n/util.ts
+++ b/src/v3/src/transformer/i18n/util.ts
@@ -41,10 +41,11 @@ export const addTranslation = ({
   // TODO: change translations to required field with default value
   // eslint-disable-next-line no-param-reassign
   element.translations = element.translations || [];
+  const useDefault = !i18nKey || (noTranslate && !!defaultValue);
   element.translations.push({
     name,
     i18nKey,
-    value: i18nKey ? loc(i18nKey, 'login', params, tokenReplacement) : defaultValue,
+    value: useDefault ? defaultValue : loc(i18nKey, 'login', params, tokenReplacement),
     noTranslate,
   });
 };
@@ -63,8 +64,9 @@ export const addLabelTranslationToFieldElement = (
   const i18nKey = getI18nKey(path);
   const params = getI18NParams(nextStep, authenticatorKey);
   if (i18nKey || element.label) {
+    const noTranslate = element.options.inputMeta.customLabel;
     addTranslation({
-      element, name: 'label', i18nKey, params, defaultValue: element.label,
+      element, name: 'label', i18nKey, params, defaultValue: element.label, noTranslate,
     });
   }
 };

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -258,7 +258,10 @@ export interface FieldElement extends UISchemaElement {
    */
   showAsterisk?: boolean;
   options: {
-    inputMeta: Input;
+    // TODO: remove customLabel after updating okta-auth-js (OKTA-626602)
+    inputMeta: Input & {
+      customLabel?: boolean;
+    };
     format?: 'select' | 'radio';
     attributes?: InputAttributes;
     type?: string;

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -435,11 +435,18 @@ export default class BaseFormObject {
   }
 
   findFormFieldInputLabel(fieldName) {
-    return this.el
-      .find(`[data-se="o-form-input-${fieldName}"]`)
-      .parent('[data-se="o-form-input-container"]')
-      .sibling('[data-se="o-form-label"]')
-      .child('label');
+    if (userVariables.v3) {
+      return this.el
+        .find(`label[for="${fieldName}"]`)
+        // get first text node
+        .find((_node, index) => index === 0);
+    } else {
+      return this.el
+        .find(`[data-se="o-form-input-${fieldName}"]`)
+        .parent('[data-se="o-form-input-container"]')
+        .sibling('[data-se="o-form-label"]')
+        .child('label');
+    }
   }
 
   getFormFieldSubLabel(fieldName) {

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -117,8 +117,7 @@ test.requestHooks(requestLogger, EnrollProfileSubmitMock)('should show submit bu
   await t.expect(await enrollProfilePage.submitButtonExists()).eql(true);
 });
 
-// TODO: OKTA-616638 - enable custom label in v3
-test.meta('v3', false).requestHooks(requestLogger, EnrollProfileSignUpWithCustomLabelsMock)('should show custom label when provided in response', async t => {
+test.requestHooks(requestLogger, EnrollProfileSignUpWithCustomLabelsMock)('should show custom label when provided in response', async t => {
   const enrollProfilePage = new EnrollProfileViewPageObject(t);
   const identityPage = await setup(t);
   await checkA11y(t);

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -326,14 +326,3 @@ test.requestHooks(mock)('should call settings.registration.click on "Sign Up" cl
   await t.expect(identityPage.getFormTitle()).eql('Sign In');
 });
 
-// TODO : OKTA-397225
-// Uncomment once we support custom labels
-// test.requestHooks(enrollProfileNewCustomLabelMock)('should show custom labels', async t => {
-//   const registrationPage = await setup(t);
-//   await checkA11y(t);
-
-//   await t.expect(await registrationPage.getFormFieldLabel('userProfile.email')).eql('This is your awesome email address');
-//   await t.expect(await registrationPage.getFormFieldLabel('userProfile.firstName')).eql('Please enter your first name');
-//   await t.expect(await registrationPage.getFormFieldLabel('userProfile.lastName')).eql('Please enter your last name');
-
-// });


### PR DESCRIPTION
## Description:

This PR fixes the failing `verify-registry-install` bacon test by removing the `ca-bundle` cert file logic since now it is handled by robo-warrior.

[This](https://github.com/atko-eng/siw-platform-scripts/pull/8) PR for the `siw-platform-scripts` repo is also part of this fix

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-628622](https://oktainc.atlassian.net/browse/OKTA-628622)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



