### PR TITLE
OKTA-586924 : G3 : fixing requirements list icon in additional langs

### DIFF
--- a/src/v3/src/components/PasswordRequirements/Icon.tsx
+++ b/src/v3/src/components/PasswordRequirements/Icon.tsx
@@ -35,8 +35,11 @@ const Icon: FunctionComponent<PasswordRequirementIconProps> = (
   return (
     <Box
       className={iconClasses}
-      marginInlineEnd={1}
-      display="flex"
+      sx={(theme) => ({
+        marginInlineEnd: theme.spacing(1),
+        // This is to force the icon align with the top of the text
+        marginBlockStart: '2px',
+      })}
       aria-hidden
     >
       {

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
@@ -32,6 +32,11 @@ const PasswordRequirementListItem: FunctionComponent<PasswordRequirementProps> =
         display="flex"
         alignItems="center"
       >
+        {/*
+          If any changes are made here, please test with addtl languages i.e. ok-pl / ok-sk
+          This is due to an issue that was found where the label text below modified the size of
+          of the icon. See: OKTA-586924
+        */}
         <Icon status={status} />
         <Box><Typography variant="body1">{label}</Typography></Box>
       </Box>

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
@@ -32,9 +32,7 @@ const PasswordRequirementListItem: FunctionComponent<PasswordRequirementProps> =
         display="flex"
         alignItems="center"
       >
-        <Box sx={{ minInlineSize: (theme) => theme.spacing(2) }}>
-          <Icon status={status} />
-        </Box>
+        <Icon status={status} />
         <Box><Typography variant="body1">{label}</Typography></Box>
       </Box>
     </Box>

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
@@ -32,11 +32,11 @@ const PasswordRequirementListItem: FunctionComponent<PasswordRequirementProps> =
         display="flex"
         alignItems="start"
       >
-        {/*
-          If any changes are made here, please test with addtl languages i.e. ok-pl / ok-sk
-          This is due to an issue that was found where the label text below modified the size of
-          of the icon. See: OKTA-586924
-        */}
+        {/**
+         * If any changes are made here, please test with addtl languages i.e. ok-pl / ok-sk
+         * This is due to an issue that was found where the label text below modified the size of
+         * of the icon. See: OKTA-586924
+        **/}
         <Icon status={status} />
         <Box><Typography variant="body1">{label}</Typography></Box>
       </Box>

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
@@ -30,7 +30,7 @@ const PasswordRequirementListItem: FunctionComponent<PasswordRequirementProps> =
     >
       <Box
         display="flex"
-        alignItems="center"
+        alignItems="start"
       >
         {/*
           If any changes are made here, please test with addtl languages i.e. ok-pl / ok-sk

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirementListItem.tsx
@@ -36,7 +36,7 @@ const PasswordRequirementListItem: FunctionComponent<PasswordRequirementProps> =
          * If any changes are made here, please test with addtl languages i.e. ok-pl / ok-sk
          * This is due to an issue that was found where the label text below modified the size of
          * of the icon. See: OKTA-586924
-        **/}
+         * */}
         <Icon status={status} />
         <Box><Typography variant="body1">{label}</Typography></Box>
       </Box>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -149,37 +149,33 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             At least 8 characters
                           </p>
@@ -193,37 +189,33 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A lowercase letter
                           </p>
@@ -237,37 +229,33 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             An uppercase letter
                           </p>
@@ -281,37 +269,33 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A number
                           </p>
@@ -325,37 +309,33 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             No parts of your username
                           </p>
@@ -369,37 +349,33 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Does not include your first name
                           </p>
@@ -413,37 +389,33 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Does not include your last name
                           </p>
@@ -470,21 +442,21 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-72"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-65"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     Enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-73"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
                     required="true"
                   >
                     <input
                       aria-describedby=" credentials.passcode-error enroll-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-67"
                       data-se="credentials.passcode"
                       id="generated"
                       name="credentials.passcode"
@@ -492,20 +464,20 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-75"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-68"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-76"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-69"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-70"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -525,7 +497,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                     class="MuiBox-root emotion-9"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-79"
+                      class="MuiFormHelperText-root Mui-error emotion-72"
                       data-se="credentials.passcode-error"
                       id="generated"
                       role="alert"
@@ -542,21 +514,21 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-72"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-65"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-73"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
                     required="true"
                   >
                     <input
                       aria-describedby="enroll-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-67"
                       data-se="confirmPassword"
                       id="generated"
                       name="confirmPassword"
@@ -564,20 +536,20 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-75"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-68"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-76"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-69"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-70"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -604,7 +576,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-90"
+                    class="MuiBox-root emotion-83"
                     id="generated"
                   >
                     <li
@@ -614,37 +586,33 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-70"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-77"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Passwords must match
                           </p>
@@ -658,7 +626,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-99"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-91"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -670,7 +638,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-93"
                   data-se="switchAuthenticator"
                   role="link"
                 >
@@ -681,7 +649,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-93"
                   data-se="cancel"
                   role="link"
                 >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -272,37 +272,33 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                         class="MuiBox-root emotion-37"
                       >
                         <div
-                          class="MuiBox-root emotion-38"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-38"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-39"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-24"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-42"
+                            class="MuiTypography-root MuiTypography-body1 emotion-41"
                           >
                             Passwords must match
                           </p>
@@ -316,7 +312,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-44"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-43"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -328,7 +324,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-46"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-45"
                   data-se="cancel"
                   role="link"
                 >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -182,37 +182,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             At least 8 characters
                           </p>
@@ -226,37 +222,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             A lowercase letter
                           </p>
@@ -270,37 +262,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             An uppercase letter
                           </p>
@@ -314,37 +302,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             A number
                           </p>
@@ -358,37 +342,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             No parts of your username
                           </p>
@@ -415,21 +395,21 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-63"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
                     required="true"
                   >
                     <input
                       aria-describedby=" credentials.passcode-error reenroll-authenticator_PasswordRequirements_okta_password_aut8eqcFiHicejNIP0g4_2 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-65"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -437,13 +417,13 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-66"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -470,34 +450,34 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                     class="MuiBox-root emotion-9"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-70"
+                      class="MuiFormHelperText-root Mui-error emotion-65"
                       data-se="credentials.passcode-error"
                       id="credentials.passcode-error"
                       role="alert"
                     >
                       <div
-                        class="MuiBox-root emotion-71"
+                        class="MuiBox-root emotion-66"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-72"
+                          class="MuiTypography-root MuiTypography-body1 emotion-67"
                         >
                           Password requirements were not met:
                         </p>
                         <ul
-                          class="MuiList-root MuiList-dense emotion-73"
+                          class="MuiList-root MuiList-dense emotion-68"
                         >
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-69"
                           >
                             At least 8 characters
                           </li>
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-69"
                           >
                             An uppercase letter
                           </li>
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-69"
                           >
                             A number
                           </li>
@@ -514,21 +494,21 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-63"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
                     required="true"
                   >
                     <input
                       aria-describedby=" confirmPassword-error reenroll-authenticator_PasswordRequirements_okta_password_aut8eqcFiHicejNIP0g4_2 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-65"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
                       data-se="confirmPassword"
                       id="confirmPassword"
                       name="confirmPassword"
@@ -536,13 +516,13 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-66"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -569,7 +549,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                     class="MuiBox-root emotion-9"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-70"
+                      class="MuiFormHelperText-root Mui-error emotion-65"
                       data-se="confirmPassword-error"
                       id="confirmPassword-error"
                       role="alert"
@@ -588,7 +568,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-89"
+                    class="MuiBox-root emotion-84"
                     id="credentials.newPassword-list"
                   >
                     <li
@@ -598,37 +578,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             Passwords must match
                           </p>
@@ -642,7 +618,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                 class="MuiBox-root emotion-18"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-98"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-92"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -654,7 +630,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                 class="MuiBox-root emotion-18"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-94"
                   data-se="switchAuthenticator"
                   role="link"
                 >
@@ -665,7 +641,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                 class="MuiBox-root emotion-18"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-94"
                   data-se="cancel"
                   role="link"
                 >
@@ -830,37 +806,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             At least 8 characters
                           </p>
@@ -874,37 +846,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A lowercase letter
                           </p>
@@ -918,37 +886,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             An uppercase letter
                           </p>
@@ -962,37 +926,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A number
                           </p>
@@ -1006,37 +966,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             No parts of your username
                           </p>
@@ -1063,21 +1019,21 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-53"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
                     required="true"
                   >
                     <input
                       aria-describedby="reenroll-authenticator_PasswordRequirements_okta_password_aut8eqcFiHicejNIP0g4_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-55"
                       data-se="credentials.passcode"
                       id="generated"
                       name="credentials.passcode"
@@ -1085,20 +1041,20 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-56"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-57"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-63"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-58"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1123,21 +1079,21 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-53"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
                     required="true"
                   >
                     <input
                       aria-describedby="reenroll-authenticator_PasswordRequirements_okta_password_aut8eqcFiHicejNIP0g4_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-55"
                       data-se="confirmPassword"
                       id="generated"
                       name="confirmPassword"
@@ -1145,20 +1101,20 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-56"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-57"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-63"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-58"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1185,7 +1141,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-74"
+                    class="MuiBox-root emotion-69"
                     id="generated"
                   >
                     <li
@@ -1195,37 +1151,33 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-58"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Passwords must match
                           </p>
@@ -1239,7 +1191,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-83"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-77"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1251,7 +1203,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-79"
                   data-se="switchAuthenticator"
                   role="link"
                 >
@@ -1262,7 +1214,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-79"
                   data-se="cancel"
                   role="link"
                 >

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -182,37 +182,33 @@ exports[`authenticator-expired-password should present field level error message
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             At least 8 characters
                           </p>
@@ -226,37 +222,33 @@ exports[`authenticator-expired-password should present field level error message
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             A lowercase letter
                           </p>
@@ -270,37 +262,33 @@ exports[`authenticator-expired-password should present field level error message
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             An uppercase letter
                           </p>
@@ -314,37 +302,33 @@ exports[`authenticator-expired-password should present field level error message
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             A number
                           </p>
@@ -358,37 +342,33 @@ exports[`authenticator-expired-password should present field level error message
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-28"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-29"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             No parts of your username
                           </p>
@@ -415,21 +395,21 @@ exports[`authenticator-expired-password should present field level error message
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-63"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
                     required="true"
                   >
                     <input
                       aria-describedby=" credentials.passcode-error reenroll-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-65"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -437,13 +417,13 @@ exports[`authenticator-expired-password should present field level error message
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-66"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -470,34 +450,34 @@ exports[`authenticator-expired-password should present field level error message
                     class="MuiBox-root emotion-9"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-70"
+                      class="MuiFormHelperText-root Mui-error emotion-65"
                       data-se="credentials.passcode-error"
                       id="credentials.passcode-error"
                       role="alert"
                     >
                       <div
-                        class="MuiBox-root emotion-71"
+                        class="MuiBox-root emotion-66"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-72"
+                          class="MuiTypography-root MuiTypography-body1 emotion-67"
                         >
                           Password requirements were not met:
                         </p>
                         <ul
-                          class="MuiList-root MuiList-dense emotion-73"
+                          class="MuiList-root MuiList-dense emotion-68"
                         >
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-69"
                           >
                             At least 8 characters
                           </li>
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-69"
                           >
                             An uppercase letter
                           </li>
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-74"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-69"
                           >
                             A number
                           </li>
@@ -514,21 +494,21 @@ exports[`authenticator-expired-password should present field level error message
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-63"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
                     required="true"
                   >
                     <input
                       aria-describedby=" confirmPassword-error reenroll-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-65"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
                       data-se="confirmPassword"
                       id="confirmPassword"
                       name="confirmPassword"
@@ -536,13 +516,13 @@ exports[`authenticator-expired-password should present field level error message
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-66"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-67"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -569,7 +549,7 @@ exports[`authenticator-expired-password should present field level error message
                     class="MuiBox-root emotion-9"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-70"
+                      class="MuiFormHelperText-root Mui-error emotion-65"
                       data-se="confirmPassword-error"
                       id="confirmPassword-error"
                       role="alert"
@@ -588,7 +568,7 @@ exports[`authenticator-expired-password should present field level error message
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-89"
+                    class="MuiBox-root emotion-84"
                     id="credentials.newPassword-list"
                   >
                     <li
@@ -598,37 +578,33 @@ exports[`authenticator-expired-password should present field level error message
                         class="MuiBox-root emotion-26"
                       >
                         <div
-                          class="MuiBox-root emotion-27"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-27"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-28"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-31"
+                            class="MuiTypography-root MuiTypography-body1 emotion-30"
                           >
                             Passwords must match
                           </p>
@@ -642,7 +618,7 @@ exports[`authenticator-expired-password should present field level error message
                 class="MuiBox-root emotion-18"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-98"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-92"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -654,7 +630,7 @@ exports[`authenticator-expired-password should present field level error message
                 class="MuiBox-root emotion-18"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-94"
                   data-se="cancel"
                   role="link"
                 >
@@ -819,37 +795,33 @@ exports[`authenticator-expired-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             At least 8 characters
                           </p>
@@ -863,37 +835,33 @@ exports[`authenticator-expired-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A lowercase letter
                           </p>
@@ -907,37 +875,33 @@ exports[`authenticator-expired-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             An uppercase letter
                           </p>
@@ -951,37 +915,33 @@ exports[`authenticator-expired-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A number
                           </p>
@@ -995,37 +955,33 @@ exports[`authenticator-expired-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             No parts of your username
                           </p>
@@ -1052,21 +1008,21 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-53"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
                     required="true"
                   >
                     <input
                       aria-describedby="reenroll-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-55"
                       data-se="credentials.passcode"
                       id="generated"
                       name="credentials.passcode"
@@ -1074,20 +1030,20 @@ exports[`authenticator-expired-password should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-56"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-57"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-63"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-58"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1112,21 +1068,21 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-53"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
                     required="true"
                   >
                     <input
                       aria-describedby="reenroll-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-55"
                       data-se="confirmPassword"
                       id="generated"
                       name="confirmPassword"
@@ -1134,20 +1090,20 @@ exports[`authenticator-expired-password should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-56"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-57"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-63"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-58"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1174,7 +1130,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-74"
+                    class="MuiBox-root emotion-69"
                     id="generated"
                   >
                     <li
@@ -1184,37 +1140,33 @@ exports[`authenticator-expired-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-58"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Passwords must match
                           </p>
@@ -1228,7 +1180,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-83"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-77"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1240,7 +1192,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-79"
                   data-se="cancel"
                   role="link"
                 >

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -197,37 +197,33 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         class="MuiBox-root emotion-29"
                       >
                         <div
-                          class="MuiBox-root emotion-30"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-30"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-31"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                           >
                             At least 8 characters
                           </p>
@@ -241,37 +237,33 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         class="MuiBox-root emotion-29"
                       >
                         <div
-                          class="MuiBox-root emotion-30"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-30"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-31"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                           >
                             A lowercase letter
                           </p>
@@ -285,37 +277,33 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         class="MuiBox-root emotion-29"
                       >
                         <div
-                          class="MuiBox-root emotion-30"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-30"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-31"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                           >
                             An uppercase letter
                           </p>
@@ -329,37 +317,33 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         class="MuiBox-root emotion-29"
                       >
                         <div
-                          class="MuiBox-root emotion-30"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-30"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-31"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                           >
                             A number
                           </p>
@@ -373,37 +357,33 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         class="MuiBox-root emotion-29"
                       >
                         <div
-                          class="MuiBox-root emotion-30"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-30"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-31"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                           >
                             A symbol
                           </p>
@@ -417,37 +397,33 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         class="MuiBox-root emotion-29"
                       >
                         <div
-                          class="MuiBox-root emotion-30"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-30"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-31"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                           >
                             No parts of your username
                           </p>
@@ -461,37 +437,33 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         class="MuiBox-root emotion-29"
                       >
                         <div
-                          class="MuiBox-root emotion-30"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-30"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-31"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                           >
                             Does not include your first name
                           </p>
@@ -505,37 +477,33 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         class="MuiBox-root emotion-29"
                       >
                         <div
-                          class="MuiBox-root emotion-30"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-30"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-31"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-32"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                           >
                             Does not include your last name
                           </p>
@@ -562,21 +530,21 @@ exports[`authenticator-expiry-warning-password should present field level error 
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-87"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-79"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-88"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-80"
                     required="true"
                   >
                     <input
                       aria-describedby=" credentials.passcode-error reenroll-authenticator-warning_PasswordRequirements_okta_password_aut6ci0ZJwJCQ5v6f0g4_3 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-89"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-81"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -584,13 +552,13 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-90"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-82"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-91"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-83"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -617,39 +585,39 @@ exports[`authenticator-expiry-warning-password should present field level error 
                     class="MuiBox-root emotion-9"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-94"
+                      class="MuiFormHelperText-root Mui-error emotion-86"
                       data-se="credentials.passcode-error"
                       id="credentials.passcode-error"
                       role="alert"
                     >
                       <div
-                        class="MuiBox-root emotion-95"
+                        class="MuiBox-root emotion-87"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-96"
+                          class="MuiTypography-root MuiTypography-body1 emotion-88"
                         >
                           Password requirements were not met:
                         </p>
                         <ul
-                          class="MuiList-root MuiList-dense emotion-97"
+                          class="MuiList-root MuiList-dense emotion-89"
                         >
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-90"
                           >
                             At least 8 characters
                           </li>
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-90"
                           >
                             An uppercase letter
                           </li>
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-90"
                           >
                             A number
                           </li>
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-90"
                           >
                             A symbol
                           </li>
@@ -666,21 +634,21 @@ exports[`authenticator-expiry-warning-password should present field level error 
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-87"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-79"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-88"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-80"
                     required="true"
                   >
                     <input
                       aria-describedby=" confirmPassword-error reenroll-authenticator-warning_PasswordRequirements_okta_password_aut6ci0ZJwJCQ5v6f0g4_3 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-89"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-81"
                       data-se="confirmPassword"
                       id="confirmPassword"
                       name="confirmPassword"
@@ -688,13 +656,13 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-90"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-82"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-91"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-83"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -721,7 +689,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                     class="MuiBox-root emotion-9"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-94"
+                      class="MuiFormHelperText-root Mui-error emotion-86"
                       data-se="confirmPassword-error"
                       id="confirmPassword-error"
                       role="alert"
@@ -740,7 +708,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-114"
+                    class="MuiBox-root emotion-106"
                     id="credentials.newPassword-list"
                   >
                     <li
@@ -750,37 +718,33 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         class="MuiBox-root emotion-29"
                       >
                         <div
-                          class="MuiBox-root emotion-30"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-30"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-31"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-15"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                           >
                             Passwords must match
                           </p>
@@ -794,7 +758,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                 class="MuiBox-root emotion-18"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-123"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-114"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -806,7 +770,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                 class="MuiBox-root emotion-18"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-125"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-116"
                   data-se="skip"
                   role="link"
                 >
@@ -817,7 +781,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                 class="MuiBox-root emotion-18"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-125"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-116"
                   data-se="cancel"
                   role="link"
                 >
@@ -997,37 +961,33 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-24"
                       >
                         <div
-                          class="MuiBox-root emotion-25"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-25"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-26"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-29"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             At least 8 characters
                           </p>
@@ -1041,37 +1001,33 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-24"
                       >
                         <div
-                          class="MuiBox-root emotion-25"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-25"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-26"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-29"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             A lowercase letter
                           </p>
@@ -1085,37 +1041,33 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-24"
                       >
                         <div
-                          class="MuiBox-root emotion-25"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-25"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-26"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-29"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             An uppercase letter
                           </p>
@@ -1129,37 +1081,33 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-24"
                       >
                         <div
-                          class="MuiBox-root emotion-25"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-25"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-26"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-29"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             A number
                           </p>
@@ -1173,37 +1121,33 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-24"
                       >
                         <div
-                          class="MuiBox-root emotion-25"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-25"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-26"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-29"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             A symbol
                           </p>
@@ -1217,37 +1161,33 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-24"
                       >
                         <div
-                          class="MuiBox-root emotion-25"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-25"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-26"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-29"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             No parts of your username
                           </p>
@@ -1261,37 +1201,33 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-24"
                       >
                         <div
-                          class="MuiBox-root emotion-25"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-25"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-26"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-29"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             Does not include your first name
                           </p>
@@ -1305,37 +1241,33 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-24"
                       >
                         <div
-                          class="MuiBox-root emotion-25"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-25"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-26"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-27"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-29"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             Does not include your last name
                           </p>
@@ -1362,21 +1294,21 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-82"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-74"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-83"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-75"
                     required="true"
                   >
                     <input
                       aria-describedby="reenroll-authenticator-warning_PasswordRequirements_okta_password_aut6ci0ZJwJCQ5v6f0g4_3"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-84"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-76"
                       data-se="credentials.passcode"
                       id="generated"
                       name="credentials.passcode"
@@ -1384,20 +1316,20 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-85"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-77"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-86"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-78"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-87"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-79"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1422,21 +1354,21 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-82"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-74"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-83"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-75"
                     required="true"
                   >
                     <input
                       aria-describedby="reenroll-authenticator-warning_PasswordRequirements_okta_password_aut6ci0ZJwJCQ5v6f0g4_3"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-84"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-76"
                       data-se="confirmPassword"
                       id="generated"
                       name="confirmPassword"
@@ -1444,20 +1376,20 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-85"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-77"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-86"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-78"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-87"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-79"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1484,7 +1416,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-98"
+                    class="MuiBox-root emotion-90"
                     id="generated"
                   >
                     <li
@@ -1494,37 +1426,33 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-24"
                       >
                         <div
-                          class="MuiBox-root emotion-25"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-25"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-26"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-79"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-87"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-29"
+                            class="MuiTypography-root MuiTypography-body1 emotion-28"
                           >
                             Passwords must match
                           </p>
@@ -1538,7 +1466,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-107"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-98"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1550,7 +1478,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-109"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
                   data-se="skip"
                   role="link"
                 >
@@ -1561,7 +1489,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-109"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
                   data-se="cancel"
                   role="link"
                 >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -149,37 +149,33 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             At least 8 characters
                           </p>
@@ -193,37 +189,33 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A lowercase letter
                           </p>
@@ -237,37 +229,33 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             An uppercase letter
                           </p>
@@ -281,37 +269,33 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A number
                           </p>
@@ -325,37 +309,33 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             No parts of your username
                           </p>
@@ -369,37 +349,33 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Does not include your first name
                           </p>
@@ -413,37 +389,33 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Does not include your last name
                           </p>
@@ -470,21 +442,21 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-72"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-65"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-73"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
                     required="true"
                   >
                     <input
                       aria-describedby="reset-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-67"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -492,20 +464,20 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-75"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-68"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-76"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-69"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-70"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -530,21 +502,21 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-72"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-65"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-73"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
                     required="true"
                   >
                     <input
                       aria-describedby="reset-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-67"
                       data-se="confirmPassword"
                       id="confirmPassword"
                       name="confirmPassword"
@@ -552,20 +524,20 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-75"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-68"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-76"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-69"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-70"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -592,7 +564,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-88"
+                    class="MuiBox-root emotion-81"
                     id="credentials.newPassword-list"
                   >
                     <li
@@ -602,37 +574,33 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-70"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-77"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Passwords must match
                           </p>
@@ -646,16 +614,16 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <fieldset
-                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-97"
+                  class="MuiFormControl-root MuiFormControl-marginNormal emotion-89"
                 >
                   <label
-                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-98"
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-90"
                   >
                     <span
-                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-99"
+                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-91"
                     >
                       <input
-                        class="PrivateSwitchBase-input emotion-100"
+                        class="PrivateSwitchBase-input emotion-92"
                         data-indeterminate="false"
                         data-se="credentials.revokeSessions"
                         data-se-for-name="credentials.revokeSessions"
@@ -665,7 +633,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-101"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-93"
                         data-testid="CheckBoxOutlineBlankIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -676,7 +644,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-25"
                     >
                       Sign me out of all other devices.
                     </span>
@@ -687,7 +655,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-104"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-96"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -699,7 +667,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-106"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-98"
                   data-se="cancel"
                   role="link"
                 >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -149,37 +149,33 @@ exports[`authenticator-reset-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             At least 8 characters
                           </p>
@@ -193,37 +189,33 @@ exports[`authenticator-reset-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A lowercase letter
                           </p>
@@ -237,37 +229,33 @@ exports[`authenticator-reset-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             An uppercase letter
                           </p>
@@ -281,37 +269,33 @@ exports[`authenticator-reset-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A number
                           </p>
@@ -325,37 +309,33 @@ exports[`authenticator-reset-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             No parts of your username
                           </p>
@@ -382,21 +362,21 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-53"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
                     required="true"
                   >
                     <input
                       aria-describedby="reset-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-55"
                       data-se="credentials.passcode"
                       id="generated"
                       name="credentials.passcode"
@@ -404,20 +384,20 @@ exports[`authenticator-reset-password should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-56"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-57"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-63"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-58"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -442,21 +422,21 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-53"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
                     required="true"
                   >
                     <input
                       aria-describedby="reset-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-55"
                       data-se="confirmPassword"
                       id="generated"
                       name="confirmPassword"
@@ -464,20 +444,20 @@ exports[`authenticator-reset-password should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-56"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-57"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-63"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-58"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -504,7 +484,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-74"
+                    class="MuiBox-root emotion-69"
                     id="generated"
                   >
                     <li
@@ -514,37 +494,33 @@ exports[`authenticator-reset-password should render form 1`] = `
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-58"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Passwords must match
                           </p>
@@ -558,7 +534,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-83"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-77"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -570,7 +546,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-79"
                   data-se="cancel"
                   role="link"
                 >
@@ -735,37 +711,33 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             At least 8 characters
                           </p>
@@ -779,37 +751,33 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A lowercase letter
                           </p>
@@ -823,37 +791,33 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             An uppercase letter
                           </p>
@@ -867,37 +831,33 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             A number
                           </p>
@@ -911,37 +871,33 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-23"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-24"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             No parts of your username
                           </p>
@@ -968,21 +924,21 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-53"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
                     required="true"
                   >
                     <input
                       aria-describedby="reset-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-55"
                       data-se="credentials.passcode"
                       id="generated"
                       name="credentials.passcode"
@@ -990,20 +946,20 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-56"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-57"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-63"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-58"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1028,21 +984,21 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-9"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-58"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-53"
                     data-shrink="false"
                     for="confirmPassword"
                   >
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
                     required="true"
                   >
                     <input
                       aria-describedby="reset-authenticator_PasswordRequirements_okta_password_aut2h3ffszv3me6O31d7_2"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-60"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-55"
                       data-se="confirmPassword"
                       id="generated"
                       name="confirmPassword"
@@ -1050,20 +1006,20 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-61"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-56"
                     >
                       <button
                         aria-controls="confirmPassword"
                         aria-label="Show re-entered password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-62"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-57"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-63"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-58"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1090,7 +1046,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 >
                   <ul
                     aria-hidden="true"
-                    class="MuiBox-root emotion-74"
+                    class="MuiBox-root emotion-69"
                     id="generated"
                   >
                     <li
@@ -1100,37 +1056,33 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         class="MuiBox-root emotion-21"
                       >
                         <div
-                          class="MuiBox-root emotion-22"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-22"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-23"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-58"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorGrey.500 MuiSvgIcon-fontSizeInherit emotion-63"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                incomplete
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 7.2929L2.35355 1.64645L1.64644 2.35355L7.29289 8L1.64645 13.6464L2.35355 14.3536L8 8.70711L13.6464 14.3536L14.3535 13.6464L8.7071 8L14.3536 2.35355L13.6464 1.64645L8 7.2929Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              incomplete
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-9"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-26"
+                            class="MuiTypography-root MuiTypography-body1 emotion-25"
                           >
                             Passwords must match
                           </p>
@@ -1144,7 +1096,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-83"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-77"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1156,7 +1108,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 class="MuiBox-root emotion-13"
               >
                 <button
-                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                  class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-79"
                   data-se="cancel"
                   role="link"
                 >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -122,37 +122,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             At least 8 characters
                           </p>
@@ -166,37 +162,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             A lowercase letter
                           </p>
@@ -210,37 +202,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             An uppercase letter
                           </p>
@@ -254,37 +242,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             A number
                           </p>
@@ -298,37 +282,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             No parts of your username
                           </p>
@@ -345,26 +325,26 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     data-shrink="false"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-60"
+                      class="no-translate MuiBox-root emotion-55"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-62"
+                      class="MuiInputBase-input emotion-57"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -382,26 +362,26 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     data-shrink="false"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-60"
+                      class="no-translate MuiBox-root emotion-55"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-62"
+                      class="MuiInputBase-input emotion-57"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -418,26 +398,26 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     data-shrink="false"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-60"
+                      class="no-translate MuiBox-root emotion-55"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-62"
+                      class="MuiInputBase-input emotion-57"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -454,27 +434,27 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     Password
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-60"
+                      class="no-translate MuiBox-root emotion-55"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-61"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-56"
                     required="true"
                   >
                     <input
                       aria-describedby=" credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_3 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-57"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -482,13 +462,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-81"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-76"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-82"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-77"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -515,29 +495,29 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-20"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-85"
+                      class="MuiFormHelperText-root Mui-error emotion-80"
                       data-se="credentials.passcode-error"
                       id="credentials.passcode-error"
                       role="alert"
                     >
                       <div
-                        class="MuiBox-root emotion-86"
+                        class="MuiBox-root emotion-81"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-87"
+                          class="MuiTypography-root MuiTypography-body1 emotion-82"
                         >
                           Password requirements were not met:
                         </p>
                         <ul
-                          class="MuiList-root MuiList-dense emotion-88"
+                          class="MuiList-root MuiList-dense emotion-83"
                         >
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-89"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-84"
                           >
                             At least 8 characters
                           </li>
                           <li
-                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-89"
+                            class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-84"
                           >
                             An uppercase letter
                           </li>
@@ -551,7 +531,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-92"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-87"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -563,11 +543,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-94"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-89"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-95"
+                class="MuiBox-root emotion-90"
               >
                 <div
                   class="MuiBox-root emotion-12"
@@ -588,7 +568,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-95"
                     data-se="back"
                     role="link"
                   >
@@ -727,37 +707,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             At least 8 characters
                           </p>
@@ -771,37 +747,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             A lowercase letter
                           </p>
@@ -815,37 +787,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             An uppercase letter
                           </p>
@@ -859,37 +827,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             A number
                           </p>
@@ -903,37 +867,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-23"
                       >
                         <div
-                          class="MuiBox-root emotion-24"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-24"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-25"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-25"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-26"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 emotion-27"
                           >
                             No parts of your username
                           </p>
@@ -950,26 +910,26 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     data-shrink="false"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-60"
+                      class="no-translate MuiBox-root emotion-55"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-62"
+                      class="MuiInputBase-input emotion-57"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -987,26 +947,26 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     data-shrink="false"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-60"
+                      class="no-translate MuiBox-root emotion-55"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-62"
+                      class="MuiInputBase-input emotion-57"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -1023,26 +983,26 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     data-shrink="false"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-60"
+                      class="no-translate MuiBox-root emotion-55"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-62"
+                      class="MuiInputBase-input emotion-57"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -1059,27 +1019,27 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-20"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     Password
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-60"
+                      class="no-translate MuiBox-root emotion-55"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-61"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-56"
                     required="true"
                   >
                     <input
                       aria-describedby=" credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_3 "
                       aria-invalid="true"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-57"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -1087,13 +1047,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-81"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-76"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-82"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-77"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -1120,7 +1080,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-20"
                   >
                     <p
-                      class="MuiFormHelperText-root Mui-error emotion-85"
+                      class="MuiFormHelperText-root Mui-error emotion-80"
                       data-se="credentials.passcode-error"
                       id="credentials.passcode-error"
                       role="alert"
@@ -1134,7 +1094,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-87"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-82"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1146,11 +1106,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                 class="MuiBox-root emotion-12"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-89"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-84"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-90"
+                class="MuiBox-root emotion-85"
               >
                 <div
                   class="MuiBox-root emotion-12"
@@ -1171,7 +1131,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-95"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-90"
                     data-se="back"
                     role="link"
                   >
@@ -1277,37 +1237,33 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-19"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-19"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-20"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-20"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-23"
+                            class="MuiTypography-root MuiTypography-body1 emotion-22"
                           >
                             At least 8 characters
                           </p>
@@ -1321,37 +1277,33 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-19"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-19"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-20"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-20"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-23"
+                            class="MuiTypography-root MuiTypography-body1 emotion-22"
                           >
                             A lowercase letter
                           </p>
@@ -1365,37 +1317,33 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-19"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-19"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-20"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-20"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-23"
+                            class="MuiTypography-root MuiTypography-body1 emotion-22"
                           >
                             An uppercase letter
                           </p>
@@ -1409,37 +1357,33 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-19"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-19"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-20"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-20"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-23"
+                            class="MuiTypography-root MuiTypography-body1 emotion-22"
                           >
                             A number
                           </p>
@@ -1453,37 +1397,33 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiBox-root emotion-19"
+                          aria-hidden="true"
+                          class="passwordRequirementIcon MuiBox-root emotion-19"
                         >
-                          <div
-                            aria-hidden="true"
-                            class="passwordRequirementIcon MuiBox-root emotion-20"
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-20"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              class="MuiSvgIcon-root MuiSvgIcon-colorInfo MuiSvgIcon-fontSizeInherit emotion-21"
-                              fill="none"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              <title>
-                                info
-                              </title>
-                            </svg>
-                          </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8.5 7.5C8.5 7.22386 8.27614 7 8 7C7.72386 7 7.5 7.22386 7.5 7.5V12H8.5V7.5Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              info
+                            </title>
+                          </svg>
                         </div>
                         <div
                           class="MuiBox-root emotion-15"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-23"
+                            class="MuiTypography-root MuiTypography-body1 emotion-22"
                           >
                             No parts of your username
                           </p>
@@ -1500,26 +1440,26 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-49"
                     data-shrink="false"
                     for="userProfile.email"
                   >
                     Email
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-55"
+                      class="no-translate MuiBox-root emotion-50"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-51"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="email"
-                      class="MuiInputBase-input emotion-57"
+                      class="MuiInputBase-input emotion-52"
                       data-se="userProfile.email"
                       id="userProfile.email"
                       inputmode="email"
@@ -1537,26 +1477,26 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-49"
                     data-shrink="false"
                     for="userProfile.firstName"
                   >
                     First name
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-55"
+                      class="no-translate MuiBox-root emotion-50"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-51"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="given-name"
-                      class="MuiInputBase-input emotion-57"
+                      class="MuiInputBase-input emotion-52"
                       data-se="userProfile.firstName"
                       id="userProfile.firstName"
                       name="userProfile.firstName"
@@ -1573,26 +1513,26 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-49"
                     data-shrink="false"
                     for="userProfile.lastName"
                   >
                     Last name
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-55"
+                      class="no-translate MuiBox-root emotion-50"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-56"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-51"
                     required="true"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="family-name"
-                      class="MuiInputBase-input emotion-57"
+                      class="MuiInputBase-input emotion-52"
                       data-se="userProfile.lastName"
                       id="userProfile.lastName"
                       name="userProfile.lastName"
@@ -1609,27 +1549,27 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   class="MuiBox-root emotion-15"
                 >
                   <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-54"
+                    class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-49"
                     data-shrink="false"
                     for="credentials.passcode"
                   >
                     Password
                     <span
                       aria-hidden="true"
-                      class="no-translate MuiBox-root emotion-55"
+                      class="no-translate MuiBox-root emotion-50"
                     >
                       *
                     </span>
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-56"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-51"
                     required="true"
                   >
                     <input
                       aria-describedby="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
                       aria-invalid="false"
                       autocomplete="new-password"
-                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-57"
+                      class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-52"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -1637,20 +1577,20 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       type="password"
                     />
                     <div
-                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-76"
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-71"
                     >
                       <button
                         aria-controls="credentials.passcode"
                         aria-label="Show password"
                         aria-pressed="false"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-77"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-72"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-78"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-73"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 16 16"
@@ -1672,7 +1612,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-80"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-75"
                   data-type="save"
                   tabindex="0"
                   type="submit"
@@ -1684,11 +1624,11 @@ exports[`enroll-profile-with-password should render form 1`] = `
                 class="MuiBox-root emotion-7"
               >
                 <hr
-                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-82"
+                  class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-77"
                 />
               </div>
               <div
-                class="MuiBox-root emotion-83"
+                class="MuiBox-root emotion-78"
               >
                 <div
                   class="MuiBox-root emotion-7"
@@ -1709,7 +1649,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   class="MuiBox-root emotion-7"
                 >
                   <button
-                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-88"
+                    class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-83"
                     data-se="back"
                     role="link"
                   >


### PR DESCRIPTION
## Description:
The purpose of this PR is to fix an issue in SIW Gen 3 where the password requirements list icon size changes with the language (see before and after attachments). 

**Before fix:** 
![image](https://github.com/okta/okta-signin-widget/assets/97472729/3966e606-8d65-4f40-8268-3fe3d0246342)

**After fix:**
![image](https://github.com/okta/okta-signin-widget/assets/97472729/48b22334-4c49-4299-8170-033ba0592358)

<img width="530" alt="image" src="https://github.com/okta/okta-signin-widget/assets/97472729/3e022ea4-dd9b-4c15-9c22-004ad7aabb0a">


English:
![image](https://github.com/okta/okta-signin-widget/assets/97472729/81eea64b-3ddf-4c45-be69-d92bc462230d)

OK-SK:
![image](https://github.com/okta/okta-signin-widget/assets/97472729/6485dc73-aefd-40bc-b75e-cdcb31d0a668)



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-586924](https://oktainc.atlassian.net/browse/OKTA-586924)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



