### PR TITLE
OKTA-645323 fix word break for nicknames

### DIFF
--- a/assets/sass/v2/_select-authenticator.scss
+++ b/assets/sass/v2/_select-authenticator.scss
@@ -3,6 +3,14 @@
   .okta-form-subtitle {
     text-align: center;
   }
+
+  .siw-main-body {
+    span.authenticator-verify-nickname {
+      // inherits from .strong, but overrides word-break
+      @extend .strong;
+      word-break: break-word;
+    }
+  }
 }
 
 .authenticator-enroll-list {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "7.10.0",
+  "version": "7.11.0",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
@@ -42,7 +42,7 @@ const Body = BaseForm.extend(
       let extraNicknameCssClasses = '';
       if (nicknameText !== '') {
         nicknameText = ' (' + nicknameText + ')';
-        extraNicknameCssClasses = 'strong no-translate authenticator-enrollment-nickname';
+        extraNicknameCssClasses = 'strong no-translate authenticator-verify-nickname';
       }
       const nicknameTemplate = nicknameText ? `<span ${ extraNicknameCssClasses ? 
         'class="' + extraNicknameCssClasses + '"' : ''}>

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -62,7 +62,7 @@ const Body = BaseForm.extend(Object.assign(
       let extraNicknameCssClasses = '';
       if (nicknameText !== '') {
         nicknameText = ' (' + nicknameText + ')';
-        extraNicknameCssClasses = 'strong no-translate authenticator-enrollment-nickname';
+        extraNicknameCssClasses = 'no-translate authenticator-verify-nickname';
       }
 
       const nicknameTemplate = nicknameText ? `<span ${ extraNicknameCssClasses ? 'class="' + 


### PR DESCRIPTION
## Description:
Fix text wrap for nicknames

<img width="598" alt="image" src="https://github.com/okta/okta-signin-widget/assets/88336366/d498c5b8-44fc-4d29-a859-988a856f376a">


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-645323](https://oktainc.atlassian.net/browse/OKTA-645323)

### Reviewers:
@glenfannin-okta 
@jaredperreault-okta 

### Screenshot/Video:
<img width="618" alt="image" src="https://github.com/okta/okta-signin-widget/assets/88336366/c0458a18-25a4-4a47-80df-8e2a439ada55">


### Downstream Monolith Build:
