### PR TITLE
OKTA-621214 fix: wrap long labels

### DIFF
--- a/src/v3/src/bin/properties-to-json.js
+++ b/src/v3/src/bin/properties-to-json.js
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+const path = require('path');
 const {
   ensureDirSync,
   readFileSync,
@@ -17,7 +18,6 @@ const {
   removeSync,
   writeFileSync,
 } = require('fs-extra');
-const path = require('path');
 const properties = require('properties');
 
 const PROPERTIES_EXTENSION = '.properties';

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -101,7 +101,12 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
           </Box>
         )}
         {required === false && (
-          <Typography variant="subtitle1">{optionalLabel}</Typography>
+          <Typography
+            variant="subtitle1"
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            {optionalLabel}
+          </Typography>
         )}
       </InputLabel>
       {hint && (

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -86,7 +86,12 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
           </Box>
         )}
         {required === false && (
-          <Typography variant="subtitle1">{optionalLabel}</Typography>
+          <Typography
+            variant="subtitle1"
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            {optionalLabel}
+          </Typography>
         )}
       </InputLabel>
       {

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -167,7 +167,12 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
           </Box>
         )}
         {required === false && (
-          <Typography variant="subtitle1">{optionalLabel}</Typography>
+          <Typography
+            variant="subtitle1"
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            {optionalLabel}
+          </Typography>
         )}
       </InputLabel>
       <Select
@@ -206,7 +211,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
 
   return (
     <Box>
-      { renderCountrySelect() }
+      {renderCountrySelect()}
       <Box
         display="flex"
         flexWrap="wrap"
@@ -276,7 +281,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
             />
           )}
         </Box>
-        { renderExtension() }
+        {renderExtension()}
       </Box>
     </Box>
   );

--- a/src/v3/src/components/Radio/Radio.tsx
+++ b/src/v3/src/components/Radio/Radio.tsx
@@ -85,7 +85,12 @@ const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProp
             </Box>
           )}
           {required === false && (
-            <Typography variant="subtitle1">{optionalLabel}</Typography>
+            <Typography
+              variant="subtitle1"
+              sx={{ whiteSpace: 'nowrap' }}
+            >
+              {optionalLabel}
+            </Typography>
           )}
         </FormLabel>
       )}
@@ -111,7 +116,7 @@ const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProp
                 handleBlur?.(e?.currentTarget?.value);
               }}
               // eslint-disable-next-line react/jsx-props-no-spreading
-              {...(index === 0 && { inputRef: focusRef } )}
+              {...(index === 0 && { inputRef: focusRef })}
             />
           ))
         }

--- a/src/v3/src/components/Select/Select.tsx
+++ b/src/v3/src/components/Select/Select.tsx
@@ -91,7 +91,12 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
           </Box>
         )}
         {required === false && (
-          <Typography variant="subtitle1">{optionalLabel}</Typography>
+          <Typography
+            variant="subtitle1"
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            {optionalLabel}
+          </Typography>
         )}
       </InputLabel>
       <MuiSelect

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -117,7 +117,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
   // merge themes
   const theme = useMemo(() => mergeThemes(
-    mapMuiThemeFromBrand(brandColors, languageDirection),
+    mapMuiThemeFromBrand(brandColors, languageDirection, muiThemeOverrides),
     {
       components: {
         MuiInputLabel: {
@@ -129,8 +129,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
           },
         },
       },
-    },
-    muiThemeOverrides ?? {},
+    }
   ), [brandColors, languageDirection, muiThemeOverrides]);
 
   // on unmount, remove the language

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -129,7 +129,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
           },
         },
       },
-    }
+    },
   ), [brandColors, languageDirection, muiThemeOverrides]);
 
   // on unmount, remove the language

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -122,10 +122,10 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       components: {
         MuiInputLabel: {
           styleOverrides: {
-            root: () => ({
+            root: {
               wordBreak: 'break-word',
               whiteSpace: 'normal',
-            }),
+            },
           },
         },
       },

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -30,6 +30,7 @@ import {
   useRef,
   useState,
 } from 'preact/hooks';
+import { mergeThemes } from 'src/util/mergeThemes';
 
 import Bundles from '../../../../util/Bundles';
 import { IDX_STEP } from '../../constants';
@@ -112,22 +113,39 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const [loginHint, setloginHint] = useState<string | null>(null);
   const languageCode = getLanguageCode(widgetProps);
   const languageDirection = getLanguageDirection(languageCode);
-  const brandedTheme = mapMuiThemeFromBrand(brandColors, languageDirection, muiThemeOverrides);
   const { stateHandle, unsetStateHandle } = useStateHandle(widgetProps);
+
+  // merge themes
+  const theme = useMemo(() => mergeThemes(
+    mapMuiThemeFromBrand(brandColors, languageDirection),
+    {
+      components: {
+        MuiInputLabel: {
+          styleOverrides: {
+            root: () => ({
+              wordBreak: 'break-word',
+              whiteSpace: 'normal',
+            }),
+          },
+        },
+      },
+    },
+    muiThemeOverrides ?? {},
+  ), [brandColors, languageDirection, muiThemeOverrides]);
 
   // on unmount, remove the language
   useEffect(() => () => {
     if (Bundles.isLoaded(languageCode)) {
       Bundles.remove();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const initLanguage = useCallback(async () => {
     if (!Bundles.isLoaded(languageCode)) {
       await loadLanguage(widgetProps);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleError = (error: unknown) => {
@@ -184,7 +202,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
         handleError(error);
       }
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authClient, stateHandle, setIdxTransaction, setResponseError, initLanguage]);
 
   // Derived value from idxTransaction
@@ -203,8 +221,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     }
 
     if ([IdxStatus.TERMINAL, IdxStatus.SUCCESS].includes(idxTransaction.status)
-        || idxTransaction.nextStep?.name === IDX_STEP.SKIP // force safe mode to be terminal
-        || !idxTransaction.nextStep) {
+      || idxTransaction.nextStep?.name === IDX_STEP.SKIP // force safe mode to be terminal
+      || !idxTransaction.nextStep) {
       return transformTerminalTransaction(idxTransaction, widgetProps, bootstrap);
     }
 
@@ -231,8 +249,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     // Mobile devices cannot scan QR codes while navigating through flow
     // so we force them to select either email / sms for enrollment
     if (idxTransaction.context.currentAuthenticator?.value.key === AuthenticatorKey.OKTA_VERIFY
-        && idxTransaction.nextStep.name === 'enroll-poll'
-        && isAndroidOrIOS()) {
+      && idxTransaction.nextStep.name === 'enroll-poll'
+      && isAndroidOrIOS()) {
       step = 'select-enrollment-channel';
     }
     return transformIdxTransaction({
@@ -243,7 +261,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       setMessage,
       isClientTransaction,
     });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     idxTransaction,
     responseError,
@@ -300,7 +318,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
       handleError(error);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authClient, setIdxTransaction, setResponseError, initLanguage]);
 
   // bootstrap / resume the widget
@@ -329,7 +347,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     if (!areTransactionsEqual(idxTransaction, pollingTransaction)) {
       setIdxTransaction(pollingTransaction);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pollingTransaction]); // only watch on pollingTransaction changes
 
   useEffect(() => {
@@ -348,7 +366,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       && uischema.elements.length > 0) {
       events?.afterRender?.(getEventContext(idxTransaction));
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [widgetRendered, idxTransaction]);
 
   useEffect(() => {
@@ -358,7 +376,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
         formName: 'terminal',
       });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [responseError]);
 
   return (
@@ -388,7 +406,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     }}
     >
       <OdysseyCacheProvider nonce={cspNonce}>
-        <MuiThemeProvider theme={brandedTheme}>
+        <MuiThemeProvider theme={theme}>
           {/* the style is to allow the widget to inherit the parent's bg color */}
           <ScopedCssBaseline
             sx={{

--- a/src/v3/src/util/cssInterpolate.ts
+++ b/src/v3/src/util/cssInterpolate.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { toCamelCase } from './inflect';
+
+export const cssInterpolate = (style: string) => (
+  style.split(';')
+    .filter(Boolean)
+    .map((decl) => decl.split(':', 2))
+    .reduce((css, [prop, val]) => ({
+      ...css,
+      [toCamelCase(prop.trim())]: val.trim(),
+    }), {})
+);

--- a/src/v3/src/util/inflect.test.ts
+++ b/src/v3/src/util/inflect.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  capitalize,
+  decapitalize,
+  toCamelCase,
+  toKebabCase,
+  tokenize,
+  toPascalCase,
+  toSnakeCase,
+  toTitleCase,
+} from './inflect';
+
+describe('inflect', () => {
+  describe('decapitalize', () => {
+    test('lowercase', () => expect(decapitalize('lowercase')).toBe('lowercase'));
+    test('uppercase', () => expect(decapitalize('UPPERCASE')).toBe('uPPERCASE'));
+    test('camelCase', () => expect(decapitalize('camelCase')).toBe('camelCase'));
+    test('PascalCase', () => expect(decapitalize('PascalCase')).toBe('pascalCase'));
+    test('kebab-case', () => expect(decapitalize('kebab-case')).toBe('kebab-case'));
+    test('snake_case', () => expect(decapitalize('snake_case')).toBe('snake_case'));
+    test('Title Case', () => expect(decapitalize('Title Case')).toBe('title Case'));
+  });
+  describe('capitalize', () => {
+    test('lowercase', () => expect(capitalize('lowercase')).toBe('Lowercase'));
+    test('uppercase', () => expect(capitalize('UPPERCASE')).toBe('UPPERCASE'));
+    test('camelCase', () => expect(capitalize('camelCase')).toBe('CamelCase'));
+    test('PascalCase', () => expect(capitalize('PascalCase')).toBe('PascalCase'));
+    test('kebab-case', () => expect(capitalize('kebab-case')).toBe('Kebab-case'));
+    test('snake_case', () => expect(capitalize('snake_case')).toBe('Snake_case'));
+    test('Title Case', () => expect(capitalize('Title Case')).toBe('Title Case'));
+  });
+  describe('tokenize', () => {
+    test('lowercase', () => expect(tokenize('lowercase')).toEqual(['lowercase']));
+    test('UPPERCASE', () => expect(tokenize('UPPERCASE')).toEqual(['UPPERCASE']));
+    test('camelCase', () => expect(tokenize('camelCase')).toEqual(['camel', 'Case']));
+    test('PascalCase', () => expect(tokenize('PascalCase')).toEqual(['Pascal', 'Case']));
+    test('kebab-case', () => expect(tokenize('kebab-case')).toEqual(['kebab', 'case']));
+    test('snake_case', () => expect(tokenize('snake_case')).toEqual(['snake', 'case']));
+    test('__dunder_case__', () => expect(tokenize('__dunder_case__')).toEqual(['dunder', 'case']));
+    test('Sentence case', () => expect(tokenize('Sentence case')).toEqual(['Sentence', 'case']));
+  });
+  describe('toTitleCase', () => {
+    test('lowercase', () => expect(toTitleCase('lowercase')).toEqual('Lowercase'));
+    test('UPPERCASE', () => expect(toTitleCase('UPPERCASE')).toEqual('UPPERCASE'));
+    test('camelCase', () => expect(toTitleCase('camelCase')).toEqual('Camel Case'));
+    test('PascalCase', () => expect(toTitleCase('PascalCase')).toEqual('Pascal Case'));
+    test('kebab-case', () => expect(toTitleCase('kebab-case')).toEqual('Kebab Case'));
+    test('snake_case', () => expect(toTitleCase('snake_case')).toEqual('Snake Case'));
+    test('__dunder_case__', () => expect(toTitleCase('__dunder_case__')).toEqual('Dunder Case'));
+    test('Sentence case', () => expect(toTitleCase('Sentence case')).toEqual('Sentence Case'));
+    test('Title Case', () => expect(toTitleCase('Title Case')).toEqual('Title Case'));
+  });
+  describe('toKebabCase', () => {
+    test('lowercase', () => expect(toKebabCase('lowercase')).toBe('lowercase'));
+    test('UPPERCASE', () => expect(toKebabCase('UPPERCASE')).toBe('uppercase'));
+    test('camelCase', () => expect(toKebabCase('camelCase')).toBe('camel-case'));
+    test('PascalCase', () => expect(toKebabCase('PascalCase')).toBe('pascal-case'));
+    test('kebab-case', () => expect(toKebabCase('kebab-case')).toBe('kebab-case'));
+    test('snake_case', () => expect(toKebabCase('snake_case')).toBe('snake-case'));
+    test('__dunder_case__', () => expect(toKebabCase('__dunder_case__')).toBe('dunder-case'));
+    test('Sentence case', () => expect(toKebabCase('Sentence case')).toBe('sentence-case'));
+    test('Title Case', () => expect(toKebabCase('Title Case')).toBe('title-case'));
+  });
+  describe('toSnakeCase', () => {
+    test('lowercase', () => expect(toSnakeCase('lowercase')).toBe('lowercase'));
+    test('UPPERCASE', () => expect(toSnakeCase('UPPERCASE')).toBe('uppercase'));
+    test('camelCase', () => expect(toSnakeCase('camelCase')).toBe('camel_case'));
+    test('PascalCase', () => expect(toSnakeCase('PascalCase')).toBe('pascal_case'));
+    test('kebab-case', () => expect(toSnakeCase('kebab-case')).toBe('kebab_case'));
+    test('snake_case', () => expect(toSnakeCase('snake_case')).toBe('snake_case'));
+    test('__dunder_case__', () => expect(toSnakeCase('__dunder_case__')).toBe('dunder_case'));
+    test('Sentence case', () => expect(toSnakeCase('Sentence case')).toBe('sentence_case'));
+    test('Title Case', () => expect(toSnakeCase('Title Case')).toBe('title_case'));
+  });
+  describe('toCamelCase', () => {
+    test('lowercase', () => expect(toCamelCase('lowercase')).toBe('lowercase'));
+    test('UPPERCASE', () => expect(toCamelCase('UPPERCASE')).toBe('uppercase'));
+    test('camelCase', () => expect(toCamelCase('camelCase')).toBe('camelCase'));
+    test('PascalCase', () => expect(toCamelCase('PascalCase')).toBe('pascalCase'));
+    test('kebab-case', () => expect(toCamelCase('kebab-case')).toBe('kebabCase'));
+    test('snake_case', () => expect(toCamelCase('snake_case')).toBe('snakeCase'));
+    test('__dunder_case__', () => expect(toCamelCase('__dunder_case__')).toBe('dunderCase'));
+    test('Sentence case', () => expect(toCamelCase('Sentence case')).toBe('sentenceCase'));
+    test('Title Case', () => expect(toCamelCase('Title Case')).toBe('titleCase'));
+  });
+
+  describe('acronyms', () => {
+    test('tokenize', () => expect(tokenize('HTMLInputElement')).toEqual(['HTML', 'Input', 'Element']));
+    test('toTitleCase', () => expect(toTitleCase('HTMLInputElement')).toBe('HTML Input Element'));
+    test('toKebabCase', () => expect(toKebabCase('HTMLInputElement')).toBe('html-input-element'));
+    test('toSnakeCase', () => expect(toSnakeCase('HTMLInputElement')).toBe('html_input_element'));
+    test('toCamelCase', () => expect(toCamelCase('HTMLInputElement')).toBe('htmlInputElement'));
+    test('toPascalCase', () => expect(toPascalCase('HTMLInputElement')).toBe('HtmlInputElement'));
+  });
+});

--- a/src/v3/src/util/inflect.ts
+++ b/src/v3/src/util/inflect.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export const chop = (str: string, n = 1): [string, string] => {
+  const first = str.slice(0, n);
+  const rest = str.slice(n);
+  return [first, rest];
+};
+
+export const tokenize = (str: string): string[] => (
+  str.split(/\W+/g)
+    .filter(Boolean)
+    .map((token) => {
+      // eslint-disable-next-line no-nested-ternary
+      const matches = /(^[A-Z]+$)/.test(token)
+        ? [token]
+        : (/([A-Z]{2,})/.test(token)
+          ? token.match(/([A-Z]{2,}(?=[A-Z]))|([A-Z][a-z]*)|(\d+)/g)
+          : token.match(/([A-Z]*[a-z]*)|(\d+)/g));
+      return matches
+        ?.flat()
+        ?.filter(Boolean) ?? [];
+    })
+    .flat()
+);
+
+export const capitalize = (str: string): string => {
+  const [first, rest] = chop(str);
+  return `${first.toLocaleUpperCase()}${rest}`;
+};
+
+export const decapitalize = (str: string): string => {
+  const [first, rest] = chop(str);
+  return `${first.toLocaleLowerCase()}${rest}`;
+};
+
+export const toTitleCase = (str: string): string => tokenize(str)
+  .map(capitalize)
+  .join(' ');
+
+export const toKebabCase = (str: string): string => tokenize(str)
+  .map(capitalize)
+  .map((token) => token.toLocaleLowerCase())
+  .join('-');
+
+export const toSnakeCase = (str: string): string => tokenize(str)
+  .map((token) => token.toLocaleLowerCase())
+  .join('_');
+
+export const toPascalCase = (str: string): string => tokenize(str)
+  .map((s) => s.toLocaleLowerCase())
+  .map(capitalize)
+  .join('');
+
+export const toCamelCase = (str: string): string => decapitalize(toPascalCase(str));

--- a/src/v3/src/util/mergeThemes.test.tsx
+++ b/src/v3/src/util/mergeThemes.test.tsx
@@ -18,6 +18,7 @@ import { mergeThemes } from './mergeThemes';
 
 test('mergeThemes()', () => {
   const merged = mergeThemes(
+    odysseyTheme,
     {
       components: {
         MuiInputLabel: {

--- a/src/v3/src/util/mergeThemes.test.tsx
+++ b/src/v3/src/util/mergeThemes.test.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { TextField, ThemeProvider } from '@mui/material';
+import { CSSObject, TextField, ThemeProvider } from '@mui/material';
 import { odysseyTheme } from '@okta/odyssey-react-mui';
 import { render } from '@testing-library/preact';
 
@@ -31,12 +31,11 @@ test('mergeThemes()', () => {
       components: {
         MuiInputLabel: {
           styleOverrides: {
-            // @ts-expect-error
             root: () => ({
               whiteSpace: 'break-spaces',
               justifyContent: 'revert',
               color: 'blue',
-            }),
+            } as CSSObject),
           },
         },
       },

--- a/src/v3/src/util/mergeThemes.test.tsx
+++ b/src/v3/src/util/mergeThemes.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { TextField, ThemeProvider } from '@mui/material';
+import { odysseyTheme } from '@okta/odyssey-react-mui';
+import { render } from '@testing-library/preact';
+
+import { mergeThemes } from './mergeThemes';
+
+test('mergeThemes()', () => {
+  const merged = mergeThemes(
+    {
+      components: {
+        MuiInputLabel: {
+          styleOverrides: {
+            root: 'white-space: nowrap; background-color: #456; justify-content: flex-start;',
+          },
+        },
+      },
+    },
+    {
+      components: {
+        MuiInputLabel: {
+          styleOverrides: {
+            root: () => ({
+              whiteSpace: 'break-spaces',
+              justifyContent: 'revert',
+              color: 'blue',
+            }),
+          },
+        },
+      },
+    },
+    {
+      components: {
+        MuiInputLabel: {
+          styleOverrides: {
+            root: {
+              whiteSpace: 'pre-wrap',
+              backgroundColor: '#abc',
+              display: 'flex',
+            },
+          },
+        },
+      },
+    },
+  );
+  const root = merged.components?.MuiInputLabel?.styleOverrides?.root;
+
+  expect(typeof root).toBe('function');
+
+  const expected = {
+    display: 'flex',
+    justifyContent: 'revert',
+    whiteSpace: 'pre-wrap',
+    backgroundColor: '#abc',
+    color: 'blue',
+  };
+
+  if (typeof root === 'function') {
+    const actual = root({
+      ownerState: {},
+      theme: odysseyTheme,
+    });
+    expect(actual).toEqual(expected);
+  } else {
+    fail('expected styleOverrides.root to be function');
+  }
+
+  const { getByText } = render(
+    <ThemeProvider theme={merged}>
+      <TextField label="Label" />
+    </ThemeProvider>,
+  );
+  const el = getByText('Label', { selector: 'label' });
+  expect(el).toHaveStyle(expected);
+});

--- a/src/v3/src/util/mergeThemes.test.tsx
+++ b/src/v3/src/util/mergeThemes.test.tsx
@@ -31,6 +31,7 @@ test('mergeThemes()', () => {
       components: {
         MuiInputLabel: {
           styleOverrides: {
+            // @ts-expect-error
             root: () => ({
               whiteSpace: 'break-spaces',
               justifyContent: 'revert',
@@ -66,15 +67,14 @@ test('mergeThemes()', () => {
     color: 'blue',
   };
 
-  if (typeof root === 'function') {
-    const actual = root({
-      ownerState: {},
-      theme: odysseyTheme,
-    });
-    expect(actual).toEqual(expected);
-  } else {
-    fail('expected styleOverrides.root to be function');
-  }
+  expect(typeof root).toBe('function');
+
+  // @ts-expect-error root is function
+  const actual = root({
+    ownerState: {},
+    theme: odysseyTheme,
+  });
+  expect(actual).toEqual(expected);
 
   const { getByText } = render(
     <ThemeProvider theme={merged}>

--- a/src/v3/src/util/mergeThemes.ts
+++ b/src/v3/src/util/mergeThemes.ts
@@ -14,6 +14,7 @@ import { CSSInterpolation, ThemeOptions } from '@mui/material';
 import { odysseyTheme } from '@okta/odyssey-react-mui';
 
 import { cssInterpolate } from './cssInterpolate';
+import { merge } from 'lodash';
 
 type Theme = typeof odysseyTheme;
 type Props = Record<string, unknown>;
@@ -42,10 +43,10 @@ const resolve = (override: StyleOverride, arg: Props): CSSInterpolation => {
 /**
  * Merge themes
  */
-export const mergeThemes = (...themes: Array<ThemeOptions | Partial<Theme>>): ThemeOptions => (
-  themes.reduce((base, theme) => (
+export const mergeThemes = (first: Theme, ...rest: Array<ThemeOptions | Partial<Theme>>): ThemeOptions => (
+  rest.reduce((prev, theme) => (
     !theme.components
-      ? base
+      ? merge(prev, theme)
       : [...Object.entries(theme.components)]
         .reduce((t, [component, config]) => ({
           ...t,
@@ -59,13 +60,13 @@ export const mergeThemes = (...themes: Array<ThemeOptions | Partial<Theme>>): Th
                 ...t.components[component].styleOverrides,
                 root: (options: Record<string, unknown>) => ({
                   // @ts-expect-error
-                  ...resolve(base.components?.[component]?.styleOverrides?.root, options),
+                  ...resolve(prev.components?.[component]?.styleOverrides?.root, options),
                   // @ts-expect-error
                   ...resolve(config.styleOverrides?.root, options),
                 }),
               },
             },
           },
-        }), base)
-  ), odysseyTheme)
+        }), prev)
+  ), first)
 );

--- a/src/v3/src/util/mergeThemes.ts
+++ b/src/v3/src/util/mergeThemes.ts
@@ -10,11 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { CSSInterpolation, ThemeOptions } from '@mui/material';
+import { CSSInterpolation, CSSObject, ThemeOptions } from '@mui/material';
 import { odysseyTheme } from '@okta/odyssey-react-mui';
+import { merge } from 'lodash';
 
 import { cssInterpolate } from './cssInterpolate';
-import { merge } from 'lodash';
 
 type Theme = typeof odysseyTheme;
 type Props = Record<string, unknown>;
@@ -53,15 +53,15 @@ export const mergeThemes = (first: Theme, ...rest: Array<ThemeOptions | Partial<
           components: {
             ...t.components,
             [component]: {
-              // @ts-expect-error
+              // @ts-expect-error cannot index Components by string
               ...t.components[component],
               styleOverrides: {
-                // @ts-expect-error
+                // @ts-expect-error cannot index Components by string
                 ...t.components[component].styleOverrides,
                 root: (options: Record<string, unknown>) => ({
-                  // @ts-expect-error
+                  // @ts-expect-error FIXME CSSInterpolation may not be CSSObject
                   ...resolve(prev.components?.[component]?.styleOverrides?.root, options),
-                  // @ts-expect-error
+                  // @ts-expect-error FIXME CSSInterpolation may not be CSSObject
                   ...resolve(config.styleOverrides?.root, options),
                 }),
               },

--- a/src/v3/src/util/mergeThemes.ts
+++ b/src/v3/src/util/mergeThemes.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { CSSInterpolation, CSSObject, ThemeOptions } from '@mui/material';
+import { CSSInterpolation, ThemeOptions } from '@mui/material';
 import { odysseyTheme } from '@okta/odyssey-react-mui';
 import { merge } from 'lodash';
 
@@ -35,7 +35,7 @@ const resolve = (override: StyleOverride, arg: Props): CSSInterpolation => {
     return cssInterpolate(override);
   }
   if (typeof override !== 'object') {
-    console.warn(`unrecognized type ${typeof override}`);
+    // console.warn(`unrecognized type ${typeof override}`);
   }
   return override;
 };
@@ -43,7 +43,10 @@ const resolve = (override: StyleOverride, arg: Props): CSSInterpolation => {
 /**
  * Merge themes
  */
-export const mergeThemes = (first: Theme, ...rest: Array<ThemeOptions | Partial<Theme>>): ThemeOptions => (
+export const mergeThemes = (
+  first: Theme,
+  ...rest: Array<ThemeOptions | Partial<Theme>>
+): ThemeOptions => (
   rest.reduce((prev, theme) => (
     !theme.components
       ? merge(prev, theme)

--- a/src/v3/src/util/mergeThemes.ts
+++ b/src/v3/src/util/mergeThemes.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { CSSInterpolation, ThemeOptions } from '@mui/material';
+import { odysseyTheme } from '@okta/odyssey-react-mui';
+
+import { cssInterpolate } from './cssInterpolate';
+
+type Theme = typeof odysseyTheme;
+type Props = Record<string, unknown>;
+type StyleOverrideFunction = (override: Props) => CSSInterpolation;
+type StyleOverride = string | CSSInterpolation | StyleOverrideFunction;
+
+/**
+ * Resolve style override
+ */
+const resolve = (override: StyleOverride, arg: Props): CSSInterpolation => {
+  if (!override) {
+    return {};
+  }
+  if (typeof override === 'function') {
+    return override(arg);
+  }
+  if (typeof override === 'string') {
+    return cssInterpolate(override);
+  }
+  if (typeof override !== 'object') {
+    console.warn(`unrecognized type ${typeof override}`);
+  }
+  return override;
+};
+
+/**
+ * Merge themes
+ */
+export const mergeThemes = (...themes: Array<ThemeOptions | Partial<Theme>>): ThemeOptions => (
+  themes.reduce((base, theme) => (
+    !theme.components
+      ? base
+      : [...Object.entries(theme.components)]
+        .reduce((t, [component, config]) => ({
+          ...t,
+          components: {
+            ...t.components,
+            [component]: {
+              // @ts-expect-error
+              ...t.components[component],
+              styleOverrides: {
+                // @ts-expect-error
+                ...t.components[component].styleOverrides,
+                root: (options: Record<string, unknown>) => ({
+                  // @ts-expect-error
+                  ...resolve(base.components?.[component]?.styleOverrides?.root, options),
+                  // @ts-expect-error
+                  ...resolve(config.styleOverrides?.root, options),
+                }),
+              },
+            },
+          },
+        }), base)
+  ), odysseyTheme)
+);

--- a/src/v3/src/util/theme.ts
+++ b/src/v3/src/util/theme.ts
@@ -10,11 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { ThemeOptions } from '@mui/material';
 import { Theme } from '@mui/material/styles/createTheme';
 import { odysseyTheme } from '@okta/odyssey-react-mui';
 import chroma from 'chroma-js';
-import { cloneDeep, merge } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 import { BrandColors, LanguageDirection } from '../types';
 
@@ -95,7 +94,6 @@ export const deriveThemeFromBrand = (brand: BrandColors): DerivedTheme | null =>
 export const mapMuiThemeFromBrand = (
   brand: BrandColors | undefined,
   languageDirection: LanguageDirection,
-  muiThemeOverrides?: ThemeOptions,
 ): Theme => {
   // TODO: OKTA-517723 temporary override until odyssey-react-mui theme borderRadius value is fixed
   odysseyTheme.shape.borderRadius = 4;
@@ -119,5 +117,5 @@ export const mapMuiThemeFromBrand = (
     }
   }
 
-  return merge(odysseyThemeCopy, muiThemeOverrides);
+  return odysseyThemeCopy;
 };

--- a/src/v3/src/util/theme.ts
+++ b/src/v3/src/util/theme.ts
@@ -10,10 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { ThemeOptions } from '@mui/material';
 import { Theme } from '@mui/material/styles/createTheme';
 import { odysseyTheme } from '@okta/odyssey-react-mui';
 import chroma from 'chroma-js';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, merge } from 'lodash';
 
 import { BrandColors, LanguageDirection } from '../types';
 
@@ -94,6 +95,7 @@ export const deriveThemeFromBrand = (brand: BrandColors): DerivedTheme | null =>
 export const mapMuiThemeFromBrand = (
   brand: BrandColors | undefined,
   languageDirection: LanguageDirection,
+  muiThemeOverrides?: ThemeOptions,
 ): Theme => {
   // TODO: OKTA-517723 temporary override until odyssey-react-mui theme borderRadius value is fixed
   odysseyTheme.shape.borderRadius = 4;
@@ -117,5 +119,5 @@ export const mapMuiThemeFromBrand = (
     }
   }
 
-  return odysseyThemeCopy;
+  return merge(odysseyThemeCopy, muiThemeOverrides);
 };

--- a/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
+++ b/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
@@ -10,13 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { IdxActionParams } from '@okta/okta-auth-js';
+import { within, waitFor } from '@testing-library/preact';
 import {
   RegistrationDataCallbackV3,
   RegistrationElementSchema,
   RegistrationSchemaCallbackV3,
 } from 'src/types';
-import { IdxActionParams } from '@okta/okta-auth-js';
-import { within, waitFor } from '@testing-library/preact';
 
 import enrollProfileResponse from '../../../../playground/mocks/data/idp/idx/enroll-profile.json';
 import enrollProfileTerminalResponse from '../../../../playground/mocks/data/idp/idx/terminal-registration.json';


### PR DESCRIPTION
## Description:

Wraps long label text to prevent overflow.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-621214](https://oktainc.atlassian.net/browse/OKTA-621214)

### Reviewers:

### Screenshot/Video:

Before:

![localhost_3000_ (9)](https://github.com/okta/okta-signin-widget/assets/77294605/959ea22c-b201-430d-9b2f-77458303e191)

After:

![localhost_3000_ (8)](https://github.com/okta/okta-signin-widget/assets/77294605/3c503b3b-0216-42af-a9f0-b859b5d970c9)

### Downstream Monolith Build:



