### PR TITLE
SIW Gen 3: Support otp API

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -66,6 +66,7 @@ import {
   isOauth2Enabled,
   loadLanguage,
   SessionStorage,
+  triggerEmailVerifyCallback,
 } from '../../util';
 import { getEventContext } from '../../util/getEventContext';
 import { mapMuiThemeFromBrand } from '../../util/theme';
@@ -95,6 +96,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     globalErrorFn,
     proxyIdxResponse,
     eventEmitter,
+    otp,
   } = widgetProps;
 
   const [hide, setHide] = useState<boolean>(false);
@@ -179,6 +181,11 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
           // remove ts-expect-error ASAP to avoid risk of trying to access property that does not exist
           context: proxyIdxResponse,
         });
+        return;
+      }
+      // If widget is passed 'otp' config option, proceed with email verify callback
+      if (otp) {
+        setIdxTransaction(await triggerEmailVerifyCallback(widgetProps));
         return;
       }
       const transaction: IdxTransaction = await authClient.idx.start({
@@ -294,7 +301,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     } else {
       setData(formBag.data);
     }
-
     setUischema(formBag.uischema);
   }, [formBag, isClientTransaction]);
 
@@ -310,6 +316,11 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
           // remove ts-expect-error ASAP to avoid risk of trying to access property that does not exist
           context: proxyIdxResponse,
         });
+        return;
+      }
+      // If widget is passed 'otp' config option, proceed with email verify callback
+      if (otp) {
+        setIdxTransaction(await triggerEmailVerifyCallback(widgetProps));
         return;
       }
       const transaction = await authClient.idx.proceed({
@@ -336,7 +347,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     })) {
       return;
     }
-
     if (authClient.idx.canProceed()) {
       resume();
     } else {

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -157,6 +157,7 @@ export type WidgetOptions = {
 
   el?: string;
   cspNonce?: string;
+  otp?: string;
   baseUrl?: string;
   brandName?: string;
   brandColors?: BrandColors;

--- a/src/v3/test/integration/__snapshots__/trigger-email-verify-callback.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/trigger-email-verify-callback.test.tsx.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`triggerEmailVerifyCallback with otp flow should create proxy server response and render terminal state when interactionHandle is absent 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-2"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader authCoinSpacing MuiBox-root emotion-3"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-4"
+          />
+          <div
+            aria-hidden="true"
+            class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-5"
+            data-se="factor-beacon"
+          >
+            <svg
+              aria-labelledby="mfa-okta-email"
+              fill="none"
+              height="48"
+              role="img"
+              viewBox="0 0 48 48"
+              width="48"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="mfa-okta-email"
+              >
+                Email Authentication
+              </title>
+              <circle
+                class="siwFillBg"
+                cx="24"
+                cy="24"
+                fill="#F5F5F6"
+                r="24"
+              />
+              <path
+                class="siwFillSecondary"
+                d="M32 18v1h5.3L32 24.29v1.42l6-6.01v12.8a1.5 1.5 0 0 1-1.5 1.5h-17a1.5 1.5 0 0 1-1.5-1.5V31h-1v1.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V18h-7Z"
+                fill="#A7B5EC"
+              />
+              <path
+                class="siwFillPrimaryDark"
+                d="M9 13v14.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V13H9Zm20.293 1-8.81 8.81L10.794 14h18.499ZM28.5 29h-17a1.5 1.5 0 0 1-1.5-1.5V14.63l10.517 9.56L30 14.707V27.5a1.5 1.5 0 0 1-1.5 1.5Z"
+                fill="#00297A"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root emotion-6"
+        >
+          <form
+            class="o-form siwForm"
+            data-se="o-form"
+            novalidate=""
+          >
+            <div
+              class="MuiBox-root emotion-7"
+            >
+              <div
+                class="MuiBox-root emotion-8"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h4 emotion-10"
+                    data-se="o-form-head"
+                    tabindex="-1"
+                  >
+                    Your verification code
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-8"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-13"
+                    data-se="enter-code-instr"
+                  >
+                    Enter the OTP in your original authentication location.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-8"
+              >
+                <div
+                  class="MuiBox-root emotion-15"
+                >
+                  <h3
+                    class="MuiTypography-root MuiTypography-h3 no-translate emotion-16"
+                    data-se="otp-value"
+                  />
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-8"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-13"
+                    data-se="otp-warning"
+                  >
+                    If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;

--- a/src/v3/test/integration/trigger-email-verify-callback.test.tsx
+++ b/src/v3/test/integration/trigger-email-verify-callback.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { setup } from './util';
+
+import mockResponse from '../../src/mocks/response/idp/idx/introspect/default.json';
+
+describe('triggerEmailVerifyCallback with otp flow', () => {
+  const otp = 'fake-otp';
+
+  // Currently we only test the terminal error path of this flow. Testing the happy path e2e requires the widget to hit the resume() callback,
+  // meaning it must already have transaction meta loaded in the authClient, but the authClient gets reinstantiated on every call to setup().
+  // TODO: Write a testcafe test to validate the happy path flow in which triggerEmailVerifyCallback() passes the otp to authClient.idx.proceed()
+  it('should create proxy server response and render terminal state when interactionHandle is absent', async () => {
+    const { container, findByText } = await setup({ mockResponse, widgetOptions: { otp } });
+    await findByText(/Your verification code/);
+    await findByText(/Enter the OTP in your original authentication location./);
+    expect(container).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Description:
- Adds support for the [otp config option](https://github.com/okta/okta-signin-widget/tree/master#otp) that can be set on self-hosted widgets to handle email magic link callbacks
- Ports over `emailVerifyCallback()` from v2 as `triggerEmailVerifyCallback()` in `idxUtils.ts`
- See comment in integration test, but a testcafe test should probably be added later on to validate the e2e happy path in which the email callback successfully calls `authClient.idx.proceed()`. Mocking this in the integration test would require some refactoring of our integration setup utils (specifically `createAuthClient`) to force `authClient` to have saved transaction meta

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-594747](https://oktainc.atlassian.net/browse/OKTA-594747)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-594747-v3-otp&page=1&pageSize=6&sha=3ebe180ec9487d3e634f1701f27027545962ee85&tab=main)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



