### PR TITLE
OKTA-615788 : Default LTR Input direction fix

### DIFF
--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -51,7 +51,12 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
   const {
-    translations = [], focus, parserOptions, noTranslate, showAsterisk,
+    translations = [],
+    focus,
+    parserOptions,
+    noTranslate,
+    showAsterisk,
+    dir,
   } = uischema;
   const {
     attributes,
@@ -141,6 +146,7 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
           ...attributes,
         }}
         className={noTranslate ? 'no-translate' : undefined}
+        dir={dir}
         endAdornment={(
           <InputAdornment position="end">
             <Tooltip title={showPassword ? getTranslation(translations, 'hide') : getTranslation(translations, 'show')}>

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -44,7 +44,11 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
   const {
-    translations = [], focus, parserOptions, showAsterisk,
+    translations = [],
+    focus,
+    parserOptions,
+    showAsterisk,
+    dir,
   } = uischema;
   const label = getTranslation(translations, 'label');
   const hint = getTranslation(translations, 'hint');
@@ -127,6 +131,7 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
           ...attributes,
         }}
         inputRef={focusRef}
+        dir={dir}
       />
       {hasErrors && (
         <FieldLevelMessageContainer

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -48,7 +48,11 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
   describedByIds,
 }) => {
   const {
-    data, dataSchemaRef, loading, widgetProps,
+    data,
+    dataSchemaRef,
+    loading,
+    widgetProps,
+    languageDirection,
   } = useWidgetContext();
   const {
     translations = [],
@@ -124,12 +128,19 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
   const renderExtension = () => (
     showExtension && (
       <Box width={0.25}>
-        <InputLabel htmlFor="phoneExtension">{extensionLabel}</InputLabel>
+        <InputLabel
+          htmlFor="phoneExtension"
+          // label should remain in rtl format if rtl language is set
+          dir={languageDirection}
+        >
+          {extensionLabel}
+        </InputLabel>
         <InputBase
           value={extension}
           type="text"
           name="extension"
           id="phoneExtension"
+          dir="ltr"
           disabled={loading}
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
             setExtension(e.currentTarget.value);
@@ -215,6 +226,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
       <Box
         display="flex"
         flexWrap="wrap"
+        dir="ltr"
       >
         <Box
           width={showExtension ? 0.7 : 1}
@@ -224,6 +236,8 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
             htmlFor={fieldName}
             // To prevent asterisk from shifting far right
             sx={{ justifyContent: showAsterisk ? 'flex-start' : undefined }}
+            // label should remain in rtl format if rtl language is set
+            dir={languageDirection}
           >
             {mainLabel}
             {showAsterisk && (
@@ -249,6 +263,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
             id={fieldName}
             error={phoneHasErrors}
             disabled={loading}
+            dir="ltr"
             onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
               // Set new phone value without phone code
               setPhone(e.currentTarget.value);

--- a/src/v3/src/transformer/layout/rsa/__snapshots__/transformRSAAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/layout/rsa/__snapshots__/transformRSAAuthenticator.test.ts.snap
@@ -23,6 +23,7 @@ Object {
         "type": "Title",
       },
       Object {
+        "dir": "ltr",
         "options": Object {
           "inputMeta": Object {
             "name": "credentials.clientData",
@@ -77,6 +78,7 @@ Object {
         "type": "Title",
       },
       Object {
+        "dir": "ltr",
         "options": Object {
           "inputMeta": Object {
             "name": "credentials.clientData",
@@ -131,6 +133,7 @@ Object {
         "type": "Title",
       },
       Object {
+        "dir": "ltr",
         "options": Object {
           "inputMeta": Object {
             "name": "credentials.clientData",
@@ -185,6 +188,7 @@ Object {
         "type": "Title",
       },
       Object {
+        "dir": "ltr",
         "options": Object {
           "inputMeta": Object {
             "name": "credentials.clientData",
@@ -240,6 +244,7 @@ Object {
         "type": "Title",
       },
       Object {
+        "dir": "ltr",
         "options": Object {
           "inputMeta": Object {
             "name": "credentials.clientData",

--- a/src/v3/src/transformer/layout/rsa/transformRSAAuthenticator.ts
+++ b/src/v3/src/transformer/layout/rsa/transformRSAAuthenticator.ts
@@ -24,6 +24,7 @@ export const transformRSAAuthenticator: IdxStepTransformer = ({ transaction, for
   const userNameField = getUIElementWithName('credentials.clientData', uischema.elements);
   if (userNameField) {
     data['credentials.clientData'] = (userNameField as FieldElement).options.inputMeta.value as string;
+    userNameField.dir = 'ltr';
   }
 
   if (containsMessageKey(ON_PREM_TOKEN_CHANGE_ERROR_KEY, messages)) {

--- a/src/v3/src/transformer/uischema/setLtrFields.ts
+++ b/src/v3/src/transformer/uischema/setLtrFields.ts
@@ -24,15 +24,15 @@ export const setLtrFields: TransformStepFn = (formbag) => {
         return false;
       }
 
-      // fields with these names should always be LTR
+      // fields with these names should stay LTR by default
       const ltrOnlyFieldNames = ['credentials.passcode', 'identifier', 'credentials.newPassword', 'confirmPassword'];
       const fieldElement = (el as FieldElement);
       return ltrOnlyFieldNames.includes(fieldElement.options.inputMeta.name);
     },
     callback: (el) => {
-      if (el.type === 'Field') {
-        const fieldElement = (el as FieldElement);
-        fieldElement.dir = 'ltr';
+      // only set dir here when it has not already been set and overridden
+      if (el.type === 'Field' && typeof el.dir === 'undefined') {
+        el.dir = 'ltr';
       }
     },
   });

--- a/src/v3/src/transformer/uischema/setLtrFields.ts
+++ b/src/v3/src/transformer/uischema/setLtrFields.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  FieldElement,
+  TransformStepFn,
+} from '../../types';
+import { traverseLayout } from '../util';
+
+export const setLtrFields: TransformStepFn = (formbag) => {
+  console.log(formbag.uischema.elements);
+  traverseLayout({
+    layout: formbag.uischema,
+    predicate: (el) => {
+      if (el.type === 'Field') {
+        // fields with these names should always be LTR
+        const ltrOnlyFieldNames = ['credentials.passcode', 'identifier', 'credentials.newPassword', 'confirmPassword'];
+        const fieldElement = (el as FieldElement);
+        if (ltrOnlyFieldNames.includes(fieldElement.options.inputMeta.name)) {
+          return true;
+        }
+      }
+      return false;
+    },
+    callback: (el) => {
+      const fieldElement = (el as FieldElement);
+      fieldElement.dir = 'ltr';
+    },
+  });
+  return formbag;
+};

--- a/src/v3/src/transformer/uischema/setLtrFields.ts
+++ b/src/v3/src/transformer/uischema/setLtrFields.ts
@@ -17,7 +17,6 @@ import {
 import { traverseLayout } from '../util';
 
 export const setLtrFields: TransformStepFn = (formbag) => {
-  console.log(formbag.uischema.elements);
   traverseLayout({
     layout: formbag.uischema,
     predicate: (el) => {

--- a/src/v3/src/transformer/uischema/setLtrFields.ts
+++ b/src/v3/src/transformer/uischema/setLtrFields.ts
@@ -20,19 +20,20 @@ export const setLtrFields: TransformStepFn = (formbag) => {
   traverseLayout({
     layout: formbag.uischema,
     predicate: (el) => {
-      if (el.type === 'Field') {
-        // fields with these names should always be LTR
-        const ltrOnlyFieldNames = ['credentials.passcode', 'identifier', 'credentials.newPassword', 'confirmPassword'];
-        const fieldElement = (el as FieldElement);
-        if (ltrOnlyFieldNames.includes(fieldElement.options.inputMeta.name)) {
-          return true;
-        }
+      if (el.type !== 'Field') {
+        return false;
       }
-      return false;
+
+      // fields with these names should always be LTR
+      const ltrOnlyFieldNames = ['credentials.passcode', 'identifier', 'credentials.newPassword', 'confirmPassword'];
+      const fieldElement = (el as FieldElement);
+      return ltrOnlyFieldNames.includes(fieldElement.options.inputMeta.name);
     },
     callback: (el) => {
-      const fieldElement = (el as FieldElement);
-      fieldElement.dir = 'ltr';
+      if (el.type === 'Field') {
+        const fieldElement = (el as FieldElement);
+        fieldElement.dir = 'ltr';
+      }
     },
   });
   return formbag;

--- a/src/v3/src/transformer/uischema/setLtrFields.ts
+++ b/src/v3/src/transformer/uischema/setLtrFields.ts
@@ -32,6 +32,7 @@ export const setLtrFields: TransformStepFn = (formbag) => {
     callback: (el) => {
       // only set dir here when it has not already been set and overridden
       if (el.type === 'Field' && typeof el.dir === 'undefined') {
+        // eslint-disable-next-line no-param-reassign
         el.dir = 'ltr';
       }
     },

--- a/src/v3/src/transformer/uischema/transform.test.ts
+++ b/src/v3/src/transformer/uischema/transform.test.ts
@@ -64,7 +64,6 @@ describe('UISchema transformer', () => {
     jest.spyOn(mocked.updatePasswordEle, 'updatePasswordDescribedByValue');
     jest.spyOn(mocked.setLtrField, 'setLtrFields');
 
-
     const formBag = getStubFormBag();
     const mockOptions = {
       transaction: {},
@@ -87,6 +86,5 @@ describe('UISchema transformer', () => {
     expect(mocked.applyAsterisk.applyAsteriskToFieldElements).toHaveBeenCalled();
     expect(mocked.updatePasswordEle.updatePasswordDescribedByValue).toHaveBeenCalled();
     expect(mocked.setLtrField.setLtrFields).toHaveBeenCalled();
-
   });
 });

--- a/src/v3/src/transformer/uischema/transform.test.ts
+++ b/src/v3/src/transformer/uischema/transform.test.ts
@@ -36,6 +36,9 @@ jest.mock('./applyAsteriskToFieldElements', () => ({
 jest.mock('./updatePasswordDescribedByValue', () => ({
   updatePasswordDescribedByValue: () => ({}),
 }));
+jest.mock('./setLtrFields', () => ({
+  setLtrFields: () => ({}),
+}));
 
 /* eslint-disable global-require */
 const mocked = {
@@ -46,6 +49,7 @@ const mocked = {
   setFocus: require('./setFocusOnFirstElement'),
   applyAsterisk: require('./applyAsteriskToFieldElements'),
   updatePasswordEle: require('./updatePasswordDescribedByValue'),
+  setLtrField: require('./setLtrFields'),
 };
 /* eslint-enable global-require */
 
@@ -58,6 +62,8 @@ describe('UISchema transformer', () => {
     jest.spyOn(mocked.setFocus, 'setFocusOnFirstElement');
     jest.spyOn(mocked.applyAsterisk, 'applyAsteriskToFieldElements');
     jest.spyOn(mocked.updatePasswordEle, 'updatePasswordDescribedByValue');
+    jest.spyOn(mocked.setLtrField, 'setLtrFields');
+
 
     const formBag = getStubFormBag();
     const mockOptions = {
@@ -80,5 +86,7 @@ describe('UISchema transformer', () => {
     expect(mocked.setFocus.setFocusOnFirstElement).toHaveBeenCalled();
     expect(mocked.applyAsterisk.applyAsteriskToFieldElements).toHaveBeenCalled();
     expect(mocked.updatePasswordEle.updatePasswordDescribedByValue).toHaveBeenCalled();
+    expect(mocked.setLtrField.setLtrFields).toHaveBeenCalled();
+
   });
 });

--- a/src/v3/src/transformer/uischema/transform.ts
+++ b/src/v3/src/transformer/uischema/transform.ts
@@ -19,6 +19,7 @@ import { addIdToElements } from './addIdToElements';
 import { applyAsteriskToFieldElements } from './applyAsteriskToFieldElements';
 import { createTextElementKeys } from './createTextElementKeys';
 import { setFocusOnFirstElement } from './setFocusOnFirstElement';
+import { setLtrFields } from './setLtrFields';
 import { updateCustomFields } from './updateCustomFields';
 import { updateElementKeys } from './updateElementKeys';
 import { updatePasswordDescribedByValue } from './updatePasswordDescribedByValue';
@@ -33,4 +34,5 @@ export const transformUISchema: TransformStepFnWithOptions = (
   updateElementKeys(options),
   addIdToElements,
   updatePasswordDescribedByValue,
+  setLtrFields,
 )(formbag);

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -208,6 +208,7 @@ export interface UISchemaElement {
    * and rendered in the UI. See htmlContentParserUtils.tsx for reference.
    */
   parserOptions?: HTMLReactParserOptions;
+  dir?: 'ltr' | 'rtl'
 }
 
 /**

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -255,6 +256,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -445,6 +447,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -1506,6 +1506,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                     </div>
                     <div
                       class="MuiBox-root emotion-44"
+                      dir="ltr"
                     >
                       <div
                         class="MuiBox-root emotion-45"
@@ -1513,12 +1514,14 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
                           data-shrink="false"
+                          dir="ltr"
                           for="authenticator.phoneNumber"
                         >
                           Phone number
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-47"
+                          dir="ltr"
                           required="true"
                         >
                           <span
@@ -3096,6 +3099,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
                     </div>
                     <div
                       class="MuiBox-root emotion-44"
+                      dir="ltr"
                     >
                       <div
                         class="MuiBox-root emotion-45"
@@ -3103,12 +3107,14 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
                           data-shrink="false"
+                          dir="ltr"
                           for="authenticator.phoneNumber"
                         >
                           Phone number
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-47"
+                          dir="ltr"
                           required="true"
                         >
                           <span
@@ -4686,6 +4692,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                     </div>
                     <div
                       class="MuiBox-root emotion-44"
+                      dir="ltr"
                     >
                       <div
                         class="MuiBox-root emotion-45"
@@ -4693,12 +4700,14 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
                           data-shrink="false"
+                          dir="ltr"
                           for="authenticator.phoneNumber"
                         >
                           Phone number
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-47"
+                          dir="ltr"
                           required="true"
                         >
                           <span
@@ -4729,12 +4738,14 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
                           data-shrink="false"
+                          dir="ltr"
                           for="phoneExtension"
                         >
                           Extension
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary emotion-53"
+                          dir="ltr"
                           required="true"
                         >
                           <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -164,6 +164,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -423,6 +423,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                     </label>
                     <div
                       class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                      dir="ltr"
                       required="true"
                     >
                       <input
@@ -897,6 +898,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     </label>
                     <div
                       class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                      dir="ltr"
                       required="true"
                     >
                       <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -450,6 +450,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -522,6 +523,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -791,6 +791,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -183,6 +183,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -198,6 +198,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-25"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-20"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -209,6 +210,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-20"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -403,6 +403,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -502,6 +503,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1027,6 +1029,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1087,6 +1090,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -402,7 +402,7 @@ exports[`authenticator-expired-password should present field level error message
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
                     required="true"
                   >
                     <input
@@ -501,7 +501,7 @@ exports[`authenticator-expired-password should present field level error message
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
                     required="true"
                   >
                     <input
@@ -1015,7 +1015,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
                     required="true"
                   >
                     <input
@@ -1075,7 +1075,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -402,7 +402,8 @@ exports[`authenticator-expired-password should present field level error message
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -501,7 +502,8 @@ exports[`authenticator-expired-password should present field level error message
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-64"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1015,7 +1017,8 @@ exports[`authenticator-expired-password should render form 1`] = `
                     New password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1075,7 +1078,8 @@ exports[`authenticator-expired-password should render form 1`] = `
                     Re-enter password
                   </label>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-59"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -538,6 +538,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-80"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -642,6 +643,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-80"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1302,6 +1304,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-75"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1362,6 +1365,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-75"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -130,6 +131,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-20"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -406,6 +408,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -436,6 +439,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-20"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -677,6 +681,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -707,6 +712,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -450,6 +450,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -510,6 +511,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-66"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -370,6 +370,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -430,6 +431,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -932,6 +934,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -992,6 +995,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
@@ -160,6 +160,7 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -164,6 +164,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -579,6 +579,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     </label>
                     <div
                       class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused emotion-24"
+                      dir="ltr"
                       required="true"
                     >
                       <input
@@ -828,6 +829,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     </label>
                     <div
                       class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-29"
+                      dir="ltr"
                       required="true"
                     >
                       <input
@@ -1145,6 +1147,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     </label>
                     <div
                       class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-36"
+                      dir="ltr"
                       required="true"
                     >
                       <input
@@ -1478,6 +1481,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                     </label>
                     <div
                       class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused emotion-24"
+                      dir="ltr"
                       required="true"
                     >
                       <input

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -189,6 +189,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -189,6 +189,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-26"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -157,6 +157,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-22"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -1506,6 +1506,7 @@ exports[`byol loading custom language should load custom language with "language
                     </div>
                     <div
                       class="MuiBox-root emotion-44"
+                      dir="ltr"
                     >
                       <div
                         class="MuiBox-root emotion-45"
@@ -1513,12 +1514,14 @@ exports[`byol loading custom language should load custom language with "language
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
                           data-shrink="false"
+                          dir="ltr"
                           for="authenticator.phoneNumber"
                         >
                           Phone number
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-47"
+                          dir="ltr"
                           required="true"
                         >
                           <span
@@ -3096,6 +3099,7 @@ exports[`byol loading custom language should load custom language with assets.ba
                     </div>
                     <div
                       class="MuiBox-root emotion-44"
+                      dir="ltr"
                     >
                       <div
                         class="MuiBox-root emotion-45"
@@ -3103,12 +3107,14 @@ exports[`byol loading custom language should load custom language with assets.ba
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
                           data-shrink="false"
+                          dir="ltr"
                           for="authenticator.phoneNumber"
                         >
                           Phone number
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-47"
+                          dir="ltr"
                           required="true"
                         >
                           <span
@@ -4686,6 +4692,7 @@ exports[`byol loading default language should not load custom language when the 
                     </div>
                     <div
                       class="MuiBox-root emotion-44"
+                      dir="ltr"
                     >
                       <div
                         class="MuiBox-root emotion-45"
@@ -4693,12 +4700,14 @@ exports[`byol loading default language should not load custom language when the 
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
                           data-shrink="false"
+                          dir="ltr"
                           for="authenticator.phoneNumber"
                         >
                           Phone number
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-47"
+                          dir="ltr"
                           required="true"
                         >
                           <span
@@ -6276,6 +6285,7 @@ exports[`byol loading default language should not load custom language with "lan
                     </div>
                     <div
                       class="MuiBox-root emotion-44"
+                      dir="ltr"
                     >
                       <div
                         class="MuiBox-root emotion-45"
@@ -6283,12 +6293,14 @@ exports[`byol loading default language should not load custom language with "lan
                         <label
                           class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
                           data-shrink="false"
+                          dir="ltr"
                           for="authenticator.phoneNumber"
                         >
                           Phone number
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-47"
+                          dir="ltr"
                           required="true"
                         >
                           <span

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -448,6 +448,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-56"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1033,6 +1034,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-56"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1563,6 +1565,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-51"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`identify-recovery renders form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -98,6 +98,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-18"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -141,6 +142,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-18"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -417,6 +419,7 @@ exports[`identify-with-password Client-side field change validation tests should
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-18"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -460,6 +463,7 @@ exports[`identify-with-password Client-side field change validation tests should
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-18"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -736,6 +740,7 @@ exports[`identify-with-password Client-side field change validation tests should
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-18"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -779,6 +784,7 @@ exports[`identify-with-password Client-side field change validation tests should
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-18"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1022,6 +1028,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1052,6 +1059,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1282,6 +1290,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input
@@ -1312,6 +1321,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1370,6 +1370,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                   </div>
                   <div
                     class="MuiBox-root emotion-23"
+                    dir="ltr"
                   >
                     <div
                       class="MuiBox-root emotion-24"
@@ -1377,12 +1378,14 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                       <label
                         class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-19"
                         data-shrink="false"
+                        dir="ltr"
                         for="phoneNumber"
                       >
                         Phone number
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-26"
+                        dir="ltr"
                         required="true"
                       >
                         <span
@@ -2854,6 +2857,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
                   </div>
                   <div
                     class="MuiBox-root emotion-23"
+                    dir="ltr"
                   >
                     <div
                       class="MuiBox-root emotion-24"
@@ -2861,12 +2865,14 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
                       <label
                         class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-19"
                         data-shrink="false"
+                        dir="ltr"
                         for="phoneNumber"
                       >
                         Phone number
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedStart emotion-26"
+                        dir="ltr"
                         required="true"
                       >
                         <span

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`user-unlock-account renders form 1`] = `
                   </label>
                   <div
                     class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-13"
+                    dir="ltr"
                     required="true"
                   >
                     <input

--- a/src/v3/test/integration/authenticator-enroll-data-phone.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-data-phone.test.tsx
@@ -79,6 +79,21 @@ describe('authenticator-enroll-data-phone', () => {
     );
   });
 
+  it('phone number and extension fields should be ltr even when a rtl language is set', async () => {
+    const {
+      findByTestId, user, findByLabelText,
+    } = await setup({ mockResponse, widgetOptions: { language: 'ar' } });
+
+    const phoneNumberEle = await findByTestId('authenticator.phoneNumber') as HTMLInputElement;
+
+    const methodType = await findByLabelText(/Voice call/);
+    await user.click(methodType);
+    const extensionEle = await findByTestId('extension') as HTMLInputElement;
+
+    expect(phoneNumberEle.parentElement?.getAttribute('dir')).toBe('ltr');
+    expect(extensionEle.parentElement?.getAttribute('dir')).toBe('ltr');
+  });
+
   it('should send correct payload when selecting voice', async () => {
     const {
       authClient, user, findByTestId, findByText, findByLabelText, container,

--- a/src/v3/test/integration/authenticator-reset-password.test.tsx
+++ b/src/v3/test/integration/authenticator-reset-password.test.tsx
@@ -33,6 +33,18 @@ describe('authenticator-reset-password', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('password fields should be ltr even when a rtl language is set', async () => {
+    const {
+      findByTestId,
+    } = await setup({ mockResponse, widgetOptions: { language: 'ar' } });
+
+    const newPasswordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const confirmPasswordEle = await findByTestId('confirmPassword') as HTMLInputElement;
+
+    expect(newPasswordEle.parentElement?.getAttribute('dir')).toBe('ltr');
+    expect(confirmPasswordEle.parentElement?.getAttribute('dir')).toBe('ltr');
+  });
+
   it('should send correct payload', async () => {
     const {
       authClient, user, findByTestId, findByText,

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -417,4 +417,16 @@ describe('identify-with-password', () => {
     await user.dblClick(cancelLink);
     expect(authClient.options.httpRequestClient).toHaveBeenCalledTimes(1);
   });
+
+  it('identifier and password fields should be ltr even when a rtl language is set', async () => {
+    const {
+      findByTestId,
+    } = await setup({ mockResponse, widgetOptions: { language: 'ar' } });
+
+    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+
+    expect(usernameEl.parentElement?.getAttribute('dir')).toBe('ltr');
+    expect(passwordEl.parentElement?.getAttribute('dir')).toBe('ltr');
+  });
 });

--- a/src/v3/test/integration/util/setup.tsx
+++ b/src/v3/test/integration/util/setup.tsx
@@ -25,7 +25,7 @@ type Options = CreateAuthClientOptions & {
 };
 
 /*
- * See manual mock for okta package in src/v3/__mocks__/okta.js
+ * See manual mock for okta package in src/v3/jest.setup.js
  * This globally overwrites the okta package's loc function
  * For integration tests we want the translated string to render
  * According to jest documentation, must use the unmock function below


### PR DESCRIPTION
## Description:

This PR fixes the issue where inputs that expect Latin/English(LTR) characters are inheriting the RTL language direction when a RTL language is set.  This is fixed by setting inputs that only expect numeric/Latin characters to LTR only.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-615788](https://oktainc.atlassian.net/browse/OKTA-615788)

### Reviewers:

### Screenshot/Video:
<img width="945" alt="Screenshot 2023-08-22 at 9 49 17 PM" src="https://github.com/okta/okta-signin-widget/assets/107433508/8f6203d0-8b74-4de8-a482-b481e532c364">
<img width="1009" alt="Screenshot 2023-08-22 at 9 50 05 PM" src="https://github.com/okta/okta-signin-widget/assets/107433508/c2848a2a-26dd-432c-9bf9-7fcb9f839420">

### Downstream Monolith Build:



