### PR TITLE
G3: Support before/after hooks API

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,7 +20,6 @@ export interface RouterEventsAPI {
 export type RenderSuccessCallback = (res: RenderResult) => void;
 export type RenderErrorCallback = (err: RenderError) => void;
 export interface OktaSignInAPI extends HooksAPI, RouterEventsAPI {
-  readonly options: Pick<WidgetOptions, 'brandName'>;
   authClient: OktaAuthOAuthInterface;
   show(): void;
   hide(): void;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -238,6 +238,7 @@ export interface HookDefinition {
   before?: HookFunction[];
   after?: HookFunction[];
 }
+export type HookType = keyof HookDefinition;
 export interface HooksOptions {
   [name: string]: HookDefinition;
 }

--- a/src/util/Hooks.js
+++ b/src/util/Hooks.js
@@ -33,9 +33,9 @@ export async function executeHooksAfter(hook) {
 export function mergeHook(hooks, formName, hookToMerge) {
   const existingHook = hooks[formName] = hooks[formName] || { before: [], after: [] };
   if (hookToMerge.before) {
-    existingHook.before = existingHook.before.concat(hookToMerge.before);
+    existingHook.before = (existingHook.before || []).concat(hookToMerge.before);
   }
   if (hookToMerge.after) {
-    existingHook.after = existingHook.after.concat(hookToMerge.after);
+    existingHook.after = (existingHook.after || []).concat(hookToMerge.after);
   }
 }

--- a/src/v3/src/OktaSignIn/index.ts
+++ b/src/v3/src/OktaSignIn/index.ts
@@ -16,19 +16,23 @@ import { h, render } from 'preact';
 import { TinyEmitter as EventEmitter } from 'tiny-emitter';
 
 import {
-  EventContext, EventErrorContext,
+  EventContext,
+  EventErrorContext,
   HookFunction,
-  OktaSignInAPI, RenderErrorCallback, RenderResult, RenderSuccessCallback,
+  RenderErrorCallback,
+  RenderResult,
+  RenderSuccessCallback,
 } from '../../../types';
-import { Widget } from '../components/Widget';
-import { JsonObject } from '../types';
 import {
+  JsonObject,
   OktaWidgetEventHandler,
   OktaWidgetEventType,
+  OktaSignInAPI,
   RenderOptions,
   WidgetOptions,
   WidgetProps,
-} from '../types/widget';
+} from '../types';
+import { Widget } from '../components/Widget';
 import { WidgetHooks } from '../util/widgetHooks';
 
 const EVENTS_LIST = ['ready', 'afterError', 'afterRender'];
@@ -148,8 +152,7 @@ export default class OktaSignIn implements OktaSignInAPI {
     onSuccess?: RenderSuccessCallback,
     onError?: RenderErrorCallback,
   ): Promise<RenderResult> {
-    const { el } = options;
-    this.el = el!;
+    this.el = options.el ?? null;
 
     return new Promise<RenderResult>((resolve, reject) => {
       const onSuccessWrapper = (res: RenderResult): void => {
@@ -176,7 +179,7 @@ export default class OktaSignIn implements OktaSignInAPI {
             widgetHooks: this.widgetHooks,
           }), target);
         } else {
-          throw new Error(`could not find element ${el}`);
+          throw new Error(`could not find element ${this.el}`);
         }
       } catch (error) {
         if (typeof onError === 'function') {

--- a/src/v3/src/OktaSignIn/index.ts
+++ b/src/v3/src/OktaSignIn/index.ts
@@ -260,7 +260,7 @@ export default class OktaSignIn implements OktaSignInAPI {
         } catch (err) {
           console.error(`[okta-signin-widget] "${eventName}" event handler error:`, err);
         }
-      }) as OktaWidgetEventHandler;
+      });
       this.eventCallbackMap.set(origHandler, registeredEventHandler);
     }
     this.eventEmitter.on(eventName, registeredEventHandler);

--- a/src/v3/src/OktaSignIn/index.ts
+++ b/src/v3/src/OktaSignIn/index.ts
@@ -23,16 +23,16 @@ import {
   RenderResult,
   RenderSuccessCallback,
 } from '../../../types';
+import { Widget } from '../components/Widget';
 import {
   JsonObject,
+  OktaSignInAPI,
   OktaWidgetEventHandler,
   OktaWidgetEventType,
-  OktaSignInAPI,
   RenderOptions,
   WidgetOptions,
   WidgetProps,
 } from '../types';
-import { Widget } from '../components/Widget';
 import { WidgetHooks } from '../util/widgetHooks';
 
 const EVENTS_LIST = ['ready', 'afterError', 'afterRender'];

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -480,10 +480,15 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     }
     if (widgetRendered) {
       (async () => {
-        const executeAfterHooks = () => widgetHooks.callHooks('after', responseError ? undefined : idxTransaction);
+        const executeAfterHooks = () => {
+          if (uischema.elements.length > 0) {
+            // Don't execute hooks in the end of authentication flow
+            widgetHooks.callHooks('after', responseError ? undefined : idxTransaction);
+          }
+        };
         const emitAfterRender = () => {
-          if (idxTransaction?.status !== IdxStatus.SUCCESS) {
-            // Don't emit events in the end of authentication flow (OKTA-604105)
+          if (uischema.elements.length > 0) {
+            // Don't emit events in the end of authentication flow
             eventEmitter.emit('afterRender', getEventContext(idxTransaction));
           }
         };

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -475,11 +475,11 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   }, [interactionCodeFlowFormBag]);
 
   useEffect(() => {
-    if (isClientTransaction) {
-      return;
-    }
-    if (widgetRendered) {
-      (async () => {
+    const asyncEffect = async () => {
+      if (isClientTransaction) {
+        return;
+      }
+      if (widgetRendered) {
         const executeAfterHooks = () => {
           if (uischema.elements.length > 0) {
             // Don't execute hooks in the end of authentication flow
@@ -504,8 +504,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
           emitAfterRender();
           await executeAfterHooks();
         }
-      })();
-    }
+      }
+    };
+    asyncEffect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [widgetRendered, idxTransaction]);
 

--- a/src/v3/src/types/api.ts
+++ b/src/v3/src/types/api.ts
@@ -1,6 +1,17 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import { OktaAuthIdxInterface, Tokens } from '@okta/okta-auth-js';
 
-import { RenderOptions, WidgetOptions } from './widget';
 import {
   HooksAPI,
   RenderErrorCallback,
@@ -8,6 +19,7 @@ import {
   RenderSuccessCallback,
   RouterEventsAPI,
 } from '../../../types';
+import { RenderOptions, WidgetOptions } from './widget';
 
 // Keep a duplicate OktaSignInAPI interface because the version of auth-js differs between
 // Gen3 and Gen2 so there are type mismatches in their exposed type interfaces

--- a/src/v3/src/types/api.ts
+++ b/src/v3/src/types/api.ts
@@ -1,0 +1,33 @@
+import { OktaAuthIdxInterface, Tokens } from '@okta/okta-auth-js';
+
+import { RenderOptions, WidgetOptions } from './widget';
+import {
+  HooksAPI,
+  RenderErrorCallback,
+  RenderResult,
+  RenderSuccessCallback,
+  RouterEventsAPI,
+} from '../../../types';
+
+// Keep a duplicate OktaSignInAPI interface because the version of auth-js differs between
+// Gen3 and Gen2 so there are type mismatches in their exposed type interfaces
+export interface OktaSignInAPI extends HooksAPI, RouterEventsAPI {
+  // Gen3 only
+  readonly options: Pick<WidgetOptions, 'brandName'>;
+
+  // Gen3 supports only IDX
+  authClient: OktaAuthIdxInterface;
+  show(): void;
+  hide(): void;
+  remove(): void;
+  showSignIn(options: RenderOptions): Promise<RenderResult>;
+  showSignInToGetTokens(options: RenderOptions): Promise<Tokens>;
+  showSignInAndRedirect(options: RenderOptions): Promise<void>;
+  renderEl(
+    options: RenderOptions,
+    success?: RenderSuccessCallback,
+    error?: RenderErrorCallback
+  ): Promise<RenderResult>;
+
+  getUser(): void
+}

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -15,7 +15,7 @@ import {
   IdxMessage,
   IdxTransaction,
   OAuthError,
-  OktaAuth,
+  OktaAuthIdxInterface,
 } from '@okta/okta-auth-js';
 import { MutableRef, StateUpdater } from 'preact/hooks';
 
@@ -23,7 +23,7 @@ import { FormBag, LanguageDirection, UISchemaLayoutType } from './schema';
 import { WidgetProps } from './widget';
 
 export type IWidgetContext = {
-  authClient: OktaAuth;
+  authClient: OktaAuthIdxInterface;
   widgetProps: WidgetProps;
   message: IdxMessage | undefined;
   setMessage: StateUpdater<IdxMessage | undefined>;

--- a/src/v3/src/types/index.ts
+++ b/src/v3/src/types/index.ts
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+export * from './api';
 export * from './appInfo';
 export * from './authcoin';
 export * from './component';

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -32,9 +32,9 @@ import {
   RenderResult,
   UserOperation,
 } from '../../../types';
-import { OktaSignInAPI } from './api';
 import { InterstitialRedirectView } from '../constants';
 import { WidgetHooks } from '../util/widgetHooks';
+import { OktaSignInAPI } from './api';
 import { JsonObject } from './json';
 import { Modify } from './jsonforms';
 import { FormBag, RegistrationElementSchema } from './schema';

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -23,6 +23,8 @@ import { TinyEmitter as EventEmitter } from 'tiny-emitter';
 
 import {
   EventContext,
+  EventCallback,
+  EventCallbackWithError,
   HooksOptions,
   LanguageCallback,
   LanguageCode,
@@ -70,10 +72,7 @@ export type RenderOptions = {
 
 export type AuthenticationMode = 'remediation' | 'relying-party';
 
-export type OktaWidgetEventHandler = {
-  (context: EventContext, error?: EventErrorContext): void;
-  (context: EventContext, error: EventErrorContext): void;
-};
+export type OktaWidgetEventHandler = EventCallback | EventCallbackWithError;
 
 export type WidgetProceedArgs = {
   idxMethod?: IdxMethod,

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -23,6 +23,7 @@ import { TinyEmitter as EventEmitter } from 'tiny-emitter';
 
 import {
   EventContext,
+  HooksOptions,
   LanguageCallback,
   LanguageCode,
   OktaSignInAPI,
@@ -33,6 +34,7 @@ import {
   UserOperation,
 } from '../../../types';
 import { InterstitialRedirectView } from '../constants';
+import { WidgetHooks } from '../util/widgetHooks';
 import { JsonObject } from './json';
 import { Modify } from './jsonforms';
 import { FormBag, RegistrationElementSchema } from './schema';
@@ -59,7 +61,7 @@ export interface ErrorXHR {
 }
 
 export type RenderOptions = {
-  el: string;
+  el?: string;
   clientId?: string;
   redirectUri?: string;
   redirect?: 'always' | 'never';
@@ -69,7 +71,8 @@ export type RenderOptions = {
 export type AuthenticationMode = 'remediation' | 'relying-party';
 
 export type OktaWidgetEventHandler = {
-  (...args: unknown[]): void;
+  (context: EventContext, error?: EventErrorContext): void;
+  (context: EventContext, error: EventErrorContext): void;
 };
 
 export type WidgetProceedArgs = {
@@ -107,7 +110,10 @@ export type PageTitleCallback = (context: EventContext, param: PageTitleCallback
 export type OktaWidgetEventType = 'ready' | 'afterError' | 'afterRender';
 export type IDPDisplayType = 'PRIMARY' | 'SECONDARY';
 
-export type WidgetProps = Partial<WidgetOptions>;
+export type WidgetProps = Partial<WidgetOptions> & {
+  eventEmitter: EventEmitter;
+  widgetHooks: WidgetHooks; // instance of class WidgetHooks
+};
 
 export type WidgetOptions = {
   // // ui customizations
@@ -120,8 +126,8 @@ export type WidgetOptions = {
   // Override MUI Theming
   muiThemeOverrides?: MuiThemeOptions;
 
-  // events
-  eventEmitter?: EventEmitter;
+  // hooks
+  hooks?: HooksOptions; // object in options
 
   // callbacks
   onChange?: (data: JsonObject) => void;

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -22,9 +22,9 @@ import {
 import { TinyEmitter as EventEmitter } from 'tiny-emitter';
 
 import {
-  EventContext,
   EventCallback,
   EventCallbackWithError,
+  EventContext,
   HooksOptions,
   LanguageCallback,
   LanguageCode,

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -26,13 +26,13 @@ import {
   HooksOptions,
   LanguageCallback,
   LanguageCode,
-  OktaSignInAPI,
   RegistrationErrorCallback,
   RegistrationOptions as RegOptions,
   RenderError,
   RenderResult,
   UserOperation,
 } from '../../../types';
+import { OktaSignInAPI } from './api';
 import { InterstitialRedirectView } from '../constants';
 import { WidgetHooks } from '../util/widgetHooks';
 import { JsonObject } from './json';

--- a/src/v3/src/util/formatError.ts
+++ b/src/v3/src/util/formatError.ts
@@ -14,6 +14,7 @@ import { HttpResponse, RawIdxResponse } from '@okta/okta-auth-js';
 
 import Util from '../../../util/Util';
 import IonResponseHelper from '../../../v2/ion/IonResponseHelper';
+import { ErrorXHR, EventErrorContext } from '../types';
 import { loc } from './locUtil';
 
 export const formatError = (
@@ -27,4 +28,14 @@ export const formatError = (
 
   Util.logConsoleError(data);
   return { responseJSON: { errorSummary: loc('error.unsupported.response', 'login') } };
+};
+
+export const getErrorEventContext = (
+  resp: RawIdxResponse | HttpResponse['responseJSON'],
+): EventErrorContext => {
+  const error = formatError(resp);
+  return {
+    xhr: error as unknown as ErrorXHR,
+    errorSummary: error.responseJSON && error.responseJSON.errorSummary,
+  };
 };

--- a/src/v3/src/util/getEventContext.ts
+++ b/src/v3/src/util/getEventContext.ts
@@ -19,7 +19,10 @@ import { getAuthenticatorKey } from './getAuthenticatorKey';
 import { getAuthenticatorMethod } from './getAuthenticatorMethod';
 import { isPasswordRecovery } from './isPasswordRecovery';
 
-export const getFormNameForTransaction = (transaction: IdxTransaction): string | undefined => {
+export const getFormNameForTransaction = (transaction?: IdxTransaction): string | undefined => {
+  if (!transaction) {
+    return 'terminal';
+  }
   const {
     nextStep: { name: formName } = {},
     neededToProceed,
@@ -46,7 +49,14 @@ export const getFormNameForTransaction = (transaction: IdxTransaction): string |
   return formName;
 };
 
-export const getEventContext = (transaction: IdxTransaction): EventContext => {
+export const getEventContext = (transaction?: IdxTransaction): EventContext => {
+  if (!transaction) {
+    return {
+      controller: null,
+      formName: 'terminal',
+    };
+  }
+
   const { context } = transaction;
   const authenticatorKey = context.currentAuthenticator?.value?.key
     || getAuthenticatorKey(transaction);

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -49,4 +49,5 @@ export * from './setUrlQueryParams';
 export * from './shouldShowCancelLink';
 export * from './toNestedObject';
 export * from './webauthnUtils';
+export * from './widgetHooks';
 export * from './widgetUtils';

--- a/src/v3/src/util/widgetHooks.test.ts
+++ b/src/v3/src/util/widgetHooks.test.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxTransaction } from '@okta/okta-auth-js';
+
+import { getStubTransaction } from '../mocks/utils/utils';
+import { WidgetHooks } from './widgetHooks';
+
+describe('WidgetHooks', () => {
+  it('can construct instance of WidgetHooks from "hooks" in widget options', () => {
+    const hooksOptions = {
+      terminal: {
+        before: [
+          jest.fn().mockResolvedValue(undefined),
+          jest.fn().mockResolvedValue(undefined),
+        ],
+        after: [
+          jest.fn().mockResolvedValue(undefined),
+        ],
+      },
+      'success-redirect': {
+        before: [
+          jest.fn().mockResolvedValue(undefined),
+        ],
+      },
+    };
+    const hooksInstance = new WidgetHooks(hooksOptions);
+    expect(hooksInstance).toEqual({
+      hooks: new Map(Object.entries({
+        terminal: new Map(Object.entries({
+          before: hooksOptions.terminal.before,
+          after: hooksOptions.terminal.after,
+        })),
+        'success-redirect': new Map(Object.entries({
+          before: hooksOptions['success-redirect'].before,
+        })),
+      })),
+    });
+  });
+
+  it('can add hooks with .addHook()', () => {
+    const hooksOptions = {
+      terminal: {
+        before: [
+          jest.fn().mockResolvedValue(undefined),
+          jest.fn().mockResolvedValue(undefined),
+        ],
+      },
+    };
+    const hooksInstance = new WidgetHooks(hooksOptions);
+    const beforeTerminalHook = jest.fn().mockResolvedValue(undefined);
+    const afterTerminalHook = jest.fn().mockResolvedValue(undefined);
+    const afterSuccessHook = jest.fn().mockResolvedValue(undefined);
+    hooksInstance.addHook('before', 'terminal', beforeTerminalHook);
+    hooksInstance.addHook('after', 'terminal', afterTerminalHook);
+    hooksInstance.addHook('after', 'success-redirect', afterSuccessHook);
+    expect(hooksInstance).toEqual({
+      hooks: new Map(Object.entries({
+        terminal: new Map(Object.entries({
+          before: [
+            ...hooksOptions.terminal.before,
+            beforeTerminalHook,
+          ],
+          after: [
+            afterTerminalHook,
+          ],
+        })),
+        'success-redirect': new Map(Object.entries({
+          after: [
+            afterSuccessHook,
+          ],
+        })),
+      })),
+    });
+  });
+
+  it('can execute hooks with .callHooks(hookType, idxTransaction)', async () => {
+    const hook1 = jest.fn().mockResolvedValue(undefined);
+    const hook2 = jest.fn().mockResolvedValue(undefined);
+    const hook3 = jest.fn().mockResolvedValue(undefined);
+    const hooksOptions = {
+      identify: {
+        before: [
+          hook1,
+          hook2,
+        ],
+        after: [
+          hook3,
+        ],
+      },
+    };
+    const hooksInstance = new WidgetHooks(hooksOptions);
+    const transactionIdentify = {
+      ...getStubTransaction(),
+      nextStep: { name: 'identify' },
+    } as IdxTransaction;
+    await expect(hooksInstance.callHooks('before', transactionIdentify)).resolves.toEqual(undefined);
+    expect(hook1).toHaveBeenCalledTimes(1);
+    expect(hook2).toHaveBeenCalledTimes(1);
+    expect(hook3).not.toHaveBeenCalled();
+  });
+
+  it('should get correct form name from idxTransaction argument of .callHooks()', async () => {
+    const hookSuccess = jest.fn().mockResolvedValue(undefined);
+    const hookTerminal = jest.fn().mockResolvedValue(undefined);
+    const hooksOptions = {
+      'success-redirect': {
+        before: [
+          hookSuccess,
+        ],
+      },
+      terminal: {
+        before: [
+          hookTerminal,
+        ],
+      },
+    };
+    const hooksInstance = new WidgetHooks(hooksOptions);
+    const stubTransaction = getStubTransaction();
+    const transactionSuccess = {
+      ...stubTransaction,
+      neededToProceed: [],
+      context: {
+        ...stubTransaction.context,
+        success: {
+          name: 'success-redirect',
+          href: 'http://localhost:3000/app/UserHome?stateToken=mockedStateToken123',
+        },
+      },
+    } as IdxTransaction;
+    await expect(hooksInstance.callHooks('before', transactionSuccess)).resolves.toEqual(undefined);
+    expect(hookSuccess).toHaveBeenCalledTimes(1);
+    expect(hookTerminal).not.toHaveBeenCalled();
+
+    const transactionTerminal = {
+      ...stubTransaction,
+      neededToProceed: [],
+      context: {
+        ...stubTransaction.context,
+        messages: {
+          type: 'array',
+          value: [{
+            message: 'Some message',
+            class: 'ERROR',
+            i18n: { key: 'some.key' },
+          }],
+        },
+      },
+    } as IdxTransaction;
+    await expect(hooksInstance.callHooks('before', transactionTerminal)).resolves.toEqual(undefined);
+    expect(hookTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it('can execute hooks for terminal page with .callHooks(hookType, undefined)', async () => {
+    const hook1 = jest.fn().mockResolvedValue(undefined);
+    const hook2 = jest.fn().mockResolvedValue(undefined);
+    const hooksOptions = {
+      terminal: {
+        before: [
+          hook1,
+          hook2,
+        ],
+      },
+    };
+    const hooksInstance = new WidgetHooks(hooksOptions);
+    await expect(hooksInstance.callHooks('before', undefined)).resolves.toEqual(undefined);
+    expect(hook1).toHaveBeenCalledTimes(1);
+    expect(hook2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/v3/src/util/widgetHooks.ts
+++ b/src/v3/src/util/widgetHooks.ts
@@ -48,10 +48,8 @@ export class WidgetHooks {
     const formName = getFormNameForTransaction(idxTransaction);
     if (formName) {
       const hooksToExecute = this.hooks.get(formName)?.get(hookType) || [];
-      if (hooksToExecute.length) {
-        for (const hook of hooksToExecute) {
-          await hook();
-        }
+      for (const hook of hooksToExecute) {
+        await hook();
       }
     }
   }

--- a/src/v3/src/util/widgetHooks.ts
+++ b/src/v3/src/util/widgetHooks.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxTransaction } from '@okta/okta-auth-js';
+
+import { HookFunction, HooksOptions, HookType } from '../../../types';
+import { getFormNameForTransaction } from './getEventContext';
+
+export class WidgetHooks {
+  private hooks: Map<string, Map<string, HookFunction[]>>;
+
+  /* eslint-disable no-restricted-syntax */
+  constructor(hooksOptions?: HooksOptions) {
+    this.hooks = new Map();
+    if (hooksOptions) {
+      for (const [formName, formHooks] of Object.entries(hooksOptions)) {
+        for (const [hookType, hooksByType] of Object.entries(formHooks)) {
+          for (const hook of (hooksByType || []) as HookFunction[]) {
+            this.addHook(hookType as HookType, formName, hook);
+          }
+        }
+      }
+    }
+  }
+
+  public addHook(hookType: HookType, formName: string, hook: HookFunction): void {
+    const formHooks = this.hooks.get(formName) || new Map<string, HookFunction[]>();
+    const hooksByType = formHooks.get(hookType) || [];
+    hooksByType.push(hook);
+    formHooks.set(hookType, hooksByType);
+    this.hooks.set(formName, formHooks);
+  }
+
+  /* eslint-disable no-await-in-loop */
+  public async callHooks(
+    hookType: HookType,
+    idxTransaction?: IdxTransaction,
+  ): Promise<void> {
+    const formName = getFormNameForTransaction(idxTransaction);
+    if (formName) {
+      const hooksToExecute = this.hooks.get(formName)?.get(hookType) || [];
+      if (hooksToExecute.length) {
+        for (const hook of hooksToExecute) {
+          await hook();
+        }
+      }
+    }
+  }
+}

--- a/src/v3/src/util/widgetHooks.ts
+++ b/src/v3/src/util/widgetHooks.ts
@@ -15,6 +15,8 @@ import { IdxTransaction } from '@okta/okta-auth-js';
 import { HookFunction, HooksOptions, HookType } from '../../../types';
 import { getFormNameForTransaction } from './getEventContext';
 
+const hookTypes: HookType[] = ['before', 'after'];
+
 export class WidgetHooks {
   private hooks: Map<string, Map<string, HookFunction[]>>;
 
@@ -23,9 +25,9 @@ export class WidgetHooks {
     this.hooks = new Map();
     if (hooksOptions) {
       for (const [formName, formHooks] of Object.entries(hooksOptions)) {
-        for (const [hookType, hooksByType] of Object.entries(formHooks)) {
-          for (const hook of (hooksByType || []) as HookFunction[]) {
-            this.addHook(hookType as HookType, formName, hook);
+        for (const hookType of hookTypes) {
+          for (const hook of (formHooks[hookType] || []) as HookFunction[]) {
+            this.addHook(hookType, formName, hook);
           }
         }
       }

--- a/src/v3/test/integration/util/setup.tsx
+++ b/src/v3/test/integration/util/setup.tsx
@@ -13,12 +13,14 @@
 import userEvent from '@testing-library/user-event';
 import { render, RenderResult } from '@testing-library/preact';
 import { h } from 'preact';
+import { TinyEmitter as EventEmitter } from 'tiny-emitter';
 import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 import { OktaAuth } from '@okta/okta-auth-js';
 import { WidgetOptions } from 'src/types';
 import { createAuthClient, CreateAuthClientOptions } from './createAuthClient';
 
 import { Widget } from '../../../src/components/Widget';
+import { WidgetHooks } from '../../../src/util/widgetHooks';
 
 type Options = CreateAuthClientOptions & {
   widgetOptions?: Partial<WidgetOptions>;
@@ -39,12 +41,16 @@ export async function setup(options: Options): Promise<RenderResult & {
 }> {
   const { widgetOptions = {}, ...rest } = options;
   const authClient = createAuthClient(rest);
+  const eventEmitter = new EventEmitter();
+  const widgetHooks = new WidgetHooks(widgetOptions.hooks);
   const renderResult = await render(
     <Widget
       authScheme="Oauth2"
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...widgetOptions}
       authClient={authClient}
+      eventEmitter={eventEmitter}
+      widgetHooks={widgetHooks}
     />,
   );
 


### PR DESCRIPTION
## Description:

Adds support of [hooks](https://github.com/okta/okta-signin-widget#hooks) for Gen 3.
Hooks can be added with config and added in runtime with `.before` and `.after` methods.

Notes:
1. Emitting `ready` and `afterRender` events [moved](https://github.com/okta/okta-signin-widget/pull/3376/files#diff-d9fe8ef09b73767f05c2fc2b3edc767f2e9db1e1232ae515581b457f66196b0aR386) to useEffect on `widgetRendered` change. This is needed to keep the order of `ready`, `afterRender` events and `after` hooks same as in Gen2
2. `OktaSignIn` class owns instance of `WidgetHooks` class and passes it in widget props
3. There is only 1 discrepancy between in Gen2 and Gen3 in terms of events/hooks:
https://github.com/okta/okta-signin-widget/blob/3fff3b30de02ce50b4f9fd8a1f7ff9f7ecf19d45/test/testcafe/spec/OktaSignIn_spec.js#L604-L610
When user submits form which results in error, context of `afterError` event contains `terminal` form for Gen3, not current form as in Gen2. This is also noticeable in UI: Gen3 hides the form and renders only alert, while Gen2 still presents the form after error.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](hxtps://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-594745](https://oktainc.atlassian.net/browse/OKTA-594745)
- [OKTA-508861](https://oktainc.atlassian.net/browse/OKTA-508861)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



