### PR TITLE
OKTA-626752 : Gen 3 flow param support

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -230,15 +230,15 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     return null;
   };
 
-  const shouldRedirectToEnrollFlow = (transaction: IdxTransaction, widgetProps: WidgetProps) : boolean => {
-    const { flow } = widgetProps;
+  const shouldRedirectToEnrollFlow = (transaction: IdxTransaction) : boolean => {
     const { nextStep, neededToProceed } = transaction;
     if (flow !== CONFIGURED_FLOW.REGISTRATION || nextStep?.name !== IDX_STEP.IDENTIFY) {
       return false;
     }
-    const isRegistrationEnabled = neededToProceed.find(remediation => remediation.name === 'select-enroll-profile') !== undefined
+    const isRegistrationEnabled = neededToProceed
+      .find((remediation) => remediation.name === 'select-enroll-profile') !== undefined;
     return isRegistrationEnabled;
-  }
+  };
 
   const bootstrap = useCallback(async () => {
     const usingStateHandleFromSession = stateHandle
@@ -275,9 +275,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
       // TODO
       // OKTA-651781
-      if(shouldRedirectToEnrollFlow(transaction, widgetProps)) {
+      if (shouldRedirectToEnrollFlow(transaction)) {
         transaction = await authClient.idx.proceed({
-          step: 'select-enroll-profile'
+          step: 'select-enroll-profile',
         });
       }
 
@@ -411,9 +411,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       // TODO
       // OKTA-651781
       // bootstrap into enroll flow when flow param is set to signup
-      if(shouldRedirectToEnrollFlow(transaction, widgetProps)) {
+      if (shouldRedirectToEnrollFlow(transaction)) {
         transaction = await authClient.idx.proceed({
-          step: 'select-enroll-profile'
+          step: 'select-enroll-profile',
         });
       }
 

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -279,7 +279,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       if (shouldRedirectToEnrollFlow(transaction)) {
         transaction = await authClient.idx.proceed({
           stateHandle: transaction?.context.stateHandle,
-          step: 'select-enroll-profile',
+          step: IDX_STEP.SELECT_ENROLL_PROFILE,
         });
       }
 
@@ -415,7 +415,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       if (shouldRedirectToEnrollFlow(transaction)) {
         transaction = await authClient.idx.proceed({
           stateHandle: transaction?.context.stateHandle,
-          step: 'select-enroll-profile',
+          step: IDX_STEP.SELECT_ENROLL_PROFILE,
         });
       }
 

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -236,8 +236,12 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       return false;
     }
     const isRegistrationEnabled = neededToProceed
-      .find((remediation) => remediation.name === 'select-enroll-profile') !== undefined;
-    return isRegistrationEnabled;
+      .find((remediation) => remediation.name === IDX_STEP.SELECT_ENROLL_PROFILE) !== undefined;
+    
+    if (!isRegistrationEnabled) {
+      throw new Error('flow param error: No remediation can match current flow, check policy settings in your org.')
+    }
+    return true;
   };
 
   const bootstrap = useCallback(async () => {

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -275,8 +275,10 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
       // TODO
       // OKTA-651781
+      // bootstrap into enroll flow when flow param is set to signup
       if (shouldRedirectToEnrollFlow(transaction)) {
         transaction = await authClient.idx.proceed({
+          stateHandle: transaction?.context.stateHandle,
           step: 'select-enroll-profile',
         });
       }
@@ -410,9 +412,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
       // TODO
       // OKTA-651781
-      // bootstrap into enroll flow when flow param is set to signup
       if (shouldRedirectToEnrollFlow(transaction)) {
         transaction = await authClient.idx.proceed({
+          stateHandle: transaction?.context.stateHandle,
           step: 'select-enroll-profile',
         });
       }

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -34,7 +34,7 @@ import {
 import { mergeThemes } from 'src/util/mergeThemes';
 
 import Bundles from '../../../../util/Bundles';
-import { CONFIGURED_FLOW, IDX_STEP } from '../../constants';
+import { IDX_STEP } from '../../constants';
 import { WidgetContextProvider } from '../../contexts';
 import {
   useInteractionCodeFlow, useOnce,
@@ -63,6 +63,7 @@ import {
   getLanguageDirection,
   isAndroidOrIOS,
   isAuthClientSet,
+  isConfigRegisterFlow,
   isConsentStep,
   isOauth2Enabled,
   loadLanguage,
@@ -232,14 +233,14 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
   const shouldRedirectToEnrollFlow = (transaction: IdxTransaction) : boolean => {
     const { nextStep, neededToProceed } = transaction;
-    if (flow !== CONFIGURED_FLOW.REGISTRATION || nextStep?.name !== IDX_STEP.IDENTIFY) {
+    if (!isConfigRegisterFlow(flow) || nextStep?.name !== IDX_STEP.IDENTIFY) {
       return false;
     }
     const isRegistrationEnabled = neededToProceed
       .find((remediation) => remediation.name === IDX_STEP.SELECT_ENROLL_PROFILE) !== undefined;
-    
+
     if (!isRegistrationEnabled) {
-      throw new Error('flow param error: No remediation can match current flow, check policy settings in your org.')
+      throw new Error('flow param error: No remediation can match current flow, check policy settings in your org.');
     }
     return true;
   };

--- a/src/v3/src/constants/idxConstants.ts
+++ b/src/v3/src/constants/idxConstants.ts
@@ -293,12 +293,3 @@ export const SCOPE_GROUP_CONFIG: Record<string, ConsentScopeGroup> = {
   sessions: 'system',
   trustedOrigins: 'system',
 };
-
-export const CONFIGURED_FLOW = {
-  DEFAULT: 'default',
-  PROCEED: 'proceed',
-  LOGIN: 'login',
-  REGISTRATION: 'signup',
-  RESET_PASSWORD: 'resetPassword',
-  UNLOCK_ACCOUNT: 'unlockAccount',
-};

--- a/src/v3/src/constants/idxConstants.ts
+++ b/src/v3/src/constants/idxConstants.ts
@@ -293,3 +293,12 @@ export const SCOPE_GROUP_CONFIG: Record<string, ConsentScopeGroup> = {
   sessions: 'system',
   trustedOrigins: 'system',
 };
+
+export const CONFIGURED_FLOW = {
+  DEFAULT: 'default',
+  PROCEED: 'proceed',
+  LOGIN: 'login',
+  REGISTRATION: 'signup',
+  RESET_PASSWORD: 'resetPassword',
+  UNLOCK_ACCOUNT: 'unlockAccount',
+};

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -22,7 +22,7 @@ import {
 import { cloneDeep, merge, omit } from 'lodash';
 import { useCallback } from 'preact/hooks';
 
-import { CONFIGURED_FLOW, IDX_STEP, ON_PREM_TOKEN_CHANGE_ERROR_KEY } from '../constants';
+import { IDX_STEP, ON_PREM_TOKEN_CHANGE_ERROR_KEY } from '../constants';
 import { useWidgetContext } from '../contexts';
 import { ErrorXHR, EventErrorContext, MessageType } from '../types';
 import {
@@ -30,6 +30,7 @@ import {
   containsMessageKey,
   formatError,
   getImmutableData,
+  isConfigRecoverFlow,
   isOauth2Enabled,
   loc,
   postRegistrationSubmit,
@@ -213,7 +214,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
 
       // TODO
       // OKTA-651781
-      if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD && step === IDX_STEP.IDENTIFY) {
+      if (isConfigRecoverFlow(widgetProps.flow) && step === IDX_STEP.IDENTIFY) {
         // when in identifier first flow, there are a couple steps before we can get to recovery page
         // thats why we need to run proceed twice
         newTransaction = await authClient.idx.proceed({

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -88,9 +88,9 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       };
     };
 
-    const getFormPasswordAuthenticatorId = (transaction: IdxTransaction) => (
+    const getFormPasswordAuthenticatorId = (transaction: IdxTransaction) : string | undefined => (
       transaction?.neededToProceed
-        ?.find((remediation) => remediation.name === 'select-authenticator-authenticate')
+        ?.find((remediation) => remediation.name === IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE)
         ?.value?.find((val) => val.name === 'authenticator')
         ?.options?.find((option) => option.label === 'Password')
       // @ts-expect-error auth-js type errors
@@ -219,7 +219,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
         newTransaction = await authClient.idx.proceed({
           stateHandle: newTransaction?.context.stateHandle,
           authenticator: { id: getFormPasswordAuthenticatorId(newTransaction) },
-          step: 'select-authenticator-authenticate',
+          step: IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE,
         });
 
         newTransaction = await authClient.idx.proceed({

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -211,7 +211,11 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     try {
       let newTransaction = await fn(payload);
 
+      // TODO
+      // OKTA-651781
       if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD && step === IDX_STEP.IDENTIFY) {
+        // when in identifier first flow, there are a couple steps before we can get to recovery page
+        // thats why we need to run proceed twice
         newTransaction = await authClient.idx.proceed({
           authenticator: {id: getFormPasswordAuthenticatorId(newTransaction)},
           step: 'select-authenticator-authenticate',        

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -90,13 +90,13 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
 
     const getFormPasswordAuthenticatorId = (transaction: IdxTransaction) => (
       transaction?.neededToProceed
-          ?.find(step => step.name === 'select-authenticator-authenticate')
-          ?.value?.find(val => val.name === 'authenticator')
-          ?.options?.find(option => option.label === 'Password')
-          // @ts-expect-error auth-js type errors
-          ?.value?.form?.value?.find(formVal => formVal.name === 'id')
-          ?.value
-    )
+        ?.find((remediation) => remediation.name === 'select-authenticator-authenticate')
+        ?.value?.find((val) => val.name === 'authenticator')
+        ?.options?.find((option) => option.label === 'Password')
+      // @ts-expect-error auth-js type errors
+        ?.value?.form?.value?.find((formVal) => formVal.name === 'id')
+        ?.value
+    );
 
     // TODO: Revisit and refactor this function as it is a dupe of handleError fn in Widget/index.tsx
     const handleError = (transaction: IdxTransaction | undefined, error: unknown) => {
@@ -217,12 +217,12 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
         // when in identifier first flow, there are a couple steps before we can get to recovery page
         // thats why we need to run proceed twice
         newTransaction = await authClient.idx.proceed({
-          authenticator: {id: getFormPasswordAuthenticatorId(newTransaction)},
-          step: 'select-authenticator-authenticate',        
+          authenticator: { id: getFormPasswordAuthenticatorId(newTransaction) },
+          step: 'select-authenticator-authenticate',
         });
 
         newTransaction = await authClient.idx.proceed({
-          stateHandle: newTransaction.context.stateHandle,       
+          stateHandle: newTransaction.context.stateHandle,
         });
       }
 

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -217,12 +217,13 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
         // when in identifier first flow, there are a couple steps before we can get to recovery page
         // thats why we need to run proceed twice
         newTransaction = await authClient.idx.proceed({
+          stateHandle: newTransaction?.context.stateHandle,
           authenticator: { id: getFormPasswordAuthenticatorId(newTransaction) },
           step: 'select-authenticator-authenticate',
         });
 
         newTransaction = await authClient.idx.proceed({
-          stateHandle: newTransaction.context.stateHandle,
+          stateHandle: newTransaction?.context.stateHandle,
         });
       }
 

--- a/src/v3/src/transformer/button/transformForgotPasswordButton.ts
+++ b/src/v3/src/transformer/button/transformForgotPasswordButton.ts
@@ -43,6 +43,10 @@ export const transformForgotPasswordButton: TransformStepFnWithOptions = ({
     return formbag;
   }
 
+  // TODO
+  // OKTA-651781
+  // when flow param is set to resetPassword, the identify page is redressed as identify-recovery page
+  // so this link needs to be hidden
   if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }

--- a/src/v3/src/transformer/button/transformForgotPasswordButton.ts
+++ b/src/v3/src/transformer/button/transformForgotPasswordButton.ts
@@ -12,12 +12,14 @@
 
 import { IdxTransaction, NextStep } from '@okta/okta-auth-js';
 
-import { AUTHENTICATOR_KEY, CONFIGURED_FLOW } from '../../constants';
+import { AUTHENTICATOR_KEY } from '../../constants';
 import {
   LinkElement,
   TransformStepFnWithOptions,
 } from '../../types';
-import { getAuthenticatorKey, getForgotPasswordUri, loc } from '../../util';
+import {
+  getAuthenticatorKey, getForgotPasswordUri, isConfigRecoverFlow, loc,
+} from '../../util';
 import TransformerMap from '../layout/idxTransformerMapping';
 
 const getStepByName = (
@@ -47,7 +49,7 @@ export const transformForgotPasswordButton: TransformStepFnWithOptions = ({
   // OKTA-651781
   // when flow param is set to resetPassword, the identify page is redressed as identify-recovery page
   // so this link needs to be hidden
-  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (isConfigRecoverFlow(widgetProps.flow)) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/button/transformForgotPasswordButton.ts
+++ b/src/v3/src/transformer/button/transformForgotPasswordButton.ts
@@ -12,7 +12,7 @@
 
 import { IdxTransaction, NextStep } from '@okta/okta-auth-js';
 
-import { AUTHENTICATOR_KEY } from '../../constants';
+import { AUTHENTICATOR_KEY, CONFIGURED_FLOW } from '../../constants';
 import {
   LinkElement,
   TransformStepFnWithOptions,
@@ -40,6 +40,10 @@ export const transformForgotPasswordButton: TransformStepFnWithOptions = ({
   const forgotPasswordStep = getStepByName(forgotPasswordAuthenticatorStepName, transaction)
     ?? getStepByName(forgotPasswordAuthenticatorEnrollmentStep, transaction);
   if (!shouldAddDefaultButton || typeof forgotPasswordStep === 'undefined') {
+    return formbag;
+  }
+
+  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/button/transformForgotPasswordButton.ts
+++ b/src/v3/src/transformer/button/transformForgotPasswordButton.ts
@@ -47,7 +47,7 @@ export const transformForgotPasswordButton: TransformStepFnWithOptions = ({
   // OKTA-651781
   // when flow param is set to resetPassword, the identify page is redressed as identify-recovery page
   // so this link needs to be hidden
-  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/button/transformRegisterButton.ts
+++ b/src/v3/src/transformer/button/transformRegisterButton.ts
@@ -12,14 +12,14 @@
 
 import { IdxFeature } from '@okta/okta-auth-js';
 
-import { CONFIGURED_FLOW, IDX_STEP } from '../../constants';
+import { IDX_STEP } from '../../constants';
 import {
   DescriptionElement,
   LinkElement,
   TransformStepFnWithOptions,
   UISchemaLayoutType,
 } from '../../types';
-import { loc } from '../../util';
+import { isConfigRecoverFlow, loc } from '../../util';
 
 export const transformRegisterButton: TransformStepFnWithOptions = ({
   transaction,
@@ -41,7 +41,7 @@ export const transformRegisterButton: TransformStepFnWithOptions = ({
   // OKTA-651781
   // when flow param is set to resetPassword, the identify page is redressed as identify-recovery page
   // so this link needs to be hidden
-  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (isConfigRecoverFlow(widgetProps.flow)) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/button/transformRegisterButton.ts
+++ b/src/v3/src/transformer/button/transformRegisterButton.ts
@@ -12,7 +12,7 @@
 
 import { IdxFeature } from '@okta/okta-auth-js';
 
-import { IDX_STEP } from '../../constants';
+import { CONFIGURED_FLOW, IDX_STEP } from '../../constants';
 import {
   DescriptionElement,
   LinkElement,
@@ -36,6 +36,11 @@ export const transformRegisterButton: TransformStepFnWithOptions = ({
   const registerStep = availableSteps?.find(
     ({ name }) => name === IDX_STEP.SELECT_ENROLL_PROFILE,
   );
+
+  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+    return formbag;
+  }
+
   if (!shouldAddDefaultButton || typeof registerStep === 'undefined') {
     return formbag;
   }

--- a/src/v3/src/transformer/button/transformRegisterButton.ts
+++ b/src/v3/src/transformer/button/transformRegisterButton.ts
@@ -41,7 +41,7 @@ export const transformRegisterButton: TransformStepFnWithOptions = ({
   // OKTA-651781
   // when flow param is set to resetPassword, the identify page is redressed as identify-recovery page
   // so this link needs to be hidden
-  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/button/transformRegisterButton.ts
+++ b/src/v3/src/transformer/button/transformRegisterButton.ts
@@ -37,6 +37,10 @@ export const transformRegisterButton: TransformStepFnWithOptions = ({
     ({ name }) => name === IDX_STEP.SELECT_ENROLL_PROFILE,
   );
 
+  // TODO
+  // OKTA-651781
+  // when flow param is set to resetPassword, the identify page is redressed as identify-recovery page
+  // so this link needs to be hidden
   if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }

--- a/src/v3/src/transformer/button/transformUnlockAccountButton.ts
+++ b/src/v3/src/transformer/button/transformUnlockAccountButton.ts
@@ -32,6 +32,10 @@ export const transformUnlockAccountButton: TransformStepFnWithOptions = ({
     ({ name }) => name === 'unlock-account',
   );
 
+  // TODO
+  // OKTA-651781
+  // when flow param is set to resetPassword, the identify page is redressed as identify-recovery page
+  // so this link needs to be hidden
   if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }

--- a/src/v3/src/transformer/button/transformUnlockAccountButton.ts
+++ b/src/v3/src/transformer/button/transformUnlockAccountButton.ts
@@ -12,7 +12,7 @@
 
 import { IdxFeature } from '@okta/okta-auth-js';
 
-import { STEPS_REQUIRING_UNLOCK_ACCOUNT_LINK } from '../../constants';
+import { CONFIGURED_FLOW, STEPS_REQUIRING_UNLOCK_ACCOUNT_LINK } from '../../constants';
 import {
   LinkElement,
   TransformStepFnWithOptions,
@@ -31,6 +31,11 @@ export const transformUnlockAccountButton: TransformStepFnWithOptions = ({
   const unlockStep = availableSteps?.find(
     ({ name }) => name === 'unlock-account',
   );
+
+  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+    return formbag;
+  }
+
   if (!shouldAddDefaultButton || typeof unlockStep === 'undefined') {
     return formbag;
   }

--- a/src/v3/src/transformer/button/transformUnlockAccountButton.ts
+++ b/src/v3/src/transformer/button/transformUnlockAccountButton.ts
@@ -36,7 +36,7 @@ export const transformUnlockAccountButton: TransformStepFnWithOptions = ({
   // OKTA-651781
   // when flow param is set to resetPassword, the identify page is redressed as identify-recovery page
   // so this link needs to be hidden
-  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/button/transformUnlockAccountButton.ts
+++ b/src/v3/src/transformer/button/transformUnlockAccountButton.ts
@@ -12,12 +12,12 @@
 
 import { IdxFeature } from '@okta/okta-auth-js';
 
-import { CONFIGURED_FLOW, STEPS_REQUIRING_UNLOCK_ACCOUNT_LINK } from '../../constants';
+import { STEPS_REQUIRING_UNLOCK_ACCOUNT_LINK } from '../../constants';
 import {
   LinkElement,
   TransformStepFnWithOptions,
 } from '../../types';
-import { getUnlockAccountUri, loc } from '../../util';
+import { getUnlockAccountUri, isConfigRecoverFlow, loc } from '../../util';
 
 export const transformUnlockAccountButton: TransformStepFnWithOptions = ({
   transaction,
@@ -36,7 +36,7 @@ export const transformUnlockAccountButton: TransformStepFnWithOptions = ({
   // OKTA-651781
   // when flow param is set to resetPassword, the identify page is redressed as identify-recovery page
   // so this link needs to be hidden
-  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (isConfigRecoverFlow(widgetProps.flow)) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
+++ b/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
@@ -45,6 +45,10 @@ export const transformVerifyWithOtherButton: TransformStepFnWithOptions = ({
     return formbag;
   }
 
+  // TODO
+  // OKTA-651781
+  // when flow param is set to resetPassword and there is an api error (eg. not allowed to reset),
+  // the error will show on the Verify with password challenge page and stop the flow.  So we need to hide this link
   if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }

--- a/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
+++ b/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { AUTHENTICATOR_KEY, CONFIGURED_FLOW, IDX_STEP } from '../../constants';
+import { AUTHENTICATOR_KEY, IDX_STEP } from '../../constants';
 import {
   IWidgetContext,
   LinkElement,
@@ -19,6 +19,7 @@ import {
 import {
   getAuthenticatorKey,
   hasMinAuthenticatorOptions,
+  isConfigRecoverFlow,
   loc,
   updateTransactionWithNextStep,
 } from '../../util';
@@ -49,7 +50,7 @@ export const transformVerifyWithOtherButton: TransformStepFnWithOptions = ({
   // OKTA-651781
   // when flow param is set to resetPassword and there is an api error (eg. not allowed to reset),
   // the error will show on the Verify with password challenge page and stop the flow.  So we need to hide this link
-  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (isConfigRecoverFlow(widgetProps.flow)) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
+++ b/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { AUTHENTICATOR_KEY, IDX_STEP } from '../../constants';
+import { AUTHENTICATOR_KEY, CONFIGURED_FLOW, IDX_STEP } from '../../constants';
 import {
   IWidgetContext,
   LinkElement,
@@ -27,6 +27,7 @@ import TransformerMap from '../layout/idxTransformerMapping';
 export const transformVerifyWithOtherButton: TransformStepFnWithOptions = ({
   transaction,
   step,
+  widgetProps
 }) => (
   formbag,
 ) => {
@@ -41,6 +42,10 @@ export const transformVerifyWithOtherButton: TransformStepFnWithOptions = ({
   const selectVerifyStep = transaction.availableSteps
     ?.find(({ name }) => name === IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE);
   if (!shouldAddButton || !shouldAddDefaultLink || typeof selectVerifyStep === 'undefined') {
+    return formbag;
+  }
+
+  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
+++ b/src/v3/src/transformer/button/transformVerifyWithOtherButton.ts
@@ -27,7 +27,7 @@ import TransformerMap from '../layout/idxTransformerMapping';
 export const transformVerifyWithOtherButton: TransformStepFnWithOptions = ({
   transaction,
   step,
-  widgetProps
+  widgetProps,
 }) => (
   formbag,
 ) => {
@@ -49,7 +49,7 @@ export const transformVerifyWithOtherButton: TransformStepFnWithOptions = ({
   // OKTA-651781
   // when flow param is set to resetPassword and there is an api error (eg. not allowed to reset),
   // the error will show on the Verify with password challenge page and stop the flow.  So we need to hide this link
-  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/identify/transformIdentify.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.ts
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { CONFIGURED_FLOW } from '../../constants';
 import {
   ButtonElement,
   ButtonType,
@@ -19,6 +20,7 @@ import {
   UISchemaElement,
 } from '../../types';
 import { getUsernameCookie, loc } from '../../util';
+import { transformIdentityRecovery } from '../layout/recovery';
 import { getUIElementWithName, removeUIElementWithName } from '../utils';
 
 export const transformIdentify: IdxStepTransformer = ({
@@ -28,6 +30,10 @@ export const transformIdentify: IdxStepTransformer = ({
 }) => {
   const { features, username } = widgetProps;
   const { uischema, data } = formBag;
+
+  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+    return transformIdentityRecovery({formBag, widgetProps, transaction});
+  }
 
   const identifierElement = getUIElementWithName(
     'identifier',

--- a/src/v3/src/transformer/identify/transformIdentify.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.ts
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { CONFIGURED_FLOW } from '../../constants';
 import {
   ButtonElement,
   ButtonType,
@@ -19,7 +18,7 @@ import {
   TitleElement,
   UISchemaElement,
 } from '../../types';
-import { getUsernameCookie, loc } from '../../util';
+import { getUsernameCookie, isConfigRecoverFlow, loc } from '../../util';
 import { transformIdentityRecovery } from '../layout/recovery';
 import { getUIElementWithName, removeUIElementWithName } from '../utils';
 
@@ -37,7 +36,7 @@ export const transformIdentify: IdxStepTransformer = ({
   // where password recovery flow has extra steps in identifier-first flow
   // this is to keep the user experience consistent with identify-recovery flow
   // this is in parity with the gen 2 fix: PR#2382
-  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (isConfigRecoverFlow(widgetProps.flow)) {
     return transformIdentityRecovery({ formBag, widgetProps, transaction });
   }
 

--- a/src/v3/src/transformer/identify/transformIdentify.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.ts
@@ -31,6 +31,12 @@ export const transformIdentify: IdxStepTransformer = ({
   const { features, username } = widgetProps;
   const { uischema, data } = formBag;
 
+  // TODO
+  // OKTA-651781
+  // there is a bug with the flow param resetPassword with identifier first flow
+  // where password recovery flow has extra steps in identifier-first flow
+  // this is to keep the user experience consistent with identify-recovery flow
+  // this is in parity with the gen 2 fix: PR#2382
   if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     return transformIdentityRecovery({formBag, widgetProps, transaction});
   }

--- a/src/v3/src/transformer/identify/transformIdentify.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.ts
@@ -37,8 +37,8 @@ export const transformIdentify: IdxStepTransformer = ({
   // where password recovery flow has extra steps in identifier-first flow
   // this is to keep the user experience consistent with identify-recovery flow
   // this is in parity with the gen 2 fix: PR#2382
-  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
-    return transformIdentityRecovery({formBag, widgetProps, transaction});
+  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+    return transformIdentityRecovery({ formBag, widgetProps, transaction });
   }
 
   const identifierElement = getUIElementWithName(

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -397,7 +397,7 @@ const TransformerMap: {
       transform: transformIdentityRecovery,
       buttonConfig: {
         showDefaultSubmit: false,
-      }
+      },
     },
   },
   [IDX_STEP.LAUNCH_AUTHENTICATOR]: {

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -395,6 +395,9 @@ const TransformerMap: {
   [IDX_STEP.IDENTIFY_RECOVERY]: {
     [AUTHENTICATOR_KEY.DEFAULT]: {
       transform: transformIdentityRecovery,
+      buttonConfig: {
+        showDefaultSubmit: false,
+      }
     },
   },
   [IDX_STEP.LAUNCH_AUTHENTICATOR]: {

--- a/src/v3/src/transformer/layout/recovery/transformIdentityRecovery.test.ts
+++ b/src/v3/src/transformer/layout/recovery/transformIdentityRecovery.test.ts
@@ -13,7 +13,10 @@
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 
 import {
-  FieldElement, TitleElement, WidgetProps,
+  ButtonElement,
+  FieldElement,
+  TitleElement,
+  WidgetProps,
 } from '../../../types';
 import { transformIdentityRecovery } from './transformIdentityRecovery';
 
@@ -33,29 +36,33 @@ describe('Identity Recovery Transformer Tests', () => {
     widgetProps = {};
   });
 
-  it('should add generic title and update label for forgot password identifier field'
+  it('should add generic title and update label for forgot password identifier field and submit button'
     + ' when no brand name exists', () => {
     const updatedFormBag = transformIdentityRecovery({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(2);
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('password.reset.title.generic');
     expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
       .toBe('identifier');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oform.next');
   });
 
-  it('should add branded title and update label for forgot password identifier field'
+  it('should add branded title and update label for forgot password identifier field and submit button'
     + ' when brand name exists', () => {
     const mockBrandName = 'Acme Corp';
     widgetProps = { brandName: mockBrandName };
     const updatedFormBag = transformIdentityRecovery({ transaction, formBag, widgetProps });
 
-    expect(updatedFormBag.uischema.elements.length).toBe(2);
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('password.reset.title.specific');
     expect((updatedFormBag.uischema.elements[1] as FieldElement).options.inputMeta.name)
       .toBe('identifier');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+      .toBe('oform.next');
   });
 });

--- a/src/v3/src/transformer/layout/recovery/transformIdentityRecovery.ts
+++ b/src/v3/src/transformer/layout/recovery/transformIdentityRecovery.ts
@@ -11,6 +11,8 @@
  */
 
 import {
+  ButtonElement,
+  ButtonType,
   FieldElement,
   IdxStepTransformer,
   TitleElement,
@@ -25,7 +27,7 @@ const getContentTitleAndParams = (brandName?: string): TitleElement['options'] =
   return { content: loc('password.reset.title.generic', 'login') };
 };
 
-export const transformIdentityRecovery: IdxStepTransformer = ({ formBag, widgetProps }) => {
+export const transformIdentityRecovery: IdxStepTransformer = ({ formBag, widgetProps, transaction }) => {
   const { brandName } = widgetProps;
   const { uischema } = formBag;
 
@@ -38,9 +40,19 @@ export const transformIdentityRecovery: IdxStepTransformer = ({ formBag, widgetP
     uischema.elements,
   ) as FieldElement;
 
+  const submitBtnElement: ButtonElement = {
+    type: 'Button',
+    label: loc('oform.next', 'login'),
+    options: {
+      type: ButtonType.SUBMIT,
+      step: transaction.nextStep!.name,
+    },
+  };
+
   uischema.elements = [
     titleElement,
     identifierElement,
+    submitBtnElement,
   ];
 
   return formBag;

--- a/src/v3/src/transformer/layout/recovery/transformIdentityRecovery.ts
+++ b/src/v3/src/transformer/layout/recovery/transformIdentityRecovery.ts
@@ -27,7 +27,11 @@ const getContentTitleAndParams = (brandName?: string): TitleElement['options'] =
   return { content: loc('password.reset.title.generic', 'login') };
 };
 
-export const transformIdentityRecovery: IdxStepTransformer = ({ formBag, widgetProps, transaction }) => {
+export const transformIdentityRecovery: IdxStepTransformer = ({
+  formBag,
+  widgetProps,
+  transaction,
+}) => {
   const { brandName } = widgetProps;
   const { uischema } = formBag;
 

--- a/src/v3/src/transformer/password/transformPasswordChallenge.ts
+++ b/src/v3/src/transformer/password/transformPasswordChallenge.ts
@@ -24,6 +24,10 @@ import { removeUIElementWithName } from '../utils';
 export const transformPasswordChallenge: IdxStepTransformer = ({ formBag, transaction, widgetProps }) => {
   const { uischema } = formBag;
 
+  // TODO
+  // OKTA-651781
+  // when flow param is set to resetPassword and there is an api error (eg. not allowed to reset),
+  // the error will show on the Verify with password challenge page and stop the flow.  So we need to hide this input
   if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     uischema.elements = removeUIElementWithName('credentials.passcode', uischema.elements);
     return formBag;

--- a/src/v3/src/transformer/password/transformPasswordChallenge.ts
+++ b/src/v3/src/transformer/password/transformPasswordChallenge.ts
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { CONFIGURED_FLOW } from '../../constants';
 import {
   ButtonElement,
   ButtonType,
@@ -18,9 +19,15 @@ import {
   TitleElement,
 } from '../../types';
 import { getUserInfo, loc } from '../../util';
+import { removeUIElementWithName } from '../utils';
 
-export const transformPasswordChallenge: IdxStepTransformer = ({ formBag, transaction }) => {
+export const transformPasswordChallenge: IdxStepTransformer = ({ formBag, transaction, widgetProps }) => {
   const { uischema } = formBag;
+
+  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+    uischema.elements = removeUIElementWithName('credentials.passcode', uischema.elements);
+    return formBag;
+  }
 
   const titleElement: TitleElement = {
     type: 'Title',

--- a/src/v3/src/transformer/password/transformPasswordChallenge.ts
+++ b/src/v3/src/transformer/password/transformPasswordChallenge.ts
@@ -21,14 +21,18 @@ import {
 import { getUserInfo, loc } from '../../util';
 import { removeUIElementWithName } from '../utils';
 
-export const transformPasswordChallenge: IdxStepTransformer = ({ formBag, transaction, widgetProps }) => {
+export const transformPasswordChallenge: IdxStepTransformer = ({
+  formBag,
+  transaction,
+  widgetProps,
+}) => {
   const { uischema } = formBag;
 
   // TODO
   // OKTA-651781
   // when flow param is set to resetPassword and there is an api error (eg. not allowed to reset),
   // the error will show on the Verify with password challenge page and stop the flow.  So we need to hide this input
-  if(widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
     uischema.elements = removeUIElementWithName('credentials.passcode', uischema.elements);
     return formBag;
   }

--- a/src/v3/src/transformer/password/transformPasswordChallenge.ts
+++ b/src/v3/src/transformer/password/transformPasswordChallenge.ts
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { CONFIGURED_FLOW } from '../../constants';
 import {
   ButtonElement,
   ButtonType,
@@ -18,7 +17,7 @@ import {
   IdxStepTransformer,
   TitleElement,
 } from '../../types';
-import { getUserInfo, loc } from '../../util';
+import { getUserInfo, isConfigRecoverFlow, loc } from '../../util';
 import { removeUIElementWithName } from '../utils';
 
 export const transformPasswordChallenge: IdxStepTransformer = ({
@@ -32,7 +31,7 @@ export const transformPasswordChallenge: IdxStepTransformer = ({
   // OKTA-651781
   // when flow param is set to resetPassword and there is an api error (eg. not allowed to reset),
   // the error will show on the Verify with password challenge page and stop the flow.  So we need to hide this input
-  if (widgetProps.flow === CONFIGURED_FLOW.RESET_PASSWORD) {
+  if (isConfigRecoverFlow(widgetProps.flow)) {
     uischema.elements = removeUIElementWithName('credentials.passcode', uischema.elements);
     return formBag;
   }

--- a/src/v3/src/util/configuredFlowUtils.ts
+++ b/src/v3/src/util/configuredFlowUtils.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+const CONFIG_REGISTER_FLOWS = new Set([
+  'signup',
+  'register',
+  'enrollProfile',
+]);
+const CONFIG_AUTH_FLOWS = new Set([
+  'authenticate',
+  'login',
+  'signin',
+]);
+const CONFIG_RECOVER_FLOWS = new Set([
+  'recoverPassword',
+  'resetPassword',
+]);
+const CONFIG_UNLOCK_FLOWS = new Set([
+  'unlockAccount',
+]);
+
+export const isConfigRegisterFlow = (flow: string | undefined): boolean => CONFIG_REGISTER_FLOWS.has(flow || '');
+export const isConfigRecoverFlow = (flow: string | undefined): boolean => CONFIG_RECOVER_FLOWS.has(flow || '');
+export const isConfigUnlockFlow = (flow: string | undefined): boolean => CONFIG_UNLOCK_FLOWS.has(flow || '');
+export const isConfigAuthFlow = (flow: string | undefined): boolean => CONFIG_AUTH_FLOWS.has(flow || '');

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -14,6 +14,7 @@ export * from './browserUtils';
 export * from './buildErrorMessageIds';
 export * from './buildPasswordRequirementNotMetErrorList';
 export * from './clipboard';
+export * from './configuredFlowUtils';
 export * from './cookieUtils';
 export * from './environmentUtils';
 export * from './escape';


### PR DESCRIPTION
## Description:

This PR adds support for the `flow` param in SIW Gen 3.
This PR implements a workaround fix from gen 2 for a known issue with reset password flow with identifier first view:
- https://github.com/okta/okta-signin-widget/pull/2382
- https://oktainc.atlassian.net/browse/OKTA-462165

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-626752](https://oktainc.atlassian.net/browse/OKTA-626752)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



