### PR TITLE
fix for multiple ov in classics

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -275,6 +275,7 @@ factor.totpHard.yubikey = YubiKey
 factor.totpHard.yubikey.description = Insert your YubiKey and tap it to get a verification code.
 factor.totpHard.yubikey.placeholder = Click here, then tap your YubiKey
 factor.oktaVerifyPush = Okta Verify
+factor.oktaVerifyPushWithType = Okta Verify Push
 factor.push.description = Use a push notification sent to the mobile app.
 factor.duo = Duo Security
 factor.duo.description = Use Push Notification, SMS, or Voice call to authenticate.

--- a/playground/mocks/data/api/v1/authn/mfa-enroll-multiple-ov.json
+++ b/playground/mocks/data/api/v1/authn/mfa-enroll-multiple-ov.json
@@ -1,0 +1,172 @@
+{
+  "stateToken": "00ru8RamDs4FkMmv8rN1tLqEcNnr0M6g-_3u2KEwmL",
+  "expiresAt": "2023-08-24T20:40:28.000Z",
+  "status": "MFA_REQUIRED",
+  "_embedded": {
+      "user": {
+          "id": "00u4knrrv0ZGWmGy90g7",
+          "passwordChanged": "2023-08-21T20:19:09.000Z",
+          "profile": {
+              "login": "test@test.com",
+              "firstName": "testuser",
+              "lastName": "testuser",
+              "locale": "en_US",
+              "timeZone": "America/Los_Angeles"
+          }
+      },
+      "factorTypes": [
+          {
+              "factorType": "token:software:totp",
+              "_links": {
+                  "next": {
+                      "name": "verify",
+                      "href": "https://praveentest.trexcloud.com/api/v1/authn/factors/token:software:totp/verify",
+                      "hints": {
+                          "allow": [
+                              "POST"
+                          ]
+                      }
+                  }
+              }
+          },
+          {
+              "factorType": "push",
+              "_links": {
+                  "next": {
+                      "name": "verify",
+                      "href": "https://praveentest.trexcloud.com/api/v1/authn/factors/push/verify",
+                      "hints": {
+                          "allow": [
+                              "POST"
+                          ]
+                      }
+                  }
+              }
+          }
+      ],
+      "factors": [
+          {
+              "id": "opf4kns7bqm0XFJt50g7",
+              "factorType": "push",
+              "provider": "OKTA",
+              "vendorName": "OKTA",
+              "profile": {
+                  "credentialId": "test@test.com",
+                  "deviceType": "SmartPhone_Android",
+                  "keys": [
+                      {
+                          "kty": "RSA",
+                          "use": "sig",
+                          "kid": "default",
+                          "e": "AQAB\n",
+                          "n": "APKXUfXVdcosG0fFkodJNE67QBnXmj83WNXhxhreAX6naUY_Z2NLDTYlzWNJQNiv1JLJQKssDRx3\ncIHfmk5vf8cK6L1ZvCbsZSVrD4IV7AkWf9RN01DgZl-41kq5P-ILm43L1hDpJH2jRu038Ov_3mw3\nSU5vjJGDdtk0lfQCmEGWN7veyuy1W4AsOUsSMtKLHlii9nb0JwDaUqVhTe8sQl8V57pHTIAj6mwT\n4krdcd4HS1jq-9Xdv-YI9j_K_QnkgFsiRmSx_DCbY274G8pDTomWd3-TChSuvntjyn5Q9FgDHat5\n4_2ZLmMYGIMcCp0Y5qQ4LFVonq2X_W0D0ciKdrc=\n"
+                      }
+                  ],
+                  "name": "Pixel 6 Pro",
+                  "platform": "ANDROID",
+                  "version": "13:2023-08-05"
+              },
+              "_links": {
+                  "verify": {
+                      "href": "https://praveentest.trexcloud.com/api/v1/authn/factors/opf4kns7bqm0XFJt50g7/verify",
+                      "hints": {
+                          "allow": [
+                              "POST"
+                          ]
+                      }
+                  }
+              }
+          },
+          {
+              "id": "opf4kns8u1uS0AeUb0g7",
+              "factorType": "push",
+              "provider": "OKTA",
+              "vendorName": "OKTA",
+              "profile": {
+                  "credentialId": "test@test.com",
+                  "deviceType": "SmartPhone_Android",
+                  "keys": [
+                      {
+                          "kty": "RSA",
+                          "use": "sig",
+                          "kid": "default",
+                          "e": "AQAB\n",
+                          "n": "ALqmSCvINm2Luc7iwYwK4by4RKg4lg71acIRycDXKo371K0Wiioa5xggGcZ6zrygDyRlHArBycdh\nGUqnVMqd7KFBjccE0Oq8C2jdDX7q3xgg0mZE3TiwIBiOoIzAHr6jTY3BP88tSNyS-z7RUgrccLl1\n7KVEaBXd-Hdd4cW57MVFlLPCz7XPHcQpTAO6eHDFAm78qH2Unpi64lwGAf9IdspBY80ybXqKaQWu\nkgurppE7oQ3oHnNFHfOX7PMqunpciyFlnnjytp67uH1UprM30Qjfm8rWmU2RpGyGWWepcTW8r83m\nW5KEs9OaLJpNxv3fhIGHAjI22CrQbxiIn1fNW2M=\n"
+                      }
+                  ],
+                  "name": "Pixel 6 Pro",
+                  "platform": "ANDROID",
+                  "version": "13:2023-08-05"
+              },
+              "_links": {
+                  "verify": {
+                      "href": "https://praveentest.trexcloud.com/api/v1/authn/factors/opf4kns8u1uS0AeUb0g7/verify",
+                      "hints": {
+                          "allow": [
+                              "POST"
+                          ]
+                      }
+                  }
+              }
+          },
+          {
+              "id": "ost4kns8u3cF6Z8M70g7",
+              "factorType": "token:software:totp",
+              "provider": "OKTA",
+              "vendorName": "OKTA",
+              "profile": {
+                  "credentialId": "test@test.com"
+              },
+              "_links": {
+                  "verify": {
+                      "href": "https://praveentest.trexcloud.com/api/v1/authn/factors/ost4kns8u3cF6Z8M70g7/verify",
+                      "hints": {
+                          "allow": [
+                              "POST"
+                          ]
+                      }
+                  }
+              }
+          },
+          {
+              "id": "ost4kns7brh3fpFHm0g7",
+              "factorType": "token:software:totp",
+              "provider": "OKTA",
+              "vendorName": "OKTA",
+              "profile": {
+                  "credentialId": "test@test.com"
+              },
+              "_links": {
+                  "verify": {
+                      "href": "https://praveentest.trexcloud.com/api/v1/authn/factors/ost4kns7brh3fpFHm0g7/verify",
+                      "hints": {
+                          "allow": [
+                              "POST"
+                          ]
+                      }
+                  }
+              }
+          }
+      ],
+      "policy": {
+          "allowRememberDevice": false,
+          "rememberDeviceLifetimeInMinutes": 0,
+          "rememberDeviceByDefault": false,
+          "factorsPolicyInfo": {
+              "opf4kns7bqm0XFJt50g7": {
+                  "autoPushEnabled": false
+              }
+          }
+      }
+  },
+  "_links": {
+      "cancel": {
+          "href": "https://praveentest.trexcloud.com/api/v1/authn/cancel",
+          "hints": {
+              "allow": [
+                  "POST"
+              ]
+          }
+      }
+  }
+}

--- a/playground/mocks/data/api/v1/authn/mfa-enroll-single-ov.json
+++ b/playground/mocks/data/api/v1/authn/mfa-enroll-single-ov.json
@@ -1,0 +1,91 @@
+{
+  "stateToken": "007y_IdIc0TRDhwEG3cv647ZT4Xyfb_AtbYBlTgn8q",
+  "expiresAt": "2023-08-24T20:35:57.000Z",
+  "status": "MFA_REQUIRED",
+  "_embedded": {
+      "user": {
+          "id": "00u4kns6uuYji781p0g7",
+          "passwordChanged": "2023-08-21T22:02:11.000Z",
+          "profile": {
+              "login": "test2@test.com",
+              "firstName": "test2",
+              "lastName": "test2",
+              "locale": "en_US",
+              "timeZone": "America/Los_Angeles"
+          }
+      },
+      "factors": [
+          {
+              "id": "opf4knscsenWzl7Hd0g7",
+              "factorType": "push",
+              "provider": "OKTA",
+              "vendorName": "OKTA",
+              "profile": {
+                  "credentialId": "test2@test.com",
+                  "deviceType": "SmartPhone_Android",
+                  "keys": [
+                      {
+                          "kty": "RSA",
+                          "use": "sig",
+                          "kid": "default",
+                          "e": "AQAB",
+                          "n": "ntRK79dvfGfd9_o5-oinJA7W9-Hde-u83GDTrDLxjUveqXLZ5bHQXjJbY1flakiokVnyvNMSgaFJG0jNownQztB3CM6tzybfaEPC4Otxl5r4oFI5JwY5SitnxEJmtZDylOgi90bJp_90-6PSbc6hfP4FPvaPQqEZk2f14ExXFHEvU8aC6JLcKOYB8eA5j4khHarW2iW0l-UC-cTvYu1JSaZJXucHeP1ySJ8eUP3qA6pGZbirYJ8Dj79fCrbM1T-bqeVPPzA2Msr8KMThVnJC8fimiuGuJ_eSul8hli2kNaYEmTNjn8nI9my2neK85xfouUqFzg7pFcSN_v6w5ENsEQ"
+                      }
+                  ],
+                  "name": "Pixel 6 Pro",
+                  "platform": "ANDROID",
+                  "version": "33"
+              },
+              "_links": {
+                  "verify": {
+                      "href": "https://praveentest.trexcloud.com/api/v1/authn/factors/opf4knscsenWzl7Hd0g7/verify",
+                      "hints": {
+                          "allow": [
+                              "POST"
+                          ]
+                      }
+                  }
+              }
+          },
+          {
+              "id": "ost4knscsgwWtabwT0g7",
+              "factorType": "token:software:totp",
+              "provider": "OKTA",
+              "vendorName": "OKTA",
+              "profile": {
+                  "credentialId": "test2@test.com"
+              },
+              "_links": {
+                  "verify": {
+                      "href": "https://praveentest.trexcloud.com/api/v1/authn/factors/ost4knscsgwWtabwT0g7/verify",
+                      "hints": {
+                          "allow": [
+                              "POST"
+                          ]
+                      }
+                  }
+              }
+          }
+      ],
+      "policy": {
+          "allowRememberDevice": false,
+          "rememberDeviceLifetimeInMinutes": 0,
+          "rememberDeviceByDefault": false,
+          "factorsPolicyInfo": {
+              "opf4knscsenWzl7Hd0g7": {
+                  "autoPushEnabled": false
+              }
+          }
+      }
+  },
+  "_links": {
+      "cancel": {
+          "href": "https://praveentest.trexcloud.com/api/v1/authn/cancel",
+          "hints": {
+              "allow": [
+                  "POST"
+              ]
+          }
+      }
+  }
+}

--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -308,6 +308,9 @@ fn.getFactorNameForFactorType = function(factorType) {
   if (factorType === 'token:software:totp') {
     return 'OKTA_VERIFY';
   }
+  if (factorType === 'push') {
+    return 'OKTA_VERIFY_PUSH';
+  }
   if (factorType === 'webauthn') {
     if (this.settings.get('features.webauthn')) {
       return 'WEBAUTHN';

--- a/src/v1/views/mfa-verify/PushForm.js
+++ b/src/v1/views/mfa-verify/PushForm.js
@@ -15,7 +15,7 @@ import hbs from '@okta/handlebars-inline-precompile';
 import Util from 'util/Util';
 import NumberChallengeView from './NumberChallengeView';
 
-const titleTpl = hbs('{{factorName}} ({{{deviceName}}})');
+const titleTpl = hbs('{{factorName}} {{#if deviceName}} ({{{deviceName}}}) {{/if}}');
 // deviceName is escaped on BaseForm (see BaseForm's template)
 
 const WARNING_TIMEOUT = 30000; // milliseconds
@@ -73,8 +73,10 @@ export default Form.extend({
       }
     });
     this.title = titleTpl({
-      factorName: this.model.get('factorLabel'),
-      deviceName: this.model.get('deviceName'),
+      factorName: this.model.get('deviceName')
+        ? this.model.get('factorLabel') 
+        : loc('factor.oktaVerifyPushWithType', 'login'),
+      deviceName: this.model.get('deviceName')
     });
   },
   setSubmitState: function(ableToSubmit) {

--- a/src/v1/views/mfa-verify/dropdown/FactorsDropDownOptions.js
+++ b/src/v1/views/mfa-verify/dropdown/FactorsDropDownOptions.js
@@ -14,8 +14,7 @@
 import { _, loc } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
 import RouterUtil from 'v1/util/RouterUtil';
-const pushTitleTpl = hbs('{{factorName}} ({{{deviceName}}})');
-
+const pushTitleTpl = hbs('{{factorName}} {{#if deviceName}} ({{{deviceName}}}) {{/if}}');
 // deviceName is escaped on BaseForm (see BaseForm's template)
 
 const action = function(model) {
@@ -72,8 +71,10 @@ const dropdownOptions = {
     className: 'factor-option',
     title: function() {
       return pushTitleTpl({
-        factorName: this.model.get('factorLabel'),
-        deviceName: this.model.get('deviceName'),
+        factorName: this.model.get('deviceName')
+          ? this.model.get('factorLabel') 
+          : loc('factor.oktaVerifyPushWithType', 'login'),
+        deviceName: this.model.get('deviceName')
       });
     },
     action: function() {


### PR DESCRIPTION
## Description:

Multiple Enrollment OV Push is created in OIE and the org is downgraded to Classic.
Actual: Device name is not displayed.
Expected: Device name is displayed.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-588535](https://oktainc.atlassian.net/browse/OKTA-588535)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



