### PR TITLE
OKTA-638276: Add message to the mock responses for End User Remediation

### DIFF
--- a/playground/mocks/data/idp/idx/end-user-remediation-multiple-options-with-custom-help-url.json
+++ b/playground/mocks/data/idp/idx/end-user-remediation-multiple-options-with-custom-help-url.json
@@ -8,18 +8,21 @@
       "type": "array",
       "value": [
         {
+          "message": "Your device doesn't meet the security requirements",
           "i18n": {
             "key": "idx.error.code.access_denied.device_assurance.remediation.title"
           },
           "class": "ERROR"
         },
         {
+          "message": "To sign in, pick an option and make the updates. Then, access the app again.",
           "i18n": {
-            "key": "idx.error.code.access_denied.device_assurance.remediation.explanation_one_rule"
+            "key": "idx.error.code.access_denied.device_assurance.remediation.explanation_multiple_rules"
           },
           "class": "ERROR"
         },
         {
+          "message": "Option 1:",
           "i18n": {
             "key": "idx.error.code.access_denied.device_assurance.remediation.option_index",
             "params": ["1"]
@@ -27,6 +30,7 @@
           "class": "ERROR"
         },
         {
+            "message": "Update to iOS 12.0.1",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.ios.upgrade_os_version",
                 "params": ["12.0.1"]
@@ -37,6 +41,7 @@
             "class": "ERROR"
         },
         {
+            "message": "Set a passcode for the lock screen",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.ios.use_lock_screen"
             },
@@ -46,6 +51,7 @@
             "class": "ERROR"
         },
         {
+            "message": "Set a passcode for the lock screen and enable Touch ID or Face ID",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.ios.use_biometric_lock_screen"
             },
@@ -55,6 +61,7 @@
             "class": "ERROR"
         },
         {
+          "message": "Option 2:",
           "i18n": {
             "key": "idx.error.code.access_denied.device_assurance.remediation.option_index",
             "params": ["2"]
@@ -62,6 +69,7 @@
           "class": "ERROR"
         },
         {
+            "message": "Update to macOS 13.2",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.macos.upgrade_os_version",
                 "params": ["13.2"]
@@ -72,6 +80,7 @@
             "class": "ERROR"
         },
         {
+            "message": "Set a passcode for the lock screen",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.macos.use_lock_screen"
             },
@@ -81,6 +90,7 @@
             "class": "ERROR"
         },
         {
+            "message": "Turn on FileVault",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.macos.device_disk_encrypted"
             },
@@ -90,6 +100,7 @@
             "class": "ERROR"
         },
         {
+            "message": "Option 3:",
             "i18n": {
               "key": "idx.error.code.access_denied.device_assurance.remediation.option_index",
               "params": ["3"]
@@ -97,6 +108,7 @@
             "class": "ERROR"
         },
         {
+            "message": "Update to Windows 10.0.25530.123",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.windows.upgrade_os_version",
                 "params": ["10.0.25530.123"]
@@ -107,6 +119,7 @@
             "class": "ERROR"
         },
         {
+            "message": "Encrypt all internal disks with BitLocker",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.windows.device_disk_encrypted"
             },
@@ -116,6 +129,7 @@
             "class": "ERROR"
         },
         {
+            "message": "Option 4:",
             "i18n": {
               "key": "idx.error.code.access_denied.device_assurance.remediation.option_index",
               "params": ["4"]
@@ -123,6 +137,7 @@
             "class": "ERROR"
         },
         {
+            "message": "Enable Windows Hello for the lock screen",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.windows.use_biometric_lock_screen"
             },
@@ -132,6 +147,7 @@
             "class": "ERROR"
         },
         {
+            "message": "For more information, follow the instructions on your organization's help page or contact your administrator for help",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.additional_help_custom"
             },

--- a/playground/mocks/data/idp/idx/end-user-remediation-multiple-options.json
+++ b/playground/mocks/data/idp/idx/end-user-remediation-multiple-options.json
@@ -8,18 +8,21 @@
     "type": "array",
     "value": [
       {
+        "message": "Your device doesn't meet the security requirements",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.title"
         },
         "class": "ERROR"
       },
       {
+        "message": "To sign in, pick an option and make the updates. Then, access the app again.",
         "i18n": {
-          "key": "idx.error.code.access_denied.device_assurance.remediation.explanation_one_rule"
+          "key": "idx.error.code.access_denied.device_assurance.remediation.explanation_multiple_rules"
         },
         "class": "ERROR"
       },
       {
+        "message": "Option 1:",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.option_index",
           "params": ["1"]
@@ -30,6 +33,7 @@
         "links": [
           {"url": "https://okta.com/android-upgrade-os"}
         ],
+        "message": "Update to Android 100",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.android.upgrade_os_version",
           "params": ["100"]
@@ -40,12 +44,14 @@
         "links": [
           {"url": "https://okta.com/android-biometric-lock"}
         ],
+        "message": "Enable lock screen and biometrics",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.android.use_biometric_lock_screen"
         },
         "class": "ERROR"
       },
       {
+        "message": "Option 2:",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.option_index",
           "params": ["2"]
@@ -56,6 +62,7 @@
         "links": [
           {"url": "https://okta.com/android-lock-screen"}
         ],
+        "message": "Enable lock screen",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.android.use_lock_screen"
         },
@@ -65,6 +72,7 @@
         "links": [
           {"url": "https://okta.com/android-disk-encrypted"}
         ],
+        "message": "Encrypt your device",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.android.device_disk_encrypted"
         },
@@ -74,6 +82,7 @@
         "links": [
           {"url": "https://okta.com/help"}
         ],
+        "message": "For more information, follow the instructions on the help page or contact your administrator for help",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.additional_help_default"
         },

--- a/playground/mocks/data/idp/idx/end-user-remediation-no-options.json
+++ b/playground/mocks/data/idp/idx/end-user-remediation-no-options.json
@@ -8,12 +8,14 @@
       "type": "array",
       "value": [
         {
+          "message": "Your device doesn't meet the security requirements",
           "i18n": {
             "key": "idx.error.code.access_denied.device_assurance.remediation.title"
           },
           "class": "ERROR"
         },
         {
+            "message": "For more information, follow the instructions on your organization's help page or contact your administrator for help",
             "i18n": {
                 "key": "idx.error.code.access_denied.device_assurance.remediation.additional_help_custom"
             },

--- a/playground/mocks/data/idp/idx/end-user-remediation-one-option.json
+++ b/playground/mocks/data/idp/idx/end-user-remediation-one-option.json
@@ -8,12 +8,14 @@
     "type": "array",
     "value": [
       {
+        "message": "Your device doesn't meet the security requirements",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.title"
         },
         "class": "ERROR"
       },
       {
+        "message": "To sign in, make the following updates. Then, access the app again.",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.explanation_one_rule"
         },
@@ -23,6 +25,7 @@
         "links": [
           {"url": "https://okta.com/android-upgrade-os"}
         ],
+        "message": "Update to Android 100",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.android.upgrade_os_version",
           "params": ["100"]
@@ -33,6 +36,7 @@
         "links": [
           {"url": "https://okta.com/android-biometric-lock"}
         ],
+        "message": "Enable lock screen and biometrics",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.android.use_biometric_lock_screen"
         },
@@ -42,6 +46,7 @@
         "links": [
           {"url": "https://okta.com/help"}
         ],
+        "message": "For more information, follow the instructions on the help page or contact your administrator for help",
         "i18n": {
           "key": "idx.error.code.access_denied.device_assurance.remediation.additional_help_default"
         },

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -226,7 +226,7 @@ test.requestHooks(endUserRemediationMultipleOptionsMock)('should render end user
   await checkA11y(t);
 
   await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('Your device doesn\'t meet the security requirements').exists).eql(true);
-  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, make the following updates. Then, access the app again.').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, pick an option and make the updates. Then, access the app again.').exists).eql(true);
 
   await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-upgrade-os').withExactText('Update to Android 100').exists).eql(true);
   await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-biometric-lock').withExactText('Enable lock screen and biometrics').exists).eql(true);
@@ -246,7 +246,7 @@ test.requestHooks(endUserRemediationMultipleOptionsWithCustomHelpUrlMock)('shoul
   // platforms. The test exists to ensure all of the expected keys can be
   // localized
   await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('Your device doesn\'t meet the security requirements').exists).eql(true);
-  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, make the following updates. Then, access the app again.').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, pick an option and make the updates. Then, access the app again.').exists).eql(true);
 
   await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/ios-upgrade-os').withExactText('Update to iOS 12.0.1').exists).eql(true);
   await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/ios-lock-screen').withExactText('Set a passcode for the lock screen').exists).eql(true);


### PR DESCRIPTION
## Description:

OKTA-638276: Add message to the mock responses for End User Remediation

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-638276](https://oktainc.atlassian.net/browse/OKTA-638276)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



