### PR TITLE
OKTA-586895 : SIW Gen 3 : Update SIW container border color

### DIFF
--- a/src/v3/src/components/AuthContainer/AuthContainer.tsx
+++ b/src/v3/src/components/AuthContainer/AuthContainer.tsx
@@ -10,8 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import * as Tokens from '@okta/odyssey-design-tokens';
 import { useMediaQuery } from '@mui/material';
+import * as Tokens from '@okta/odyssey-design-tokens';
 import { Box } from '@okta/odyssey-react-mui';
 import classNames from 'classnames';
 import { FunctionComponent, h } from 'preact';

--- a/src/v3/src/components/AuthContainer/AuthContainer.tsx
+++ b/src/v3/src/components/AuthContainer/AuthContainer.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import * as Tokens from '@okta/odyssey-design-tokens';
 import { useMediaQuery } from '@mui/material';
 import { Box } from '@okta/odyssey-react-mui';
 import classNames from 'classnames';
@@ -41,7 +42,7 @@ const AuthContainer: FunctionComponent<{ hide: boolean }> = ({ children, hide })
         flexDirection="column"
         border={isMobileWidth ? 0 : 1}
         borderRadius={1}
-        borderColor="grey.400"
+        borderColor={Tokens.ColorBorderDisplay}
         bgcolor="common.white"
         fontFamily="fontFamily"
         className={style.siwContainer}

--- a/src/v3/src/components/AuthHeader/AuthHeader.tsx
+++ b/src/v3/src/components/AuthHeader/AuthHeader.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import * as Tokens from '@okta/odyssey-design-tokens';
 import { Box, Typography } from '@okta/odyssey-react-mui';
 import classNames from 'classnames/bind';
 import { FunctionComponent, h } from 'preact';
@@ -67,7 +68,7 @@ const AuthHeader: FunctionComponent<AuthHeaderProps> = ({
         paddingInlineEnd: (theme) => theme.spacing(5),
         paddingBlockEnd: (theme) => theme.spacing(showAuthCoin ? 0 : 4),
         paddingInlineStart: (theme) => theme.spacing(5),
-        borderBlockEnd: (theme) => `1px solid ${theme.palette.grey[400]}`,
+        borderBlockEnd: `1px solid ${Tokens.ColorBorderDisplay}`,
       }}
     >
       <Typography variant="h1">


### PR DESCRIPTION
## Description:
Design has identified that the border color for the Gen 3 SIW is too dark and provided the appropriate Odyssey token we should use. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-586895](https://oktainc.atlassian.net/browse/OKTA-586895)

### Reviewers:

### Screenshot/Video:
Before: 
<img width="549" alt="image" src="https://github.com/okta/okta-signin-widget/assets/97472729/938bc53d-a844-4a77-ad88-f52792dbc73c">

After:
<img width="582" alt="Screenshot 2023-08-24 at 1 07 21 PM" src="https://github.com/okta/okta-signin-widget/assets/97472729/9ec60541-dd8c-497d-ad57-aed19689729c">
<img width="623" alt="Screenshot 2023-08-24 at 1 07 28 PM" src="https://github.com/okta/okta-signin-widget/assets/97472729/5417832d-a3af-44d0-bac9-9a4b72aa9d38">


### Downstream Monolith Build:



