### PR TITLE
OKTA-616188 : Gen 3 End user remediation terminal view

### DIFF
--- a/src/v3/src/components/ConsentHeader/ConsentHeader.tsx
+++ b/src/v3/src/components/ConsentHeader/ConsentHeader.tsx
@@ -91,6 +91,7 @@ const ConsentHeader: FunctionComponent = () => {
               <Link
                 href={href}
                 target="_blank"
+                rel="noopener noreferrer"
                 aria-label={altText}
               >
                 {getAppLogo(altText, logoHref)}

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -56,7 +56,10 @@ const InfoBox: UISchemaElementComponent<{
         {
           Array.isArray(message)
             ? message.map((msg) => (
-              <Box marginBlockEnd={2}>
+              <Box
+                marginBlockEnd={2}
+                key={msg.message}
+              >
                 <WidgetMessageContainer
                   key={msg.message}
                   message={msg}

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -64,10 +64,11 @@ const InfoBox: UISchemaElementComponent<{
                   key={msg.message}
                   message={msg}
                   parserOptions={{ replace: getLinkReplacerFn({}, 'monochrome') }}
+                  linkVariant='monochrome'
                 />
               </Box>
             ))
-            : <WidgetMessageContainer message={message} />
+            : <WidgetMessageContainer message={message} linkVariant='monochrome' />
         }
       </Alert>
     </Box>

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -10,12 +10,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { List, ListItem } from '@mui/material';
 import {
   Alert,
   Box,
-  Link,
-  Typography,
 } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 
@@ -26,6 +23,7 @@ import {
   MessageTypeVariant,
   UISchemaElementComponent,
 } from '../../types';
+import { getLinkReplacerFn } from '../../util';
 import WidgetMessageContainer from '../WidgetMessageContainer';
 
 const InfoBox: UISchemaElementComponent<{
@@ -43,29 +41,6 @@ const InfoBox: UISchemaElementComponent<{
     },
   } = uischema;
 
-  const { links = [] } = message;
-  const renderLinks = () => (
-    <List
-      className="custom-links"
-      disablePadding
-    >
-      {links.map((link) => (
-        <ListItem
-          sx={{ paddingLeft: 0 }}
-          key={link.label}
-        >
-          <Link
-            href={link.url}
-            target="_blank"
-            variant="monochrome"
-          >
-            {link.label}
-          </Link>
-        </ListItem>
-      ))}
-    </List>
-  );
-
   return loading ? null : (
     <Box
       marginBlockEnd={4}
@@ -78,16 +53,17 @@ const InfoBox: UISchemaElementComponent<{
         data-se={dataSe}
         className={`infobox-${messageClass.toLowerCase()}`}
       >
-        {message.title && (
-          <Typography
-            component="h2"
-            variant="h6"
-          >
-            {message.title}
-          </Typography>
-        )}
-        <WidgetMessageContainer message={message} />
-        {links.length > 0 && renderLinks()}
+        {
+          Array.isArray(message)
+            ? message.map((msg) => (
+              <WidgetMessageContainer
+                key={msg.message}
+                message={msg}
+                parserOptions={{ replace: getLinkReplacerFn({}, 'monochrome') }}
+              />
+            ))
+            : <WidgetMessageContainer message={message} />
+        }
       </Alert>
     </Box>
   );

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -64,11 +64,16 @@ const InfoBox: UISchemaElementComponent<{
                   key={msg.message}
                   message={msg}
                   parserOptions={{ replace: getLinkReplacerFn({}, 'monochrome') }}
-                  linkVariant='monochrome'
+                  linkVariant="monochrome"
                 />
               </Box>
             ))
-            : <WidgetMessageContainer message={message} linkVariant='monochrome' />
+            : (
+              <WidgetMessageContainer
+                message={message}
+                linkVariant="monochrome"
+              />
+            )
         }
       </Alert>
     </Box>

--- a/src/v3/src/components/InfoBox/InfoBox.tsx
+++ b/src/v3/src/components/InfoBox/InfoBox.tsx
@@ -56,11 +56,13 @@ const InfoBox: UISchemaElementComponent<{
         {
           Array.isArray(message)
             ? message.map((msg) => (
-              <WidgetMessageContainer
-                key={msg.message}
-                message={msg}
-                parserOptions={{ replace: getLinkReplacerFn({}, 'monochrome') }}
-              />
+              <Box marginBlockEnd={2}>
+                <WidgetMessageContainer
+                  key={msg.message}
+                  message={msg}
+                  parserOptions={{ replace: getLinkReplacerFn({}, 'monochrome') }}
+                />
+              </Box>
             ))
             : <WidgetMessageContainer message={message} />
         }

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -88,6 +88,8 @@ const Link: UISchemaElementComponent<{
           aria-describedby={ariaDescribedBy}
           data-se={dataSe}
           target={target}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...(target === '_blank' && { rel: 'noopener noreferrer' })}
         >
           {label}
         </LinkMui>

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -40,7 +40,7 @@ const WidgetMessageContainer: FunctionComponent<{
       className="custom-links"
       disablePadding
       dense
-      sx={{ pl: 4, listStyleType: listStyleType ?? 'disc' }}
+      sx={{ pl: listStyleType ? 4 : 0, listStyleType: listStyleType ?? 'none' }}
     >
       {links.map((link) => (
         <ListItem

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -40,7 +40,7 @@ const WidgetMessageContainer: FunctionComponent<{
       className="custom-links"
       disablePadding
       dense
-      sx={{ pl: listStyleType ? 4 : 0, listStyleType: listStyleType ?? 'none' }}
+      sx={{ pl: listStyleType ? 4 : 0, listStyle: listStyleType ?? 'none' }}
     >
       {links.map((link) => (
         <ListItem
@@ -78,7 +78,7 @@ const WidgetMessageContainer: FunctionComponent<{
       <List
         dense
         disablePadding
-        sx={{ listStyleType: widgetMsg.listStyleType ?? 'disc', paddingInlineStart: 4 }}
+        sx={{ listStyle: widgetMsg.listStyleType ?? 'disc', paddingInlineStart: 4 }}
       >
         {
           (widgetMsg.message as WidgetMessage[])?.map((wm: WidgetMessage) => {

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -16,7 +16,7 @@ import { HTMLReactParserOptions } from 'html-react-parser';
 import { FunctionComponent, h } from 'preact';
 
 import { useHtmlContentParser } from '../../hooks';
-import { WidgetMessage, WidgetMessageLink } from '../../types';
+import { ListStyleType, WidgetMessage, WidgetMessageLink } from '../../types';
 
 const WidgetMessageContainer: FunctionComponent<{
   message?: WidgetMessage,
@@ -24,21 +24,21 @@ const WidgetMessageContainer: FunctionComponent<{
 }> = (props) => {
   const { message, parserOptions } = props;
 
-  const renderTitle = (title: string) => (
+  const renderTitle = (title?: string) => title ? (
     <Typography
       component="h2"
       variant="h6"
     >
       {title}
     </Typography>
-  );
+  ) : null;
 
-  const renderLinks = (links: WidgetMessageLink[]) => (
+  const renderLinks = (links?: WidgetMessageLink[], listStyleType?: ListStyleType) => links ? (
     <List
       className="custom-links"
       disablePadding
       dense
-      sx={{ pl: 4, listStyleType: message.listStyleType ?? 'disc', }}
+      sx={{ pl: 4, listStyleType: listStyleType ?? 'disc', }}
     >
       {links.map((link) => (
         <ListItem
@@ -59,7 +59,7 @@ const WidgetMessageContainer: FunctionComponent<{
         </ListItem>
       ))}
     </List>
-  );
+  ) : null;
 
   const createListMessages = (widgetMsg: WidgetMessage) => (
     <Box marginBlockStart={2}>
@@ -76,7 +76,7 @@ const WidgetMessageContainer: FunctionComponent<{
       <List
         dense
         disablePadding
-        sx={{ listStyleType: message.listStyleType ?? 'disc', paddingInlineStart: 4 }}
+        sx={{ listStyleType: widgetMsg.listStyleType ?? 'disc', paddingInlineStart: 4 }}
       >
         {
           (widgetMsg.message as WidgetMessage[])?.map((wm: WidgetMessage) => {
@@ -112,9 +112,9 @@ const WidgetMessageContainer: FunctionComponent<{
   if (typeof message !== 'undefined') {
     return (
       <Box marginBlockEnd={2}>
-        {message.title && renderTitle(message.title)}
+        {renderTitle(message.title)}
         {Array.isArray(message.message) ? createListMessages(message) : <Box>{parsedContent}</Box>}
-        {message.links && renderLinks(message.links)}
+        {renderLinks(message.links, message.listStyleType)}
       </Box>
     );
   }

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -26,16 +26,16 @@ const WidgetMessageContainer: FunctionComponent<{
 }> = (props) => {
   const { message, parserOptions, linkVariant } = props;
 
-  const renderTitle = (title?: string) => (title ? (
+  const renderTitle = (title?: string) => (title && (
     <Typography
       component="h2"
       variant="h6"
     >
       {title}
     </Typography>
-  ) : null);
+  ));
 
-  const renderLinks = (links?: WidgetMessageLink[], listStyleType?: ListStyleType) => (links ? (
+  const renderLinks = (links?: WidgetMessageLink[], listStyleType?: ListStyleType) => (links && (
     <List
       className="custom-links"
       disablePadding
@@ -61,7 +61,7 @@ const WidgetMessageContainer: FunctionComponent<{
         </ListItem>
       ))}
     </List>
-  ) : null);
+  ));
 
   const createListMessages = (widgetMsg: WidgetMessage) => (
     <Box marginBlockStart={2}>

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -14,10 +14,10 @@ import { List, ListItem } from '@mui/material';
 import { Box, Link, Typography } from '@okta/odyssey-react-mui';
 import { HTMLReactParserOptions } from 'html-react-parser';
 import { FunctionComponent, h } from 'preact';
+import React from 'preact/compat';
 
 import { useHtmlContentParser } from '../../hooks';
 import { ListStyleType, WidgetMessage, WidgetMessageLink } from '../../types';
-import React from 'preact/compat';
 
 const WidgetMessageContainer: FunctionComponent<{
   message?: WidgetMessage,

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -52,7 +52,7 @@ const WidgetMessageContainer: FunctionComponent<{
             href={link.url}
             target="_blank"
             rel="noopener noreferrer"
-            variant="monochrome"
+            variant={link.variant ?? 'body1'}
           >
             {link.label}
           </Link>

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -37,13 +37,12 @@ const WidgetMessageContainer: FunctionComponent<{
     <List
       className="custom-links"
       disablePadding
-      sx={{ pl: 4 }}
       dense
+      sx={{ pl: 4, listStyleType: message.listStyleType ?? 'disc', }}
     >
       {links.map((link) => (
         <ListItem
           sx={{
-            listStyleType: link.withBullet ? 'disc' : 'none',
             paddingLeft: 0,
             display: 'list-item',
           }}
@@ -77,7 +76,7 @@ const WidgetMessageContainer: FunctionComponent<{
       <List
         dense
         disablePadding
-        sx={{ listStyleType: 'disc', paddingInlineStart: 4 }}
+        sx={{ listStyleType: message.listStyleType ?? 'disc', paddingInlineStart: 4 }}
       >
         {
           (widgetMsg.message as WidgetMessage[])?.map((wm: WidgetMessage) => {

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -52,7 +52,7 @@ const WidgetMessageContainer: FunctionComponent<{
             href={link.url}
             target="_blank"
             rel="noopener noreferrer"
-            variant={link.variant ?? 'body1'}
+            variant={link.variant}
           >
             {link.label}
           </Link>

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -24,21 +24,21 @@ const WidgetMessageContainer: FunctionComponent<{
 }> = (props) => {
   const { message, parserOptions } = props;
 
-  const renderTitle = (title?: string) => title ? (
+  const renderTitle = (title?: string) => (title ? (
     <Typography
       component="h2"
       variant="h6"
     >
       {title}
     </Typography>
-  ) : null;
+  ) : null);
 
-  const renderLinks = (links?: WidgetMessageLink[], listStyleType?: ListStyleType) => links ? (
+  const renderLinks = (links?: WidgetMessageLink[], listStyleType?: ListStyleType) => (links ? (
     <List
       className="custom-links"
       disablePadding
       dense
-      sx={{ pl: 4, listStyleType: listStyleType ?? 'disc', }}
+      sx={{ pl: 4, listStyleType: listStyleType ?? 'disc' }}
     >
       {links.map((link) => (
         <ListItem
@@ -59,7 +59,7 @@ const WidgetMessageContainer: FunctionComponent<{
         </ListItem>
       ))}
     </List>
-  ) : null;
+  ) : null);
 
   const createListMessages = (widgetMsg: WidgetMessage) => (
     <Box marginBlockStart={2}>

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -16,7 +16,7 @@ import { HTMLReactParserOptions } from 'html-react-parser';
 import { FunctionComponent, h } from 'preact';
 
 import { useHtmlContentParser } from '../../hooks';
-import { WidgetMessage } from '../../types';
+import { WidgetMessage, WidgetMessageLink } from '../../types';
 
 const WidgetMessageContainer: FunctionComponent<{
   message?: WidgetMessage,
@@ -24,14 +24,23 @@ const WidgetMessageContainer: FunctionComponent<{
 }> = (props) => {
   const { message, parserOptions } = props;
 
-  const renderLinks = (widgetMsg: WidgetMessage) => (
+  const renderTitle = (title: string) => (
+    <Typography
+      component="h2"
+      variant="h6"
+    >
+      {title}
+    </Typography>
+  );
+
+  const renderLinks = (links: WidgetMessageLink[]) => (
     <List
       className="custom-links"
       disablePadding
       sx={{ pl: 4 }}
       dense
     >
-      {widgetMsg.links?.map((link) => (
+      {links.map((link) => (
         <ListItem
           sx={{
             listStyleType: link.withBullet ? 'disc' : 'none',
@@ -46,7 +55,7 @@ const WidgetMessageContainer: FunctionComponent<{
             rel="noopener noreferrer"
             variant="monochrome"
           >
-            {link.label ?? widgetMsg.message}
+            {link.label}
           </Link>
         </ListItem>
       ))}
@@ -104,18 +113,9 @@ const WidgetMessageContainer: FunctionComponent<{
   if (typeof message !== 'undefined') {
     return (
       <Box marginBlockEnd={2}>
-        {message.title && (
-          <Typography
-            component="h2"
-            variant="h6"
-          >
-            {message.title}
-          </Typography>
-        )}
-        {
-          Array.isArray(message.message) ? createListMessages(message) : <Box>{parsedContent}</Box>
-        }
-        {message.links && renderLinks(message)}
+        {message.title && renderTitle(message.title)}
+        {Array.isArray(message.message) ? createListMessages(message) : <Box>{parsedContent}</Box>}
+        {message.links && renderLinks(message.links)}
       </Box>
     );
   }

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -100,8 +100,8 @@ const WidgetMessageContainer: FunctionComponent<{
     </Box>
   );
 
+  const parsedContent = useHtmlContentParser(typeof message?.message === 'string' ? message.message : '', parserOptions);
   if (typeof message !== 'undefined') {
-    const parsedContent = useHtmlContentParser(typeof message.message === 'string' ? message.message : '', parserOptions)
     return (
       <Box marginBlockEnd={2}>
         {message.title && (

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -21,9 +21,10 @@ import { ListStyleType, WidgetMessage, WidgetMessageLink } from '../../types';
 
 const WidgetMessageContainer: FunctionComponent<{
   message?: WidgetMessage,
-  parserOptions?: HTMLReactParserOptions
+  parserOptions?: HTMLReactParserOptions,
+  linkVariant?: 'monochrome' | 'body1',
 }> = (props) => {
-  const { message, parserOptions } = props;
+  const { message, parserOptions, linkVariant } = props;
 
   const renderTitle = (title?: string) => (title ? (
     <Typography
@@ -53,7 +54,7 @@ const WidgetMessageContainer: FunctionComponent<{
             href={link.url}
             target="_blank"
             rel="noopener noreferrer"
-            variant={link.variant}
+            variant={linkVariant}
           >
             {link.label}
           </Link>

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -17,6 +17,7 @@ import { FunctionComponent, h } from 'preact';
 
 import { useHtmlContentParser } from '../../hooks';
 import { ListStyleType, WidgetMessage, WidgetMessageLink } from '../../types';
+import React from 'preact/compat';
 
 const WidgetMessageContainer: FunctionComponent<{
   message?: WidgetMessage,
@@ -111,11 +112,11 @@ const WidgetMessageContainer: FunctionComponent<{
   const parsedContent = useHtmlContentParser(typeof message?.message === 'string' ? message.message : '', parserOptions);
   if (typeof message !== 'undefined') {
     return (
-      <Box marginBlockEnd={2}>
+      <React.Fragment>
         {renderTitle(message.title)}
-        {Array.isArray(message.message) ? createListMessages(message) : <Box>{parsedContent}</Box>}
+        {Array.isArray(message.message) ? createListMessages(message) : parsedContent}
         {renderLinks(message.links, message.listStyleType)}
-      </Box>
+      </React.Fragment>
     );
   }
   return null;

--- a/src/v3/src/constants/idxConstants.ts
+++ b/src/v3/src/constants/idxConstants.ts
@@ -130,6 +130,8 @@ export const TERMINAL_KEY: Record<string, string> = {
   TOO_MANY_REQUESTS: 'tooManyRequests',
   UNLOCK_ACCOUNT_FAILED_PERMISSIONS_KEY: 'oie.selfservice.unlock_user.challenge.failed.permissions',
   UNLOCK_ACCOUNT_KEY: 'oie.selfservice.unlock_user.success.message',
+  SIGNED_NONCE_ERROR: 'core.auth.factor.signedNonce.error',
+  END_USER_REMEDIATION_ERROR_PREFIX: 'idx.error.code.access_denied.device_assurance.remediation',
 };
 
 export const CUSTOM_APP_UV_ENABLE_BIOMETRIC_SERVER_KEY = 'oie.authenticator.custom_app.method.push.verify.enable.biometrics';

--- a/src/v3/src/hooks/useHtmlContentParser.tsx
+++ b/src/v3/src/hooks/useHtmlContentParser.tsx
@@ -34,6 +34,6 @@ export const useHtmlContentParser = (
     parserOptions.replace = getLinkReplacerFn(parserOptions);
   }
 
-  const sanitizedContent = dompurify.sanitize(content);
+  const sanitizedContent = dompurify.sanitize(content, { ADD_ATTR: ['target'] });
   return HtmlReactParser(sanitizedContent, parserOptions);
 };

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.ts
@@ -148,9 +148,12 @@ export const transformTerminalMessages: TerminalKeyTransformer = (transaction, f
     containsMessageKeyPrefix(TERMINAL_KEY.END_USER_REMEDIATION_ERROR_PREFIX, displayedMessages)
   ) {
     // OKTA-630044 - messages from rawIdxState are used until this issue is solved
-    uischema.elements.push(
-      buildEndUserRemediationError(transaction.rawIdxState.messages?.value || []),
+    const userRemediationErrorElement = buildEndUserRemediationError(
+      transaction.rawIdxState.messages?.value || [],
     );
+    if (userRemediationErrorElement) {
+      uischema.elements.push(userRemediationErrorElement);
+    }
     return formBag;
   } else if (containsMessageKey(TERMINAL_KEY.IDX_RETURN_LINK_OTP_ONLY, displayedMessages)) {
     return transformEmailMagicLinkOTPOnly(transaction, formBag);

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.ts
@@ -23,6 +23,7 @@ import {
   WidgetMessage,
 } from '../../types';
 import {
+  buildEndUserRemediationError,
   containsMessageKey, containsMessageKeyPrefix, containsOneOfMessageKeys, loc,
 } from '../../util';
 import { transactionMessageTransformer } from '../i18n';
@@ -143,6 +144,12 @@ export const transformTerminalMessages: TerminalKeyTransformer = (transaction, f
   } else if (containsMessageKeyPrefix('core.auth.factor.signedNonce.error', displayedMessages)) {
     // custom title for signed nonce errors
     displayedMessages[0].title = loc('user.fail.verifyIdentity', 'login');
+  } else if (containsMessageKeyPrefix('idx.error.code.access_denied.device_assurance.remediation', displayedMessages)) {
+    // OKTA-630044 - messages from rawIdxState are used until this issue is solved
+    uischema.elements.push(
+      buildEndUserRemediationError(transaction.rawIdxState.messages?.value || []),
+    );
+    return formBag;
   } else if (containsMessageKey(TERMINAL_KEY.IDX_RETURN_LINK_OTP_ONLY, displayedMessages)) {
     return transformEmailMagicLinkOTPOnly(transaction, formBag);
   } else if (

--- a/src/v3/src/transformer/terminal/transformTerminalMessages.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalMessages.ts
@@ -141,10 +141,12 @@ export const transformTerminalMessages: TerminalKeyTransformer = (transaction, f
   } else if (containsMessageKey(TERMINAL_KEY.SESSION_EXPIRED, displayedMessages)) {
     displayedMessages[0].class = 'ERROR';
     displayedMessages[0].message = loc(TERMINAL_KEY.SESSION_EXPIRED, 'login');
-  } else if (containsMessageKeyPrefix('core.auth.factor.signedNonce.error', displayedMessages)) {
+  } else if (containsMessageKeyPrefix(TERMINAL_KEY.SIGNED_NONCE_ERROR, displayedMessages)) {
     // custom title for signed nonce errors
     displayedMessages[0].title = loc('user.fail.verifyIdentity', 'login');
-  } else if (containsMessageKeyPrefix('idx.error.code.access_denied.device_assurance.remediation', displayedMessages)) {
+  } else if (
+    containsMessageKeyPrefix(TERMINAL_KEY.END_USER_REMEDIATION_ERROR_PREFIX, displayedMessages)
+  ) {
     // OKTA-630044 - messages from rawIdxState are used until this issue is solved
     uischema.elements.push(
       buildEndUserRemediationError(transaction.rawIdxState.messages?.value || []),

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -67,7 +67,6 @@ export type ListStyleType = 'circle' | 'disc' | 'square' | 'decimal';
 export type WidgetMessageLink = {
   label: string,
   url: string,
-  variant?: 'monochrome' | 'body1',
 };
 
 export type AutoCompleteValue = 'username'

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -156,7 +156,7 @@ export type TokenReplacementValue = {
     class?: string;
     href?: string;
     target?: AnchorTargetType;
-    rel?: string;
+    rel?: 'noopener noreferrer';
   };
 };
 

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -156,10 +156,12 @@ export type TokenReplacementValue = {
   attributes?: {
     class?: string;
     href?: string;
-    target?: string;
+    target?: AnchorTargetType;
     rel?: string;
   };
 };
+
+export type AnchorTargetType = '_self' | '_blank' | '_parent' | 'top';
 
 export type TokenReplacement = Partial<Record<TokenSearchValue, TokenReplacementValue>>;
 
@@ -473,7 +475,7 @@ export interface LinkElement extends UISchemaElement {
     label: string;
     href?: string;
     dataSe?: string;
-    target?: '_blank';
+    target?: AnchorTargetType;
     onClick?: (widgetContext?: IWidgetContext) => unknown;
   };
 }

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -61,6 +61,7 @@ export type WidgetMessage = Modify<IdxMessage, {
   links?: {
     label: string,
     url: string,
+    withBullet?: boolean,
   }[];
 }>;
 
@@ -150,6 +151,8 @@ export type TokenReplacementValue = {
   attributes?: {
     class?: string;
     href?: string;
+    target?: string;
+    rel?: string;
   };
 };
 
@@ -502,7 +505,7 @@ export interface SpinnerElement extends UISchemaElement {
 
 export interface InfoboxElement extends UISchemaElement {
   options: {
-    message: WidgetMessage;
+    message: WidgetMessage | WidgetMessage[];
     class: string;
     dataSe?: string;
   }

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -62,13 +62,13 @@ export type WidgetMessage = Modify<IdxMessage, {
   listStyleType?: ListStyleType,
 }>;
 
-export type ListStyleType = 'circle' | 'disc' | 'square' | 'decimal'
+export type ListStyleType = 'circle' | 'disc' | 'square' | 'decimal';
 
 export type WidgetMessageLink = {
   label: string,
   url: string,
   variant?: 'monochrome' | 'body1',
-}
+};
 
 export type AutoCompleteValue = 'username'
 | 'current-password'

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -59,12 +59,12 @@ export type WidgetMessage = Modify<IdxMessage, {
   name?: string;
   description?: string;
   links?: WidgetMessageLink[];
+  listStyleType?: 'circle' | 'disc' | 'square' | 'decimal',
 }>;
 
 export type WidgetMessageLink = {
   label: string,
   url: string,
-  withBullet?: boolean,
 }
 
 export type AutoCompleteValue = 'username'

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -58,12 +58,14 @@ export type WidgetMessage = Modify<IdxMessage, {
   title?: string;
   name?: string;
   description?: string;
-  links?: {
-    label: string,
-    url: string,
-    withBullet?: boolean,
-  }[];
+  links?: WidgetMessageLink[];
 }>;
+
+export type WidgetMessageLink = {
+  label: string,
+  url: string,
+  withBullet?: boolean,
+}
 
 export type AutoCompleteValue = 'username'
 | 'current-password'

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -67,6 +67,7 @@ export type ListStyleType = 'circle' | 'disc' | 'square' | 'decimal'
 export type WidgetMessageLink = {
   label: string,
   url: string,
+  variant?: 'monochrome' | 'body1',
 }
 
 export type AutoCompleteValue = 'username'

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -59,8 +59,10 @@ export type WidgetMessage = Modify<IdxMessage, {
   name?: string;
   description?: string;
   links?: WidgetMessageLink[];
-  listStyleType?: 'circle' | 'disc' | 'square' | 'decimal',
+  listStyleType?: ListStyleType,
 }>;
+
+export type ListStyleType = 'circle' | 'disc' | 'square' | 'decimal'
 
 export type WidgetMessageLink = {
   label: string,

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -26,6 +26,7 @@ import {
   IWidgetContext,
   LaunchAuthenticatorButtonElement,
   WidgetMessage,
+  WidgetMessageLink,
   WidgetProps,
 } from '../types';
 import { idpIconMap } from './idpIconMap';
@@ -333,9 +334,10 @@ export const buildEndUserRemediationError = (messages: IdxMessage[]) : InfoboxEl
       if (lastIndex < 0) {
         return;
       }
-      const linkObject = {
+      const linkObject: WidgetMessageLink = {
         url: links[0].url,
         label: message,
+        variant: 'monochrome'
       };
       if (resultMessageArray[lastIndex].links) {
         resultMessageArray[lastIndex].links?.push(linkObject);

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -320,7 +320,7 @@ InfoboxElement | undefined => {
     // @ts-expect-error OKTA-630508 links is missing from IdxMessage type
     const { i18n: { key, params }, links, message } = msg;
 
-    const widgetMsg = {} as WidgetMessage;
+    const widgetMsg = { listStyleType: 'disc' } as WidgetMessage;
     if (key === TITLE_KEY) {
       widgetMsg.title = loc(TITLE_KEY, 'login');
     } else if (key === REMEDIATION_OPTION_INDEX_KEY) {

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -17,7 +17,9 @@ import classNames from 'classnames';
 
 import IDP from '../../../util/IDP';
 import Util from '../../../util/Util';
-import { CUSTOM_APP_UV_ENABLE_BIOMETRIC_SERVER_KEY, IDX_STEP, SOCIAL_IDP_TYPE_TO_I18KEY } from '../constants';
+import {
+  CUSTOM_APP_UV_ENABLE_BIOMETRIC_SERVER_KEY, IDX_STEP, SOCIAL_IDP_TYPE_TO_I18KEY, TERMINAL_KEY,
+} from '../constants';
 import SmartCardIconSvg from '../img/smartCardButtonIcon.svg';
 import {
   ButtonElement,
@@ -303,7 +305,7 @@ export const getBiometricsErrorMessageElement = (
 };
 
 export const buildEndUserRemediationError = (messages: IdxMessage[]) : InfoboxElement => {
-  const I18N_KEY_PREFIX = 'idx.error.code.access_denied.device_assurance.remediation';
+  const I18N_KEY_PREFIX = TERMINAL_KEY.END_USER_REMEDIATION_ERROR_PREFIX;
   const HELP_AND_CONTACT_KEY_PREFIX = `${I18N_KEY_PREFIX}.additional_help_`;
   const REMEDIATION_OPTION_INDEX_KEY = `${I18N_KEY_PREFIX}.option_index`;
   const TITLE_KEY = `${I18N_KEY_PREFIX}.title`;

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -327,7 +327,7 @@ export const buildEndUserRemediationError = (messages: IdxMessage[]) : InfoboxEl
         },
       );
     } else if (links && links[0] && links[0].url) {
-      // each link is inside an invidual message
+      // each link is inside an individual message
       // We find the last message which contains the option title key and insert the link into that message
       const lastIndex = resultMessageArray.length - 1;
       if (lastIndex < 0) {

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -336,7 +336,6 @@ export const buildEndUserRemediationError = (messages: IdxMessage[]) : InfoboxEl
       const linkObject = {
         url: links[0].url,
         label: message,
-        withBullet: true,
       };
       if (resultMessageArray[lastIndex].links) {
         resultMessageArray[lastIndex].links?.push(linkObject);

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -304,7 +304,12 @@ export const getBiometricsErrorMessageElement = (
   };
 };
 
-export const buildEndUserRemediationError = (messages: IdxMessage[]) : InfoboxElement => {
+export const buildEndUserRemediationError = (messages: IdxMessage[]) :
+InfoboxElement | undefined => {
+  if (messages.length === 0) {
+    return undefined;
+  }
+
   const I18N_KEY_PREFIX = TERMINAL_KEY.END_USER_REMEDIATION_ERROR_PREFIX;
   const HELP_AND_CONTACT_KEY_PREFIX = `${I18N_KEY_PREFIX}.additional_help_`;
   const REMEDIATION_OPTION_INDEX_KEY = `${I18N_KEY_PREFIX}.option_index`;

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -10,7 +10,9 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxRemediation, IdxTransaction, NextStep } from '@okta/okta-auth-js';
+import {
+  IdxMessage, IdxRemediation, IdxTransaction, NextStep,
+} from '@okta/okta-auth-js';
 import classNames from 'classnames';
 
 import IDP from '../../../util/IDP';
@@ -20,6 +22,7 @@ import SmartCardIconSvg from '../img/smartCardButtonIcon.svg';
 import {
   ButtonElement,
   ButtonType,
+  InfoboxElement,
   IWidgetContext,
   LaunchAuthenticatorButtonElement,
   WidgetMessage,
@@ -296,4 +299,64 @@ export const getBiometricsErrorMessageElement = (
     description: customMessage,
     message: messageBullets.map((msg: string) => ({ class: 'INFO', message: msg })) as WidgetMessage[],
   };
+};
+
+export const buildEndUserRemediationError = (messages: IdxMessage[]) : InfoboxElement => {
+  const I18N_KEY_PREFIX = 'idx.error.code.access_denied.device_assurance.remediation';
+  const HELP_AND_CONTACT_KEY_PREFIX = `${I18N_KEY_PREFIX}.additional_help_`;
+  const REMEDIATION_OPTION_INDEX_KEY = `${I18N_KEY_PREFIX}.option_index`;
+  const TITLE_KEY = `${I18N_KEY_PREFIX}.title`;
+  const resultMessageArray: WidgetMessage[] = [];
+
+  messages.forEach((msg) => {
+    // @ts-expect-error OKTA-630508 links is missing from IdxMessage type
+    const { i18n: { key, params }, links, message } = msg;
+
+    const widgetMsg = {} as WidgetMessage;
+    if (key === TITLE_KEY) {
+      widgetMsg.title = loc(TITLE_KEY, 'login');
+    } else if (key === REMEDIATION_OPTION_INDEX_KEY) {
+      widgetMsg.title = loc(REMEDIATION_OPTION_INDEX_KEY, 'login', params);
+    } else if (key.startsWith(HELP_AND_CONTACT_KEY_PREFIX)) {
+      widgetMsg.message = loc(
+        key,
+        'login',
+        undefined,
+        {
+          $1: { element: 'a', attributes: { href: links[0].url, target: '_blank', rel: 'noopener noreferrer' } },
+        },
+      );
+    } else if (links && links[0] && links[0].url) {
+      // each link is inside an invidual message
+      // We find the last message which contains the option title key and insert the link into that message
+      const lastIndex = resultMessageArray.length - 1;
+      if (lastIndex < 0) {
+        return;
+      }
+      const linkObject = {
+        url: links[0].url,
+        label: message,
+        withBullet: true,
+      };
+      if (resultMessageArray[lastIndex].links) {
+        resultMessageArray[lastIndex].links?.push(linkObject);
+      } else {
+        resultMessageArray[lastIndex].links = [linkObject];
+      }
+      return;
+    } else {
+      widgetMsg.message = loc(key, 'login');
+    }
+
+    resultMessageArray.push(widgetMsg);
+  });
+
+  return {
+    type: 'InfoBox',
+    options: {
+      message: resultMessageArray,
+      class: 'ERROR',
+      dataSe: 'callout',
+    },
+  } as InfoboxElement;
 };

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -344,7 +344,6 @@ InfoboxElement | undefined => {
       const linkObject: WidgetMessageLink = {
         url: links[0].url,
         label: message,
-        variant: 'monochrome',
       };
       if (resultMessageArray[lastIndex].links) {
         resultMessageArray[lastIndex].links?.push(linkObject);

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -337,7 +337,7 @@ export const buildEndUserRemediationError = (messages: IdxMessage[]) : InfoboxEl
       const linkObject: WidgetMessageLink = {
         url: links[0].url,
         label: message,
-        variant: 'monochrome'
+        variant: 'monochrome',
       };
       if (resultMessageArray[lastIndex].links) {
         resultMessageArray[lastIndex].links?.push(linkObject);

--- a/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`granular-consent should render form 1`] = `
                   aria-label="Logo for the app"
                   class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-9"
                   href="https://client._funky-ch4rs.com"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   <svg
@@ -435,6 +436,7 @@ exports[`granular-consent should render form 1`] = `
                   class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-9"
                   data-se="terms-of-service"
                   href="https://example.com/tos"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   Terms of Service
@@ -447,6 +449,7 @@ exports[`granular-consent should render form 1`] = `
                   class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-9"
                   data-se="privacy-policy"
                   href="https://example.com/privacypolicy"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   Privacy Policy

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
@@ -347,8 +347,27 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
                                   class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways download-ov-link emotion-23"
                                   href="https://play.google.com/store/apps/details?id=com.okta.android.auth"
                                   id="download-ov"
+                                  target="_blank"
                                 >
                                   download the app.
+                                  <span
+                                    class="Link-indicator"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-24"
+                                      focusable="false"
+                                      viewBox="0 0 16 16"
+                                    >
+                                      <path
+                                        clip-rule="evenodd"
+                                        d="M13.2929 2H7.99998V1H14.5C14.7761 1 15 1.22386 15 1.5V8H14V2.70711L6.35353 10.3536L5.64642 9.64645L13.2929 2ZM1.5 4H1V4.5V14.5V15H1.5H11.5H12V14.5V8H11V14H2V5H8V4H1.5Z"
+                                        fill="currentColor"
+                                        fill-rule="evenodd"
+                                      />
+                                    </svg>
+                                  </span>
                                 </a>
                               </p>
                             </div>
@@ -419,7 +438,7 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
                             class="MuiBox-root emotion-9"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-38"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-39"
                               tabindex="0"
                               type="button"
                             >
@@ -440,7 +459,7 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
                   class="MuiBox-root emotion-9"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     role="link"
                   >
                     Back

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -207,8 +207,7 @@ test.requestHooks(terminalCustomAccessDeniedErrorMessageMock)('should render cus
   await t.expect(errorLink2.getAttribute('href')).eql('https://www.okta.com/help?page=1');
 });
 
-// TODO: OKTA-616188 - add end user remediation changes in v3
-test.meta('v3', false).requestHooks(endUserRemediationOneOptionMock)('should render end user remediation error message when there is one option', async t => {
+test.requestHooks(endUserRemediationOneOptionMock)('should render end user remediation error message when there is one option', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
 
@@ -222,8 +221,7 @@ test.meta('v3', false).requestHooks(endUserRemediationOneOptionMock)('should ren
   await t.expect(terminalViewPage.form.getAnchorsWithBlankTargetsWithoutRelevantAttributes().exists).eql(false);
 });
 
-// TODO: OKTA-616188 - add end user remediation changes in v3
-test.meta('v3', false).requestHooks(endUserRemediationMultipleOptionsMock)('should render end user remediation error message when there are multiple options', async t => {
+test.requestHooks(endUserRemediationMultipleOptionsMock)('should render end user remediation error message when there are multiple options', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
 
@@ -240,8 +238,7 @@ test.meta('v3', false).requestHooks(endUserRemediationMultipleOptionsMock)('shou
   await t.expect(terminalViewPage.form.getAnchorsWithBlankTargetsWithoutRelevantAttributes().exists).eql(false);
 });
 
-// TODO: OKTA-616188 - add end user remediation changes in v3
-test.meta('v3', false).requestHooks(endUserRemediationMultipleOptionsWithCustomHelpUrlMock)('should render end user remediation error message when there are multiple options and a custom URL is set for the organization help page', async t => {
+test.requestHooks(endUserRemediationMultipleOptionsWithCustomHelpUrlMock)('should render end user remediation error message when there are multiple options and a custom URL is set for the organization help page', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
 
@@ -268,8 +265,7 @@ test.meta('v3', false).requestHooks(endUserRemediationMultipleOptionsWithCustomH
   await t.expect(terminalViewPage.form.getAnchorsWithBlankTargetsWithoutRelevantAttributes().exists).eql(false);
 });
 
-// TODO: OKTA-616188 - add end user remediation changes in v3
-test.meta('v3', false).requestHooks(endUserRemediationNoOptionsMock)('should render end user remediation error message when there are no options', async t => {
+test.requestHooks(endUserRemediationNoOptionsMock)('should render end user remediation error message when there are no options', async t => {
   const terminalViewPage = await setup(t);
   await checkA11y(t);
 


### PR DESCRIPTION
## Description:

This PR implements the End user remediation terminal view in SIW gen 3.

Gen 2 PR: https://github.com/okta/okta-signin-widget/pull/3198

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-616188](https://oktainc.atlassian.net/browse/OKTA-616188)

### Reviewers:

### Screenshot/Video:

![image](https://github.com/okta/okta-signin-widget/assets/107433508/c9828ab6-627c-46ca-9e55-c20b21dedf29)
![image](https://github.com/okta/okta-signin-widget/assets/107433508/4bf4d704-fdc6-4d65-8335-0e73c0a2bf31)
![image](https://github.com/okta/okta-signin-widget/assets/107433508/593cd046-8054-4f29-94ea-e594ebfee292)

### Downstream Monolith Build:



