### PR TITLE
OKTA-616429 : Gen 3 embedded phone number ltr fix

### DIFF
--- a/src/v3/src/transformer/phone/__snapshots__/phoneChallengeTransformer.test.ts.snap
+++ b/src/v3/src/transformer/phone/__snapshots__/phoneChallengeTransformer.test.ts.snap
@@ -71,7 +71,7 @@ Object {
       Object {
         "contentType": "subtitle",
         "options": Object {
-          "content": "oie.phone.verify.sms.codeSentText <span class=\\"strong no-translate\\">+1 XXX-XXX-4601.</span> oie.phone.verify.enterCodeText",
+          "content": "oie.phone.verify.sms.codeSentText <span class=\\"strong no-translate\\">&lrm;+1 XXX-XXX-4601.</span> oie.phone.verify.enterCodeText",
         },
         "type": "Description",
       },
@@ -131,7 +131,7 @@ Object {
       Object {
         "contentType": "subtitle",
         "options": Object {
-          "content": "oie.phone.verify.sms.codeSentText <span class=\\"strong no-translate\\">+1 XXX-XXX-4601.</span> oie.phone.verify.enterCodeText",
+          "content": "oie.phone.verify.sms.codeSentText <span class=\\"strong no-translate\\">&lrm;+1 XXX-XXX-4601.</span> oie.phone.verify.enterCodeText",
         },
         "type": "Description",
       },
@@ -179,7 +179,7 @@ Object {
       Object {
         "contentType": "subtitle",
         "options": Object {
-          "content": "mfa.calling <span class=\\"strong no-translate\\">+1 XXX-XXX-4601.</span> oie.phone.verify.enterCodeText",
+          "content": "mfa.calling <span class=\\"strong no-translate\\">&lrm;+1 XXX-XXX-4601.</span> oie.phone.verify.enterCodeText",
         },
         "type": "Description",
       },

--- a/src/v3/src/transformer/phone/__snapshots__/phoneEnrollmentCodeTransformer.test.ts.snap
+++ b/src/v3/src/transformer/phone/__snapshots__/phoneEnrollmentCodeTransformer.test.ts.snap
@@ -71,7 +71,7 @@ Object {
       Object {
         "contentType": "subtitle",
         "options": Object {
-          "content": "oie.phone.verify.sms.codeSentText <span class=\\"strong no-translate\\">1215XXXXXX8.</span> oie.phone.verify.enterCodeText",
+          "content": "oie.phone.verify.sms.codeSentText <span class=\\"strong no-translate\\">&lrm;1215XXXXXX8.</span> oie.phone.verify.enterCodeText",
         },
         "type": "Description",
       },
@@ -167,7 +167,7 @@ Object {
       Object {
         "contentType": "subtitle",
         "options": Object {
-          "content": "mfa.calling <span class=\\"strong no-translate\\">1215XXXXXX8.</span> oie.phone.verify.enterCodeText",
+          "content": "mfa.calling <span class=\\"strong no-translate\\">&lrm;1215XXXXXX8.</span> oie.phone.verify.enterCodeText",
         },
         "type": "Description",
       },

--- a/src/v3/src/transformer/phone/__snapshots__/phoneVerificationTransformer.test.ts.snap
+++ b/src/v3/src/transformer/phone/__snapshots__/phoneVerificationTransformer.test.ts.snap
@@ -200,7 +200,7 @@ Object {
       Object {
         "contentType": "subtitle",
         "options": Object {
-          "content": "oie.phone.verify.sms.sendText <span class=\\"strong no-translate\\">+121xxxxx34</span>",
+          "content": "oie.phone.verify.sms.sendText <span class=\\"strong no-translate\\">&lrm;+121xxxxx34</span>",
         },
         "type": "Description",
       },
@@ -302,7 +302,7 @@ Object {
       Object {
         "contentType": "subtitle",
         "options": Object {
-          "content": "oie.phone.verify.call.sendText <span class=\\"strong no-translate\\">+121xxxxx34</span>",
+          "content": "oie.phone.verify.call.sendText <span class=\\"strong no-translate\\">&lrm;+121xxxxx34</span>",
         },
         "type": "Description",
       },

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
@@ -57,7 +57,7 @@ describe('PhoneChallengeTransformer Tests', () => {
       .toBe('oie.phone.verify.title');
     expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
-      .toBe(`oie.phone.verify.sms.codeSentText <span class="strong no-translate">${redactedPhone}.</span> oie.phone.verify.enterCodeText`);
+      .toBe(`oie.phone.verify.sms.codeSentText <span class="strong no-translate">&lrm;${redactedPhone}.</span> oie.phone.verify.enterCodeText`);
 
     expect(updatedFormBag.uischema.elements[3].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[3] as DescriptionElement).options?.content)
@@ -91,7 +91,7 @@ describe('PhoneChallengeTransformer Tests', () => {
       .toBe('oie.phone.verify.title');
     expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe(`oie.phone.verify.sms.codeSentText <span class="strong no-translate">${redactedPhone}.</span> oie.phone.verify.enterCodeText`);
+      .toBe(`oie.phone.verify.sms.codeSentText <span class="strong no-translate">&lrm;${redactedPhone}.</span> oie.phone.verify.enterCodeText`);
 
     expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
@@ -182,7 +182,7 @@ describe('PhoneChallengeTransformer Tests', () => {
       .toBe('oie.phone.verify.title');
     expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe(`mfa.calling <span class="strong no-translate">${redactedPhone}.</span> oie.phone.verify.enterCodeText`);
+      .toBe(`mfa.calling <span class="strong no-translate">&lrm;${redactedPhone}.</span> oie.phone.verify.enterCodeText`);
 
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
@@ -50,7 +50,7 @@ export const transformPhoneChallenge: IdxStepTransformer = ({ transaction, formB
   const sendInfoText = smsMethodType
     ? loc('oie.phone.verify.sms.codeSentText', 'login')
     : loc('mfa.calling', 'login');
-  const phoneNumberSpan = phoneNumber ? `<span class="strong no-translate">${phoneNumber}.</span>` : null;
+  const phoneNumberSpan = phoneNumber ? `<span class="strong no-translate">&lrm;${phoneNumber}.</span>` : null;
   const phoneInfoText = phoneNumberSpan || `${loc('oie.phone.alternate.title', 'login')}.`;
   const enterCodeInfoText = loc('oie.phone.verify.enterCodeText', 'login');
   const informationalText: DescriptionElement = {

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
@@ -50,6 +50,8 @@ export const transformPhoneChallenge: IdxStepTransformer = ({ transaction, formB
   const sendInfoText = smsMethodType
     ? loc('oie.phone.verify.sms.codeSentText', 'login')
     : loc('mfa.calling', 'login');
+  // using the &lrm; unicode mark to keep the phone number in ltr format, while maintaining rtl punctuation (period)
+  // https://www.w3.org/TR/WCAG20-TECHS/H34.html
   const phoneNumberSpan = phoneNumber ? `<span class="strong no-translate">&lrm;${phoneNumber}.</span>` : null;
   const phoneInfoText = phoneNumberSpan || `${loc('oie.phone.alternate.title', 'login')}.`;
   const enterCodeInfoText = loc('oie.phone.verify.enterCodeText', 'login');

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.test.ts
@@ -106,7 +106,7 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
       .toBe('oie.phone.enroll.title');
     expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe(`oie.phone.verify.sms.codeSentText <span class="strong no-translate">${mockPhoneNumber}.</span> oie.phone.verify.enterCodeText`);
+      .toBe(`oie.phone.verify.sms.codeSentText <span class="strong no-translate">&lrm;${mockPhoneNumber}.</span> oie.phone.verify.enterCodeText`);
     expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
       .toBe('oie.phone.carrier.charges');
@@ -136,7 +136,7 @@ describe('PhoneEnrollmentCodeTransformer Tests', () => {
       .toBe('oie.phone.enroll.title');
     expect(updatedFormBag.uischema.elements[1].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement)
-      .options?.content).toBe(`mfa.calling <span class="strong no-translate">${mockPhoneNumber}.</span> oie.phone.verify.enterCodeText`);
+      .options?.content).toBe(`mfa.calling <span class="strong no-translate">&lrm;${mockPhoneNumber}.</span> oie.phone.verify.enterCodeText`);
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
       .toBe('oie.phone.carrier.charges');

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -56,7 +56,7 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, 
   const sendInfoText = smsMethodType
     ? loc('oie.phone.verify.sms.codeSentText', 'login')
     : loc('mfa.calling', 'login');
-  const phoneNumberSpan = phoneNumber ? `<span class="strong no-translate">${phoneNumber}.</span>` : null;
+  const phoneNumberSpan = phoneNumber ? `<span class="strong no-translate">&lrm;${phoneNumber}.</span>` : null;
   const phoneInfoText = phoneNumberSpan || `${loc('oie.phone.alternate.title', 'login')}.`;
   const enterCodeInfoText = loc('oie.phone.verify.enterCodeText', 'login');
   const informationalTextElement: DescriptionElement = {

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -56,6 +56,8 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, 
   const sendInfoText = smsMethodType
     ? loc('oie.phone.verify.sms.codeSentText', 'login')
     : loc('mfa.calling', 'login');
+  // using the &lrm; unicode mark to keep the phone number in ltr format, while maintaining rtl punctuation (period)
+  // https://www.w3.org/TR/WCAG20-TECHS/H34.html
   const phoneNumberSpan = phoneNumber ? `<span class="strong no-translate">&lrm;${phoneNumber}.</span>` : null;
   const phoneInfoText = phoneNumberSpan || `${loc('oie.phone.alternate.title', 'login')}.`;
   const enterCodeInfoText = loc('oie.phone.verify.enterCodeText', 'login');

--- a/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
@@ -184,7 +184,7 @@ describe('Phone verification Transformer Tests', () => {
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.phone.verify.title');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe(`oie.phone.verify.sms.sendText <span class="strong no-translate">${mockPhoneNumber}</span>`);
+      .toBe(`oie.phone.verify.sms.sendText <span class="strong no-translate">&lrm;${mockPhoneNumber}</span>`);
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
       .toBe('oie.phone.carrier.charges');
     // primary button
@@ -225,7 +225,7 @@ describe('Phone verification Transformer Tests', () => {
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.phone.verify.title');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
-      .toBe(`oie.phone.verify.call.sendText <span class="strong no-translate">${mockPhoneNumber}</span>`);
+      .toBe(`oie.phone.verify.call.sendText <span class="strong no-translate">&lrm;${mockPhoneNumber}</span>`);
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
       .toBe('oie.phone.carrier.charges');
     // primary button

--- a/src/v3/src/transformer/phone/phoneVerificationTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneVerificationTransformer.ts
@@ -59,6 +59,8 @@ export const transformPhoneVerification: IdxStepTransformer = ({ transaction, fo
   uischema.elements.unshift(carrierInfoText);
 
   const redactedPhoneNumber = nextStep.relatesTo?.value?.profile?.phoneNumber as string;
+  // using the &lrm; unicode mark to keep the phone number in ltr format
+  // https://www.w3.org/TR/WCAG20-TECHS/H34.html
   const phoneNumberSpan = redactedPhoneNumber ? `<span class="strong no-translate">&lrm;${redactedPhoneNumber}</span>` : null;
   const phoneInfoText = phoneNumberSpan || loc('oie.phone.alternate.title', 'login');
   const smsInfoTextElement: DescriptionElement = {

--- a/src/v3/src/transformer/phone/phoneVerificationTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneVerificationTransformer.ts
@@ -59,7 +59,7 @@ export const transformPhoneVerification: IdxStepTransformer = ({ transaction, fo
   uischema.elements.unshift(carrierInfoText);
 
   const redactedPhoneNumber = nextStep.relatesTo?.value?.profile?.phoneNumber as string;
-  const phoneNumberSpan = redactedPhoneNumber ? `<span class="strong no-translate">${redactedPhoneNumber}</span>` : null;
+  const phoneNumberSpan = redactedPhoneNumber ? `<span class="strong no-translate">&lrm;${redactedPhoneNumber}</span>` : null;
   const phoneInfoText = phoneNumberSpan || loc('oie.phone.alternate.title', 'login');
   const smsInfoTextElement: DescriptionElement = {
     type: 'Description',

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -144,13 +144,13 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-18"
                     data-se="o-form-explain"
-                    id="authenticator-verification-data_Description_Send_a_code_via_SMS_to_<span_class=strong_no-translate>1_XXX-XXX-4601</span>_phone_number_sms4bvjioge7Sdu3p5d7_2"
+                    id="authenticator-verification-data_Description_Send_a_code_via_SMS_to_<span_class=strong_no-translate>&lrm;1_XXX-XXX-4601</span>_phone_number_sms4bvjioge7Sdu3p5d7_2"
                   >
                     Send a code via SMS to 
                     <span
                       class="strong no-translate"
                     >
-                      +1 XXX-XXX-4601
+                      ‎+1 XXX-XXX-4601
                     </span>
                   </p>
                 </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -147,13 +147,13 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   <p
                     class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-19"
                     data-se="o-form-explain"
-                    id="challenge-authenticator_Description_A_code_was_sent_to_<span_class=strong_no-translate>1_XXX-XXX-4601</span>_Enter_the_code_below_to_verify_phone_number_sms4bvjioge7Sdu3p5d7_3"
+                    id="challenge-authenticator_Description_A_code_was_sent_to_<span_class=strong_no-translate>&lrm;1_XXX-XXX-4601</span>_Enter_the_code_below_to_verify_phone_number_sms4bvjioge7Sdu3p5d7_3"
                   >
                     A code was sent to 
                     <span
                       class="strong no-translate"
                     >
-                      +1 XXX-XXX-4601.
+                      ‎+1 XXX-XXX-4601.
                     </span>
                      Enter the code below to verify.
                   </p>


### PR DESCRIPTION
## Description:

This PR is to fix the issue of embedded phone number text in the phone authenticator view not displaying properly when a RTL language is set.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-616429](https://oktainc.atlassian.net/browse/OKTA-616429)

### Reviewers:

### Screenshot/Video:
**Before:**
![Screenshot 2023-08-23 at 9 57 29 PM](https://github.com/okta/okta-signin-widget/assets/107433508/d3c67c96-c571-453c-be1f-386a2f20cd09)

**After:**
![Screenshot 2023-08-23 at 9 56 06 PM](https://github.com/okta/okta-signin-widget/assets/107433508/b8505567-77cf-45e7-868e-48cfb2838d15)
### Downstream Monolith Build:



