### PR TITLE
OKTA-642762 : SIW Gen 3 On-Prem authenticator support

### DIFF
--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -193,6 +193,10 @@ const TransformerMap: {
       transform: transformPasswordChallenge,
       buttonConfig: { showDefaultSubmit: false, showForgotPassword: true },
     },
+    [AUTHENTICATOR_KEY.ON_PREM]: {
+      transform: transformRSAAuthenticator,
+      buttonConfig: { showDefaultSubmit: false },
+    },
     [AUTHENTICATOR_KEY.OV]: {
       transform: transformTOTPChallenge,
       buttonConfig: {
@@ -308,6 +312,10 @@ const TransformerMap: {
     },
     [AUTHENTICATOR_KEY.IDP]: {
       transform: transformIdpAuthenticator,
+      buttonConfig: { showDefaultSubmit: false },
+    },
+    [AUTHENTICATOR_KEY.ON_PREM]: {
+      transform: transformRSAAuthenticator,
       buttonConfig: { showDefaultSubmit: false },
     },
     [AUTHENTICATOR_KEY.PASSWORD]: {

--- a/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock } from 'testcafe';
+import { RequestMock, userVariables } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import EnrollOnPremPageObject from '../framework/page-objects/EnrollOnPremPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
@@ -19,11 +19,12 @@ const passcodeChangeMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrPasscodeChange, 403);
 
-fixture('Authenticator On Prem');
+fixture('Authenticator On Prem').meta('v3', true);
 
 async function setup(t) {
   const enrollOnPremPage = new EnrollOnPremPageObject(t);
   await enrollOnPremPage.navigateToPage();
+  await t.expect(enrollOnPremPage.formExists()).eql(true);
   await checkConsoleMessages({
     controller: 'enroll-onprem',
     formName: 'enroll-authenticator',
@@ -51,7 +52,12 @@ test
 
     // fields are required
     await enrollOnPremPage.fillUserName('');
-    await enrollOnPremPage.clickNextButton();
+    // this is to prevent a miss click due to the onBlur validation errors shifting the button down in gen 3
+    if (userVariables.v3) {
+      await t.pressKey('tab');
+      await t.pressKey('tab');
+    }
+    await enrollOnPremPage.clickNextButton('Verify');
     await enrollOnPremPage.waitForGeneralErrorBox();
     await t.expect(enrollOnPremPage.getPasscodeError()).eql('This field cannot be left blank');
     await t.expect(enrollOnPremPage.getUserNameError()).eql('This field cannot be left blank');
@@ -67,7 +73,7 @@ test
 
     await enrollOnPremPage.fillUserName('abcdabcd');
     await enrollOnPremPage.fillPasscode('abcdabcd');
-    await enrollOnPremPage.clickNextButton();
+    await enrollOnPremPage.clickNextButton('Verify');
 
     const pageUrl = await successPage.getPageUrl();
     await t.expect(pageUrl)
@@ -81,7 +87,7 @@ test
 
     await enrollOnPremPage.fillUserName('abcdabcd');
     await enrollOnPremPage.fillPasscode('abcdabcd');
-    await enrollOnPremPage.clickNextButton();
+    await enrollOnPremPage.clickNextButton('Verify');
 
     await enrollOnPremPage.form.waitForAnyAlertBox();
     await t.expect(enrollOnPremPage.getErrorBoxText())


### PR DESCRIPTION
## Description:

This PR enables the OnPrem authenticator in SIW gen 3.  RSA and OnPrem are the same agent and share the same View/transformer.

See: 
https://help.okta.com/en-us/content/topics/security/mfa_onprem.htm
https://okta.slack.com/archives/C04NBJW1WJ3/p1694639101165589

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-642762](https://oktainc.atlassian.net/browse/OKTA-642762)

### Reviewers:

### Screenshot/Video:
<img width="1067" alt="Screenshot 2023-09-14 at 12 22 28 PM" src="https://github.com/okta/okta-signin-widget/assets/107433508/8e27e005-c0cd-41d3-9c97-97e9c2986b31">
<img width="1344" alt="Screenshot 2023-09-14 at 12 23 40 PM" src="https://github.com/okta/okta-signin-widget/assets/107433508/f9a006c5-2540-414d-a420-5293aabc619f">
<img width="1468" alt="Screenshot 2023-09-14 at 12 24 16 PM" src="https://github.com/okta/okta-signin-widget/assets/107433508/f893eeda-2cca-41c0-8b54-5e12634a47e3">

### Downstream Monolith Build:



