### PR TITLE
OKTA-642777 : SIW G3 Failure redirect view

### DIFF
--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
@@ -21,6 +21,7 @@ import {
 import { TERMINAL_KEY, TERMINAL_TITLE_KEY } from '../../constants';
 import { getStubTransaction } from '../../mocks/utils/utils';
 import { removeUsernameCookie, setUsernameCookie } from '../../util';
+import { redirectTransformer } from '../redirect';
 import { transformTerminalTransaction } from '.';
 import { transformOdaEnrollment } from './odaEnrollment/transformOdaEnrollment';
 
@@ -301,5 +302,28 @@ describe('Terminal Transaction Transformer Tests', () => {
     transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
 
     expect(transformOdaEnrollment).toHaveBeenCalled();
+  });
+
+  it('should not invoke redirect transformer when failure href is present and Oauth2 is enabled', () => {
+    transaction.context = {
+      failure: {
+        href: 'www.failure.com',
+      },
+    } as unknown as IdxContext;
+    widgetProps = { clientId: 'abcd1234', authScheme: 'oauth2' };
+    transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
+
+    expect(redirectTransformer).not.toHaveBeenCalled();
+  });
+
+  it('should invoke redirect transformer when failure redirect href is present in transaction context', () => {
+    transaction.context = {
+      failure: {
+        href: 'www.failure.com',
+      },
+    } as unknown as IdxContext;
+    transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
+
+    expect(redirectTransformer).toHaveBeenCalled();
   });
 });

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -171,6 +171,20 @@ export const transformTerminalTransaction = (
     );
   }
 
+  if (transaction.context?.failure?.href) {
+    // Direct auth clients display the error instead of redirecting
+    // when redirect option is set to 'always' it will override the default behavior
+    const shouldRedirect = isOauth2Enabled(widgetProps) === false || widgetProps.redirect === 'always';
+    if (shouldRedirect) {
+      SessionStorage.removeStateHandle();
+      return redirectTransformer(
+        transaction,
+        transaction.context.failure.href,
+        widgetProps,
+      );
+    }
+  }
+
   const { messages } = transaction;
 
   if (containsMessageKey(TERMINAL_KEY.SESSION_EXPIRED, messages)) {

--- a/test/testcafe/framework/page-objects/PlaygroundErrorPageObject.js
+++ b/test/testcafe/framework/page-objects/PlaygroundErrorPageObject.js
@@ -9,6 +9,6 @@ export default class PlaygroundErrorPageObject extends BasePageObject {
   }
 
   hasTitle() {
-    return !!this.title;
+    return this.title.exists;
   }
 }

--- a/test/testcafe/spec/FailureRedirect_spec.js
+++ b/test/testcafe/spec/FailureRedirect_spec.js
@@ -30,7 +30,8 @@ test.requestHooks(userNotAssignedMock)('oauth: shows the error message', async t
     codeChallenge: 'abc', // cannot do PKCE calcs on http://localhost
     authParams: {
       pkce: true // required for interaction code flow
-    }
+    },
+    authScheme: 'oauth2',
   });
   await t.expect(terminalPage.formExists()).eql(true);
   await terminalPage.waitForErrorBox();
@@ -47,7 +48,8 @@ test.requestHooks(userNotAssignedMock)('oauth: will redirect if `redirect === "a
     authParams: {
       pkce: true // required for interaction code flow
     },
-    redirect: 'always'
+    authScheme: 'oauth2',
+    redirect: 'always',
   });
   const errorPage = new PlaygroundErrorPageObject(t);
   await t.expect(errorPage.hasTitle()).eql(true);


### PR DESCRIPTION
## Description:

This PR implements support for the failure redirect terminal view in SIW Gen 3.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-642777](https://oktainc.atlassian.net/browse/OKTA-642777)

### Reviewers:

### Screenshot/Video:
**View in Gen 2:**
<img width="1207" alt="Screenshot 2023-09-12 at 10 13 39 PM" src="https://github.com/okta/okta-signin-widget/assets/107433508/eed9cf76-756a-433d-bf64-a42144194551">
**View in Gen 3:**
<img width="1171" alt="Screenshot 2023-09-12 at 10 15 19 PM" src="https://github.com/okta/okta-signin-widget/assets/107433508/ba3d4031-bedf-47db-a270-66277a7de394">

### Downstream Monolith Build:



