### PR TITLE
Add `Open Okta Verify` button during OV enrollment

### DIFF
--- a/assets/sass/v2/_success-redirect.scss
+++ b/assets/sass/v2/_success-redirect.scss
@@ -4,3 +4,7 @@
     margin-top: 24px;
   }
 }
+
+.hide-underline {
+  text-decoration: none;
+}

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -191,6 +191,7 @@ Util.enrollmentRedirect = function(view) {
   const currentViewState = view.options.appState.getCurrentViewState();
   const ovEnrollment = window.location.href.includes('redirect_uri=https%3A%2F%2Flogin.okta.com');
 
+  // OKTA-635926: add user gesture for ov enrollment on android
   if (BrowserFeatures.isAndroid() && ovEnrollment) {
     view.add(createButton({
       className: 'ul-button button button-wide button-primary',

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -18,6 +18,7 @@ import Logger from './Logger';
 import BrowserFeatures from './BrowserFeatures';
 
 const Util = {};
+const ovDeepLink = 'redirect_uri=https://login.okta.com/oauth/callback';
 
 const buildInputForParameter = function(name, value) {
   const input = document.createElement('input');
@@ -189,7 +190,7 @@ Util.redirect = function(url, win = window, isAppLink = false) {
 
 Util.enrollmentRedirect = function(view) {
   const currentViewState = view.options.appState.getCurrentViewState();
-  const ovEnrollment = window.location.href.includes('redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback');
+  const ovEnrollment = decodeURIComponent(window.location.href).includes(ovDeepLink);
 
   // OKTA-635926: add user gesture for ov enrollment on android
   if (BrowserFeatures.isAndroid() && ovEnrollment) {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -12,7 +12,7 @@
  */
 
 /* eslint complexity: [2, 13], max-depth: [2, 3] */
-import {_, loc} from '@okta/courage';
+import { _, loc } from '@okta/courage';
 import Enums from './Enums';
 import Logger from './Logger';
 import BrowserFeatures from './BrowserFeatures';

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -191,7 +191,7 @@ Util.redirect = function(url, win = window, isAppLink = false) {
 Util.isAndroidOVEnrollment = function() {
   const ovEnrollment = decodeURIComponent(window.location.href).includes(ovDeepLink);
   return BrowserFeatures.isAndroid() && ovEnrollment;
-}
+};
 
 /**
  * Why redirect via Form get rather using `window.location.href`?

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -188,24 +188,10 @@ Util.redirect = function(url, win = window, isAppLink = false) {
   }
 };
 
-Util.enrollmentRedirect = function(view) {
-  const currentViewState = view.options.appState.getCurrentViewState();
+Util.isAndroidOVEnrollment = function(view) {
   const ovEnrollment = decodeURIComponent(window.location.href).includes(ovDeepLink);
-
-  // OKTA-635926: add user gesture for ov enrollment on android
-  if (BrowserFeatures.isAndroid() && ovEnrollment) {
-    view.add(createButton({
-      className: 'ul-button button button-wide button-primary',
-      title: loc('oktaVerify.open.button', 'login'),
-      id: 'launch-enrollment-ov',
-      click: () => {
-        Util.redirectWithFormGet(currentViewState.href);
-      }
-    }));
-  } else {
-    Util.redirectWithFormGet(currentViewState.href);
-  }
-};
+  return BrowserFeatures.isAndroid() && ovEnrollment;
+}
 
 /**
  * Why redirect via Form get rather using `window.location.href`?

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -189,7 +189,7 @@ Util.redirect = function(url, win = window, isAppLink = false) {
 
 Util.enrollmentRedirect = function(view) {
   const currentViewState = view.options.appState.getCurrentViewState();
-  const ovEnrollment = window.location.href.includes('redirect_uri=https%3A%2F%2Flogin.okta.com');
+  const ovEnrollment = window.location.href.includes('redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback');
 
   // OKTA-635926: add user gesture for ov enrollment on android
   if (BrowserFeatures.isAndroid() && ovEnrollment) {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -196,7 +196,7 @@ Util.enrollmentRedirect = function(view) {
     view.add(createButton({
       className: 'ul-button button button-wide button-primary',
       title: loc('oktaVerify.open.button', 'login'),
-      id: 'launch-ov',
+      id: 'launch-enrollment-ov',
       click: () => {
         Util.redirectWithFormGet(currentViewState.href);
       }

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -12,7 +12,7 @@
  */
 
 /* eslint complexity: [2, 13], max-depth: [2, 3] */
-import { _, loc } from '@okta/courage';
+import {_, createButton, loc} from '@okta/courage';
 import Enums from './Enums';
 import Logger from './Logger';
 import BrowserFeatures from './BrowserFeatures';
@@ -88,7 +88,7 @@ Util.transformErrorXHR = function(xhr) {
       }
     } else if (typeof xhr.responseText === 'object') {
       xhr.responseJSON = xhr.responseText;
-    } 
+    }
   }
   // Temporary solution to display field errors
   // Assuming there is only one field error in a response
@@ -184,6 +184,24 @@ Util.redirect = function(url, win = window, isAppLink = false) {
     Util.redirectWithFormGet(url);
   } else {
     win.location.href = url;
+  }
+};
+
+Util.enrollmentRedirect = function(view) {
+  const currentViewState = view.options.appState.getCurrentViewState();
+  const ovEnrollment = window.location.href.includes('redirect_uri=https%3A%2F%2Flogin.okta.com');
+
+  if (BrowserFeatures.isAndroid() && ovEnrollment) {
+    view.add(createButton({
+      className: 'ul-button button button-wide button-primary',
+      title: loc('oktaVerify.open.button', 'login'),
+      id: 'launch-ov',
+      click: () => {
+        Util.redirectWithFormGet(currentViewState.href);
+      }
+    }));
+  } else {
+    Util.redirectWithFormGet(currentViewState.href);
   }
 };
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -12,7 +12,7 @@
  */
 
 /* eslint complexity: [2, 13], max-depth: [2, 3] */
-import {_, createButton, loc} from '@okta/courage';
+import {_, loc} from '@okta/courage';
 import Enums from './Enums';
 import Logger from './Logger';
 import BrowserFeatures from './BrowserFeatures';
@@ -188,7 +188,7 @@ Util.redirect = function(url, win = window, isAppLink = false) {
   }
 };
 
-Util.isAndroidOVEnrollment = function(view) {
+Util.isAndroidOVEnrollment = function() {
   const ovEnrollment = decodeURIComponent(window.location.href).includes(ovDeepLink);
   return BrowserFeatures.isAndroid() && ovEnrollment;
 }

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -245,6 +245,7 @@ export default Controller.extend({
 
       const currentViewState = this.options.appState.getCurrentViewState();
 
+      // OKTA-635926: add user gesture for android ov enrollment
       const ovEnrollment = window.location.href.includes('redirect_uri=https%3A%2F%2Flogin.okta.com');
       if (BrowserFeatures.isAndroid() && ovEnrollment) {
         this.add('<div class="o-form-button-bar"><button id="androidOpenOV" class="button button-primary">Open Okta Verify</button></div>');

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -241,8 +241,10 @@ export default Controller.extend({
     if (model.get('useRedirect')) {
       // Clear when navigates away from SIW page, e.g. success, IdP Authenticator.
       // Because SIW sort of finished its current /transaction/
+      sessionStorageHelper.removeStateHandle();
 
       // OKTA-635926: do not redirect without user gesture for ov enrollment on android
+      // if Util.isAndroidOVEnrollment() returns true we use a user gesture to complete the redirect in AutoRedirectView
       if (!Util.isAndroidOVEnrollment()) {
         const currentViewState = this.options.appState.getCurrentViewState();
         Util.redirectWithFormGet(currentViewState.href);

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -23,7 +23,6 @@ import { CONFIGURED_FLOW } from '../client/constants';
 import { ConfigError } from 'util/Errors';
 import { updateAppState } from 'v2/client';
 import CookieUtil from '../../util/CookieUtil';
-import BrowserFeatures from 'util/BrowserFeatures'
 
 export interface ContextData {
   controller: string;

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -23,6 +23,7 @@ import { CONFIGURED_FLOW } from '../client/constants';
 import { ConfigError } from 'util/Errors';
 import { updateAppState } from 'v2/client';
 import CookieUtil from '../../util/CookieUtil';
+import BrowserFeatures from "util/BrowserFeatures";
 
 export interface ContextData {
   controller: string;
@@ -240,9 +241,12 @@ export default Controller.extend({
     if (model.get('useRedirect')) {
       // Clear when navigates away from SIW page, e.g. success, IdP Authenticator.
       // Because SIW sort of finished its current /transaction/
-      sessionStorageHelper.removeStateHandle();
 
-      Util.enrollmentRedirect(this);
+      // OKTA-635926: do not redirect without user gesture for ov enrollment on android
+      if (!Util.isAndroidOVEnrollment(this)) {
+        const currentViewState = this.options.appState.getCurrentViewState();
+        Util.redirectWithFormGet(currentViewState.href);
+      }
 
       return;
     }

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -245,7 +245,8 @@ export default Controller.extend({
 
       const currentViewState = this.options.appState.getCurrentViewState();
 
-      if (BrowserFeatures.isAndroid()) {
+      const ovEnrollment = window.location.href.includes('redirect_uri=https%3A%2F%2Flogin.okta.com');
+      if (BrowserFeatures.isAndroid() && ovEnrollment) {
         this.add('<div class="o-form-button-bar"><button id="androidOpenOV" class="button button-primary">Open Okta Verify</button></div>');
         document.getElementById("androidOpenOV").addEventListener("click", () => Util.redirectWithFormGet(currentViewState.href));
       } else {

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -23,6 +23,7 @@ import { CONFIGURED_FLOW } from '../client/constants';
 import { ConfigError } from 'util/Errors';
 import { updateAppState } from 'v2/client';
 import CookieUtil from '../../util/CookieUtil';
+import BrowserFeatures from 'util/BrowserFeatures'
 
 export interface ContextData {
   controller: string;
@@ -244,14 +245,12 @@ export default Controller.extend({
 
       const currentViewState = this.options.appState.getCurrentViewState();
 
-      // this.add('<button onclick="Util.redirectWithFormGet(currentViewState.href)">Open OV</button>');
-      this.add('<button id="sdhingraButton">Open OV</button>');
-      document.getElementById("sdhingraButton").addEventListener("click", sdhingraFunction);
-      function sdhingraFunction(){
-        console.log('redirect');
+      if (BrowserFeatures.isAndroid()) {
+        this.add('<div class="o-form-button-bar"><button id="androidOpenOV" class="button button-primary">Open Okta Verify</button></div>');
+        document.getElementById("androidOpenOV").addEventListener("click", () => Util.redirectWithFormGet(currentViewState.href));
+      } else {
         Util.redirectWithFormGet(currentViewState.href);
       }
-      // Util.redirectWithFormGet(currentViewState.href);
       return;
     }
 

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -243,7 +243,15 @@ export default Controller.extend({
       sessionStorageHelper.removeStateHandle();
 
       const currentViewState = this.options.appState.getCurrentViewState();
-      Util.redirectWithFormGet(currentViewState.href);
+
+      // this.add('<button onclick="Util.redirectWithFormGet(currentViewState.href)">Open OV</button>');
+      this.add('<button id="sdhingraButton">Open OV</button>');
+      document.getElementById("sdhingraButton").addEventListener("click", sdhingraFunction);
+      function sdhingraFunction(){
+        console.log('redirect');
+        Util.redirectWithFormGet(currentViewState.href);
+      }
+      // Util.redirectWithFormGet(currentViewState.href);
       return;
     }
 

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -243,16 +243,8 @@ export default Controller.extend({
       // Because SIW sort of finished its current /transaction/
       sessionStorageHelper.removeStateHandle();
 
-      const currentViewState = this.options.appState.getCurrentViewState();
+      Util.enrollmentRedirect(this);
 
-      // OKTA-635926: add user gesture for android ov enrollment
-      const ovEnrollment = window.location.href.includes('redirect_uri=https%3A%2F%2Flogin.okta.com');
-      if (BrowserFeatures.isAndroid() && ovEnrollment) {
-        this.add('<div class="o-form-button-bar"><button id="androidOpenOV" class="button button-primary">Open Okta Verify</button></div>');
-        document.getElementById("androidOpenOV").addEventListener("click", () => Util.redirectWithFormGet(currentViewState.href));
-      } else {
-        Util.redirectWithFormGet(currentViewState.href);
-      }
       return;
     }
 

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -243,7 +243,7 @@ export default Controller.extend({
       // Because SIW sort of finished its current /transaction/
 
       // OKTA-635926: do not redirect without user gesture for ov enrollment on android
-      if (!Util.isAndroidOVEnrollment(this)) {
+      if (!Util.isAndroidOVEnrollment()) {
         const currentViewState = this.options.appState.getCurrentViewState();
         Util.redirectWithFormGet(currentViewState.href);
       }

--- a/src/v2/view-builder/utils/AutoRedirectUtil.js
+++ b/src/v2/view-builder/utils/AutoRedirectUtil.js
@@ -1,0 +1,18 @@
+import Util from "../../../util/Util";
+import {BaseHeader} from "../internals";
+import {BaseAuthenticatorBeacon} from "../components/BaseAuthenticatorView";
+import {AUTHENTICATOR_KEY} from "../../ion/RemediationConstants";
+
+function getHeader() {
+  if (Util.isAndroidOVEnrollment()) {
+    return BaseHeader.extend({
+      HeaderBeacon: BaseAuthenticatorBeacon.extend({
+        authenticatorKey: AUTHENTICATOR_KEY.OV,
+      })
+    })
+  } else {
+    return BaseHeader;
+  }
+}
+
+export { getHeader }

--- a/src/v2/view-builder/utils/AutoRedirectUtil.js
+++ b/src/v2/view-builder/utils/AutoRedirectUtil.js
@@ -1,7 +1,7 @@
-import Util from "../../../util/Util";
-import {BaseHeader} from "../internals";
-import {BaseAuthenticatorBeacon} from "../components/BaseAuthenticatorView";
-import {AUTHENTICATOR_KEY} from "../../ion/RemediationConstants";
+import Util from '../../../util/Util';
+import {BaseHeader} from '../internals';
+import {BaseAuthenticatorBeacon} from '../components/BaseAuthenticatorView';
+import {AUTHENTICATOR_KEY} from '../../ion/RemediationConstants';
 
 function getHeader() {
   if (Util.isAndroidOVEnrollment()) {
@@ -9,10 +9,10 @@ function getHeader() {
       HeaderBeacon: BaseAuthenticatorBeacon.extend({
         authenticatorKey: AUTHENTICATOR_KEY.OV,
       })
-    })
+    });
   } else {
     return BaseHeader;
   }
 }
 
-export { getHeader }
+export { getHeader };

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -1,6 +1,6 @@
-import {_, loc, createCallout, createButton} from '@okta/courage';
-import {BaseForm, BaseView} from '../internals';
-import {INTERSTITIAL_REDIRECT_VIEW} from '../../ion/RemediationConstants';
+import { _, loc, createCallout, createButton } from '@okta/courage';
+import { BaseForm, BaseView } from '../internals';
+import { INTERSTITIAL_REDIRECT_VIEW } from '../../ion/RemediationConstants';
 import CustomAccessDeniedErrorMessage from '../views/shared/CustomAccessDeniedErrorMessage';
 import Util from 'util/Util';
 import { getHeader } from '../utils/AutoRedirectUtil';

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -4,7 +4,7 @@ import {AUTHENTICATOR_KEY, INTERSTITIAL_REDIRECT_VIEW} from '../../ion/Remediati
 import CustomAccessDeniedErrorMessage from '../views/shared/CustomAccessDeniedErrorMessage';
 import Util from "util/Util";
 import {BaseAuthenticatorBeacon} from "v2/view-builder/components/BaseAuthenticatorView";
-
+import { getHeader } from '../utils/AutoRedirectUtil';
 const CUSTOM_ACCESS_DENIED_KEY = 'security.access_denied_custom_message';
 const UNLOCK_USER_SUCCESS_MESSAGE = 'oie.selfservice.unlock_user.landing.to.app.success.message';
 
@@ -32,11 +32,8 @@ const Body = BaseForm.extend({
 
     const appName = appInstanceName ? appInstanceName : appDisplayName;
 
-    const ovDeepLink = 'redirect_uri=https://login.okta.com/oauth/callback';
-    const ovEnrollment = decodeURIComponent(window.location.href).includes(ovDeepLink);
-
     // OKTA-635926: add user gesture for ov enrollment on android
-    if (Util.isAndroidOVEnrollment(this)) {
+    if (Util.isAndroidOVEnrollment()) {
       titleString = loc('oie.success.text.signingIn.with.appName.android.ov.enrollment', 'login');
     } else if (appName && userEmail && !this.settings.get('features.showIdentifier')) {
       titleString = loc('oie.success.text.signingIn.with.appName.and.identifier', 'login', [appName, userEmail]);
@@ -79,7 +76,7 @@ const Body = BaseForm.extend({
     if (this.redirectView === INTERSTITIAL_REDIRECT_VIEW.DEFAULT) {
 
       // OKTA-635926: add user gesture for ov enrollment on android
-      if (Util.isAndroidOVEnrollment(this)) {
+      if (Util.isAndroidOVEnrollment()) {
         const currentViewState = this.options.appState.getCurrentViewState();
         this.add(createButton({
           className: 'ul-button button button-wide button-primary hide-underline',
@@ -96,19 +93,7 @@ const Body = BaseForm.extend({
   }
 });
 
-function getRedirectViewHeader() {
-  if (Util.isAndroidOVEnrollment()) {
-    return BaseHeader.extend({
-      HeaderBeacon: BaseAuthenticatorBeacon.extend({
-        authenticatorKey: AUTHENTICATOR_KEY.OV,
-      })
-    })
-  } else {
-    return BaseHeader;
-  }
-}
-
 export default BaseView.extend({
-  Header: getRedirectViewHeader(),
+  Header: getHeader(),
   Body: Body
 });

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -8,7 +8,7 @@ const CUSTOM_ACCESS_DENIED_KEY = 'security.access_denied_custom_message';
 const UNLOCK_USER_SUCCESS_MESSAGE = 'oie.selfservice.unlock_user.landing.to.app.success.message';
 
 const Body = BaseForm.extend({
-  // eslint-disable-next-line complexity
+  /* eslint complexity: [2, 16] */
   title() {
     let titleString = loc('oie.success.text.signingIn', 'login');
     // For more info on the API response available in appState, see IdxResponseBuilder.java

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -1,14 +1,14 @@
 import {_, loc, createCallout, createButton} from '@okta/courage';
-import {BaseForm, BaseHeader, BaseView} from '../internals';
-import {AUTHENTICATOR_KEY, INTERSTITIAL_REDIRECT_VIEW} from '../../ion/RemediationConstants';
+import {BaseForm, BaseView} from '../internals';
+import {INTERSTITIAL_REDIRECT_VIEW} from '../../ion/RemediationConstants';
 import CustomAccessDeniedErrorMessage from '../views/shared/CustomAccessDeniedErrorMessage';
-import Util from "util/Util";
-import {BaseAuthenticatorBeacon} from "v2/view-builder/components/BaseAuthenticatorView";
+import Util from 'util/Util';
 import { getHeader } from '../utils/AutoRedirectUtil';
 const CUSTOM_ACCESS_DENIED_KEY = 'security.access_denied_custom_message';
 const UNLOCK_USER_SUCCESS_MESSAGE = 'oie.selfservice.unlock_user.landing.to.app.success.message';
 
 const Body = BaseForm.extend({
+  // eslint-disable-next-line complexity
   title() {
     let titleString = loc('oie.success.text.signingIn', 'login');
     // For more info on the API response available in appState, see IdxResponseBuilder.java

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -1,10 +1,9 @@
 /* eslint max-len: [2, 140] */
-import {$, createButton, loc} from '@okta/courage';
+import {$} from '@okta/courage';
 import $sandbox from 'sandbox';
 import Logger from 'util/Logger';
 import Util from 'util/Util';
 import BrowserFeatures from '../../../src/util/BrowserFeatures';
-import utilSpy from '../../../src/util/Util';
 
 describe('util/Util', () => {
   describe('transformErrorXHR', () => {
@@ -358,5 +357,5 @@ describe('util/Util', () => {
 
       expect(Util.isAndroidOVEnrollment()).toBe(false);
     });
-  })
+  });
 });

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -6,7 +6,6 @@ import Util from 'util/Util';
 import BrowserFeatures from '../../../src/util/BrowserFeatures';
 import utilSpy from '../../../src/util/Util';
 
-
 describe('util/Util', () => {
   describe('transformErrorXHR', () => {
     it('errorSummary shows network connection error when status is 0', () => {
@@ -294,7 +293,74 @@ describe('util/Util', () => {
     });
 
   });
-  //
+
+  describe('Test isAndroidOVEnrollment', () => {
+
+    beforeEach(() => {
+      delete window.location;
+    });
+
+    it('Test is Android and OV Enrollment', () => {
+      jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
+            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
+            '&code_challenge=challenge&client_id=id',
+        },
+        writeable: true,
+        configurable: true
+      });
+
+      expect(Util.isAndroidOVEnrollment()).toBe(true);
+    });
+
+    it('Test is Android and not OV Enrollment', () => {
+      jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
+            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Forg.com%2Fenduser%2Fcallback&nonce=nonce' +
+            '&code_challenge=challenge&client_id=id',
+        },
+        writeable: true,
+        configurable: true
+      });
+
+      expect(Util.isAndroidOVEnrollment()).toBe(false);
+    });
+
+    it('Test is not Android and is OV Enrollment', () => {
+      jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(false);
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
+            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
+            '&code_challenge=challenge&client_id=id',
+        },
+        writeable: true,
+        configurable: true
+      });
+
+      expect(Util.isAndroidOVEnrollment()).toBe(false);
+    });
+
+    it('Test is not Android and not OV Enrollment', () => {
+      jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(false);
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
+            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Forg.com%2Fenduser%2Fcallback&nonce=nonce' +
+            '&code_challenge=challenge&client_id=id',
+        },
+        writeable: true,
+        configurable: true
+      });
+
+      expect(Util.isAndroidOVEnrollment()).toBe(false);
+    });
+  })
+
   // describe('enrollmentRedirect', () => {
   //
   //   class EnrollmentView {

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -294,107 +294,107 @@ describe('util/Util', () => {
     });
 
   });
-
-  describe('enrollmentRedirect', () => {
-
-    class EnrollmentView {
-      add() {}
-      options = { appState: { getCurrentViewState() {} }}
-    }
-    const enrollmentView = new EnrollmentView();
-    const expectedAddArgs = [];
-
-    beforeEach(() => {
-      spyOn(enrollmentView, 'add').and.callFake((addArg) => {expectedAddArgs.push(addArg);});
-      jest.spyOn(utilSpy, 'redirectWithFormGet').mockReturnValue(() => {});
-      jest.spyOn(enrollmentView.options.appState, 'getCurrentViewState').mockReturnValue({
-        href:'https://org.okta.com/login/token/redirect?stateToken=mockedStateToken123'});
-      delete window.location;
-    });
-
-    afterEach(() => {
-      expectedAddArgs.length = 0;
-    });
-
-    it('adds Open OV button if the browser is on Android', () => {
-      // create mocks
-      jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
-            '&code_challenge=challenge&client_id=id',
-        },
-        writeable: true,
-        configurable: true
-      });
-      let expectedCreateButton = createButton({
-        className: 'ul-button button button-wide button-primary',
-        title: loc('oktaVerify.open.button', 'login'),
-        id: 'launch-enrollment-ov'
-      });
-
-      // initiate flow
-      Util.enrollmentRedirect(enrollmentView);
-
-      // assertions
-      expect(enrollmentView.add).toHaveBeenCalledTimes(1);
-      expect(expectedAddArgs.length).toBe(1);
-      let actualCreateButton = expectedAddArgs[0].prototype;
-      expect(actualCreateButton.className).toBe(expectedCreateButton.prototype.className);
-      expect(actualCreateButton.title).toBe(expectedCreateButton.prototype.title);
-      expect(actualCreateButton.id).toBe(expectedCreateButton.prototype.id);
-      expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(0);
-      actualCreateButton.click();
-      expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not add OV button if the browser is not on Android', () => {
-      // create mocks
-      jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(false);
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
-            '&code_challenge=challenge&client_id=id',
-        },
-        writeable: true,
-        configurable: true
-      });
-
-      // initiate flow
-      Util.enrollmentRedirect(enrollmentView);
-
-      // assert button is not added
-      expect(enrollmentView.add).toHaveBeenCalledTimes(0);
-      expect(expectedAddArgs.length).toBe(0);
-
-      // assert redirect called
-      expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
-    });
-
-    it('Not OV enrollment', () => {
-      // create mocks
-      jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Forg.com%2Fenduser%2Fcallback&nonce=nonce' +
-            '&code_challenge=challenge&client_id=id',
-        },
-        writeable: true,
-        configurable: true
-      });
-
-      // initiate flow
-      Util.enrollmentRedirect(enrollmentView);
-
-      // assert button is not added
-      expect(enrollmentView.add).toHaveBeenCalledTimes(0);
-      expect(expectedAddArgs.length).toBe(0);
-
-      // assert redirect called
-      expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
-    });
-  });
+  //
+  // describe('enrollmentRedirect', () => {
+  //
+  //   class EnrollmentView {
+  //     add() {}
+  //     options = { appState: { getCurrentViewState() {} }}
+  //   }
+  //   const enrollmentView = new EnrollmentView();
+  //   const expectedAddArgs = [];
+  //
+  //   beforeEach(() => {
+  //     spyOn(enrollmentView, 'add').and.callFake((addArg) => {expectedAddArgs.push(addArg);});
+  //     jest.spyOn(utilSpy, 'redirectWithFormGet').mockReturnValue(() => {});
+  //     jest.spyOn(enrollmentView.options.appState, 'getCurrentViewState').mockReturnValue({
+  //       href:'https://org.okta.com/login/token/redirect?stateToken=mockedStateToken123'});
+  //     delete window.location;
+  //   });
+  //
+  //   afterEach(() => {
+  //     expectedAddArgs.length = 0;
+  //   });
+  //
+  //   it('adds Open OV button if the browser is on Android', () => {
+  //     // create mocks
+  //     jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
+  //     Object.defineProperty(window, 'location', {
+  //       value: {
+  //         href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
+  //           '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
+  //           '&code_challenge=challenge&client_id=id',
+  //       },
+  //       writeable: true,
+  //       configurable: true
+  //     });
+  //     let expectedCreateButton = createButton({
+  //       className: 'ul-button button button-wide button-primary',
+  //       title: loc('oktaVerify.open.button', 'login'),
+  //       id: 'launch-enrollment-ov'
+  //     });
+  //
+  //     // initiate flow
+  //     Util.enrollmentRedirect(enrollmentView);
+  //
+  //     // assertions
+  //     expect(enrollmentView.add).toHaveBeenCalledTimes(1);
+  //     expect(expectedAddArgs.length).toBe(1);
+  //     let actualCreateButton = expectedAddArgs[0].prototype;
+  //     expect(actualCreateButton.className).toBe(expectedCreateButton.prototype.className);
+  //     expect(actualCreateButton.title).toBe(expectedCreateButton.prototype.title);
+  //     expect(actualCreateButton.id).toBe(expectedCreateButton.prototype.id);
+  //     expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(0);
+  //     actualCreateButton.click();
+  //     expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
+  //   });
+  //
+  //   it('does not add OV button if the browser is not on Android', () => {
+  //     // create mocks
+  //     jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(false);
+  //     Object.defineProperty(window, 'location', {
+  //       value: {
+  //         href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
+  //           '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
+  //           '&code_challenge=challenge&client_id=id',
+  //       },
+  //       writeable: true,
+  //       configurable: true
+  //     });
+  //
+  //     // initiate flow
+  //     Util.enrollmentRedirect(enrollmentView);
+  //
+  //     // assert button is not added
+  //     expect(enrollmentView.add).toHaveBeenCalledTimes(0);
+  //     expect(expectedAddArgs.length).toBe(0);
+  //
+  //     // assert redirect called
+  //     expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
+  //   });
+  //
+  //   it('Not OV enrollment', () => {
+  //     // create mocks
+  //     jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
+  //     Object.defineProperty(window, 'location', {
+  //       value: {
+  //         href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
+  //           '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Forg.com%2Fenduser%2Fcallback&nonce=nonce' +
+  //           '&code_challenge=challenge&client_id=id',
+  //       },
+  //       writeable: true,
+  //       configurable: true
+  //     });
+  //
+  //     // initiate flow
+  //     Util.enrollmentRedirect(enrollmentView);
+  //
+  //     // assert button is not added
+  //     expect(enrollmentView.add).toHaveBeenCalledTimes(0);
+  //     expect(expectedAddArgs.length).toBe(0);
+  //
+  //     // assert redirect called
+  //     expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
+  //   });
+  // });
 });

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -291,7 +291,6 @@ describe('util/Util', () => {
       expect(Logger.error).toHaveBeenCalledTimes(1);
       expect(Logger.error).toHaveBeenCalledWith('Cannot redirect to empty URL: ()');
     });
-
   });
 
   describe('Test isAndroidOVEnrollment', () => {
@@ -360,107 +359,4 @@ describe('util/Util', () => {
       expect(Util.isAndroidOVEnrollment()).toBe(false);
     });
   })
-
-  // describe('enrollmentRedirect', () => {
-  //
-  //   class EnrollmentView {
-  //     add() {}
-  //     options = { appState: { getCurrentViewState() {} }}
-  //   }
-  //   const enrollmentView = new EnrollmentView();
-  //   const expectedAddArgs = [];
-  //
-  //   beforeEach(() => {
-  //     spyOn(enrollmentView, 'add').and.callFake((addArg) => {expectedAddArgs.push(addArg);});
-  //     jest.spyOn(utilSpy, 'redirectWithFormGet').mockReturnValue(() => {});
-  //     jest.spyOn(enrollmentView.options.appState, 'getCurrentViewState').mockReturnValue({
-  //       href:'https://org.okta.com/login/token/redirect?stateToken=mockedStateToken123'});
-  //     delete window.location;
-  //   });
-  //
-  //   afterEach(() => {
-  //     expectedAddArgs.length = 0;
-  //   });
-  //
-  //   it('adds Open OV button if the browser is on Android', () => {
-  //     // create mocks
-  //     jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
-  //     Object.defineProperty(window, 'location', {
-  //       value: {
-  //         href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-  //           '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
-  //           '&code_challenge=challenge&client_id=id',
-  //       },
-  //       writeable: true,
-  //       configurable: true
-  //     });
-  //     let expectedCreateButton = createButton({
-  //       className: 'ul-button button button-wide button-primary',
-  //       title: loc('oktaVerify.open.button', 'login'),
-  //       id: 'launch-enrollment-ov'
-  //     });
-  //
-  //     // initiate flow
-  //     Util.enrollmentRedirect(enrollmentView);
-  //
-  //     // assertions
-  //     expect(enrollmentView.add).toHaveBeenCalledTimes(1);
-  //     expect(expectedAddArgs.length).toBe(1);
-  //     let actualCreateButton = expectedAddArgs[0].prototype;
-  //     expect(actualCreateButton.className).toBe(expectedCreateButton.prototype.className);
-  //     expect(actualCreateButton.title).toBe(expectedCreateButton.prototype.title);
-  //     expect(actualCreateButton.id).toBe(expectedCreateButton.prototype.id);
-  //     expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(0);
-  //     actualCreateButton.click();
-  //     expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
-  //   });
-  //
-  //   it('does not add OV button if the browser is not on Android', () => {
-  //     // create mocks
-  //     jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(false);
-  //     Object.defineProperty(window, 'location', {
-  //       value: {
-  //         href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-  //           '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
-  //           '&code_challenge=challenge&client_id=id',
-  //       },
-  //       writeable: true,
-  //       configurable: true
-  //     });
-  //
-  //     // initiate flow
-  //     Util.enrollmentRedirect(enrollmentView);
-  //
-  //     // assert button is not added
-  //     expect(enrollmentView.add).toHaveBeenCalledTimes(0);
-  //     expect(expectedAddArgs.length).toBe(0);
-  //
-  //     // assert redirect called
-  //     expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
-  //   });
-  //
-  //   it('Not OV enrollment', () => {
-  //     // create mocks
-  //     jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
-  //     Object.defineProperty(window, 'location', {
-  //       value: {
-  //         href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-  //           '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Forg.com%2Fenduser%2Fcallback&nonce=nonce' +
-  //           '&code_challenge=challenge&client_id=id',
-  //       },
-  //       writeable: true,
-  //       configurable: true
-  //     });
-  //
-  //     // initiate flow
-  //     Util.enrollmentRedirect(enrollmentView);
-  //
-  //     // assert button is not added
-  //     expect(enrollmentView.add).toHaveBeenCalledTimes(0);
-  //     expect(expectedAddArgs.length).toBe(0);
-  //
-  //     // assert redirect called
-  //     expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
-  //   });
-  // });
 });

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -301,15 +301,14 @@ describe('util/Util', () => {
       add() {}
       options = { appState: { getCurrentViewState() {} }}
     }
-
     const enrollmentView = new EnrollmentView();
     const expectedAddArgs = [];
 
     beforeEach(() => {
+      spyOn(enrollmentView, 'add').and.callFake((addArg) => {expectedAddArgs.push(addArg);});
       jest.spyOn(utilSpy, 'redirectWithFormGet').mockReturnValue(() => {});
       jest.spyOn(enrollmentView.options.appState, 'getCurrentViewState').mockReturnValue({
         href:'https://org.okta.com/login/token/redirect?stateToken=mockedStateToken123'});
-      spyOn(enrollmentView, 'add').and.callFake((addArg) => {expectedAddArgs.push(addArg);});
     });
 
     afterEach(() => {
@@ -320,7 +319,6 @@ describe('util/Util', () => {
     it('adds Open OV button if the browser is on Android', () => {
       // create mocks
       jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
-
       Object.defineProperty(window, 'location', {
         value: {
           href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
@@ -339,7 +337,7 @@ describe('util/Util', () => {
       let expectedCreateButton = createButton({
         className: 'ul-button button button-wide button-primary',
         title: loc('oktaVerify.open.button', 'login'),
-        id: 'launch-ov'
+        id: 'launch-enrollment-ov'
       });
 
       let actualCreateButton = expectedAddArgs[0].prototype;
@@ -349,13 +347,11 @@ describe('util/Util', () => {
       expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(0);
       actualCreateButton.click();
       expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
-
     });
 
     it('does not add OV button if the browser is not on Android', () => {
       // create mocks
       jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(false);
-
       Object.defineProperty(window, 'location', {
         value: {
           href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
@@ -375,13 +371,11 @@ describe('util/Util', () => {
 
       // assert redirect called
       expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
-
     });
 
     it('Not OV enrollment', () => {
       // create mocks
       jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
-
       Object.defineProperty(window, 'location', {
         value: {
           href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
@@ -401,7 +395,6 @@ describe('util/Util', () => {
 
       // assert redirect called
       expect(utilSpy.redirectWithFormGet).toHaveBeenCalledTimes(1);
-
     });
   });
 });

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -309,10 +309,10 @@ describe('util/Util', () => {
       jest.spyOn(utilSpy, 'redirectWithFormGet').mockReturnValue(() => {});
       jest.spyOn(enrollmentView.options.appState, 'getCurrentViewState').mockReturnValue({
         href:'https://org.okta.com/login/token/redirect?stateToken=mockedStateToken123'});
+      delete window.location;
     });
 
     afterEach(() => {
-      delete window.location;
       expectedAddArgs.length = 0;
     });
 
@@ -334,7 +334,7 @@ describe('util/Util', () => {
         id: 'launch-enrollment-ov'
       });
 
-      // initate flow
+      // initiate flow
       Util.enrollmentRedirect(enrollmentView);
 
       // assertions

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -1,5 +1,5 @@
 /* eslint max-len: [2, 140] */
-import {$} from '@okta/courage';
+import { $ } from '@okta/courage';
 import $sandbox from 'sandbox';
 import Logger from 'util/Logger';
 import Util from 'util/Util';

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -328,18 +328,18 @@ describe('util/Util', () => {
         writeable: true,
         configurable: true
       });
-
-      // assertions
-      Util.enrollmentRedirect(enrollmentView);
-      expect(enrollmentView.add).toHaveBeenCalledTimes(1);
-      expect(expectedAddArgs.length).toBe(1);
-
       let expectedCreateButton = createButton({
         className: 'ul-button button button-wide button-primary',
         title: loc('oktaVerify.open.button', 'login'),
         id: 'launch-enrollment-ov'
       });
 
+      // initate flow
+      Util.enrollmentRedirect(enrollmentView);
+
+      // assertions
+      expect(enrollmentView.add).toHaveBeenCalledTimes(1);
+      expect(expectedAddArgs.length).toBe(1);
       let actualCreateButton = expectedAddArgs[0].prototype;
       expect(actualCreateButton.className).toBe(expectedCreateButton.prototype.className);
       expect(actualCreateButton.title).toBe(expectedCreateButton.prototype.title);

--- a/test/unit/spec/v2/view-builder/utils/AutoRedirectUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/AutoRedirectUtil_spec.js
@@ -1,8 +1,8 @@
-import {getHeader} from '../../../../../../src/v2/view-builder/utils/AutoRedirectUtil';
+import { getHeader } from '../../../../../../src/v2/view-builder/utils/AutoRedirectUtil';
 import Util from '../../../../../../src/util/Util';
-import {BaseHeader} from '../../../../../../src/v2/view-builder/internals';
-import {BaseAuthenticatorBeacon} from '../../../../../../src/v2/view-builder/components/BaseAuthenticatorView';
-import {AUTHENTICATOR_KEY} from '../../../../../../src/v2/ion/RemediationConstants';
+import { BaseHeader } from '../../../../../../src/v2/view-builder/internals';
+import { BaseAuthenticatorBeacon } from '../../../../../../src/v2/view-builder/components/BaseAuthenticatorView';
+import { AUTHENTICATOR_KEY } from '../../../../../../src/v2/ion/RemediationConstants';
 describe('v2/view-builder/utils/AutoRedirectUtil', () => {
 
   it('Android OV Enrollment', ()=> {

--- a/test/unit/spec/v2/view-builder/utils/AutoRedirectUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/AutoRedirectUtil_spec.js
@@ -1,0 +1,23 @@
+import {getHeader} from "../../../../../../src/v2/view-builder/utils/AutoRedirectUtil";
+import Util from '../../../../../../src/util/Util';
+import {BaseHeader} from "../../../../../../src/v2/view-builder/internals";
+import {BaseAuthenticatorBeacon} from "../../../../../../src/v2/view-builder/components/BaseAuthenticatorView";
+import {AUTHENTICATOR_KEY} from "../../../../../../src/v2/ion/RemediationConstants";
+describe('v2/view-builder/utils/AutoRedirectUtil', () => {
+
+  it('Android OV Enrollment', ()=> {
+    jest.spyOn(Util, 'isAndroidOVEnrollment').mockReturnValue(true);
+    const beaconHeader = BaseHeader.extend({
+      HeaderBeacon: BaseAuthenticatorBeacon.extend({
+        authenticatorKey: AUTHENTICATOR_KEY.OV,
+      })
+    });
+    expect(getHeader().toString()).toBe(beaconHeader.toString());
+  });
+
+  it('Not Android OV Enrollment', ()=> {
+    jest.spyOn(Util, 'isAndroidOVEnrollment').mockReturnValue(false);
+    expect(getHeader()).toBe(BaseHeader);
+  });
+
+});

--- a/test/unit/spec/v2/view-builder/utils/AutoRedirectUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/AutoRedirectUtil_spec.js
@@ -1,8 +1,8 @@
-import {getHeader} from "../../../../../../src/v2/view-builder/utils/AutoRedirectUtil";
+import {getHeader} from '../../../../../../src/v2/view-builder/utils/AutoRedirectUtil';
 import Util from '../../../../../../src/util/Util';
-import {BaseHeader} from "../../../../../../src/v2/view-builder/internals";
-import {BaseAuthenticatorBeacon} from "../../../../../../src/v2/view-builder/components/BaseAuthenticatorView";
-import {AUTHENTICATOR_KEY} from "../../../../../../src/v2/ion/RemediationConstants";
+import {BaseHeader} from '../../../../../../src/v2/view-builder/internals';
+import {BaseAuthenticatorBeacon} from '../../../../../../src/v2/view-builder/components/BaseAuthenticatorView';
+import {AUTHENTICATOR_KEY} from '../../../../../../src/v2/ion/RemediationConstants';
 describe('v2/view-builder/utils/AutoRedirectUtil', () => {
 
   it('Android OV Enrollment', ()=> {

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -132,7 +132,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
     it('Do not add User Gesture if not OV enrollment on Android', () => {
       jest.spyOn(utilSpy, 'isAndroidOVEnrollment').mockReturnValue(false);
       testContext.init();
-      expect(testContext.view.el).toMatchSnapshot('should show user gesture');
+      expect(testContext.view.el).toMatchSnapshot('should not show user gesture');
     });
 
   });

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -1,14 +1,10 @@
-import { loc, Model, createButton } from '@okta/courage';
+import { Model } from '@okta/courage';
 import AutoRedirectView from 'v2/view-builder/views/AutoRedirectView';
 import AppState from 'v2/models/AppState';
 import Settings from 'models/Settings';
 import SuccessWithAppUser from '../../../../../../playground/mocks/data/idp/idx/success-with-app-user.json';
 import { INTERSTITIAL_REDIRECT_VIEW } from 'v2/ion/RemediationConstants';
-import BrowserFeatures from '../../../../../../src/util/BrowserFeatures';
 import utilSpy from '../../../../../../src/util/Util';
-import {BaseHeader} from "../../../../../../src/v2/view-builder/internals";
-import {BaseAuthenticatorBeacon} from "../../../../../../src/v2/view-builder/components/BaseAuthenticatorView";
-import {AUTHENTICATOR_KEY} from "../../../../../../src/v2/ion/RemediationConstants";
 
 describe('v2/view-builder/views/AutoRedirectView', function() {
   let testContext;

--- a/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
+++ b/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
@@ -75,7 +75,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Add User G
 </div>
 `;
 
-exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add User Gesture if not OV enrollment on Android: should show user gesture 1`] = `
+exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add User Gesture if not OV enrollment on Android: should not show user gesture 1`] = `
 <div
   class="siw-main-view "
 >

--- a/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
+++ b/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
@@ -1,5 +1,150 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Add User Gesture if OV enrollment on Android: should show user gesture 1`] = `
+<div
+  class="siw-main-view "
+>
+  <div
+    class="siw-main-header"
+  >
+    <div />
+  </div>
+  <div
+    class="siw-main-body"
+  >
+    <form
+      action="/"
+      class="ion-form o-form o-form-edit-mode"
+      data-se="o-form"
+      id="form90"
+      method="POST"
+      slot="content"
+    >
+      <div
+        class="o-form-content o-form-theme clearfix"
+        data-se="o-form-content"
+      >
+        <h2
+          class="okta-form-title o-form-head"
+          data-se="o-form-head"
+        >
+          To continue, tap "Open Okta Verify"
+        </h2>
+        <div
+          class="identifier-container"
+        >
+          <span
+            class="identifier no-translate"
+            data-se="identifier"
+            title="testUser@okta.com"
+          >
+            testUser@okta.com
+          </span>
+        </div>
+        <div
+          class="o-form-info-container"
+        />
+        <div
+          class="o-form-error-container"
+          data-se="o-form-error-container"
+          role="alert"
+        />
+        <div
+          class="o-form-fieldset-container"
+          data-se="o-form-fieldset-container"
+        >
+          <a
+            class="ul-button button button-wide button-primary hide-underline link-button"
+            data-se="button"
+            href="#"
+            id="launch-enrollment-ov"
+          >
+            Open Okta Verify
+          </a>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div
+    class="siw-main-footer"
+  >
+    <div
+      class="auth-footer"
+    />
+  </div>
+</div>
+`;
+
+exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add User Gesture if not OV enrollment on Android: should show user gesture 1`] = `
+<div
+  class="siw-main-view "
+>
+  <div
+    class="siw-main-header"
+  >
+    <div />
+  </div>
+  <div
+    class="siw-main-body"
+  >
+    <form
+      action="/"
+      class="ion-form o-form o-form-edit-mode"
+      data-se="o-form"
+      id="form109"
+      method="POST"
+      slot="content"
+    >
+      <div
+        class="o-form-content o-form-theme clearfix"
+        data-se="o-form-content"
+      >
+        <h2
+          class="okta-form-title o-form-head"
+          data-se="o-form-head"
+        >
+          Signing in to Okta Administration
+        </h2>
+        <div
+          class="identifier-container"
+        >
+          <span
+            class="identifier no-translate"
+            data-se="identifier"
+            title="testUser@okta.com"
+          >
+            testUser@okta.com
+          </span>
+        </div>
+        <div
+          class="o-form-info-container"
+        />
+        <div
+          class="o-form-error-container"
+          data-se="o-form-error-container"
+          role="alert"
+        />
+        <div
+          class="o-form-fieldset-container"
+          data-se="o-form-fieldset-container"
+        >
+          <div
+            class="okta-waiting-spinner"
+          />
+        </div>
+      </div>
+    </form>
+  </div>
+  <div
+    class="siw-main-footer"
+  >
+    <div
+      class="auth-footer"
+    />
+  </div>
+</div>
+`;
+
 exports[`v2/view-builder/views/AutoRedirectView renders custom error message 1`] = `"<div class=\\"siw-main-header\\"><div></div></div><div class=\\"siw-main-body\\"><form method=\\"POST\\" action=\\"/\\" data-se=\\"o-form\\" slot=\\"content\\" id=\\"form69\\" class=\\"ion-form o-form o-form-edit-mode\\"><div data-se=\\"o-form-content\\" class=\\"o-form-content o-form-theme clearfix\\"><h2 data-se=\\"o-form-head\\" class=\\"okta-form-title o-form-head\\">Signing in</h2><div class=\\"o-form-info-container\\"></div><div class=\\"o-form-error-container\\" data-se=\\"o-form-error-container\\" role=\\"alert\\"></div><div class=\\"o-form-fieldset-container\\" data-se=\\"o-form-fieldset-container\\"><div data-se=\\"callout\\" class=\\"infobox clearfix infobox-error\\"><span data-se=\\"icon\\" class=\\"icon error-16\\"></span><div class=\\"custom-access-denied-error-message\\"><p>You do not have permission to perform the requested action.</p><ul class=\\"custom-links\\"><li><a href=\\"https://www.okta.com/\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Help link 1</a></li><li><a href=\\"https://www.okta.com/help?page=1\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Help link 2</a></li></ul></div></div><div class=\\"okta-waiting-spinner\\"></div></div></div></form></div><div class=\\"siw-main-footer\\"><div class=\\"auth-footer\\"></div></div>"`;
 
 exports[`v2/view-builder/views/AutoRedirectView renders user identifier in title when features.showIdentifier is false: should show identifier in title 1`] = `


### PR DESCRIPTION
## Description:

When users choose to enroll Okta Verify using a sign-in URL after already being logged into chrome on android, they are redirected to `https://login.okta.com/` after succesful authentication and cannot complete the enrollment.

Okta-verify has a [deep link](https://github.com/atko-devices/okta-android-verify/blob/1854471c1ceb9b542e7663f1ba933b13504eb916/okta-auth-app/src/main/AndroidManifest.xml#L355) on `login.okta.com`, but deep links [do not work without a user gesture](https://developer.chrome.com/docs/multidevice/android/intents/) on android. This is why some authentication methods like a 2FA push notification would cause the issue. As such the solution is to add a user gesture prior to redirection to `login.okta.com` so the deep link can open the app.

UI mocks provided by @stevennguyen-okta 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-635926](https://oktainc.atlassian.net/browse/OKTA-635926)

### Reviewers:
@lesterchoi-okta @jaredperreault-okta 

### Screenshot/Video:
Demo of bug: https://okta.box.com/s/9ik685wwbwpf2mb21bbs1vasjih82oz9
Demo with code in PR: https://okta.box.com/s/msywbks2q85nx0res57zypa1mea77bsz
New View:
![final_view](https://github.com/okta/okta-signin-widget/assets/83233975/b3867a03-3db0-4800-a3fe-7268469db2c9)

### Downstream Monolith Build:



