### PR TITLE
OKTA-643896 : SIW Gen3 : Fixing Duo authenticator

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "generate:types": "ttsc --noEmit false --declaration --emitDeclarationOnly --declarationMap",
     "copy:types": "grunt copy:types",
     "build:types": "yarn clean:types && yarn generate:types && yarn copy:types",
-    "test:parity-setup": "mkdir -p test-reports/testcafe && yarn generate-config && yarn workspace v3 dev",
+    "test:parity-setup": "mkdir -p test-reports/testcafe && yarn generate-config && MOCK_DUO=true yarn workspace v3 dev",
     "test:parity-run": "OKTA_SIW_V3=true yarn testcafe -c 2 chrome:headless --reporter spec,xunit:build2/reports/junit/testcafe-results.xml",
     "test:parity-ci": "OKTA_SIW_SKIP_FLAKY=true yarn codegen && run-p -r test:parity-setup test:parity-run",
     "test:parity-ci-flaky": "OKTA_SIW_V3=true OKTA_SIW_ONLY_FLAKY=true yarn test:parity-ci"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "generate:types": "ttsc --noEmit false --declaration --emitDeclarationOnly --declarationMap",
     "copy:types": "grunt copy:types",
     "build:types": "yarn clean:types && yarn generate:types && yarn copy:types",
-    "test:parity-setup": "mkdir -p test-reports/testcafe && yarn generate-config && MOCK_DUO=true yarn workspace v3 dev",
+    "test:parity-setup": "mkdir -p test-reports/testcafe && yarn generate-config && yarn workspace v3 dev:testcafe",
     "test:parity-run": "OKTA_SIW_V3=true yarn testcafe -c 2 chrome:headless --reporter spec,xunit:build2/reports/junit/testcafe-results.xml",
     "test:parity-ci": "OKTA_SIW_SKIP_FLAKY=true yarn codegen && run-p -r test:parity-setup test:parity-run",
     "test:parity-ci-flaky": "OKTA_SIW_V3=true OKTA_SIW_ONLY_FLAKY=true yarn test:parity-ci"

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -22,6 +22,7 @@
     "clean-svg": "svgo -f src/img/authCoinIcons",
     "codegen": "yarn workspace @okta/okta-signin-widget codegen",
     "dev": "yarn codegen && webpack-dev-server --config webpack.dev.config.ts",
+    "dev:testcafe": "yarn codegen && webpack-dev-server --config webpack.testcafe.config.ts",
     "lint": "yarn codegen && eslint .",
     "lint:report": "scripts/buildtools/lint-report.sh",
     "lint:styles": "stylelint **/*.css",

--- a/src/v3/webpack.common.config.ts
+++ b/src/v3/webpack.common.config.ts
@@ -132,8 +132,6 @@ const baseConfig: Partial<Configuration> = {
       'react-dom': 'preact/compat',
       'react/jsx-runtime': 'preact/jsx-runtime',
 
-      'duo_web_sdk': 'duo_web_sdk',
-
       // @mui -> @mui/legacy
       // use the legacy @mui/* bundles for ie11 support
       // https://mui.com/material-ui/guides/minimizing-bundle-size/#legacy-bundle

--- a/src/v3/webpack.common.config.ts
+++ b/src/v3/webpack.common.config.ts
@@ -27,10 +27,6 @@ const getShortGitHash = () => {
   return hash.slice(0, 7);
 };
 
-const {
-  MOCK_DUO
-} = process.env;
-
 const baseConfig: Partial<Configuration> = {
   mode: 'production',
   devtool: 'source-map',
@@ -136,7 +132,7 @@ const baseConfig: Partial<Configuration> = {
       'react-dom': 'preact/compat',
       'react/jsx-runtime': 'preact/jsx-runtime',
 
-      'duo_web_sdk': MOCK_DUO ? resolve(__dirname, 'src/__mocks__/duo_web_sdk') : 'duo_web_sdk',
+      'duo_web_sdk': 'duo_web_sdk',
 
       // @mui -> @mui/legacy
       // use the legacy @mui/* bundles for ie11 support

--- a/src/v3/webpack.common.config.ts
+++ b/src/v3/webpack.common.config.ts
@@ -27,6 +27,10 @@ const getShortGitHash = () => {
   return hash.slice(0, 7);
 };
 
+const {
+  MOCK_DUO
+} = process.env;
+
 const baseConfig: Partial<Configuration> = {
   mode: 'production',
   devtool: 'source-map',
@@ -131,6 +135,8 @@ const baseConfig: Partial<Configuration> = {
       'react-dom/test-utils': 'preact/test-utils',
       'react-dom': 'preact/compat',
       'react/jsx-runtime': 'preact/jsx-runtime',
+
+      'duo_web_sdk': MOCK_DUO ? resolve(__dirname, 'src/__mocks__/duo_web_sdk') : 'duo_web_sdk',
 
       // @mui -> @mui/legacy
       // use the legacy @mui/* bundles for ie11 support

--- a/src/v3/webpack.dev.config.ts
+++ b/src/v3/webpack.dev.config.ts
@@ -82,13 +82,6 @@ const devConfig: Configuration = merge<Partial<Configuration>>(
     output: {
       path: `${PLAYGROUND}/target`,
     },
-    resolve: {
-      alias: {
-        // mock duo
-        '@okta/duo': resolve(PLAYGROUND, '/mocks/spec-duo/duo-mock.js'),
-        duo_web_sdk: resolve(__dirname, 'src/__mocks__/duo_web_sdk'),
-      }
-    },
     plugins: [
       new MiniCssExtractPlugin({
         filename: 'css/okta-sign-in.css',

--- a/src/v3/webpack.testcafe.config.ts
+++ b/src/v3/webpack.testcafe.config.ts
@@ -10,127 +10,22 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import fs from 'fs';
 import { resolve } from 'path';
-
-import nodemon from 'nodemon';
-import webpack from 'webpack';
 import { merge } from 'webpack-merge';
-import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
-import baseConfig from './webpack.common.config';
+import devConfig from './webpack.dev.config';
 
 import type { Configuration } from 'webpack';
-// loads augmented Configuration type containing `devServer` type definition
-import 'webpack-dev-server';
 
-const DEV_SERVER_PORT = 3000;
-const MOCK_SERVER_PORT = 3030;
-
-const WIDGET_RC_JS = resolve(__dirname, '../..', '.widgetrc.js');
-const PLAYGROUND = resolve(__dirname, '../..', 'playground');
-const TARGET = resolve(__dirname, '../..', 'target');
-const ASSETS = resolve(__dirname, '../..', 'assets');
-
-const HOST = process.env.OKTA_SIW_HOST || 'localhost';
-const STATIC_DIRS = [PLAYGROUND, TARGET, ASSETS];
-
-const headers = (() => {
-  if (!process.env.DISABLE_CSP) {
-    // Allow google domains for testing recaptcha
-    const scriptSrc = `script-src http://${HOST}:${DEV_SERVER_PORT} https://www.google.com https://www.gstatic.com`;
-    const styleSrc = `style-src http://${HOST}:${DEV_SERVER_PORT} 'nonce-playground'`;
-
-    return {
-      'Content-Security-Policy': `${scriptSrc}; ${styleSrc};`,
-    };
-  }
-  return;
-})();
-
-if (!fs.existsSync(WIDGET_RC_JS)) {
-  // create default WIDGET_RC if it doesn't exist to simplify the build process
-  fs.copyFileSync(resolve(__dirname, '../..', '.widgetrc.sample.js'), WIDGET_RC_JS);
-}
-
-const devConfig: Configuration = merge<Partial<Configuration>>(
-  baseConfig,
+const testcafeConfig: Configuration = merge<Partial<Configuration>>(
+  devConfig,
   {
-    mode: 'development',
-    devtool: 'source-map',
-    entry: {
-      playground: {
-        import: [
-          `${PLAYGROUND}/main.ts`,
-        ],
-        filename: 'playground.bundle.js',
-      },
-      widget: {
-        import: [
-          // polyfill must appear first in entry point array
-          resolve(__dirname, '../..', './polyfill/modern.js'),
-          resolve(__dirname, 'src/index.ts'),
-        ],
-        filename: 'js/okta-sign-in.js',
-        library: {
-          name: 'OktaSignIn',
-          type: 'umd',
-          export: 'default',
-        },
-      },
-    },
-    output: {
-      path: `${PLAYGROUND}/target`,
-    },
     resolve: {
       alias: {
         'duo_web_sdk': resolve(__dirname, 'src/__mocks__/duo_web_sdk'),
       }
     },
-    plugins: [
-      new MiniCssExtractPlugin({
-        filename: 'css/okta-sign-in.css',
-      }),
-      new webpack.DefinePlugin({
-        DEBUG: true,
-        OMIT_MSWJS: process.env.OMIT_MSWJS === 'true',
-      }),
-    ],
-    devServer: {
-      host: HOST,
-      watchFiles: STATIC_DIRS,
-      static: STATIC_DIRS,
-      historyApiFallback: true,
-      headers,
-      compress: true,
-      port: DEV_SERVER_PORT,
-      proxy: [{
-        context: [
-          '/oauth2/',
-          '/api/v1/',
-          '/idp/idx/',
-          '/login/getimage',
-          '/sso/idps/',
-          '/app/UserHome',
-          '/oauth2/v1/authorize',
-          '/auth/services/',
-          '/.well-known/webfinger'
-        ],
-        target: `http://${HOST}:${MOCK_SERVER_PORT}`
-      }],
-      // https://webpack.js.org/configuration/dev-server/#devserversetupmiddlewares
-      setupMiddlewares(middlewares) {
-        const script = resolve(PLAYGROUND, 'mocks/server.js');
-        const watch = [resolve(PLAYGROUND, 'mocks')];
-        const env = { MOCK_SERVER_PORT, DEV_SERVER_PORT };
-
-        nodemon({ script, watch, env, delay: 50 })
-          ?.on('crash', console.error);
-
-        return middlewares;
-      },
-    },
   },
 );
 
-export default devConfig;
+export default testcafeConfig;

--- a/src/v3/webpack.testcafe.config.ts
+++ b/src/v3/webpack.testcafe.config.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import fs from 'fs';
+import { resolve } from 'path';
+
+import nodemon from 'nodemon';
+import webpack from 'webpack';
+import { merge } from 'webpack-merge';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+
+import baseConfig from './webpack.common.config';
+
+import type { Configuration } from 'webpack';
+// loads augmented Configuration type containing `devServer` type definition
+import 'webpack-dev-server';
+
+const DEV_SERVER_PORT = 3000;
+const MOCK_SERVER_PORT = 3030;
+
+const WIDGET_RC_JS = resolve(__dirname, '../..', '.widgetrc.js');
+const PLAYGROUND = resolve(__dirname, '../..', 'playground');
+const TARGET = resolve(__dirname, '../..', 'target');
+const ASSETS = resolve(__dirname, '../..', 'assets');
+
+const HOST = process.env.OKTA_SIW_HOST || 'localhost';
+const STATIC_DIRS = [PLAYGROUND, TARGET, ASSETS];
+
+const headers = (() => {
+  if (!process.env.DISABLE_CSP) {
+    // Allow google domains for testing recaptcha
+    const scriptSrc = `script-src http://${HOST}:${DEV_SERVER_PORT} https://www.google.com https://www.gstatic.com`;
+    const styleSrc = `style-src http://${HOST}:${DEV_SERVER_PORT} 'nonce-playground'`;
+
+    return {
+      'Content-Security-Policy': `${scriptSrc}; ${styleSrc};`,
+    };
+  }
+  return;
+})();
+
+if (!fs.existsSync(WIDGET_RC_JS)) {
+  // create default WIDGET_RC if it doesn't exist to simplify the build process
+  fs.copyFileSync(resolve(__dirname, '../..', '.widgetrc.sample.js'), WIDGET_RC_JS);
+}
+
+const devConfig: Configuration = merge<Partial<Configuration>>(
+  baseConfig,
+  {
+    mode: 'development',
+    devtool: 'source-map',
+    entry: {
+      playground: {
+        import: [
+          `${PLAYGROUND}/main.ts`,
+        ],
+        filename: 'playground.bundle.js',
+      },
+      widget: {
+        import: [
+          // polyfill must appear first in entry point array
+          resolve(__dirname, '../..', './polyfill/modern.js'),
+          resolve(__dirname, 'src/index.ts'),
+        ],
+        filename: 'js/okta-sign-in.js',
+        library: {
+          name: 'OktaSignIn',
+          type: 'umd',
+          export: 'default',
+        },
+      },
+    },
+    output: {
+      path: `${PLAYGROUND}/target`,
+    },
+    resolve: {
+      alias: {
+        'duo_web_sdk': resolve(__dirname, 'src/__mocks__/duo_web_sdk'),
+      }
+    },
+    plugins: [
+      new MiniCssExtractPlugin({
+        filename: 'css/okta-sign-in.css',
+      }),
+      new webpack.DefinePlugin({
+        DEBUG: true,
+        OMIT_MSWJS: process.env.OMIT_MSWJS === 'true',
+      }),
+    ],
+    devServer: {
+      host: HOST,
+      watchFiles: STATIC_DIRS,
+      static: STATIC_DIRS,
+      historyApiFallback: true,
+      headers,
+      compress: true,
+      port: DEV_SERVER_PORT,
+      proxy: [{
+        context: [
+          '/oauth2/',
+          '/api/v1/',
+          '/idp/idx/',
+          '/login/getimage',
+          '/sso/idps/',
+          '/app/UserHome',
+          '/oauth2/v1/authorize',
+          '/auth/services/',
+          '/.well-known/webfinger'
+        ],
+        target: `http://${HOST}:${MOCK_SERVER_PORT}`
+      }],
+      // https://webpack.js.org/configuration/dev-server/#devserversetupmiddlewares
+      setupMiddlewares(middlewares) {
+        const script = resolve(PLAYGROUND, 'mocks/server.js');
+        const watch = [resolve(PLAYGROUND, 'mocks')];
+        const env = { MOCK_SERVER_PORT, DEV_SERVER_PORT };
+
+        nodemon({ script, watch, env, delay: 50 })
+          ?.on('crash', console.error);
+
+        return middlewares;
+      },
+    },
+  },
+);
+
+export default devConfig;


### PR DESCRIPTION
## Description:

SIW Gen3 was failing to load the DUO iframe due to a build tooling change we made. This PR fixes this issue. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-643896](https://oktainc.atlassian.net/browse/OKTA-643896)

### Reviewers:

### Screenshot/Video:

https://github.com/okta/okta-signin-widget/assets/97472729/ddcaf519-ac07-4bd4-bb4e-8d43487c34f7


### Downstream Monolith Build:



