### PR TITLE
OKTA-645397 : SIW G3 : Fix DUO authentication callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 
 ```html
 <!-- Latest CDN production Javascript and CSS -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.9.1/js/okta-sign-in.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.10.0/js/okta-sign-in.min.js" type="text/javascript"></script>
 
-<link href="https://global.oktacdn.com/okta-signin-widget/7.9.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/7.10.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 **NOTE:** The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](https://github.com/okta/okta-signin-widget/releases). We recommend using the latest widget version.
@@ -268,13 +268,13 @@ When using one of the bundles without the polyfill included, you may want to con
 
 ```html
 <!-- Polyfill for older browsers -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.9.1/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.10.0/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
 
 <!-- Widget bundle for Okta Identity Engine -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.9.1/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.10.0/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
 
 <!-- CSS for widget -->
-<link href="https://global.oktacdn.com/okta-signin-widget/7.9.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/7.10.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -241,7 +241,6 @@
     "chokidar": "^3.5.1",
     "clipboard": "^1.5.16",
     "cross-fetch": "^3.1.5",
-    "ejs": "^3.1.7",
     "handlebars": "^4.7.7",
     "jquery": "^3.6.0",
     "parse-ms": "^2.0.0",
@@ -255,7 +254,7 @@
   "resolutions": {
     "chokidar": "^3.5.1",
     "dot-prop": "^5.3.0",
-    "ejs": "^3.1.7",
+    "ejs": "^3.1.9",
     "ini": "^1.3.8",
     "is-installed-globally": "^0.4.0",
     "wait-on/axios": "^0.27.2",
@@ -263,7 +262,10 @@
     "grunt/minimatch": "^3.1.2",
     "**/globule/minimatch": "^3.1.2",
     "ansi-regex": "^5.0.1",
-    "testcafe/**/jsonwebtoken": "^9.0.0"
+    "testcafe/**/jsonwebtoken": "^9.0.0",
+    "**/loader-utils/json5": "^1.0.2",
+    "**/json5": "^2.2.2",
+    "**/semver": "^7.5.4"
   },
   "workspaces": {
     "packages": [

--- a/playground/index.html
+++ b/playground/index.html
@@ -10,6 +10,7 @@
   
   <body>
     <div id="okta-login-container"></div>
+    <script src="/runtime.js"></script>
     <script src="/js/okta-sign-in.js"></script>
     <script src="/js/okta-plugin-a11y.js"></script>
     <script src="/playground.bundle.js"></script>

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-qr-enable-biometrics.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-qr-enable-biometrics.json
@@ -118,41 +118,6 @@
                 "relatesTo": "$.authenticators.value[0]"
               },
               {
-                "label": "Okta Phone",
-                "value": {
-                  "form": {
-                    "value": [
-                      {
-                        "name": "id",
-                        "value": "aid568g3mXgtID0X1SLH",
-                        "mutable": false,
-                        "required": true
-                      },
-                      {
-                        "name": "methodType",
-                        "required": false,
-                        "options": [
-                          {
-                            "label": "SMS",
-                            "value": "sms"
-                          },
-                          {
-                            "label": "VOICE",
-                            "value": "voice"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "phoneNumber",
-                        "required": false,
-                        "type": "string"
-                      }
-                    ]
-                  }
-                },
-                "relatesTo": "$.authenticators.value[2]"
-              },
-              {
                 "label": "Security Key or Biometric Authenticator (FIDO2)",
                 "value": {
                   "form": {
@@ -177,21 +142,39 @@
                 "relatesTo": "$.authenticators.value[1]"
               },
               {
-                "label": "Okta Security Question",
+                "label": "Okta Verify",
                 "value": {
                   "form": {
                     "value": [
                       {
                         "name": "id",
-                        "value": "aid568g3mXgtID0X1GGG",
+                        "value": "auteq0lLiL9o1cYoN0g4",
                         "required": true,
-                        "mutable": false,
-                        "visible": false
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "options": [
+                          {
+                            "value": "signed_nonce",
+                            "label": "Use Okta FastPass"
+                          },
+                          {
+                            "value": "push",
+                            "label": "Get a push notification"
+                          },
+                          {
+                            "value": "totp",
+                            "label": "Enter a code"
+                          }
+                        ],
+                        "required": true,
+                        "mutable": false
                       }
                     ]
                   }
                 },
-                "relatesTo": "$.authenticators.value[3]"
+                "relatesTo": "$.authenticators.value[2]"
               }
             ]
           },

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-qr-version-upgrade-non-ios.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-qr-version-upgrade-non-ios.json
@@ -118,35 +118,6 @@
                   "relatesTo": "$.authenticators.value[0]"
                 },
                 {
-                  "label": "Okta Phone",
-                  "value": {
-                    "form": {
-                      "value": [
-                        {
-                          "name": "id",
-                          "value": "aid568g3mXgtID0X1SLH",
-                          "mutable": false,
-                          "required": true
-                      },
-                      {
-                          "name": "methodType",
-                          "required": false,
-                          "options": [
-                              { "label": "SMS", "value": "sms" },
-                              { "label": "VOICE", "value": "voice" }
-                          ]
-                      },
-                      {
-                          "name": "phoneNumber",
-                          "required": false,
-                          "type": "string"
-                      }
-                      ]
-                    }
-                  },
-                  "relatesTo": "$.authenticators.value[2]"
-                },
-                {
                   "label": "Security Key or Biometric Authenticator (FIDO2)",
                   "value": {
                     "form": {
@@ -171,21 +142,39 @@
                   "relatesTo": "$.authenticators.value[1]"
                 },
                 {
-                  "label": "Okta Security Question",
+                  "label": "Okta Verify",
                   "value": {
                     "form": {
                       "value": [
                         {
                           "name": "id",
-                          "value": "aid568g3mXgtID0X1GGG",
+                          "value": "auteq0lLiL9o1cYoN0g4",
                           "required": true,
-                          "mutable": false,
-                          "visible": false
+                          "mutable": false
+                        },
+                        {
+                          "name": "methodType",
+                          "options": [
+                            {
+                              "value": "signed_nonce",
+                              "label": "Use Okta FastPass"
+                            },
+                            {
+                              "value": "push",
+                              "label": "Get a push notification"
+                            },
+                            {
+                              "value": "totp",
+                              "label": "Enter a code"
+                            }
+                          ],
+                          "required": true,
+                          "mutable": false
                         }
                       ]
                     }
                   },
-                  "relatesTo": "$.authenticators.value[3]"
+                  "relatesTo": "$.authenticators.value[2]"
                 }
               ]
             },

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-qr-version-upgrade.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-qr-version-upgrade.json
@@ -118,35 +118,6 @@
                   "relatesTo": "$.authenticators.value[0]"
                 },
                 {
-                  "label": "Okta Phone",
-                  "value": {
-                    "form": {
-                      "value": [
-                        {
-                          "name": "id",
-                          "value": "aid568g3mXgtID0X1SLH",
-                          "mutable": false,
-                          "required": true
-                      },
-                      {
-                          "name": "methodType",
-                          "required": false,
-                          "options": [
-                              { "label": "SMS", "value": "sms" },
-                              { "label": "VOICE", "value": "voice" }
-                          ]
-                      },
-                      {
-                          "name": "phoneNumber",
-                          "required": false,
-                          "type": "string"
-                      }
-                      ]
-                    }
-                  },
-                  "relatesTo": "$.authenticators.value[2]"
-                },
-                {
                   "label": "Security Key or Biometric Authenticator (FIDO2)",
                   "value": {
                     "form": {
@@ -171,21 +142,39 @@
                   "relatesTo": "$.authenticators.value[1]"
                 },
                 {
-                  "label": "Okta Security Question",
+                  "label": "Okta Verify",
                   "value": {
                     "form": {
                       "value": [
                         {
                           "name": "id",
-                          "value": "aid568g3mXgtID0X1GGG",
+                          "value": "auteq0lLiL9o1cYoN0g4",
                           "required": true,
-                          "mutable": false,
-                          "visible": false
+                          "mutable": false
+                        },
+                        {
+                          "name": "methodType",
+                          "options": [
+                            {
+                              "value": "signed_nonce",
+                              "label": "Use Okta FastPass"
+                            },
+                            {
+                              "value": "push",
+                              "label": "Get a push notification"
+                            },
+                            {
+                              "value": "totp",
+                              "label": "Enter a code"
+                            }
+                          ],
+                          "required": true,
+                          "mutable": false
                         }
                       ]
                     }
                   },
-                  "relatesTo": "$.authenticators.value[3]"
+                  "relatesTo": "$.authenticators.value[2]"
                 }
               ]
             },

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-qr.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-qr.json
@@ -118,35 +118,6 @@
                 "relatesTo": "$.authenticators.value[0]"
               },
               {
-                "label": "Okta Phone",
-                "value": {
-                  "form": {
-                    "value": [
-                      {
-                        "name": "id",
-                        "value": "aid568g3mXgtID0X1SLH",
-                        "mutable": false,
-                        "required": true
-                    },
-                    {
-                        "name": "methodType",
-                        "required": false,
-                        "options": [
-                            { "label": "SMS", "value": "sms" },
-                            { "label": "VOICE", "value": "voice" }
-                        ]
-                    },
-                    {
-                        "name": "phoneNumber",
-                        "required": false,
-                        "type": "string"
-                    }
-                    ]
-                  }
-                },
-                "relatesTo": "$.authenticators.value[2]"
-              },
-              {
                 "label": "Security Key or Biometric Authenticator (FIDO2)",
                 "value": {
                   "form": {
@@ -171,21 +142,39 @@
                 "relatesTo": "$.authenticators.value[1]"
               },
               {
-                "label": "Okta Security Question",
+                "label": "Okta Verify",
                 "value": {
-                  "form": {
-                    "value": [
-                      {
-                        "name": "id",
-                        "value": "aid568g3mXgtID0X1GGG",
-                        "required": true,
-                        "mutable": false,
-                        "visible": false
-                      }
-                    ]
-                  }
+                    "form": {
+                        "value": [
+                            {
+                                "name": "id",
+                                "required": true,
+                                "value": "aut2h3fft4y9pDPCS1d7",
+                                "mutable": false
+                            },
+                            {
+                                "name": "channel",
+                                "type": "string",
+                                "required": false,
+                                "options": [
+                                    {
+                                        "label": "QRCODE",
+                                        "value": "qrcode"
+                                    },
+                                    {
+                                        "label": "EMAIL",
+                                        "value": "email"
+                                    },
+                                    {
+                                        "label": "SMS",
+                                        "value": "sms"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
                 },
-                "relatesTo": "$.authenticators.value[3]"
+                "relatesTo": "$.authenticators.value[2]"
               }
             ]
           },

--- a/playground/mocks/data/idp/idx/authenticator-verification-number-challenge.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-number-challenge.json
@@ -96,7 +96,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[2]"
+                "relatesTo": "$.authenticators.value[1]"
               }
             ]
           },
@@ -144,6 +144,37 @@
         ]
       }
     }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "catalogKey": "okta_verify",
+        "authenticatorId": "aut1erh5wK1M8wA3g0g4",
+        "authenticatorName": "Okta Verify",
+        "methods": [
+          {
+            "methodType": "signed_nonce"
+          },
+          {
+            "methodType": "push"
+          },
+          {
+            "methodType": "totp"
+          }
+        ]
+      },
+      {
+        "catalogKey": "okta_password",
+        "authenticatorId": "aidtmbseAWnMPtLe20g3",
+        "authenticatorName": "Okta Password",
+        "methods": [
+          {
+            "methodType": "password"
+          }
+        ]
+      }
+    ]
   },
   "user": {
     "type": "object",

--- a/playground/mocks/data/idp/idx/error-400-user-not-assigned.json
+++ b/playground/mocks/data/idp/idx/error-400-user-not-assigned.json
@@ -115,5 +115,13 @@
       "label":"oktaprise",
       "id":"0oa14q13b78mZ5dVy1d8"
     }
+  },
+  "authenticatorChallenge": {
+    "type": "object",
+    "value": {
+      "challengeMethod": "CUSTOM_URI",
+      "href": "com-okta-authenticator:/deviceChallenge?challengeRequest=abcd.1234.5678",
+      "downloadHref": "https://apps.apple.com/us/app/okta-verify/id490179405"
+    }
   }
 }

--- a/playground/runtime.js
+++ b/playground/runtime.js
@@ -1,0 +1,1 @@
+// For v3 `runtime.js` will be provided by webpack when using `runtimeChunk: 'single'`

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -9,13 +9,13 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 
 ```html
 <!-- Polyfill for older browsers -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.9.1/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.10.0/js/okta-sign-in.polyfill.min.js" type="text/javascript"></script>
 
 <!-- Widget bundle for Okta Identity Engine -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.9.1/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.10.0/js/okta-sign-in.oie.min.js" type="text/javascript"></script>
 
 <!-- CSS for widget -->
-<link href="https://global.oktacdn.com/okta-signin-widget/7.9.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/7.10.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 **NOTE:** The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](https://github.com/okta/okta-signin-widget/releases). We recommend using the latest widget version.

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -44,7 +44,7 @@
     "@mui/material": "^5.8.5",
     "@okta/odyssey-design-tokens": "^0.17.1",
     "@okta/odyssey-react-mui": "^0.17.0",
-    "@okta/okta-auth-js": "^7.2.0",
+    "@okta/okta-auth-js": "^7.4.2",
     "babel-jest": "^27.3.1",
     "chroma-js": "^2.4.2",
     "classnames": "^2.3.1",

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -67,6 +67,8 @@
     "@okta/odyssey-babel-loader": "^0.17.1",
     "@okta/odyssey-babel-preset": "^0.17.1",
     "@okta/odyssey-postcss-preset": "^0.15.3",
+    "@prefresh/babel-plugin": "^0.5.0",
+    "@prefresh/webpack": "^4.0.0",
     "@testcafe-community/axe": "^3.5.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/preact": "^2.0.1",

--- a/src/v3/src/components/Checkbox/Checkbox.tsx
+++ b/src/v3/src/components/Checkbox/Checkbox.tsx
@@ -123,4 +123,5 @@ const Checkbox: UISchemaElementComponent<UISchemaElementComponentWithValidationP
   );
 };
 
-export default withFormValidationState(Checkbox);
+const WrappedCheckbox = withFormValidationState(Checkbox);
+export default WrappedCheckbox;

--- a/src/v3/src/components/ConsentHeader/ConsentHeader.tsx
+++ b/src/v3/src/components/ConsentHeader/ConsentHeader.tsx
@@ -16,7 +16,7 @@ import { Box, Typography } from '@okta/odyssey-react-mui';
 import { escape } from 'lodash';
 import { Fragment, FunctionComponent, h } from 'preact';
 
-import { CONSENT_HEADER_STEPS, IDX_STEP } from '../../constants';
+import { IDX_STEP } from '../../constants';
 import { useWidgetContext } from '../../contexts';
 import { useHtmlContentParser } from '../../hooks';
 import { getAppInfo, getHeadingReplacerFn, loc } from '../../util';
@@ -40,11 +40,6 @@ const ConsentHeader: FunctionComponent = () => {
     granularConsentTitle,
     { replace: getHeadingReplacerFn({}, 'h2', 2, 6) },
   );
-
-  if (!idxTransaction?.nextStep || !CONSENT_HEADER_STEPS.includes(idxTransaction.nextStep.name)) {
-    return null;
-  }
-  const stepName = idxTransaction.nextStep.name;
 
   const getAppLogo = (altText: string, logoHref?: string) => (
     typeof logoHref !== 'undefined' && (
@@ -90,6 +85,7 @@ const ConsentHeader: FunctionComponent = () => {
   };
 
   const getHeaderContent = () => {
+    const stepName = idxTransaction!.nextStep!.name;
     if ([IDX_STEP.CONSENT_ADMIN, IDX_STEP.CONSENT_ENDUSER].includes(stepName)) {
       // @ts-expect-error OKTA-598777 authentication missing from IdxContext interface
       const { rawIdxState: { authentication: { value: { issuer } } = {} } } = idxTransaction;

--- a/src/v3/src/components/DuoWindow/DuoWindow.tsx
+++ b/src/v3/src/components/DuoWindow/DuoWindow.tsx
@@ -43,10 +43,14 @@ const DuoWindow: UISchemaElementComponent<{
         sig_request: signedToken,
         iframe: 'duo_iframe',
 
-        // @ts-expect-error type mismatch on post_action
-        post_action: (signedData: string) => {
+        submit_callback: (duoForm: HTMLFormElement) => {
+          const formInput = duoForm.getElementsByTagName('input')?.[0];
+          if (!formInput) {
+            console.error('DUO callback form element does not exist.');
+            return;
+          }
           handleDuoAuthSuccess({
-            params: { 'credentials.signatureData': signedData },
+            params: { 'credentials.signatureData': formInput.value },
             step,
           });
         },

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -191,4 +191,5 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
   );
 };
 
-export default withFormValidationState(InputPassword);
+const WrappedInputPassword = withFormValidationState(InputPassword);
+export default WrappedInputPassword;

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -156,4 +156,5 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
   );
 };
 
-export default withFormValidationState(InputText);
+const WrappedInputText = withFormValidationState(InputText);
+export default WrappedInputText;

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -74,6 +74,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
   const countryLabel = getTranslation(translations, 'country');
   const optionalLabel = getTranslation(translations, 'optionalLabel');
 
+  const { features: { disableAutocomplete } = {} } = widgetProps;
   const countries = CountryUtil.getCountries() as Record<string, string>;
   const [phone, setPhone] = useState<string>('');
   // Sets the default country code
@@ -147,7 +148,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
           }}
           inputProps={{
             'data-se': 'extension',
-            autocomplete: 'tel-extension',
+            autocomplete: disableAutocomplete ? 'off' : 'tel-extension',
             'aria-describedby': ariaDescribedBy,
           }}
         />
@@ -201,7 +202,7 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
         inputRef={focusRef}
         inputProps={{
           'data-se': 'country',
-          autocomplete: 'tel-country-code',
+          autocomplete: disableAutocomplete ? 'off' : 'tel-country-code',
           'aria-describedby': ariaDescribedBy,
         }}
       >

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -302,4 +302,5 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
   );
 };
 
-export default withFormValidationState(PhoneAuthenticator);
+const WrappedPhoneAuthenticator = withFormValidationState(PhoneAuthenticator);
+export default WrappedPhoneAuthenticator;

--- a/src/v3/src/components/Radio/Radio.tsx
+++ b/src/v3/src/components/Radio/Radio.tsx
@@ -131,4 +131,5 @@ const Radio: UISchemaElementComponent<UISchemaElementComponentWithValidationProp
   );
 };
 
-export default withFormValidationState(Radio);
+const WrappedRadio = withFormValidationState(Radio);
+export default WrappedRadio;

--- a/src/v3/src/components/Select/Select.tsx
+++ b/src/v3/src/components/Select/Select.tsx
@@ -154,4 +154,5 @@ const Select: UISchemaElementComponent<UISchemaElementComponentWithValidationPro
   );
 };
 
-export default withFormValidationState(Select);
+const WrappedSelect = withFormValidationState(Select);
+export default WrappedSelect;

--- a/src/v3/src/components/Title/Title.tsx
+++ b/src/v3/src/components/Title/Title.tsx
@@ -49,7 +49,7 @@ const Title: UISchemaElementComponent<{
           outline: 'none',
         }}
       >
-        {options?.content}
+        {options.content}
       </Typography>
     </Box>
   );

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -55,6 +55,7 @@ import {
 import {
   areTransactionsEqual,
   buildAuthCoinProps,
+  canBootstrapWidget,
   getLanguageCode,
   getLanguageDirection,
   isAndroidOrIOS,
@@ -327,12 +328,18 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
   // bootstrap / resume the widget
   useEffect(() => {
+    if (!canBootstrapWidget({
+      authClient, stateHandle, setIdxTransaction, setResponseError,
+    })) {
+      return;
+    }
+
     if (authClient.idx.canProceed()) {
       resume();
     } else {
       bootstrap();
     }
-  }, [authClient, setIdxTransaction, bootstrap, resume]);
+  }, [authClient, setIdxTransaction, bootstrap, resume, stateHandle]);
 
   // Update idxTransaction when new status comes back from polling
   useEffect(() => {

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -56,10 +56,13 @@ import {
   areTransactionsEqual,
   buildAuthCoinProps,
   canBootstrapWidget,
+  escape,
+  extractPageTitle,
   getLanguageCode,
   getLanguageDirection,
   isAndroidOrIOS,
   isAuthClientSet,
+  isConsentStep,
   isOauth2Enabled,
   loadLanguage,
   SessionStorage,
@@ -394,12 +397,25 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const toggleVisibility = useCallback((hideValue: boolean) => {
     setHide(hideValue);
   }, []);
+
   useOnce(() => {
     eventEmitter?.on('hide', toggleVisibility);
   });
+
   useEffect(() => () => {
     eventEmitter?.off('hide', toggleVisibility);
   }, [eventEmitter, toggleVisibility]);
+
+  const getDocumentTitle = useCallback(() => (
+    escape(extractPageTitle(formBag.uischema, widgetProps, idxTransaction))
+  ), [idxTransaction, widgetProps, formBag.uischema]);
+
+  useEffect(() => {
+    const title = getDocumentTitle();
+    if (title !== null) {
+      document.title = title;
+    }
+  }, [getDocumentTitle]);
 
   return (
     <WidgetContextProvider value={{
@@ -447,7 +463,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
                 authCoinProps={buildAuthCoinProps(idxTransaction)}
               />
               <AuthContent>
-                <ConsentHeader />
+                {isConsentStep(idxTransaction) && <ConsentHeader />}
                 <IdentifierContainer />
                 {
                   uischema.elements.length > 0

--- a/src/v3/src/components/hocs/getDisplayName.ts
+++ b/src/v3/src/components/hocs/getDisplayName.ts
@@ -10,10 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { FieldElement, RendererComponent } from '../../types';
+import { FieldElement, UISchemaElementComponent } from '../../types';
 
 export const getDisplayName = (
-  WrappedComponent: RendererComponent<{ uischema: FieldElement }>,
+  WrappedComponent: UISchemaElementComponent<{ uischema: FieldElement }>,
 ): string => (
   WrappedComponent.displayName || WrappedComponent.name || 'Component'
 );

--- a/src/v3/src/components/hocs/withFormValidationState.tsx
+++ b/src/v3/src/components/hocs/withFormValidationState.tsx
@@ -28,6 +28,15 @@ export type WrappedFunctionComponent<T> = (
   Component: UISchemaElementComponent<T>
 ) => RendererComponent<T>;
 
+/**
+ * Please name your wrapped component while exporting
+ * This is needed for fast-refresh
+ * @see https://github.com/preactjs/prefresh#recognition
+ *
+ * @example
+ *  const WrappedSelect = withFormValidationState(Select);
+ *  export default WrappedSelect;
+ */
 export const withFormValidationState: WrappedFunctionComponent<
 { uischema: FieldElement }> = (Component) => {
   const ParentComponent: RendererComponent<
@@ -82,6 +91,6 @@ export const withFormValidationState: WrappedFunctionComponent<
     // eslint-disable-next-line react/jsx-props-no-spreading
     return <Component {...combinedProps} />;
   };
-  ParentComponent.displayName = `WithFormValidationState(${getDisplayName(ParentComponent)})`;
+  ParentComponent.displayName = `WithFormValidationState(${getDisplayName(Component)})`;
   return ParentComponent;
 };

--- a/src/v3/src/global.d.ts
+++ b/src/v3/src/global.d.ts
@@ -15,3 +15,4 @@ import JSX = preact.JSX;
 
 declare const OKTA_SIW_COMMIT_HASH: string;
 declare const OKTA_SIW_VERSION: string;
+declare const __PREFRESH__: Record<string, unknown> | undefined;

--- a/src/v3/src/mocks/response/idp/idx/credential/enroll/enroll-ov-qr-version-upgrade.json
+++ b/src/v3/src/mocks/response/idp/idx/credential/enroll/enroll-ov-qr-version-upgrade.json
@@ -118,41 +118,6 @@
                 "relatesTo": "$.authenticators.value[0]"
               },
               {
-                "label": "Okta Phone",
-                "value": {
-                  "form": {
-                    "value": [
-                      {
-                        "name": "id",
-                        "value": "aid568g3mXgtID0X1SLH",
-                        "mutable": false,
-                        "required": true
-                      },
-                      {
-                        "name": "methodType",
-                        "required": false,
-                        "options": [
-                          {
-                            "label": "SMS",
-                            "value": "sms"
-                          },
-                          {
-                            "label": "VOICE",
-                            "value": "voice"
-                          }
-                        ]
-                      },
-                      {
-                        "name": "phoneNumber",
-                        "required": false,
-                        "type": "string"
-                      }
-                    ]
-                  }
-                },
-                "relatesTo": "$.authenticators.value[2]"
-              },
-              {
                 "label": "Security Key or Biometric Authenticator (FIDO2)",
                 "value": {
                   "form": {
@@ -177,21 +142,39 @@
                 "relatesTo": "$.authenticators.value[1]"
               },
               {
-                "label": "Okta Security Question",
+                "label": "Okta Verify",
                 "value": {
                   "form": {
                     "value": [
                       {
                         "name": "id",
-                        "value": "aid568g3mXgtID0X1GGG",
+                        "value": "auteq0lLiL9o1cYoN0g4",
                         "required": true,
-                        "mutable": false,
-                        "visible": false
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "options": [
+                          {
+                            "value": "signed_nonce",
+                            "label": "Use Okta FastPass"
+                          },
+                          {
+                            "value": "push",
+                            "label": "Get a push notification"
+                          },
+                          {
+                            "value": "totp",
+                            "label": "Enter a code"
+                          }
+                        ],
+                        "required": true,
+                        "mutable": false
                       }
                     ]
                   }
                 },
-                "relatesTo": "$.authenticators.value[3]"
+                "relatesTo": "$.authenticators.value[2]"
               }
             ]
           },

--- a/src/v3/src/transformer/field/attributes.test.ts
+++ b/src/v3/src/transformer/field/attributes.test.ts
@@ -11,32 +11,16 @@
  */
 
 import { Input } from '@okta/okta-auth-js';
-import { WidgetProps } from 'src/types';
 
 import { transformer } from './attributes';
 
 describe('Attributes transformer', () => {
-  let widgetProps: WidgetProps;
-
-  beforeEach(() => {
-    widgetProps = {};
-  });
-
   it('should return uischema object with options.attributes.autocomplete === "username" if formfield.name === "identifier" is present in ion object', () => {
     const formfield: Input = { name: 'identifier' };
 
     const result = { attributes: { autocomplete: 'username' } };
 
-    expect(transformer(formfield, widgetProps)).toEqual(result);
-  });
-
-  it('should return uischema object with options.attributes.autocomplete === "off" when features.disableAutocomplete === "false"', () => {
-    const formfield: Input = { name: 'identifier' };
-    widgetProps = { features: { disableAutocomplete: true } };
-
-    const result = { attributes: { autocomplete: 'off' } };
-
-    expect(transformer(formfield, widgetProps)).toEqual(result);
+    expect(transformer(formfield)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "current-password" if formfield.name === "password" is present in ion object', () => {
@@ -44,7 +28,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'current-password' } };
 
-    expect(transformer(formfield, widgetProps)).toEqual(result);
+    expect(transformer(formfield)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "current-password" if formfield.name === "newPassword" is present in ion object', () => {
@@ -52,7 +36,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'current-password' } };
 
-    expect(transformer(formfield, widgetProps)).toEqual(result);
+    expect(transformer(formfield)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "current-password" if formfield.name === "passcode" & formfield.secret === true is present in ion object', () => {
@@ -60,7 +44,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'current-password' } };
 
-    expect(transformer(formfield, widgetProps)).toEqual(result);
+    expect(transformer(formfield)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "one-time-code" and options.attributes.inputmode === "numeric" if formfield.name === "passcode" & secret property doesnt exist in ion object when on ios device', () => {
@@ -72,7 +56,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'one-time-code', inputmode: 'numeric' } };
 
-    expect(transformer(formfield, widgetProps)).toEqual(result);
+    expect(transformer(formfield)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "off" if formfield.name === "passcode" & secret property doesnt exist in ion object when on desktop', () => {
@@ -84,7 +68,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'off', inputmode: 'numeric' } };
 
-    expect(transformer(formfield, widgetProps)).toEqual(result);
+    expect(transformer(formfield)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "one-time-code" if formfield.name === "totp" is present in ion object when on ios device', () => {
@@ -96,7 +80,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'one-time-code', inputmode: 'numeric' } };
 
-    expect(transformer(formfield, widgetProps)).toEqual(result);
+    expect(transformer(formfield)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "off" if formfield.name === "totp" is present in ion object when on desktop', () => {
@@ -108,7 +92,7 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'off', inputmode: 'numeric' } };
 
-    expect(transformer(formfield, widgetProps)).toEqual(result);
+    expect(transformer(formfield)).toEqual(result);
   });
 
   it('should return uischema object with options.attributes.autocomplete === "tel-national" if formfield.name === "phoneNumber" is present in ion object', () => {
@@ -116,6 +100,6 @@ describe('Attributes transformer', () => {
 
     const result = { attributes: { autocomplete: 'tel-national', inputmode: 'tel' } };
 
-    expect(transformer(formfield, widgetProps)).toEqual(result);
+    expect(transformer(formfield)).toEqual(result);
   });
 });

--- a/src/v3/src/transformer/field/attributes.ts
+++ b/src/v3/src/transformer/field/attributes.ts
@@ -12,12 +12,7 @@
 
 import { Input } from '@okta/okta-auth-js';
 
-import {
-  AutoCompleteValue,
-  InputAttributes,
-  InputModeValue,
-  WidgetProps,
-} from '../../types';
+import { AutoCompleteValue, InputAttributes, InputModeValue } from '../../types';
 import { isAndroidOrIOS } from '../../util';
 
 type Result = {
@@ -78,15 +73,11 @@ const inputModeValueTransformer = (input: Input): InputModeValue | null => {
   return key ? inputModeValueMap.get(key) ?? null : null;
 };
 
-export const transformer = (
-  input: Input,
-  widgetProps: WidgetProps,
-): Result | null => {
+export const transformer = (input: Input): Result | null => {
   const attributes: InputAttributes = {};
   const autocompleteValue = autocompleteValueTransformer(input);
   if (autocompleteValue) {
-    const { features: { disableAutocomplete } = {} } = widgetProps;
-    attributes.autocomplete = disableAutocomplete ? 'off' : autocompleteValue;
+    attributes.autocomplete = autocompleteValue;
   }
 
   // Inputmode is used to optimize the mobile virtual keyboard based on the type of content entered

--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -24,13 +24,10 @@ import { isCustomizedI18nKey } from '../i18n';
 import { transformer as attributesTransformer } from './attributes';
 import { transformer as typeTransformer } from './type';
 
-const mapUiElement = (
-  input: Input,
-  widgetProps: WidgetProps,
-): FieldElement => {
+const mapUiElement = (input: Input): FieldElement => {
   const { label, name } = input;
   const fieldType = typeTransformer(input);
-  const attributes = attributesTransformer(input, widgetProps);
+  const attributes = attributesTransformer(input);
 
   return {
     type: 'Field',
@@ -92,7 +89,7 @@ export const transformStepInputs = (
       } = input;
 
       // add uischema
-      const uischema = mapUiElement(input, widgetProps);
+      const uischema = mapUiElement(input);
       acc.uischema.elements = [...acc.uischema.elements, uischema];
 
       if (type === 'boolean' && required) {

--- a/src/v3/src/transformer/layout/consent/__snapshots__/transformEnduserConsent.test.ts.snap
+++ b/src/v3/src/transformer/layout/consent/__snapshots__/transformEnduserConsent.test.ts.snap
@@ -27,6 +27,7 @@ Object {
         "type": "Description",
       },
       Object {
+        "key": "consent.scopes.custom1",
         "options": Object {
           "inputMeta": Object {
             "mutable": false,
@@ -51,6 +52,7 @@ Object {
         "type": "Field",
       },
       Object {
+        "key": "consent.scopes.custom2",
         "options": Object {
           "inputMeta": Object {
             "mutable": false,
@@ -155,6 +157,7 @@ Object {
         "type": "Description",
       },
       Object {
+        "key": "consent.scopes.email",
         "options": Object {
           "inputMeta": Object {
             "mutable": false,
@@ -179,6 +182,7 @@ Object {
         "type": "Field",
       },
       Object {
+        "key": "consent.scopes.phone",
         "options": Object {
           "inputMeta": Object {
             "mutable": false,

--- a/src/v3/src/transformer/layout/consent/transformEnduserConsent.ts
+++ b/src/v3/src/transformer/layout/consent/transformEnduserConsent.ts
@@ -65,6 +65,7 @@ export const transformEnduserConsent: IdxStepTransformer = ({ transaction, formB
       data[fieldName] = true;
       return {
         type: 'Field',
+        key: fieldName,
         translations: [
           {
             name: 'label',

--- a/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
+++ b/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
@@ -203,7 +203,7 @@ Object {
 }
 `;
 
-exports[`Enroll Profile Transformer Tests should add password requirements along with title, and submit button when passcode exists but password settings are empty 1`] = `
+exports[`Enroll Profile Transformer Tests should not add password requirements but should add title, password, and button elements when passcode exists but password settings are empty 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {

--- a/src/v3/src/transformer/profile/transformEnrollProfile.test.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfile.test.ts
@@ -67,7 +67,7 @@ describe('Enroll Profile Transformer Tests', () => {
       .toBe(ButtonType.SUBMIT);
   });
 
-  it('should add password requirements along with title, and submit button when passcode exists but password settings are empty', () => {
+  it('should not add password requirements but should add title, password, and button elements when passcode exists but password settings are empty', () => {
     formBag.uischema.elements.push({
       type: 'Field',
       label: 'Password',

--- a/src/v3/src/transformer/uischema/__snapshots__/overwriteAutocomplete.test.ts.snap
+++ b/src/v3/src/transformer/uischema/__snapshots__/overwriteAutocomplete.test.ts.snap
@@ -1,0 +1,240 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`overwriteAutocomplete Tests should set appropriate autocomplete attribute on elements when disableAutocomplete feature is false 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`overwriteAutocomplete Tests should set appropriate autocomplete attribute on elements when disableAutocomplete feature is true 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "off",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`overwriteAutocomplete Tests should set appropriate autocomplete attribute on elements when disableAutocomplete feature is undefined 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "new-password",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`overwriteAutocomplete Tests should update all elements in array with appropriate autocomplete value when  disableAutocomplete feature is true 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "Sign in",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "inputMeta": Object {
+            "name": "identifier",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "off",
+          },
+          "inputMeta": Object {
+            "name": "credentials.passcode",
+          },
+        },
+        "type": "Field",
+      },
+      Object {
+        "options": Object {
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+      Object {
+        "options": Object {
+          "label": "Forgot Password",
+        },
+        "type": "Link",
+      },
+      Object {
+        "options": Object {
+          "attributes": Object {
+            "autocomplete": "off",
+          },
+          "inputMeta": Object {
+            "name": "confirmPassword",
+          },
+        },
+        "type": "Field",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/uischema/overwriteAutocomplete.test.ts
+++ b/src/v3/src/transformer/uischema/overwriteAutocomplete.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxTransaction } from '@okta/okta-auth-js';
+import { IDX_STEP } from 'src/constants';
+import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
+import {
+  ButtonElement,
+  ButtonType,
+  FieldElement,
+  FormBag,
+  LinkElement,
+  TitleElement,
+  UISchemaElement,
+  WidgetProps,
+} from 'src/types';
+
+import { overwriteAutocomplete } from './overwriteAutocomplete';
+
+describe('overwriteAutocomplete Tests', () => {
+  let transaction: IdxTransaction;
+  let formBag: FormBag;
+  let widgetProps: WidgetProps;
+
+  beforeEach(() => {
+    transaction = getStubTransactionWithNextStep();
+    formBag = getStubFormBag();
+
+    transaction.nextStep!.name = IDX_STEP.CHALLENGE_AUTHENTICATOR;
+    formBag.uischema.elements = [
+      { type: 'Title', options: { content: 'Sign in' } } as TitleElement,
+      { type: 'Field', options: { inputMeta: { name: 'identifier' } } } as FieldElement,
+      {
+        type: 'Field',
+        options: {
+          inputMeta: { name: 'credentials.passcode' },
+          attributes: { autocomplete: 'new-password' },
+        },
+      } as FieldElement,
+      { type: 'Button', options: { type: ButtonType.SUBMIT } } as ButtonElement,
+      { type: 'Link', options: { label: 'Forgot Password' } } as LinkElement,
+    ];
+    widgetProps = {};
+  });
+
+  it.each`
+    disableAutocomplete
+    ${undefined}
+    ${false}
+    ${true}
+  `('should set appropriate autocomplete attribute on elements when disableAutocomplete feature is $disableAutocomplete', ({ disableAutocomplete }) => {
+    widgetProps = { features: { disableAutocomplete } };
+    const updatedFormBag = overwriteAutocomplete({
+      transaction, widgetProps, step: '', isClientTransaction: false, setMessage: () => {},
+    })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    const expectedAutocompleteValue = disableAutocomplete ? 'off' : 'new-password';
+    expect(updatedFormBag).toMatchSnapshot();
+    expect((elements[2] as FieldElement).options.attributes?.autocomplete)
+      .toBe(expectedAutocompleteValue);
+  });
+
+  it('should update all elements in array with appropriate autocomplete value when  disableAutocomplete feature is true', async () => {
+    widgetProps = { features: { disableAutocomplete: true } };
+    formBag.uischema.elements.push({
+      type: 'Field',
+      options: {
+        inputMeta: { name: 'confirmPassword' },
+        attributes: { autocomplete: 'new-password' },
+      },
+    } as FieldElement);
+    const updatedFormBag = overwriteAutocomplete({
+      transaction, widgetProps, step: '', isClientTransaction: false, setMessage: () => {},
+    })(formBag);
+    const { elements } = <{ elements: UISchemaElement[] }>updatedFormBag.uischema;
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect((elements[2] as FieldElement).options.attributes?.autocomplete)
+      .toBe('off');
+    expect((elements[5] as FieldElement).options.attributes?.autocomplete)
+      .toBe('off');
+  });
+});

--- a/src/v3/src/transformer/uischema/overwriteAutocomplete.ts
+++ b/src/v3/src/transformer/uischema/overwriteAutocomplete.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  FieldElement,
+  TransformStepFnWithOptions,
+} from '../../types';
+import { traverseLayout } from '../util';
+
+export const overwriteAutocomplete: TransformStepFnWithOptions = ({
+  widgetProps,
+}) => (formbag) => {
+  const { features: { disableAutocomplete } = {} } = widgetProps;
+  if (disableAutocomplete !== true) {
+    return formbag;
+  }
+
+  traverseLayout({
+    layout: formbag.uischema,
+    predicate: (el) => (
+      // Only grab elements that have autocomplete set to some value other than 'off'
+      el.type === 'Field'
+      && typeof (el as FieldElement).options.attributes?.autocomplete !== 'undefined'
+      && (el as FieldElement).options.attributes?.autocomplete !== 'off'
+    ),
+    callback: (el) => {
+      const fieldElement = (el as FieldElement);
+      fieldElement.options.attributes!.autocomplete = 'off';
+    },
+  });
+  return formbag;
+};

--- a/src/v3/src/transformer/uischema/transform.test.ts
+++ b/src/v3/src/transformer/uischema/transform.test.ts
@@ -39,6 +39,9 @@ jest.mock('./updatePasswordDescribedByValue', () => ({
 jest.mock('./setLtrFields', () => ({
   setLtrFields: () => ({}),
 }));
+jest.mock('./overwriteAutocomplete', () => ({
+  overwriteAutocomplete: () => () => ({}),
+}));
 
 /* eslint-disable global-require */
 const mocked = {
@@ -50,6 +53,7 @@ const mocked = {
   applyAsterisk: require('./applyAsteriskToFieldElements'),
   updatePasswordEle: require('./updatePasswordDescribedByValue'),
   setLtrField: require('./setLtrFields'),
+  overwriteAutocomplete: require('./overwriteAutocomplete'),
 };
 /* eslint-enable global-require */
 
@@ -63,6 +67,7 @@ describe('UISchema transformer', () => {
     jest.spyOn(mocked.applyAsterisk, 'applyAsteriskToFieldElements');
     jest.spyOn(mocked.updatePasswordEle, 'updatePasswordDescribedByValue');
     jest.spyOn(mocked.setLtrField, 'setLtrFields');
+    jest.spyOn(mocked.overwriteAutocomplete, 'overwriteAutocomplete');
 
     const formBag = getStubFormBag();
     const mockOptions = {
@@ -86,5 +91,6 @@ describe('UISchema transformer', () => {
     expect(mocked.applyAsterisk.applyAsteriskToFieldElements).toHaveBeenCalled();
     expect(mocked.updatePasswordEle.updatePasswordDescribedByValue).toHaveBeenCalled();
     expect(mocked.setLtrField.setLtrFields).toHaveBeenCalled();
+    expect(mocked.overwriteAutocomplete.overwriteAutocomplete).toHaveBeenCalled();
   });
 });

--- a/src/v3/src/transformer/uischema/transform.ts
+++ b/src/v3/src/transformer/uischema/transform.ts
@@ -18,6 +18,7 @@ import {
 import { addIdToElements } from './addIdToElements';
 import { applyAsteriskToFieldElements } from './applyAsteriskToFieldElements';
 import { createTextElementKeys } from './createTextElementKeys';
+import { overwriteAutocomplete } from './overwriteAutocomplete';
 import { setFocusOnFirstElement } from './setFocusOnFirstElement';
 import { setLtrFields } from './setLtrFields';
 import { updateCustomFields } from './updateCustomFields';
@@ -35,4 +36,5 @@ export const transformUISchema: TransformStepFnWithOptions = (
   addIdToElements,
   updatePasswordDescribedByValue,
   setLtrFields,
+  overwriteAutocomplete(options),
 )(formbag);

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -272,10 +272,7 @@ export interface FieldElement extends UISchemaElement {
    */
   showAsterisk?: boolean;
   options: {
-    // TODO: remove customLabel after updating okta-auth-js (OKTA-626602)
-    inputMeta: Input & {
-      customLabel?: boolean;
-    };
+    inputMeta: Input;
     format?: 'select' | 'radio';
     attributes?: InputAttributes;
     type?: string;

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -508,6 +508,7 @@ export interface SpinnerElement extends UISchemaElement {
 }
 
 export interface InfoboxElement extends UISchemaElement {
+  type: 'InfoBox',
   options: {
     message: WidgetMessage | WidgetMessage[];
     class: string;

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -22,6 +22,7 @@ import {
 import EventEmitter from 'tiny-emitter';
 
 import {
+  EventContext,
   LanguageCallback,
   LanguageCode,
   OktaSignInAPI,
@@ -97,6 +98,11 @@ export type RegistrationOptionsV3 = Modify<RegOptions, {
     onFailure: RegistrationErrorCallback
   ) => void;
 }>;
+type PageTitleCallbackParam = {
+  brandName?: string;
+  formTitle: string;
+};
+export type PageTitleCallback = (context: EventContext, param: PageTitleCallbackParam) => string;
 
 export type OktaWidgetEventType = 'ready' | 'afterError' | 'afterRender';
 export type IDPDisplayType = 'PRIMARY' | 'SECONDARY';
@@ -261,6 +267,7 @@ export type OktaWidgetFeatures = {
   restrictRedirectToForeground?: boolean;
   showPasswordRequirementsAsHtmlList?: boolean;
   disableAutocomplete?: boolean;
+  setPageTitle?: boolean | string | PageTitleCallback;
 };
 
 interface ProxyIdxResponse {

--- a/src/v3/src/util/escape.test.ts
+++ b/src/v3/src/util/escape.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { escape } from './escape';
+
+describe('escape function tests', () => {
+  it('should return null when string provided is undefined', () => {
+    expect(escape()).toBeNull();
+  });
+
+  it('should return empty string when empty string is provided', () => {
+    expect(escape('')).toBe('');
+  });
+
+  it('should convert text with a quote into html entities', () => {
+    expect(escape('My Workflow\'s Application')).toBe('My Workflow&#39;s Application');
+  });
+
+  it('should convert text with an ampersand into html entities', () => {
+    expect(escape('John & Joe\'s Application')).toBe('John &amp; Joe&#39;s Application');
+  });
+});

--- a/src/v3/src/util/escape.ts
+++ b/src/v3/src/util/escape.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export const escape = (str?: string | null): string | null => {
+  if (typeof str === 'undefined' || str === null) {
+    return null;
+  }
+
+  const CHARACTER_MAP: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  };
+  return str.replace(/[&<>"']/g, (m) => CHARACTER_MAP[m]);
+};

--- a/src/v3/src/util/extractPageTitle.test.ts
+++ b/src/v3/src/util/extractPageTitle.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxTransaction } from '@okta/okta-auth-js';
+import { IDX_STEP } from 'src/constants';
+import { getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
+import {
+  DescriptionElement,
+  InfoboxElement,
+  LinkElement,
+  TitleElement,
+  UISchemaLayout,
+  UISchemaLayoutType,
+  WidgetMessage,
+  WidgetProps,
+} from 'src/types';
+
+import { extractFirstWidgetMessageStr, extractPageTitle } from '.';
+
+describe('FormUtils Tests', () => {
+  describe('WidgetMessage extraction tests', () => {
+    it('should extract first message string from an array of widget messages', () => {
+      const TEST_MESSAGE_STR = 'This is a test message';
+      const message: WidgetMessage = { message: TEST_MESSAGE_STR };
+      const message2: WidgetMessage = { message: 'This is another message' };
+      const messageStr = extractFirstWidgetMessageStr([message, message2]);
+
+      expect(messageStr).toBe(TEST_MESSAGE_STR);
+    });
+
+    it('should extract first message string from a widget message object', () => {
+      const TEST_MESSAGE_STR = 'This is a test message';
+      const message: WidgetMessage = { message: TEST_MESSAGE_STR };
+      const messageStr = extractFirstWidgetMessageStr(message);
+
+      expect(messageStr).toBe(TEST_MESSAGE_STR);
+    });
+
+    it('should extract first message string from a nested widget message object', () => {
+      const TEST_MESSAGE_STR = 'This is a test message';
+      const message: WidgetMessage = {
+        message: [{
+          message: [{ message: TEST_MESSAGE_STR }] as WidgetMessage[],
+        }] as WidgetMessage[],
+      };
+      const messageStr = extractFirstWidgetMessageStr(message);
+
+      expect(messageStr).toBe(TEST_MESSAGE_STR);
+    });
+  });
+
+  describe('ExtractPageTitle tests', () => {
+    let uischema: UISchemaLayout;
+    let widgetProps: WidgetProps;
+    let transaction: IdxTransaction;
+
+    beforeEach(() => {
+      uischema = {
+        type: UISchemaLayoutType.VERTICAL,
+        elements: [],
+      };
+      widgetProps = {};
+      transaction = getStubTransactionWithNextStep();
+    });
+
+    it('should return application name as title when nextStep is consent-admin', () => {
+      transaction.nextStep = {
+        ...transaction.nextStep,
+        name: IDX_STEP.CONSENT_ADMIN,
+      };
+      transaction.rawIdxState = {
+        ...transaction.rawIdxState,
+        // @ts-expect-error OKTA-598868 app is missing from rawIdxState type
+        app: {
+          type: 'object',
+          value: {
+            label: 'Workflow Application',
+          },
+        },
+      };
+
+      const title = extractPageTitle(uischema, widgetProps, transaction);
+
+      expect(title).toBe('Workflow Application');
+    });
+
+    it('should not return page title when no title elements exist and no page content', () => {
+      const linkEle: LinkElement = {
+        type: 'Link',
+        options: {
+          label: 'Back to signin',
+          step: 'identify',
+        },
+      };
+      uischema.elements.push(linkEle);
+
+      const title = extractPageTitle(uischema, widgetProps, transaction);
+
+      expect(title).toBeNull();
+    });
+
+    it('should extract page title when Title element exists in uischema', () => {
+      const TEST_MESSAGE_STR = 'This is a test message';
+      const titleEle: TitleElement = {
+        type: 'Title',
+        options: { content: TEST_MESSAGE_STR },
+      };
+      uischema.elements.push(titleEle);
+
+      const title = extractPageTitle(uischema, widgetProps, transaction);
+
+      expect(title).toBe(TEST_MESSAGE_STR);
+    });
+
+    it('should extract page title from first Title element when multiple Title elements exists in uischema', () => {
+      const TEST_MESSAGE_STR = 'This is a test message';
+      const titleEle: TitleElement = {
+        type: 'Title',
+        options: { content: TEST_MESSAGE_STR },
+      };
+      const titleEle2: TitleElement = {
+        type: 'Title',
+        options: { content: 'This is another message' },
+      };
+      uischema.elements.push(titleEle);
+      uischema.elements.push(titleEle2);
+
+      const title = extractPageTitle(uischema, widgetProps, transaction);
+
+      expect(title).toBe(TEST_MESSAGE_STR);
+    });
+
+    it('should extract page title when Error Info Box exists in uischema', () => {
+      const TEST_MESSAGE_STR = 'This is a test message';
+      const errorBoxEle: InfoboxElement = {
+        type: 'InfoBox',
+        options: {
+          message: {
+            message: TEST_MESSAGE_STR,
+          },
+          class: 'ERROR',
+        },
+      };
+      uischema.elements.push(errorBoxEle);
+
+      const title = extractPageTitle(uischema, widgetProps, transaction);
+
+      expect(title).toBe(TEST_MESSAGE_STR);
+    });
+
+    it('should extract page title when Error Info Box exists in uischema with nested message object', () => {
+      const TEST_MESSAGE_STR = 'This is a test message';
+      const errorBoxEle: InfoboxElement = {
+        type: 'InfoBox',
+        options: {
+          message: {
+            message: [{
+              message: [{
+                message: [{ message: TEST_MESSAGE_STR } as WidgetMessage] as WidgetMessage[],
+              }] as WidgetMessage[],
+            }, { message: 'This is another test message' }] as WidgetMessage[],
+          },
+          class: 'ERROR',
+        },
+      };
+      const linkEle: LinkElement = {
+        type: 'Link',
+        options: {
+          label: 'Back to signin',
+          step: 'identify',
+        },
+      };
+      uischema.elements.push(errorBoxEle);
+      uischema.elements.push(linkEle);
+
+      const title = extractPageTitle(uischema, widgetProps, transaction);
+
+      expect(title).toBe(TEST_MESSAGE_STR);
+    });
+
+    it('should extract page title when only description exists in uischema', () => {
+      const TEST_MESSAGE_STR = 'This is a test message';
+      const descrEle: DescriptionElement = {
+        type: 'Description',
+        options: { content: TEST_MESSAGE_STR },
+      };
+      const linkEle: LinkElement = {
+        type: 'Link',
+        options: {
+          label: 'Back to signin',
+          step: 'identify',
+        },
+      };
+      uischema.elements.push(descrEle);
+      uischema.elements.push(linkEle);
+
+      const title = extractPageTitle(uischema, widgetProps, transaction);
+
+      expect(title).toBe(TEST_MESSAGE_STR);
+    });
+  });
+});

--- a/src/v3/src/util/extractPageTitle.ts
+++ b/src/v3/src/util/extractPageTitle.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxTransaction } from '@okta/okta-auth-js';
+
+import { traverseLayout } from '../transformer/util';
+import {
+  DescriptionElement,
+  InfoboxElement,
+  TitleElement,
+  UISchemaLayout,
+  WidgetMessage,
+  WidgetProps,
+} from '../types';
+import { getApplicationName, isConsentStep } from './idxUtils';
+import { getPageTitle } from './settingsUtils';
+
+export const extractFirstWidgetMessageStr = (
+  widgetMessage?: WidgetMessage | WidgetMessage[],
+): string | null => {
+  if (Array.isArray(widgetMessage)) {
+    const [message] = widgetMessage;
+    return extractFirstWidgetMessageStr(message);
+  }
+
+  if (typeof widgetMessage?.message === 'string') {
+    return widgetMessage.message;
+  }
+
+  if (typeof widgetMessage !== 'undefined' && Array.isArray(widgetMessage.message)) {
+    return extractFirstWidgetMessageStr(widgetMessage.message);
+  }
+  return null;
+};
+
+export const extractPageTitle = (
+  uischema: UISchemaLayout,
+  widgetProps: WidgetProps,
+  idxTransaction?: IdxTransaction,
+): string | null => {
+  // Consent remediations should set title to the Application name
+  if (isConsentStep(idxTransaction)) {
+    return getApplicationName(idxTransaction);
+  }
+
+  let headerTitleContent: string | null = null;
+  // Title Header
+  traverseLayout({
+    layout: uischema,
+    predicate: (element) => element.type === 'Title',
+    callback: (element) => {
+      if (headerTitleContent === null) {
+        headerTitleContent = (element as TitleElement).options.content;
+      }
+    },
+  });
+
+  // Error Info Boxes
+  traverseLayout({
+    layout: uischema,
+    predicate: (element) => element.type === 'InfoBox',
+    callback: (element) => {
+      if (headerTitleContent !== null) {
+        return;
+      }
+      const widgetMessage = (element as InfoboxElement).options.message;
+      const message = Array.isArray(widgetMessage) ? widgetMessage[0] : widgetMessage;
+      headerTitleContent = typeof message.title === 'undefined'
+        ? extractFirstWidgetMessageStr(message)
+        : message.title;
+    },
+  });
+
+  // Description text only (terminal pages)
+  traverseLayout({
+    layout: uischema,
+    predicate: (element) => element.type === 'Description',
+    callback: (element) => {
+      if (headerTitleContent === null) {
+        headerTitleContent = (element as DescriptionElement).options.content;
+      }
+    },
+  });
+
+  return getPageTitle(widgetProps, headerTitleContent, idxTransaction);
+};

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -24,6 +24,7 @@ import { StateUpdater } from 'preact/hooks';
 import { getMessage } from '../../../v2/ion/i18nTransformer';
 import {
   AUTHENTICATOR_KEY,
+  CONSENT_HEADER_STEPS,
   DEVICE_ENROLLMENT_TYPE,
   EMAIL_AUTHENTICATOR_TERMINAL_KEYS,
   IDX_STEP,
@@ -355,3 +356,18 @@ export const isVerifyFlow = (transaction: IdxTransaction): boolean => {
 
 // @ts-expect-error OKTA-627610 captcha missing from context type
 export const isCaptchaEnabled = (transaction: IdxTransaction): boolean => typeof transaction.context?.captcha !== 'undefined';
+
+export const isConsentStep = (transaction?: IdxTransaction): boolean => (
+  transaction?.nextStep?.name
+    ? CONSENT_HEADER_STEPS.includes(transaction.nextStep.name)
+    : false
+);
+
+export const getApplicationName = (transaction?: IdxTransaction): string | null => {
+  if (typeof transaction === 'undefined') {
+    return null;
+  }
+
+  const { label } = getAppInfo(transaction);
+  return label ?? null;
+};

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -46,3 +46,4 @@ export * from './setUrlQueryParams';
 export * from './shouldShowCancelLink';
 export * from './toNestedObject';
 export * from './webauthnUtils';
+export * from './widgetUtils';

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -16,6 +16,8 @@ export * from './buildPasswordRequirementNotMetErrorList';
 export * from './clipboard';
 export * from './cookieUtils';
 export * from './environmentUtils';
+export * from './escape';
+export * from './extractPageTitle';
 export * from './flattenInputs';
 export * from './formatError';
 export * from './formUtils';

--- a/src/v3/src/util/settingsUtils.ts
+++ b/src/v3/src/util/settingsUtils.ts
@@ -10,11 +10,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { APIError, IdxActionParams } from '@okta/okta-auth-js';
+import { APIError, IdxActionParams, IdxTransaction } from '@okta/okta-auth-js';
 import { union } from 'lodash';
 
 import config from '../../../config/config.json';
 import {
+  EventContext,
   LanguageCode,
   RegistrationErrorCallback,
   RegistrationPostSubmitCallback,
@@ -32,6 +33,7 @@ import {
   RegistrationSchemaCallbackV3,
   WidgetProps,
 } from '../types';
+import { getEventContext } from './getEventContext';
 import { loc } from './locUtil';
 
 export const getSupportedLanguages = (widgetProps: WidgetProps): string[] => {
@@ -245,4 +247,41 @@ export const isOauth2Enabled = (widgetProps: WidgetProps): boolean => {
     clientId = authClient.options?.clientId;
   }
   return typeof clientId !== 'undefined' && authScheme?.toLowerCase() === 'oauth2';
+};
+
+export const getPageTitle = (
+  widgetProps: WidgetProps,
+  formTitle: string | null,
+  idxTransaction?: IdxTransaction,
+): string | null => {
+  if (formTitle === null) {
+    return null;
+  }
+
+  const { brandName, features: { setPageTitle } = {} } = widgetProps;
+  const eventContext: EventContext = typeof idxTransaction === 'undefined'
+    ? { controller: null }
+    : getEventContext(idxTransaction);
+
+  switch (typeof setPageTitle) {
+    // When setPageTitle option is 'undefined', default will be to set title based on page header
+    // When setPageTitle option is 'true', set title based on page header
+    case 'boolean':
+    case 'undefined':
+      if (setPageTitle === false) {
+        // Indicates setPageTitle config option was purposefully disabled
+        return null;
+      }
+      return brandName ? `${brandName} | ${formTitle}` : formTitle;
+    case 'string':
+      return setPageTitle;
+    case 'function':
+      return setPageTitle(eventContext, { formTitle, brandName });
+    default:
+      console.error(
+        'Invalid value passed to setPageTitle, valid types include boolean, string or function.',
+      );
+      // Indicates an invalid/unexpected value was passed into the config option
+      return null;
+  }
 };

--- a/src/v3/src/util/widgetUtils.ts
+++ b/src/v3/src/util/widgetUtils.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { isDevelopmentEnvironment } from './environmentUtils';
+
+/* global __PREFRESH__ */
+
+export const canBootstrapWidget = (deps: Record<string, unknown>) => {
+  if (isDevelopmentEnvironment()) {
+    /**
+     * Only for HMR at development:
+     *  If some file change triggers hot update of current file, all `useEffect` hooks will be triggered.
+     *  `useCallback` hooks will be re-executed, so values of `bootstrap` and `resume` will be updated.
+     *  But values of `useState` hooks will not update, so eg. `setIdxTransaction` value will remain.
+     *  To avoid unnecessary `bootstrap` call, compare old and new values in reduced dependencies list.
+     */
+    if (typeof __PREFRESH__ !== 'undefined') {
+      const prevDeps = __PREFRESH__.widgetBootstrapDeps as typeof deps;
+      const depsChanged = !prevDeps || Object.keys(prevDeps).some((k) => deps[k] !== prevDeps[k]);
+      __PREFRESH__.widgetBootstrapDeps = deps;
+      if (!depsChanged) {
+        // eslint-disable-next-line no-console
+        console.info('[HMR] Skip Widget bootstrap');
+        return false;
+      }
+    }
+  }
+  return true;
+};

--- a/src/v3/webpack.common.config.ts
+++ b/src/v3/webpack.common.config.ts
@@ -27,6 +27,31 @@ const getShortGitHash = () => {
   return hash.slice(0, 7);
 };
 
+const babelOptions = {
+  sourceType: 'unambiguous',
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        // TODO: resolve issue with authjs esm bundle, then switch to "usage" to reduce polyfill size
+        useBuiltIns: 'entry',
+        corejs: '3.9',
+      },
+    ],
+    '@babel/preset-react',
+    '@babel/preset-typescript',
+  ],
+  plugins: [
+    [
+      '@babel/plugin-transform-react-jsx',
+      {
+        runtime: 'automatic',
+        importSource: 'preact',
+      },
+    ],
+  ],
+};
+
 const baseConfig: Partial<Configuration> = {
   mode: 'production',
   devtool: 'source-map',
@@ -48,6 +73,8 @@ const baseConfig: Partial<Configuration> = {
             '/node_modules/p-cancelable',
           ].some(filePathContains);
           const shallBeExcluded = [
+            // /src/ will be handled in next rule
+            resolve(__dirname, '..'),
             '/node_modules/',
             'packages/@okta/qtip2',
           ].some(filePathContains);
@@ -55,30 +82,17 @@ const baseConfig: Partial<Configuration> = {
           return shallBeExcluded && !npmRequiresTransform;
         },
         loader: 'babel-loader',
-        options: {
-          sourceType: 'unambiguous',
-          presets: [
-            [
-              '@babel/preset-env',
-              {
-                // TODO: resolve issue with authjs esm bundle, then switch to "usage" to reduce polyfill size
-                useBuiltIns: 'entry',
-                corejs: '3.9',
-              },
-            ],
-            '@babel/preset-react',
-            '@babel/preset-typescript',
-          ],
-          plugins: [
-            [
-              '@babel/plugin-transform-react-jsx',
-              {
-                runtime: 'automatic',
-                importSource: 'preact',
-              },
-            ],
-          ],
-        },
+        options: babelOptions,
+      },
+      // Need to separate rule for files in /src/
+      // Rule will be modified in dev config
+      {
+        test: /\.[jt]sx?$/,
+        include: [
+          resolve(__dirname, '..'), // /src/
+        ],
+        loader: 'babel-loader',
+        options: babelOptions,
       },
       {
         test: /\.css$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,10 +3648,10 @@
     "@mui/utils" "^5.10.9"
     "@okta/odyssey-design-tokens" "^0.17.0"
 
-"@okta/okta-auth-js@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.2.0.tgz#7380d1ab8a5d62ce289a1320346079ff24d58cee"
-  integrity sha512-0YZ8cEbTGwlw9KGey+4ZnGJs4qKs8PkQsbaCyQ1q9jKMftuDlGXL85jrLpnEqg3jfYCpi6GDtEl/QquOKMvAFw==
+"@okta/okta-auth-js@^7.4.2":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.4.2.tgz#f3b110779293c30b072c67ea1ab78c3188ce9443"
+  integrity sha512-7FV40urxesNv7pn5O0/7JeQKoXpbePqbj3qQTDn/2trKd+M2cDjXpOLebbTYs07iSK/YbsUkQXsvnJI5F5Pyqg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@peculiar/webcrypto" "^1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3787,6 +3787,29 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
+"@prefresh/babel-plugin@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@prefresh/babel-plugin/-/babel-plugin-0.5.0.tgz#61d8ef959007390077c9eddb7e9307c46e19277c"
+  integrity sha512-joAwpkUDwo7ZqJnufXRGzUb+udk20RBgfA8oLPBh5aJH2LeStmV1luBfeJTztPdyCscC2j2SmZ/tVxFRMIxAEw==
+
+"@prefresh/core@^1.5.0":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@prefresh/core/-/core-1.5.1.tgz#2f51c0dd509a7b302d67ee889815653abdf4c0d1"
+  integrity sha512-e0mB0Oxtog6ZpKPDBYbzFniFJDIktuKMzOHp7sguntU+ot0yi6dbhJRE9Css1qf0u16wdSZjpL2W2ODWuU05Cw==
+
+"@prefresh/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@prefresh/utils/-/utils-1.2.0.tgz#cbdfe549b207041e38bb6cc382408b30cd24fec8"
+  integrity sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ==
+
+"@prefresh/webpack@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@prefresh/webpack/-/webpack-4.0.0.tgz#79493a5fb7b49291b69693a0f6a0ace565d268ee"
+  integrity sha512-Ppr8GNASfq/Zsw/dFOhHz3DYZWfAnqRhz2ryZo4b7VA4x4nQzALYLILK32w9YdSw6WYhIMQdjBkugk6PstcwFg==
+  dependencies:
+    "@prefresh/core" "^1.5.0"
+    "@prefresh/utils" "^1.2.0"
+
 "@rollup/plugin-alias@^3.1.9":
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz#a5d267548fe48441f34be8323fb64d1d4a1b3fdf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3724,7 +3724,6 @@
     chokidar "^3.5.1"
     clipboard "^1.5.16"
     cross-fetch "^3.1.5"
-    ejs "^3.1.7"
     handlebars "^4.7.7"
     jquery "^3.6.0"
     parse-ms "^2.0.0"
@@ -8828,10 +8827,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@^3.0.1, ejs@^3.1.7:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
-  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+ejs@^3.0.1, ejs@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
+  integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
   dependencies:
     jake "^10.8.5"
 
@@ -13637,34 +13636,17 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@2.x, json5@^2.2.2:
+json5@2.x, json5@^0.5.1, json5@^1.0.1, json5@^2.1.0, json5@^2.1.2, json5@^2.1.3, json5@^2.2.1, json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-  integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
-
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+json5@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
-
-json5@^2.1.0, json5@^2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
-  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
-  dependencies:
-    minimist "^1.2.5"
-
-json5@^2.1.3, json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonc-parser@^3.0.0:
   version "3.2.0"
@@ -18337,65 +18319,12 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-"semver@2 || 3 || 4":
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
-  integrity sha512-IrpJ+yoG4EOH8DFWuVg+8H1kW1Oaof0Wxe7cPcXW3x9BjkN/eVo54F15LyqemnDIUYskQWr9qvl/RihmSy6+xQ==
-
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
-
-semver@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
-
-semver@7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@7.3.7:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@7.3.8, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.8:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@7.x, semver@^7.3.7:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
-  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.5.3:
+"semver@2 || 3 || 4", "semver@2 || 3 || 4 || 5", semver@5.5.0, semver@7.3.5, semver@7.3.7, semver@7.3.8, semver@7.x, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@~7.0.0:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
-
-semver@~7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
-  integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
 send@0.18.0:
   version "0.18.0"


### PR DESCRIPTION
## Description:
DUO in SIW G3 was not working due to the incorrect callback being used. The purpose of this PR is to fix this issue and use the correct callback to pass to sig value to IDX (for Auth and Enroll).


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-645397](https://oktainc.atlassian.net/browse/OKTA-645397)

### Reviewers:

### Screenshot/Video:


https://github.com/okta/okta-signin-widget/assets/97472729/3960012f-6eba-4a28-81f9-0253a358b094


### Downstream Monolith Build:



