### PR TITLE
OKTA-587048 : feat : add disable autocomplete config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ See the [Usage Guide](#usage-guide) for more information on how to get started u
     - [features.hideSignOutLinkInMFA](#featureshidesignoutlinkinmfa)
     - [features.rememberMe](#featuresrememberme)
     - [features.autoFocus](#featuresautofocus)
+    - [features.disableAutocomplete](#featuresautofocus)
   - [cspNonce](#cspNonce)
 - [Events](#events)
   - [ready](#ready)
@@ -1354,6 +1355,11 @@ Pre-fills the identifier field with the previously used username.
 
 Defaults to `true`.
 Automatically focuses the first input field of any form when displayed. 
+
+#### features.disableAutocomplete
+
+Defaults to `false`.
+Sets the autocomplete attribute on Input fields to `off`.
 
 ### cspNonce
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ See the [Usage Guide](#usage-guide) for more information on how to get started u
     - [features.hideSignOutLinkInMFA](#featureshidesignoutlinkinmfa)
     - [features.rememberMe](#featuresrememberme)
     - [features.autoFocus](#featuresautofocus)
-    - [features.disableAutocomplete](#featuresautofocus)
+    - [features.disableAutocomplete](#featuresdisableautocomplete)
   - [cspNonce](#cspNonce)
 - [Events](#events)
   - [ready](#ready)

--- a/README.md
+++ b/README.md
@@ -1359,7 +1359,7 @@ Automatically focuses the first input field of any form when displayed.
 #### features.disableAutocomplete
 
 Defaults to `false`.
-Sets the autocomplete attribute on Input fields to `off`.
+Sets the autocomplete attribute on input fields to `off`.
 
 ### cspNonce
 

--- a/docs/classic.md
+++ b/docs/classic.md
@@ -1541,6 +1541,8 @@ features: {
 
 - **features.showSessionRevocation** - If set to `true`, it will show a checkbox that allows the user to revoke all of their active sessions during a Self Service Password Reset.
 
+- **features.disableAutocomplete** - If set to `true`, it will set the autocomplete attribute on Input fields to `off`.
+
 ### Hooks
 
 > **Note**: Hooks are only supported when using the [Okta Identity Engine](#okta-identity-engine)

--- a/docs/classic.md
+++ b/docs/classic.md
@@ -1541,7 +1541,7 @@ features: {
 
 - **features.showSessionRevocation** - If set to `true`, it will show a checkbox that allows the user to revoke all of their active sessions during a Self Service Password Reset.
 
-- **features.disableAutocomplete** - If set to `true`, it will set the autocomplete attribute on Input fields to `off`.
+- **features.disableAutocomplete** - If set to `true`, it sets the autocomplete attribute on input fields to `off`.
 
 ### Hooks
 

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -108,6 +108,7 @@ const local: Record<string, ModelProperty> = {
   'features.showIdentifier': ['boolean', false, true],
   'features.autoFocus': ['boolean', false, true],
   'features.showSessionRevocation': ['boolean', false, false],
+  'features.disableAutocomplete': ['boolean', false, false],
 
   defaultCountryCode: ['string', false, 'US'],
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -244,7 +244,7 @@ Util.isV1StateToken = function(token) {
 };
 
 Util.getAutocompleteValue = function(settings, defaultValue) {
-  const shouldDisableAutocomplete = settings.get('features.disableAutocomplete');
+  const shouldDisableAutocomplete = settings?.get('features.disableAutocomplete');
   if (shouldDisableAutocomplete) {
     return 'off';
   }

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -243,4 +243,12 @@ Util.isV1StateToken = function(token) {
   return !!(token && _.isString(token) && token.startsWith('00'));
 };
 
+Util.getAutocompleteValue = function(settings, defaultValue) {
+  const shouldDisableAutocomplete = settings.get('features.disableAutocomplete');
+  if (shouldDisableAutocomplete) {
+    return 'off';
+  }
+  return defaultValue;
+};
+
 export default Util;

--- a/src/v1/controllers/ForgotPasswordController.js
+++ b/src/v1/controllers/ForgotPasswordController.js
@@ -118,7 +118,7 @@ export default FormController.extend({
             name: 'username',
             input: TextBox,
             inputId: 'account-recovery-username',
-            autoComplete: 'username',
+            autoComplete: Util.getAutocompleteValue(this.settings, 'username'),
             type: 'text',
             inlineValidation: false,
           })

--- a/src/v1/controllers/PasswordResetController.js
+++ b/src/v1/controllers/PasswordResetController.js
@@ -99,7 +99,7 @@ export default FormController.extend({
           name: 'newPassword',
           input: TextBox,
           type: 'password',
-          autoComplete: 'new-password',
+          autoComplete: Util.getAutocompleteValue(this.settings, 'new-password'),
         }),
         FormType.Input({
           label: loc('password.confirmPassword.placeholder', 'login'),
@@ -113,7 +113,7 @@ export default FormController.extend({
           name: 'confirmPassword',
           input: TextBox,
           type: 'password',
-          autoComplete: 'new-password',
+          autoComplete: Util.getAutocompleteValue(this.settings, 'new-password'),
         }),
       ]);
 

--- a/src/v1/views/enroll-factors/PhoneTextBox.js
+++ b/src/v1/views/enroll-factors/PhoneTextBox.js
@@ -12,6 +12,8 @@
 
 import { _, internal } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
+import Util from 'util/Util';
+
 let { TextBox } = internal.views.forms.inputs;
 export default TextBox.extend({
   template: hbs(
@@ -19,7 +21,7 @@ export default TextBox.extend({
       <span class="okta-form-label-inline o-form-label-inline">{{countryCallingCode}}</span>\
       <span class="okta-form-input-field input-fix o-form-control">\
         <input type="{{type}}" placeholder="{{placeholder}}" name="{{name}}" \
-          id="{{inputId}}" value="{{value}}" autocomplete="tel">\
+          id="{{inputId}}" value="{{value}}" autocomplete="{{autocomplete}}">\
       </span>\
     '
   ),
@@ -32,6 +34,7 @@ export default TextBox.extend({
 
   preRender: function() {
     this.options.countryCallingCode = this.model.get('countryCallingCode');
+    this.options.autocomplete = Util.getAutocompleteValue(this.options.model.settings, 'tel');
   },
 
   postRender: function() {

--- a/src/v1/views/primary-auth/PrimaryAuthForm.js
+++ b/src/v1/views/primary-auth/PrimaryAuthForm.js
@@ -129,7 +129,7 @@ export default Form.extend({
       inputId: 'okta-signin-username',
       type: 'text',
       disabled: this.options.appState.get('disableUsername'),
-      autoComplete: 'username',
+      autoComplete: Util.getAutocompleteValue(this.settings, 'username'),
       // TODO: support a11y attrs in Courage - OKTA-279025
       render: function() {
         const that = this;
@@ -177,7 +177,7 @@ export default Form.extend({
       inputId: 'okta-signin-password',
       validateOnlyIfDirty: true,
       type: 'password',
-      autoComplete: 'current-password',
+      autoComplete: Util.getAutocompleteValue(this.settings, 'current-password'),
       // TODO: support a11y attrs in Courage - OKTA-279025
       render: function() {
         const that = this;

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -12,6 +12,7 @@ import { isCustomizedI18nKey } from '../../ion/i18nTransformer';
 import { getForgotPasswordLink } from '../utils/LinksUtil';
 import CookieUtil from 'util/CookieUtil';
 import CustomAccessDeniedErrorMessage from './shared/CustomAccessDeniedErrorMessage';
+import Util from 'util/Util';
 
 const CUSTOM_ACCESS_DENIED_KEY = 'security.access_denied_custom_message';
 
@@ -140,12 +141,12 @@ const Body = BaseForm.extend({
         // because we want to allow the user to choose from previously used identifiers.
         newSchema = {
           ...newSchema,
-          autoComplete: 'username'
+          autoComplete: Util.getAutocompleteValue(this.options.settings, 'username')
         };
       } else if (schema.name === 'credentials.passcode') {
         newSchema = {
           ...newSchema,
-          autoComplete: 'current-password'
+          autoComplete: Util.getAutocompleteValue(this.options.settings, 'current-password')
         };
 
         if (isCustomizedI18nKey(passwordExplainLabeli18nKey, settings)) {

--- a/src/v2/view-builder/views/IdentifyRecoveryView.js
+++ b/src/v2/view-builder/views/IdentifyRecoveryView.js
@@ -1,5 +1,6 @@
 import { loc } from '@okta/courage';
 import { BaseForm, BaseFooter, BaseView } from '../internals';
+import Util from 'util/Util';
 
 const Body = BaseForm.extend({
 
@@ -20,7 +21,7 @@ const Body = BaseForm.extend({
         // because we want to allow the user to choose from previously used identifiers.
         newSchema = {
           ...newSchema,
-          autoComplete: 'username'
+          autoComplete: Util.getAutocompleteValue(this.options.settings, 'username')
         };
       }
       return newSchema;

--- a/src/v3/src/transformer/field/attributes.test.ts
+++ b/src/v3/src/transformer/field/attributes.test.ts
@@ -11,9 +11,9 @@
  */
 
 import { Input } from '@okta/okta-auth-js';
+import { WidgetProps } from 'src/types';
 
 import { transformer } from './attributes';
-import { WidgetProps } from 'src/types';
 
 describe('Attributes transformer', () => {
   let widgetProps: WidgetProps;
@@ -32,7 +32,7 @@ describe('Attributes transformer', () => {
 
   it('should return uischema object with options.attributes.autocomplete === "off" when features.disableAutocomplete === "false"', () => {
     const formfield: Input = { name: 'identifier' };
-    widgetProps = { features: { disableAutocomplete: true }};
+    widgetProps = { features: { disableAutocomplete: true } };
 
     const result = { attributes: { autocomplete: 'off' } };
 

--- a/src/v3/src/transformer/field/attributes.test.ts
+++ b/src/v3/src/transformer/field/attributes.test.ts
@@ -13,14 +13,30 @@
 import { Input } from '@okta/okta-auth-js';
 
 import { transformer } from './attributes';
+import { WidgetProps } from 'src/types';
 
 describe('Attributes transformer', () => {
+  let widgetProps: WidgetProps;
+
+  beforeEach(() => {
+    widgetProps = {};
+  });
+
   it('should return uischema object with options.attributes.autocomplete === "username" if formfield.name === "identifier" is present in ion object', () => {
     const formfield: Input = { name: 'identifier' };
 
     const result = { attributes: { autocomplete: 'username' } };
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(transformer(formfield, widgetProps)).toEqual(result);
+  });
+
+  it('should return uischema object with options.attributes.autocomplete === "off" when features.disableAutocomplete === "false"', () => {
+    const formfield: Input = { name: 'identifier' };
+    widgetProps = { features: { disableAutocomplete: true }};
+
+    const result = { attributes: { autocomplete: 'off' } };
+
+    expect(transformer(formfield, widgetProps)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "current-password" if formfield.name === "password" is present in ion object', () => {
@@ -28,7 +44,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'current-password' } };
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(transformer(formfield, widgetProps)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "current-password" if formfield.name === "newPassword" is present in ion object', () => {
@@ -36,7 +52,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'current-password' } };
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(transformer(formfield, widgetProps)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "current-password" if formfield.name === "passcode" & formfield.secret === true is present in ion object', () => {
@@ -44,7 +60,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'current-password' } };
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(transformer(formfield, widgetProps)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "one-time-code" and options.attributes.inputmode === "numeric" if formfield.name === "passcode" & secret property doesnt exist in ion object when on ios device', () => {
@@ -56,7 +72,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'one-time-code', inputmode: 'numeric' } };
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(transformer(formfield, widgetProps)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "off" if formfield.name === "passcode" & secret property doesnt exist in ion object when on desktop', () => {
@@ -68,7 +84,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'off', inputmode: 'numeric' } };
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(transformer(formfield, widgetProps)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "one-time-code" if formfield.name === "totp" is present in ion object when on ios device', () => {
@@ -80,7 +96,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'one-time-code', inputmode: 'numeric' } };
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(transformer(formfield, widgetProps)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "off" if formfield.name === "totp" is present in ion object when on desktop', () => {
@@ -92,7 +108,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'off', inputmode: 'numeric' } };
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(transformer(formfield, widgetProps)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "tel-national" if formfield.name === "phoneNumber" is present in ion object', () => {
@@ -100,6 +116,6 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'tel-national', inputmode: 'tel' } };
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(transformer(formfield, widgetProps)).toEqual(result);
   });
 });

--- a/src/v3/src/transformer/field/attributes.ts
+++ b/src/v3/src/transformer/field/attributes.ts
@@ -12,7 +12,7 @@
 
 import { Input } from '@okta/okta-auth-js';
 
-import { AutoCompleteValue, InputAttributes, InputModeValue } from '../../types';
+import { AutoCompleteValue, InputAttributes, InputModeValue, WidgetProps } from '../../types';
 import { isAndroidOrIOS } from '../../util';
 
 type Result = {
@@ -73,11 +73,15 @@ const inputModeValueTransformer = (input: Input): InputModeValue | null => {
   return key ? inputModeValueMap.get(key) ?? null : null;
 };
 
-export const transformer = (input: Input): Result | null => {
+export const transformer = (
+  input: Input,
+  widgetProps: WidgetProps,
+): Result | null => {
   const attributes: InputAttributes = {};
   const autocompleteValue = autocompleteValueTransformer(input);
   if (autocompleteValue) {
-    attributes.autocomplete = autocompleteValue;
+    const { features: { disableAutocomplete } = {} } = widgetProps;
+    attributes.autocomplete = disableAutocomplete ? 'off' : autocompleteValue;
   }
 
   // Inputmode is used to optimize the mobile virtual keyboard based on the type of content entered

--- a/src/v3/src/transformer/field/attributes.ts
+++ b/src/v3/src/transformer/field/attributes.ts
@@ -12,7 +12,12 @@
 
 import { Input } from '@okta/okta-auth-js';
 
-import { AutoCompleteValue, InputAttributes, InputModeValue, WidgetProps } from '../../types';
+import {
+  AutoCompleteValue,
+  InputAttributes,
+  InputModeValue,
+  WidgetProps,
+} from '../../types';
 import { isAndroidOrIOS } from '../../util';
 
 type Result = {

--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -24,10 +24,13 @@ import { isCustomizedI18nKey } from '../i18n';
 import { transformer as attributesTransformer } from './attributes';
 import { transformer as typeTransformer } from './type';
 
-const mapUiElement = (input: Input): FieldElement => {
+const mapUiElement = (
+  input: Input,
+  widgetProps: WidgetProps,
+): FieldElement => {
   const { label, name } = input;
   const fieldType = typeTransformer(input);
-  const attributes = attributesTransformer(input);
+  const attributes = attributesTransformer(input, widgetProps);
 
   return {
     type: 'Field',
@@ -89,7 +92,7 @@ export const transformStepInputs = (
       } = input;
 
       // add uischema
-      const uischema = mapUiElement(input);
+      const uischema = mapUiElement(input, widgetProps);
       acc.uischema.elements = [...acc.uischema.elements, uischema];
 
       if (type === 'boolean' && required) {

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -260,6 +260,7 @@ export type OktaWidgetFeatures = {
   redirectByFormSubmit?: boolean;
   restrictRedirectToForeground?: boolean;
   showPasswordRequirementsAsHtmlList?: boolean;
+  disableAutocomplete?: boolean;
 };
 
 interface ProxyIdxResponse {

--- a/test/testcafe/framework/page-objects-v1/PrimaryAuthPageObject.js
+++ b/test/testcafe/framework/page-objects-v1/PrimaryAuthPageObject.js
@@ -1,0 +1,19 @@
+import BasePageObject from '../page-objects/BasePageObject';
+
+export default class PrimaryAuthPageObject extends BasePageObject {
+  constructor(t) {
+    super(t);
+  }
+
+  getInputField(fieldName) {
+    return this.form.findFormFieldInput(fieldName).child('input');
+  }
+
+  setUsername(username) {
+    return this.form.setTextBoxValue('username', username);
+  }
+
+  async clickNextButton() {
+    await this.form.clickSaveButton();
+  }
+}

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -300,4 +300,8 @@ export default class IdentityPageObject extends BasePageObject {
     }
     await this.t.click(Selector('.password-toggle .button-show'));
   }
+
+  getTextField(label) {
+    return this.form.getTextBox(label, true);
+  }
 }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -72,14 +72,18 @@ export default class BaseFormObject {
     });
   }
 
+  getTextBox(name, findByLabel) {
+    return findByLabel ?
+      within(this.el).getByLabelText(name) :
+      this.el.find(`input[name="${name}"]`);
+  }
+
   /**
    * @param {string} name The name or label of the text box to get
    * @param {boolean} findByLabel Find the text box by its label rather than name attribute
    */
   getTextBoxValue(name, findByLabel = false) {
-    return findByLabel ?
-      within(this.el).getByLabelText(name).value :
-      this.el.find(`input[name="${name}"]`).value;
+    return this.getTextBox(name, findByLabel).value;
   }
 
   /**

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -206,3 +206,19 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not t
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
 });
+
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should set autocomplete to off on username and password fields when features.disableAutocomplete is true', async t => {
+  const identityPage = await setup(t);
+  await checkA11y(t);
+  await renderWidget({
+    features: {
+      disableAutocomplete: true,
+    },
+  });
+
+  await t.expect(identityPage.getFormTitle()).eql('Sign In');
+  const userNameField = identityPage.getTextField('Username');
+  await t.expect(userNameField.getAttribute('autocomplete')).eql('off');
+  const passwordField = identityPage.getTextField('Password');
+  await t.expect(passwordField.getAttribute('autocomplete')).eql('off');
+});

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -478,3 +478,17 @@ test.meta('v3', false).requestHooks(identifyRequestLogger, baseIdentifyMock)('sh
   doesFormHaveFocus = identityPage.form.getElement('[data-se="o-form-input-identifier"] input').focused;
   await t.expect(doesFormHaveFocus).eql(false);
 });
+
+test.requestHooks(identifyRequestLogger, baseIdentifyMock)('should set autocomplete to off on username field when features.disableAutocomplete is true', async t => {
+  const identityPage = await setup(t);
+  await checkA11y(t);
+  await rerenderWidget({
+    features: {
+      disableAutocomplete: true,
+    },
+  });
+
+  await t.expect(identityPage.getFormTitle()).eql('Sign In');
+  const userNameField = identityPage.getTextField('Username');
+  await t.expect(userNameField.getAttribute('autocomplete')).eql('off');
+});

--- a/test/testcafe/spec/v1/PrimaryAuthForm_spec.js
+++ b/test/testcafe/spec/v1/PrimaryAuthForm_spec.js
@@ -1,0 +1,80 @@
+import { RequestMock, RequestLogger, ClientFunction } from 'testcafe';
+import PrimaryAuthPageObject from '../../framework/page-objects-v1/PrimaryAuthPageObject';
+import authnSuccessResponse from '../../../../playground/mocks/data/api/v1/authn/success-001';
+
+const renderWidget = ClientFunction((settings) => {
+  // function `renderPlaygroundWidget` is defined in playground/main.js
+  window.renderPlaygroundWidget(settings);
+});
+
+const authNSuccessMock = RequestMock()
+  .onRequestTo('http://localhost:3000//api/v1/authn')
+  .respond(authnSuccessResponse);
+
+fixture('Primary Auth Form');
+
+const logger = RequestLogger(
+  /api\/v1/,
+  {
+    logRequestBody: true,
+    stringifyRequestBody: true,
+    logResponseBody: true,
+  }
+);
+
+const defaultConfig = {
+  stateToken: null, // setting stateToken to null to trigger the V1 flow
+  features: {
+    router: true,
+  },
+  authParams: {
+    responseType: 'code',
+  },
+  useClassicEngine: true,
+};
+
+async function setup(t, config = defaultConfig) {
+  const resetPasswordPage = new PrimaryAuthPageObject(t);
+  await resetPasswordPage.navigateToPage({ render: false });
+  
+  await resetPasswordPage.mockCrypto();
+  await renderWidget(config);
+  return resetPasswordPage;
+}
+
+test.requestHooks(logger, authNSuccessMock)('should set autocomplete to off on Primary Auth Form for username and password fields when features.disableAutocomplete is set to true', async (t) => {
+  const config = {
+    ...defaultConfig,
+    features: {
+      ...defaultConfig.features,
+      disableAutocomplete: true,
+    },
+  };
+  const primaryAuthForm = await setup(t, config);
+
+  await t.expect(primaryAuthForm.getFormTitle()).eql('Sign In');
+  const userNameField = primaryAuthForm.getInputField('username');
+  await t.expect(userNameField.getAttribute('autocomplete')).eql('off');
+  const passwordField = primaryAuthForm.getInputField('password');
+  await t.expect(passwordField.getAttribute('autocomplete')).eql('off');
+});
+
+test.requestHooks(logger, authNSuccessMock)('should set autocomplete to off on username and password fields when features.disableAutocomplete and features.idpDiscovery are set to true', async (t) => {
+  const config = {
+    ...defaultConfig,
+    features: {
+      ...defaultConfig.features,
+      disableAutocomplete: true,
+      idpDiscovery: true,
+    },
+  };
+  const primaryAuthForm = await setup(t, config);
+
+  await t.expect(primaryAuthForm.getFormTitle()).eql('Sign In');
+  const userNameField = primaryAuthForm.getInputField('username');
+  await t.expect(userNameField.getAttribute('autocomplete')).eql('off');
+  await primaryAuthForm.setUsername('tester1@okta1.com');
+  await primaryAuthForm.clickNextButton();
+  const passwordField = primaryAuthForm.getInputField('password');
+  await t.expect(passwordField.getAttribute('autocomplete')).eql('off');
+});


### PR DESCRIPTION
## Description:

The purpose this PR is to add a configuration option to allow users to disable (set to `off`) the autocomplete attribute on Input elements. This resolves https://github.com/okta/okta-signin-widget/issues/3130


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-587048](https://oktainc.atlassian.net/browse/OKTA-587048)

### Reviewers:

### Screenshot/Video:

https://github.com/okta/okta-signin-widget/assets/97472729/d38cdd4c-2bb2-455e-b5f9-70ffd4eab33e


### Downstream Monolith Build:



