### PR TITLE
OKTA-625871 Add new views for high security OV enrollment channel

### DIFF
--- a/assets/sass/v2/_okta-verify.scss
+++ b/assets/sass/v2/_okta-verify.scss
@@ -21,6 +21,16 @@
     list-style-position: inside;
   }
 
+  .sameDevice-info,
+  .deviceBootstrap-info {
+    list-style: decimal;
+    list-style-position: inside;
+
+    li:last-child {
+      margin-bottom: 10px;
+    }
+  }
+
   .switch-channel-link {
     color: $link-text-color;
   }
@@ -28,6 +38,31 @@
   .o-form-error-container > .infobox + .resend-ov-link-view {
     // if error callout and warning callout show up on ov enroll screen, add margin between callouts
     margin-top: 20px;
+  }
+
+  .copy-org-clipboard-button {
+    margin-top: 15px;
+    margin-bottom: 15px;
+    margin-left: 5%;
+    height: 44px;
+    line-height: 44px;
+    width: 90%;
+    text-align: center;
+  }
+  .download-ov-link {
+    color: $primary-color;
+  }
+  .explanation {
+    margin-top: -12px;
+    margin-bottom: 12px;
+  }
+  .closing {
+    margin-top: 12px;
+    margin-bottom: 12px;
+  }
+  .semi-strong {
+    word-break: break-word;
+    font-weight: $font-weight-labels;
   }
 }
 

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1031,6 +1031,7 @@ oie.enroll.okta_verify.setup.title = Set up Okta Verify
 oie.enroll.okta_verify.setup.email.title = Check your email
 oie.enroll.okta_verify.setup.sms.title = Check your text messages
 oie.enroll.okta_verify.setup.skipAuth.subtitle = To set up Okta Verify on additional devices, you can copy an existing Okta Verify account onto a new device.
+# {0} is a enrolled device's name
 oie.enroll.okta_verify.setup.skipAuth.openOv = Open Okta Verify on any of your other Okta Verify devices (<$1>{0}</$1>).
 oie.enroll.okta_verify.setup.skipAuth.selectAccount = In the app, select your account.
 oie.enroll.okta_verify.setup.skipAuth.addAccount = Choose <$1>Add Account to Another Device.</$1>

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -45,6 +45,8 @@ const idx = {
     // 'authenticator-enroll-ov-sms-enable-biometrics',
     // 'authenticator-enroll-ov-via-sms',
     // 'authenticator-enroll-ov-qr',
+    // 'authenticator-enroll-ov-same-device',
+    // 'authenticator-enroll-ov-device-bootstrap',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'error-internal-server-error',
     // 'authenticator-enroll-security-question',

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-device-bootstrap.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-device-bootstrap.json
@@ -1,0 +1,293 @@
+{
+  "stateHandle": "02vWoN3BXxJ9oeJA05wdCO2sp1q-RimAkwgnN-6xaW",
+  "version": "1.0.0",
+  "expiresAt": "2020-04-09T16:15:46.000Z",
+  "step": "ENROLL",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-poll",
+        "href": "http://localhost:3000/idp/idx/challenge/poll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "refresh": 4000,
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-enrollment-channel",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "label": "Okta Verify",
+            "value": {
+              "form": {
+                "value": [
+                  {
+                    "name": "id",
+                    "value": "aidtheidkwh282hv8g3",
+                    "required": true,
+                    "mutable": false,
+                    "visible": false
+                  },
+                  {
+                    "name": "channel",
+                    "required": true,
+                    "visible": true,
+                    "options": [
+                      {
+                        "value": "devicebootstrap",
+                        "label": "DEVICEBOOTSTRAP"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "required": true,
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "autwa6eD9o02iBbtv0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              },
+              {
+                "label": "Okta Phone",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1SLH",
+                        "mutable": false,
+                        "required": true
+                    },
+                    {
+                        "name": "methodType",
+                        "required": false,
+                        "options": [
+                            { "label": "DEVICEBOOTSTRAP", "value": "devicebootstrap" }
+                        ]
+                    },
+                    {
+                        "name": "phoneNumber",
+                        "required": false,
+                        "type": "string"
+                    }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[2]"
+              },
+              {
+                "label": "Security Key or Biometric Authenticator (FIDO2)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[1]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1GGG",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[3]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02CqFbzJ_zMGCqXut-1CNXfafiTkh9wGlbFqi9Xupt",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "app",
+      "key": "okta_verify",
+      "authenticatorInstanceId": "aidL86XHm5Xtg3SD0I1g",
+      "contextualData": {
+        "devicebootstrap": {
+          "platform": "ios",
+          "enrolledDevices": "testDevice1"
+        },
+        "selectedChannel": "devicebootstrap"
+      }
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "catalogKey": "okta_password",
+        "authenticatorId": "aidtmbseAWnMPtLe20g3",
+        "authenticatorName": "Okta Password",
+        "methods": [
+          {
+            "methodType": "password"
+          }
+        ]
+      },
+      {
+        "catalogKey": "webauthn",
+        "authenticatorId": "aidtheidkwh282hv8g3",
+        "authenticatorName": "Security Key or Biometric Authenticator (FIDO2)",
+        "methods": [
+          {
+            "methodType": "webauthn"
+          }
+        ]
+      },
+      {
+        "catalogKey": "okta_verify",
+        "authenticatorId": "aut1erh5wK1M8wA3g0g4",
+        "authenticatorName": "Okta Verify",
+        "methods": [
+          {
+            "methodType": "signed_nonce"
+          },
+          {
+            "methodType": "push"
+          },
+          {
+            "methodType": "totp"
+          }
+        ]
+      }
+    ]
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://idx.okta1.com:1802/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "context": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "context",
+    "href": "http://idx.okta1.com:1802/idp/idx/context",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00ux9wonp6bLZVk3P0g3",
+      "identifier": "testUser@okta.com"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device.json
@@ -1,0 +1,294 @@
+{
+  "stateHandle": "02vWoN3BXxJ9oeJA05wdCO2sp1q-RimAkwgnN-6xaW",
+  "version": "1.0.0",
+  "expiresAt": "2020-04-09T16:15:46.000Z",
+  "step": "ENROLL",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-poll",
+        "href": "http://localhost:3000/idp/idx/challenge/poll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "refresh": 4000,
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-enrollment-channel",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "label": "Okta Verify",
+            "value": {
+              "form": {
+                "value": [
+                  {
+                    "name": "id",
+                    "value": "aidtheidkwh282hv8g3",
+                    "required": true,
+                    "mutable": false,
+                    "visible": false
+                  },
+                  {
+                    "name": "channel",
+                    "required": true,
+                    "visible": true,
+                    "options": [
+                      {
+                        "value": "samedevice",
+                        "label": "SAMEDEVICE"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "required": true,
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "autwa6eD9o02iBbtv0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              },
+              {
+                "label": "Okta Phone",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1SLH",
+                        "mutable": false,
+                        "required": true
+                    },
+                    {
+                        "name": "methodType",
+                        "required": false,
+                        "options": [
+                            { "label": "SAMEDEVICE", "value": "samedevice" }
+                        ]
+                    },
+                    {
+                        "name": "phoneNumber",
+                        "required": false,
+                        "type": "string"
+                    }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[2]"
+              },
+              {
+                "label": "Security Key or Biometric Authenticator (FIDO2)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[1]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1GGG",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[3]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02CqFbzJ_zMGCqXut-1CNXfafiTkh9wGlbFqi9Xupt",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "app",
+      "key": "okta_verify",
+      "authenticatorInstanceId": "aidL86XHm5Xtg3SD0I1g",
+      "contextualData": {
+        "samedevice": {
+          "orgUrl": "okta.okta.com",
+          "downloadHref": "https://apps.apple.com/us/app/okta-verify/id490179405",
+          "platform": "ios"
+        },
+        "selectedChannel": "samedevice"
+      }
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "catalogKey": "okta_password",
+        "authenticatorId": "aidtmbseAWnMPtLe20g3",
+        "authenticatorName": "Okta Password",
+        "methods": [
+          {
+            "methodType": "password"
+          }
+        ]
+      },
+      {
+        "catalogKey": "webauthn",
+        "authenticatorId": "aidtheidkwh282hv8g3",
+        "authenticatorName": "Security Key or Biometric Authenticator (FIDO2)",
+        "methods": [
+          {
+            "methodType": "webauthn"
+          }
+        ]
+      },
+      {
+        "catalogKey": "okta_verify",
+        "authenticatorId": "aut1erh5wK1M8wA3g0g4",
+        "authenticatorName": "Okta Verify",
+        "methods": [
+          {
+            "methodType": "signed_nonce"
+          },
+          {
+            "methodType": "push"
+          },
+          {
+            "methodType": "totp"
+          }
+        ]
+      }
+    ]
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://idx.okta1.com:1802/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "context": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "context",
+    "href": "http://idx.okta1.com:1802/idp/idx/context",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "022afk9OLqrN2DipVIuIxC0wqzuxMaFIbpOf6pcBh8",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00ux9wonp6bLZVk3P0g3",
+      "identifier": "testUser@okta.com"
+    }
+  }
+}

--- a/src/v2/view-builder/views/ov/EnrollChannelPollDescriptionView.js
+++ b/src/v2/view-builder/views/ov/EnrollChannelPollDescriptionView.js
@@ -1,5 +1,8 @@
-import { View, _ } from '@okta/courage';
+import { View, _, loc, internal} from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
+
+const { Notification } = internal.views.components;
+const { Clipboard } = internal.util;
 
 export default View.extend({
   template: hbs`
@@ -25,6 +28,51 @@ export default View.extend({
           <li class="switch-channel-content"></li>
         </ul>
       {{/if}}
+      {{#if sameDevice}}
+        <p class="explanation" data-se="subheader">
+          {{i18n code="oie.enroll.okta_verify.setup.subtitle " bundle="login"}}
+        </p>
+        <ol class="sameDevice-info ov-info">
+          <li>
+            {{{i18n code="enroll.oda.without.account.step1" bundle="login" arguments="sameDevice.downloadHref"}}}
+          </li>
+          <li>{{i18n code="oie.enroll.okta_verify.setup.openOv" bundle="login"}}</li>          
+          <li>
+              {{i18n code="oie.enroll.okta_verify.setup.signInUrl" bundle="login"}}
+              <br><br/>
+              <span class='semi-strong'>{{sameDevice.orgUrl}}</span>
+              <a data-clipboard-text="{{sameDevice.orgUrl}}" class="button link-button copy-org-clipboard-button">
+                {{i18n code="enroll.oda.org.copyLink" bundle="login"}}
+              </a>
+          </li>
+          <li>{{i18n code="oie.enroll.okta_verify.setup.skipAuth.followInstruction" bundle="login"}}</li>
+        </ol>
+        <p class="closing">
+          {{i18n code="oie.enroll.okta_verify.setup.skipAuth.canBeClosed" bundle="login"}}
+        </p>
+      {{/if}}
+      {{#if deviceBootstrap}}
+        <p class="explanation" data-se="subheader">
+          {{i18n code="oie.enroll.okta_verify.setup.skipAuth.subtitle" bundle="login"}}
+        </p>
+        <ol class="deviceBootstrap-info ov-info">
+          <li>
+            {{i18n code="oie.enroll.okta_verify.setup.skipAuth.openOv"
+            bundle="login"
+            arguments="deviceBootstrap.enrolledDevices"
+            $1="<span class='semi-strong'>$1</span>"}}
+          </li>          
+          <li>{{i18n code="oie.enroll.okta_verify.setup.skipAuth.selectAccount" bundle="login"}}</li>
+          <li>
+            {{i18n code="oie.enroll.okta_verify.setup.skipAuth.addAccount"
+            bundle="login" $1="<span class='semi-strong'>$1</span>"}}
+          </li>
+          <li>{{i18n code="oie.enroll.okta_verify.setup.skipAuth.followInstruction" bundle="login"}}</li>
+        </ol>
+        <p class="closing">
+          {{i18n code="oie.enroll.okta_verify.setup.skipAuth.canBeClosed" bundle="login"}}
+        </p>
+      {{/if}}
     `,
   getTemplateData() {
     const contextualData = this.options.appState.get('currentAuthenticator').contextualData;
@@ -32,6 +80,18 @@ export default View.extend({
       href: contextualData.qrcode?.href,
       email: _.escape(contextualData?.email),
       phoneNumber:  _.escape(contextualData?.phoneNumber),
+      sameDevice: contextualData?.samedevice,
+      deviceBootstrap: contextualData?.devicebootstrap,
     };
-  }
+  },
+  postRender: function() {
+    Clipboard.attach('.copy-org-clipboard-button').done(() => {
+      let notification = new Notification({
+        message: loc('enroll.oda.org.copyLink.success', 'login'),
+        level: 'success',
+      });
+      this.el.prepend(notification.render().el);
+      return false;
+    });
+  },
 });

--- a/src/v2/view-builder/views/ov/SwitchEnrollChannelLinkView.js
+++ b/src/v2/view-builder/views/ov/SwitchEnrollChannelLinkView.js
@@ -8,12 +8,18 @@ export default View.extend({
     {{#if isQRcodeChannel}}
       <a href="#" class="switch-channel-link" aria-label="{{i18n code="enroll.totp.aria.cannotScan" bundle="login" }}">
         {{i18n code="enroll.totp.cannotScan" bundle="login"}}</a>
+    {{else if isSameDeviceChannel}}
+    {{else if isDeviceBootstrapChannel}}
     {{else}}
       {{{i18n code="oie.enroll.okta_verify.switch.channel.link.text" bundle="login"}}}
     {{/if}}`,
   getTemplateData() {
+    const selectedChannel = this.options.appState.get('currentAuthenticator').contextualData.selectedChannel;
     return {
-      isQRcodeChannel: this.options.appState.get('currentAuthenticator').contextualData.selectedChannel === 'qrcode',
+      isQRcodeChannel: selectedChannel === 'qrcode',
+      // Do not show switch channel link for sameDevice or deviceBootstrap
+      isSameDeviceChannel: selectedChannel === 'samedevice',
+      isDeviceBootstrapChannel: selectedChannel === 'devicebootstrap',
     };
   },
   postRender() {

--- a/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
@@ -1,15 +1,21 @@
 import BasePageObject from './BasePageObject';
-import { userVariables } from 'testcafe';
+import { userVariables, Selector } from 'testcafe';
 import { within } from '@testing-library/testcafe';
 
 const FORM_INFOBOX_ERROR_TITLE = '[data-se="o-form-error-container"] [data-se="callout"] > h3';
 const FORM_INFOBOX_ERROR_TITLE_V3 = '[data-se="callout"] > div > h2';
 const CANT_SCAN_BUTTON_TEXT = 'Setup without scanning a QR code.';
 const FORM_SELECTOR = '[data-se="o-form-explain"]';
+const SUB_HEADER = '[data-se="subheader"]';
+const COPY_ORG_LINK_BUTTON_CLASS = '.copy-org-clipboard-button';
+const CLIPBOARD_TEXT = 'data-clipboard-text';
+const DOWNLOAD_OV_LINK_CLASS = '.download-ov-link';
+const CLOSING_CLASS = '.closing';
 
 export default class EnrollOktaVerifyPageObject extends BasePageObject {
   constructor(t) {
     super(t);
+    this.body = new Selector('.ov-info');
   }
 
   async hasEnrollViaQRInstruction() {
@@ -156,5 +162,25 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
       return this.form.getNthTitle(index);
     }
     return this.form.getTitle();
+  }
+
+  getSubHeader() {
+    return this.getTextContent(SUB_HEADER);
+  }
+  
+  getCopyOrgLinkButtonLabel() {
+    return this.getTextContent(COPY_ORG_LINK_BUTTON_CLASS);
+  }
+
+  getCopiedOrgLinkValue() {
+    return this.body.find(COPY_ORG_LINK_BUTTON_CLASS).getAttribute(CLIPBOARD_TEXT);
+  }
+
+  getDownloadAppHref() {
+    return this.body.find(DOWNLOAD_OV_LINK_CLASS).getAttribute('href');
+  }
+
+  getClosingText() {
+    return this.getTextContent(CLOSING_CLASS);
   }
 }

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -7,6 +7,8 @@ import EnrollOVViaSMSPageObject from '../framework/page-objects/EnrollOVViaSMSPa
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import { checkConsoleMessages, oktaDashboardContent, renderWidget as rerenderWidget } from '../framework/shared';
 import xhrAuthenticatorEnrollOktaVerifyQr from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-qr.json';
+import xhrAuthenticatorEnrollOktaVerifySameDevice from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device.json';
+import xhrAuthenticatorEnrollOktaVerifyDeviceBootstrap from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-device-bootstrap.json';
 import xhrAuthenticatorEnrollOktaVerifyViaEmail from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-via-email.json';
 import xhrAuthenticatorEnrollOktaVerifyEmail from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-email.json';
 import xhrAuthenticatorEnrollOktaVerifyViaSMS from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-via-sms.json';
@@ -49,6 +51,16 @@ const enrollViaQRcodeMocks = pollResponse => RequestMock()
   .respond(oktaDashboardContent);
 const enrollViaQRcodeMocks1 = enrollViaQRcodeMocks(!userVariables.v3 ? xhrSuccess : xhrAuthenticatorEnrollOktaVerifyQr);
 const enrollViaQRcodeMocks2 = enrollViaQRcodeMocks(xhrSuccess);
+
+// this mock doesn't need poll to return successful response
+const enrollSameDeviceMocks = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrAuthenticatorEnrollOktaVerifySameDevice);
+
+// this mock doesn't need poll to return successful response
+const enrollDeviceBootstrapMocks = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrap);
 
 const enrollViaEmailMocks = pollResponse => RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -233,6 +245,16 @@ const emailInstruction2 = 'Or try a different way to set up Okta Verify.';
 const qrCodeInstruction1 = 'On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).';
 const qrCodeInstruction2 = 'Open the app and follow the instructions to add your account';
 const qrCodeInstruction3 = 'When prompted, tap Scan a QR code, then scan the QR code below:';
+const sameDeviceSubtitle = 'To continue, you\'ll need an Okta Verify account on this device.';
+const sameDeviceInstruction1 = 'If you don’t have Okta Verify installed, download the app.';
+const sameDeviceInstruction2 = 'Open Okta Verify and follow the steps to add your account.';
+const sameDeviceInstruction3 = 'When prompted, choose Sign In, then enter the sign-in URL:';
+const deviceBootstrapSubtitle = 'To set up Okta Verify on additional devices, you can copy an existing Okta Verify account onto a new device.';
+const deviceBootstrapInstruction1 = 'Open Okta Verify on any of your other Okta Verify devices';
+const deviceBootstrapInstruction2 = 'In the app, select your account.';
+const deviceBootstrapInstruction3 = 'Choose Add Account to Another Device.';
+const deviceBootstrapInstruction4 = 'Follow the rest of the instructions shown in Okta Verify.';
+const deviceBootstrapClosing = 'This screen can be closed at any time.';
 
 const fipsUpgradeMessage = 'The device used to set up Okta Verify does not meet your organization’s security requirements because it is not FIPS compliant. Contact your administrator for help.';
 const fipsUpgradeMessageNonIos = 'The Okta Verify version on the device used does not meet your organization’s security requirements. To add your account, update Okta Verify to the latest version, then try again.';
@@ -240,6 +262,9 @@ const fipsUpgradeTitle = 'Update Okta Verify';
 
 const enableBiometricsMessage = 'Your organization requires biometrics. To proceed, ensure your device supports biometrics, then add your account and enable biometrics when prompted.';
 const enableBiometricsMessageTitle = 'Enable biometrics to add an account in Okta Verify';
+
+const urlCopiedToClipboardMessage = 'Copy sign-in URL to clipboard';
+const oktaVerifyAppStoreDownloadUrl = 'https://apps.apple.com/us/app/okta-verify/id490179405';
 
 fixture('Enroll Okta Verify Authenticator')
   .meta('v3', true);
@@ -802,4 +827,58 @@ test
     const pageUrl = await successPage.getPageUrl();
     await t.expect(pageUrl)
       .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+  });
+
+
+test
+  .meta('v3', false)
+  .requestHooks(logger, enrollSameDeviceMocks)('should be able to see OV same device enrollment instructions without polling', async t => {
+    const enrollOktaVerifyPage = await setup(t);
+    await checkA11y(t);
+    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql('Set up Okta Verify');
+    await t.expect(enrollOktaVerifyPage.getSubHeader()).eql(sameDeviceSubtitle);
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(0)).eql(sameDeviceInstruction1);
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(1)).eql(sameDeviceInstruction2);
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(2)).contains(sameDeviceInstruction3);
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(2)).contains('okta.okta.com');
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(3)).eql(deviceBootstrapInstruction4);
+
+    await t.expect(enrollOktaVerifyPage.getDownloadAppHref()).eql(oktaVerifyAppStoreDownloadUrl);
+    await t.expect(enrollOktaVerifyPage.getCopyOrgLinkButtonLabel()).eql(urlCopiedToClipboardMessage);
+    await t.expect(enrollOktaVerifyPage.getCopiedOrgLinkValue()).eql('okta.okta.com');
+
+    await t.expect(enrollOktaVerifyPage.getTryDifferentWayText().exists).notOk();
+    await t.expect(await enrollOktaVerifyPage.returnToAuthenticatorListLinkExists()).ok();
+    await t.expect(await enrollOktaVerifyPage.signoutLinkExists()).ok();
+
+    // expect no polling for same device page
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.url.match(/poll/)
+    )).eql(0);
+  });
+
+test
+  .meta('v3', false)
+  .requestHooks(logger, enrollDeviceBootstrapMocks)('should be able to see OV device bootstrap enrollment instructions without polling', async t => {
+    const enrollOktaVerifyPage = await setup(t);
+    await checkA11y(t);
+    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql('Set up Okta Verify');
+    await t.expect(enrollOktaVerifyPage.getSubHeader()).eql(deviceBootstrapSubtitle);
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(0)).contains(deviceBootstrapInstruction1);
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(0)).contains('testDevice1');
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(1)).eql(deviceBootstrapInstruction2);
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(2)).eql(deviceBootstrapInstruction3);
+    await t.expect(await enrollOktaVerifyPage.getNthInstructionBulletPoint(3)).eql(deviceBootstrapInstruction4);
+    await t.expect(await enrollOktaVerifyPage.getClosingText()).eql(deviceBootstrapClosing);
+
+    await t.expect(enrollOktaVerifyPage.getTryDifferentWayText().exists).notOk();
+    await t.expect(await enrollOktaVerifyPage.returnToAuthenticatorListLinkExists()).ok();
+    await t.expect(await enrollOktaVerifyPage.signoutLinkExists()).ok();
+
+    // expect no polling for device bootstrap page
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.url.match(/poll/)
+    )).eql(0);
   });


### PR DESCRIPTION
## Description:

- Added two new views for high security OV enrollment channel: same device enrollment and device bootstrap
- Added testface tests
- All code is under SIW v2 and doesn't contain any v3 items
- Design is https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2802417862/OV2OV+first+iteration+design
- UX mock: https://www.figma.com/file/d9CEqDWq0paUcoS3Ni5mEY/OV-phish-resist-phase-3?type=design&node-id=717-5&mode=design&t=z5RhF5h7cODm51Fi-0
- These two views will do polling, but it's not a hard requirement for this feature to automatically update the UI after enrollment completes.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-625871](https://oktainc.atlassian.net/browse/OKTA-625871)

### Reviewers:

@stevennguyen-okta @lesterchoi-okta @shawyu-okta 
@vakaevich-okta @bidansinha-okta @TrevorHalvorson-okta @SohamKolhatkar-okta 

### Screenshot/Video:

![Screenshot 2023-08-04 at 4 46 21 PM](https://github.com/okta/okta-signin-widget/assets/49395917/87ae4500-1632-4d3d-8d8a-71b08ba730b7)

![Screenshot 2023-08-04 at 4 46 27 PM](https://github.com/okta/okta-signin-widget/assets/49395917/796f07d2-ec17-4293-bc28-3b37dffdfedb)

![Screenshot 2023-08-04 at 4 47 04 PM](https://github.com/okta/okta-signin-widget/assets/49395917/1b202ac3-e38c-4b0e-b7b7-bb582fa169b9)

### Downstream Monolith Build:
TBA


