### PR TITLE
OKTA-645397 : SIW G3 : Fixes DUO enroll and auth

### DIFF
--- a/src/v3/src/__mocks__/duo_web_sdk/index.ts
+++ b/src/v3/src/__mocks__/duo_web_sdk/index.ts
@@ -33,9 +33,21 @@ const MockDuo = {
         const innerDoc = iframe.contentDocument ?? iframe.contentWindow?.document;
         const duoMockLink = innerDoc?.getElementById('duoVerifyLink');
         duoMockLink?.addEventListener('click', () => {
-          if (options.post_action) {
-            // @ts-expect-error mistake in @types/duo_web_sdk
-            options.post_action('successDuoAuth');
+          if (options.submit_callback) {
+            // build input and form as the real sdk does
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = 'duo-signature';
+            input.value = 'successDuoAuth';
+            
+            const form = document.createElement('form');
+            form.method = 'POST';
+            form.action = '';
+
+            // add the response token input to the form
+            form.appendChild(input);
+
+            options.submit_callback(form);
           }
         }, false);
       };

--- a/src/v3/src/__mocks__/duo_web_sdk/index.ts
+++ b/src/v3/src/__mocks__/duo_web_sdk/index.ts
@@ -39,7 +39,7 @@ const MockDuo = {
             input.type = 'hidden';
             input.name = 'duo-signature';
             input.value = 'successDuoAuth';
-            
+
             const form = document.createElement('form');
             form.method = 'POST';
             form.action = '';

--- a/src/v3/src/components/DuoWindow/DuoWindow.tsx
+++ b/src/v3/src/components/DuoWindow/DuoWindow.tsx
@@ -43,10 +43,14 @@ const DuoWindow: UISchemaElementComponent<{
         sig_request: signedToken,
         iframe: 'duo_iframe',
 
-        // @ts-expect-error type mismatch on post_action
-        post_action: (signedData: string) => {
+        submit_callback: (duoForm: HTMLFormElement) => {
+          const formInput = duoForm.getElementsByTagName('input')?.[0];
+          if (!formInput) {
+            console.error('DUO callback form element does not exist.');
+            return;
+          }
           handleDuoAuthSuccess({
-            params: { 'credentials.signatureData': signedData },
+            params: { 'credentials.signatureData': formInput.value },
             step,
           });
         },


### PR DESCRIPTION
## Description:

DUO in SIW G3 was not working due to the incorrect callback being used. The purpose of this PR is to fix this issue and use the correct callback to pass to sig value to IDX (for Auth and Enroll).

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-645397](https://oktainc.atlassian.net/browse/OKTA-645397)

### Reviewers:

### Screenshot/Video:


https://github.com/okta/okta-signin-widget/assets/97472729/cbb44547-9c4e-40a3-8fba-d8b3def26ba8


### Downstream Monolith Build:



