### PR TITLE
OKTA-637641 Fix FastPass polling issue behind CCS kill switch

### DIFF
--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -107,10 +107,16 @@ const Body = BaseFormWithPolling.extend({
             .done(() => {
               foundPort = true;
               if (deviceChallenge.enhancedPollingEnabled !== false) {
+                // this way we can gurantee that
+                // 1. the polling is triggered right away (1ms interval)
+                // 2. Only one polling queue
+                // 3. follwoing polling will continue with refresh interval from previous polling response
+                // NOTE: technically, there could still be concurrency issue where when we called stopPolling,
+                // there is already a polling triggered and hasn't completed yet
+                // but the possibility would be much smaller than previous concurrency issue
+                // this is a best effort change
                 this.stopPolling();
-                this.trigger('save', this.model);
-                // if this poll doesn't return a different remediation, start polling again
-                this.startPolling();
+                this.startPolling(1);
                 return;
               }
               // once the OV challenge succeeds,

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -108,4 +108,8 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
       await this.t.click(this.form.getLink('Open Okta Verify'));
     }
   }
+
+  hasErrorBox() {
+    return this.form.getErrorBox().exists;
+  }
 }

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -103,8 +103,8 @@ const loopbackEnhancedPollingMock = RequestMock()
     res.headers['content-type'] = 'application/json';
     if (!firstPollCalledForEnhancedPolling) {
       firstPollCalledForEnhancedPolling = true;
-      // with enhanced polling, this interval can be shorter for testing
-      await new Promise((r) => setTimeout(r, 3000));
+      // give more time for the waiting time
+      await new Promise((r) => setTimeout(r, 8000));
       res.statusCode = '200';
       res.setBody(identify);
     } else {
@@ -324,6 +324,7 @@ test
 
     // If there is redundant polling, SIW will show bad request error
     await t.expect(deviceChallengePollPageObject.form.getErrorBoxText()).contains('Bad request');
+    await t.expect(deviceChallengePollPageObject.hasErrorBox()).eql(true);
 
     const identityPage = new IdentityPageObject(t);
     await identityPage.fillIdentifierField('Test Identifier');
@@ -348,6 +349,13 @@ test
     )).eql(1);
 
     // If there is no redundant polling, SIW will not show bad request error
+    // This waiting time is necessary. It will make sure:
+    // 1. if there is a bad request the error, the hasErrorBox will be executed after error box is visible
+    // 2. if there is no error, the view is a spinner and hasErrorBox will be false
+    // Hence, it's not making sense to use await inside the hasErrorBox method
+    await t.wait(2500);
+    await t.expect(deviceChallengePollPageObject.hasErrorBox()).eql(false);
+
     const identityPage = new IdentityPageObject(t);
     await identityPage.fillIdentifierField('Test Identifier');
     await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');


### PR DESCRIPTION
## Description:

- We made a temp fix for the polling issue but still sees bad request error https://github.com/okta/okta-signin-widget/pull/3319
- This time we come with the permanent fix: `startPolling(1)` will set the poll interval as 1ms which means a polling will be triggered almost immediately, and there is only one polling queue. Following polling calls will use the refresh interval that is returned from server, like 2s or 4s.
- There will still be a very small chance that, when we call `stopPolling`, there is already a triggered polling that is pending response. but this frequency will be much smaller than the original issue and hence this is a best effort fix.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-637641](https://oktainc.atlassian.net/browse/OKTA-637641)

### Reviewers:
@lesterchoi-okta @shawyu-okta

### Screenshot/Video:
- Last time, the end to end test didn't catch the bad request so i refactored the test.
- **before fix**: old code will fail on the refactored test https://okta.box.com/s/4pfzrb99dghavexwyt6sbn50z7f41f9f
- **after fix**: new code will succeed on the refactored test https://okta.box.com/s/tvjzs3l0yontmayooeuqxknmryl6pdye
- **end to end test flow in local env**: https://okta.box.com/s/z5icn8m9p3xjkwmydvsmprnvhp32549g
- All these details were discussed with the widget team and dedicated ui engineers

### Downstream Monolith Build:
TBA


