### PR TITLE
Fixes some IE11 visual bugs

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -8,7 +8,7 @@ setup_service java 1.8.222
 setup_service google-chrome-stable 89.0.4389.72-1
 
 export TEST_SUITE_TYPE="junit"
-export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/junit"
+export TEST_RESULT_FILE_DIR="${REPO}/build2"
 echo $TEST_SUITE_TYPE > $TEST_SUITE_TYPE_FILE
 echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
 

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -140,6 +140,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
             },
             icon: ({ theme }) => ({
               paddingInlineEnd: theme.spacing(4),
+              flexShrink: 0,
             }),
           },
         },

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -144,6 +144,15 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
             }),
           },
         },
+        MuiInputBase: {
+          styleOverrides: {
+            input: {
+              '::-ms-reveal': {
+                display: 'none',
+              },
+            },
+          },
+        },
         MuiInputLabel: {
           styleOverrides: {
             root: {

--- a/src/v3/src/util/mergeThemes.ts
+++ b/src/v3/src/util/mergeThemes.ts
@@ -73,6 +73,12 @@ export const mergeThemes = (
                   // @ts-expect-error FIXME CSSInterpolation may not be CSSObject
                   ...resolve(config.styleOverrides?.icon, options),
                 }),
+                input: (options: Record<string, unknown>) => ({
+                  // @ts-expect-error FIXME CSSInterpolation may not be CSSObject
+                  ...resolve(prev.components?.[component]?.styleOverrides?.input, options),
+                  // @ts-expect-error FIXME CSSInterpolation may not be CSSObject
+                  ...resolve(config.styleOverrides?.input, options),
+                }),
               },
             },
           },


### PR DESCRIPTION
## Description:

* Fixes missing gap between icon and text in some Infobox rendering in IE11
* Hides native show/hide icon in IE11 because we have our own from components

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-651388](https://oktainc.atlassian.net/browse/OKTA-651388)

### Reviewers:

### Screenshot/Video:
Password field no longer shows duplicate show/hide icon:
![20230925_20_16_36_internet explorer_11](https://github.com/okta/okta-signin-widget/assets/72248639/815e4ed5-b8e9-4acd-8124-be42716f8c65)

Alert icon has proper spacing:
![20230925_20_16_06_internet explorer_11](https://github.com/okta/okta-signin-widget/assets/72248639/f85b9d4a-64ce-423a-9709-72d09c03c88e)


### Downstream Monolith Build:



