### PR TITLE
OKTA-623662 : G2 : Checkbox long label UI fix

### DIFF
--- a/assets/sass/modules/_forms.scss
+++ b/assets/sass/modules/_forms.scss
@@ -224,6 +224,7 @@
 .custom-checkbox {
   label {
     background-image: url('../img/ui/forms/checkbox-sign-in-widget.png');
+    height: 30px;
   }
 
   label.focus {
@@ -242,6 +243,7 @@
     label {
       background-image: url('../img/ui/forms/checkbox-sign-in-widget@2x.png');
       background-size: 50px 1155px;
+      height: 30px;
     }
   }
 }


### PR DESCRIPTION
## Description:
The purpose of this PR is to fix the checkbox UI when the label is longer than 200 characters. The UI begins to repeat the checkbox when the label length is too long causing confusion. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-623662](https://oktainc.atlassian.net/browse/OKTA-623662)

### Reviewers:

### Screenshot/Video:
**Before:** 
<img width="667" alt="Screenshot 2023-08-11 at 9 48 43 AM" src="https://github.com/okta/okta-signin-widget/assets/97472729/0cf26bf9-4711-4198-ac5c-3c118ff511bd">

**After:** 
<img width="504" alt="Screenshot 2023-08-11 at 9 49 06 AM" src="https://github.com/okta/okta-signin-widget/assets/97472729/5e2ea5e4-6c26-487a-8827-e7fdc65c49bd">


### Downstream Monolith Build:



