### PR TITLE
wip: Fix direction of LTR text embedded in RTL text

### DIFF
--- a/src/v3/src/components/Widget/style.module.css
+++ b/src/v3/src/components/Widget/style.module.css
@@ -1,6 +1,10 @@
 :global(.clearfix) {
   display: block;
 }
+:global(.dir-ltr) {
+  direction: ltr;
+  unicode-bidi: embed;
+}
 :global(.clearfix:after,
 .clearfix:before) {
   display: block;

--- a/src/v3/src/transformer/layout/email/emailVerificationTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailVerificationTransformer.ts
@@ -50,7 +50,7 @@ export const transformEmailVerification: IdxStepTransformer = ({ transaction, fo
           'oie.email.verify.subtitle.text.with.email',
           'login',
           [redactedEmailAddress],
-          { $1: { element: 'span', attributes: { class: 'strong no-translate' } } },
+          { $1: { element: 'span', attributes: { class: 'strong no-translate dir-ltr' } } },
         )
         : loc('oie.email.verify.subtitle.text.without.email', 'login'),
     },

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
@@ -70,7 +70,7 @@ export const transformEmailAuthenticatorEnroll: IdxStepTransformer = ({ transact
   } else {
     const emailAddress = getUserInfo(transaction).identifier;
     const tokenReplacement: TokenReplacement | undefined = typeof emailAddress !== 'undefined'
-      ? { $1: { element: 'span', attributes: { class: 'strong no-translate' } } }
+      ? { $1: { element: 'span', attributes: { class: 'strong no-translate dir-ltr' } } }
       : undefined;
     subTitleElement.options.content = getEmailAuthenticatorSubtitle(
       emailAddress,

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.ts
@@ -67,7 +67,7 @@ export const transformEmailAuthenticatorVerify: IdxStepTransformer = ({ transact
 
   const redactedEmailAddress = nextStep.relatesTo?.value?.profile?.email;
   const tokenReplacement: TokenReplacement | undefined = typeof redactedEmailAddress !== 'undefined'
-    ? { $1: { element: 'span', attributes: { class: 'strong no-translate' } } }
+    ? { $1: { element: 'span', attributes: { class: 'strong no-translate dir-ltr' } } }
     : undefined;
   const informationalText: DescriptionElement = {
     type: 'Description',

--- a/src/v3/src/transformer/phone/__snapshots__/phoneVerificationTransformer.test.ts.snap
+++ b/src/v3/src/transformer/phone/__snapshots__/phoneVerificationTransformer.test.ts.snap
@@ -200,7 +200,7 @@ Object {
       Object {
         "contentType": "subtitle",
         "options": Object {
-          "content": "oie.phone.verify.sms.sendText <span class=\\"strong no-translate\\">+121xxxxx34</span>",
+          "content": "oie.phone.verify.sms.sendText <span class=\\"strong no-translate dir-ltr\\">+121xxxxx34</span>",
         },
         "type": "Description",
       },
@@ -302,7 +302,7 @@ Object {
       Object {
         "contentType": "subtitle",
         "options": Object {
-          "content": "oie.phone.verify.call.sendText <span class=\\"strong no-translate\\">+121xxxxx34</span>",
+          "content": "oie.phone.verify.call.sendText <span class=\\"strong no-translate dir-ltr\\">+121xxxxx34</span>",
         },
         "type": "Description",
       },

--- a/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
@@ -184,7 +184,7 @@ describe('Phone verification Transformer Tests', () => {
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.phone.verify.title');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe(`oie.phone.verify.sms.sendText <span class="strong no-translate">${mockPhoneNumber}</span>`);
+      .toBe(`oie.phone.verify.sms.sendText <span class="strong no-translate dir-ltr">${mockPhoneNumber}</span>`);
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
       .toBe('oie.phone.carrier.charges');
     // primary button
@@ -225,7 +225,7 @@ describe('Phone verification Transformer Tests', () => {
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.phone.verify.title');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe(`oie.phone.verify.call.sendText <span class="strong no-translate">${mockPhoneNumber}</span>`);
+      .toBe(`oie.phone.verify.call.sendText <span class="strong no-translate dir-ltr">${mockPhoneNumber}</span>`);
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
       .toBe('oie.phone.carrier.charges');
     // primary button

--- a/src/v3/src/transformer/phone/phoneVerificationTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneVerificationTransformer.ts
@@ -59,7 +59,7 @@ export const transformPhoneVerification: IdxStepTransformer = ({ transaction, fo
   uischema.elements.unshift(carrierInfoText);
 
   const redactedPhoneNumber = nextStep.relatesTo?.value?.profile?.phoneNumber as string;
-  const phoneNumberSpan = redactedPhoneNumber ? `<span class="strong no-translate">${redactedPhoneNumber}</span>` : null;
+  const phoneNumberSpan = redactedPhoneNumber ? `<span class="strong no-translate dir-ltr">${redactedPhoneNumber}</span>` : null;
   const phoneInfoText = phoneNumberSpan || loc('oie.phone.alternate.title', 'login');
   const smsInfoTextElement: DescriptionElement = {
     type: 'Description',

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -137,11 +137,11 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-19"
                     data-se="o-form-explain"
-                    id="enroll-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate>testUser@oktacom</span>_Enter_the_verification_code_in_the_text_box_okta_email_aut2m2nnGGzJy8uO80g4_3"
+                    id="enroll-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate_dir-ltr>testUser@oktacom</span>_Enter_the_verification_code_in_the_text_box_okta_email_aut2m2nnGGzJy8uO80g4_3"
                   >
                     We sent an email to 
                     <span
-                      class="strong no-translate"
+                      class="strong no-translate dir-ltr"
                     >
                       testUser@okta.com
                     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -140,11 +140,11 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-20"
                       data-se="o-form-explain"
-                      id="enroll-authenticator_Description_enroll-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate>testUser@oktacom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_aut2m2nnGGzJy8uO80g4_okta_email_aut2m2nnGGzJy8uO80g4_8"
+                      id="enroll-authenticator_Description_enroll-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate_dir-ltr>testUser@oktacom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_aut2m2nnGGzJy8uO80g4_okta_email_aut2m2nnGGzJy8uO80g4_8"
                     >
                       We sent an email to 
                       <span
-                        class="strong no-translate"
+                        class="strong no-translate dir-ltr"
                       >
                         testUser@okta.com
                       </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -144,11 +144,11 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-18"
                     data-se="o-form-explain"
-                    id="authenticator-verification-data_Description_Send_a_code_via_SMS_to_<span_class=strong_no-translate>1_XXX-XXX-4601</span>_phone_number_sms4bvjioge7Sdu3p5d7_2"
+                    id="authenticator-verification-data_Description_Send_a_code_via_SMS_to_<span_class=strong_no-translate_dir-ltr>1_XXX-XXX-4601</span>_phone_number_sms4bvjioge7Sdu3p5d7_2"
                   >
                     Send a code via SMS to 
                     <span
-                      class="strong no-translate"
+                      class="strong no-translate dir-ltr"
                     >
                       +1 XXX-XXX-4601
                     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -134,11 +134,11 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-18"
                     data-se="o-form-explain"
-                    id="authenticator-verification-data_Description_Send_a_verification_email_to_<span_class=strong_no-translate>t****1@oktacom</span>_by_clicking_on_Send_me_an_email_okta_email_2"
+                    id="authenticator-verification-data_Description_Send_a_verification_email_to_<span_class=strong_no-translate_dir-ltr>t****1@oktacom</span>_by_clicking_on_Send_me_an_email_okta_email_2"
                   >
                     Send a verification email to 
                     <span
-                      class="strong no-translate"
+                      class="strong no-translate dir-ltr"
                     >
                       t****1@okta.com
                     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -137,11 +137,11 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-19"
                     data-se="o-form-explain"
-                    id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate>f****************e@examplecom</span>_Enter_the_verification_code_in_the_text_box_okta_email_eae1egri5eK5zce0V1d7_3"
+                    id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate_dir-ltr>f****************e@examplecom</span>_Enter_the_verification_code_in_the_text_box_okta_email_eae1egri5eK5zce0V1d7_3"
                   >
                     We sent an email to 
                     <span
-                      class="strong no-translate"
+                      class="strong no-translate dir-ltr"
                     >
                       f****************e@example.com
                     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -140,11 +140,11 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-20"
                       data-se="o-form-explain"
-                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate>f****************e@examplecom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eae1egri5eK5zce0V1d7_4_1"
+                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate_dir-ltr>f****************e@examplecom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eae1egri5eK5zce0V1d7_4_1"
                     >
                       We sent an email to 
                       <span
-                        class="strong no-translate"
+                        class="strong no-translate dir-ltr"
                       >
                         f****************e@example.com
                       </span>
@@ -368,11 +368,11 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-27"
                       data-se="o-form-explain"
-                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate>f****************e@examplecom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eae1egri5eK5zce0V1d7_4_1"
+                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate_dir-ltr>f****************e@examplecom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eae1egri5eK5zce0V1d7_4_1"
                     >
                       We sent an email to 
                       <span
-                        class="strong no-translate"
+                        class="strong no-translate dir-ltr"
                       >
                         f****************e@example.com
                       </span>
@@ -552,11 +552,11 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-20"
                       data-se="o-form-explain"
-                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate>f****************e@examplecom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eae1egri5eK5zce0V1d7_8_2"
+                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate_dir-ltr>f****************e@examplecom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eae1egri5eK5zce0V1d7_8_2"
                     >
                       We sent an email to 
                       <span
-                        class="strong no-translate"
+                        class="strong no-translate dir-ltr"
                       >
                         f****************e@example.com
                       </span>
@@ -801,11 +801,11 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                       data-se="o-form-explain"
-                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate>t***t@idxcom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eaexdyjzXZ3iWikza0g3_8_2"
+                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate_dir-ltr>t***t@idxcom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eaexdyjzXZ3iWikza0g3_8_2"
                     >
                       We sent an email to 
                       <span
-                        class="strong no-translate"
+                        class="strong no-translate dir-ltr"
                       >
                         t***t@idx.com
                       </span>
@@ -1118,11 +1118,11 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-32"
                       data-se="o-form-explain"
-                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate>t***t@idxcom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eaexdyjzXZ3iWikza0g3_8_2"
+                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate_dir-ltr>t***t@idxcom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eaexdyjzXZ3iWikza0g3_8_2"
                     >
                       We sent an email to 
                       <span
-                        class="strong no-translate"
+                        class="strong no-translate dir-ltr"
                       >
                         t***t@idx.com
                       </span>
@@ -1451,11 +1451,11 @@ exports[`Email authenticator verification when email magic link = undefined shou
                     <p
                       class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-20"
                       data-se="o-form-explain"
-                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate>f****************e@examplecom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eae1egri5eK5zce0V1d7_8_2"
+                      id="challenge-authenticator_Description_We_sent_an_email_to_<span_class=strong_no-translate_dir-ltr>f****************e@examplecom</span>_Click_the_verification_link_in_your_email_to_continue_or_enter_the_code_below_okta_email_eae1egri5eK5zce0V1d7_8_2"
                     >
                       We sent an email to 
                       <span
-                        class="strong no-translate"
+                        class="strong no-translate dir-ltr"
                       >
                         f****************e@example.com
                       </span>


### PR DESCRIPTION
## Description:

Fixed direction for phone number, email

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-616429](https://oktainc.atlassian.net/browse/OKTA-616429)

### Reviewers:

### Screenshot/Video:

<details>
  <summary>Before/after with lorem ipsum</summary>

<p>Before:</p>

<img width="445" alt="Screenshot 2023-08-11 at 20 19 06" src="https://github.com/okta/okta-signin-widget/assets/72614880/c000a893-090d-4d09-9f07-994159d1a6c8">

<p>After:</p>

<img width="450" alt="Screenshot 2023-08-11 at 20 16 42" src="https://github.com/okta/okta-signin-widget/assets/72614880/93b4141d-5cf7-44dc-bb68-6dbb78e7cdb5">

</details>

### Downstream Monolith Build:



