### PR TITLE
Gen3: Update OV instructions

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-device-bootstrap-multiple-devices.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-device-bootstrap-multiple-devices.json
@@ -176,7 +176,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticators.value[3]"
+                "relatesTo": "$.authenticators.value[2]"
               }
             ]
           },

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-device-bootstrap.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-device-bootstrap.json
@@ -176,7 +176,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticators.value[3]"
+                "relatesTo": "$.authenticators.value[2]"
               }
             ]
           },

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device.json
@@ -176,7 +176,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticators.value[3]"
+                "relatesTo": "$.authenticators.value[2]"
               }
             ]
           },

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
@@ -26,6 +26,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
+                "noMargin": true,
                 "options": Object {
                   "items": Array [
                     "oie.enroll.okta_verify.qrcode.step1",
@@ -115,6 +116,90 @@ Object {
                 },
                 "type": "TextWithActionLink",
                 "viewIndex": 2,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    "oie.enroll.okta_verify.qrcode.step1",
+                    "oie.enroll.okta_verify.qrcode.step2",
+                    "oie.enroll.okta_verify.qrcode.step3",
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 4,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    "oie.enroll.okta_verify.qrcode.step1",
+                    "oie.enroll.okta_verify.qrcode.step2",
+                    "oie.enroll.okta_verify.qrcode.step3",
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 4,
               },
             ],
             "type": "VerticalLayout",
@@ -171,6 +256,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
+                "noMargin": true,
                 "options": Object {
                   "items": Array [
                     "oie.enroll.okta_verify.qrcode.step1",
@@ -288,6 +374,118 @@ Object {
                 },
                 "type": "TextWithActionLink",
                 "viewIndex": 2,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.email.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
+                },
+                "type": "Reminder",
+                "viewIndex": 3,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.email.title",
+                },
+                "type": "Title",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    "oie.enroll.okta_verify.qrcode.step1",
+                    "oie.enroll.okta_verify.qrcode.step2",
+                    "oie.enroll.okta_verify.qrcode.step3",
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.email.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
+                },
+                "type": "Reminder",
+                "viewIndex": 4,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.email.title",
+                },
+                "type": "Title",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 4,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    "oie.enroll.okta_verify.qrcode.step1",
+                    "oie.enroll.okta_verify.qrcode.step2",
+                    "oie.enroll.okta_verify.qrcode.step3",
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 4,
               },
             ],
             "type": "VerticalLayout",
@@ -344,6 +542,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
+                "noMargin": true,
                 "options": Object {
                   "items": Array [
                     "oie.enroll.okta_verify.qrcode.step1",
@@ -461,6 +660,118 @@ Object {
                 },
                 "type": "TextWithActionLink",
                 "viewIndex": 2,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.sms.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
+                },
+                "type": "Reminder",
+                "viewIndex": 3,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.sms.title",
+                },
+                "type": "Title",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    "oie.enroll.okta_verify.qrcode.step1",
+                    "oie.enroll.okta_verify.qrcode.step2",
+                    "oie.enroll.okta_verify.qrcode.step3",
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "actionParams": Object {
+                    "resend": true,
+                  },
+                  "content": "oie.enroll.okta_verify.sms.notReceived",
+                  "contentClassname": "resend-link",
+                  "contentHasHtml": true,
+                  "isActionStep": true,
+                  "step": "resend",
+                },
+                "type": "Reminder",
+                "viewIndex": 4,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.sms.title",
+                },
+                "type": "Title",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 4,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    "oie.enroll.okta_verify.qrcode.step1",
+                    "oie.enroll.okta_verify.qrcode.step2",
+                    "oie.enroll.okta_verify.qrcode.step3",
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 4,
               },
             ],
             "type": "VerticalLayout",

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
@@ -1,5 +1,337 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TransformOktaVerifyEnrollPoll Tests should add Stepper elements when selectedChannel is devicebootstrap 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "elements": Array [
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.openOv.suchAs",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.selectAccount",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.addAccount",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.followInstruction",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 0,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.email.info",
+                },
+                "type": "Description",
+                "viewIndex": 1,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
+                  "step": "select-enrollment-channel",
+                  "stepToRender": "select-enrollment-channel",
+                },
+                "type": "TextWithActionLink",
+                "viewIndex": 1,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 2,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.sms.info",
+                },
+                "type": "Description",
+                "viewIndex": 2,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
+                  "step": "select-enrollment-channel",
+                  "stepToRender": "select-enrollment-channel",
+                },
+                "type": "TextWithActionLink",
+                "viewIndex": 2,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.openOv.suchAs",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.selectAccount",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.addAccount",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.followInstruction",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 4,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.openOv.suchAs",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.selectAccount",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.addAccount",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.followInstruction",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 4,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+        ],
+        "options": Object {
+          "defaultStepIndex": [Function],
+        },
+        "type": "Stepper",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
 exports[`TransformOktaVerifyEnrollPoll Tests should add Stepper elements when selectedChannel is qrcode and canResend = true 1`] = `
 Object {
   "data": Object {},
@@ -187,6 +519,389 @@ Object {
                     "oie.enroll.okta_verify.qrcode.step1",
                     "oie.enroll.okta_verify.qrcode.step2",
                     "oie.enroll.okta_verify.qrcode.step3",
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 4,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+        ],
+        "options": Object {
+          "defaultStepIndex": [Function],
+        },
+        "type": "Stepper",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`TransformOktaVerifyEnrollPoll Tests should add Stepper elements when selectedChannel is samedevice 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "elements": Array [
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "enroll.oda.without.account.step1",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.openOv",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.signInUrl",
+                          },
+                          "type": "Description",
+                        },
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "<span class=\\"strong no-translate\\">okta.okta.com</span>",
+                          },
+                          "type": "Description",
+                        },
+                        Object {
+                          "label": "enroll.oda.org.copyLink",
+                          "options": Object {
+                            "onClick": [Function],
+                            "step": "",
+                            "type": "button",
+                            "variant": "secondary",
+                          },
+                          "type": "Button",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.followInstruction",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 0,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.email.info",
+                },
+                "type": "Description",
+                "viewIndex": 1,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
+                  "step": "select-enrollment-channel",
+                  "stepToRender": "select-enrollment-channel",
+                },
+                "type": "TextWithActionLink",
+                "viewIndex": 1,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 2,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.sms.info",
+                },
+                "type": "Description",
+                "viewIndex": 2,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
+                  "step": "select-enrollment-channel",
+                  "stepToRender": "select-enrollment-channel",
+                },
+                "type": "TextWithActionLink",
+                "viewIndex": 2,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "enroll.oda.without.account.step1",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.openOv",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.signInUrl",
+                          },
+                          "type": "Description",
+                        },
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "<span class=\\"strong no-translate\\">okta.okta.com</span>",
+                          },
+                          "type": "Description",
+                        },
+                        Object {
+                          "label": "enroll.oda.org.copyLink",
+                          "options": Object {
+                            "onClick": [Function],
+                            "step": "",
+                            "type": "button",
+                            "variant": "secondary",
+                          },
+                          "type": "Button",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.followInstruction",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                  ],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 4,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "enroll.oda.without.account.step1",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.openOv",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.signInUrl",
+                          },
+                          "type": "Description",
+                        },
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "<span class=\\"strong no-translate\\">okta.okta.com</span>",
+                          },
+                          "type": "Description",
+                        },
+                        Object {
+                          "label": "enroll.oda.org.copyLink",
+                          "options": Object {
+                            "onClick": [Function],
+                            "step": "",
+                            "type": "button",
+                            "variant": "secondary",
+                          },
+                          "type": "Button",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
+                    Object {
+                      "elements": Array [
+                        Object {
+                          "noMargin": true,
+                          "options": Object {
+                            "content": "oie.enroll.okta_verify.setup.skipAuth.followInstruction",
+                          },
+                          "type": "Description",
+                        },
+                      ],
+                      "type": "VerticalLayout",
+                    },
                   ],
                   "type": "ol",
                 },

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
@@ -344,6 +344,7 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
       .toBe('select-enrollment-channel');
   });
 
+  /* eslint max-len: [2, 120] */
   it('should add Stepper elements when selectedChannel is samedevice', () => {
     transaction.context = {
       // TODO: OKTA-503490 temporary sln access missing relatesTo obj
@@ -353,7 +354,7 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
             samedevice: {
               orgUrl: 'okta.okta.com',
               downloadHref: 'https://apps.apple.com/us/app/okta-verify/id490179405',
-              platform: 'ios'
+              platform: 'ios',
             },
             selectedChannel: 'samedevice',
           },
@@ -365,7 +366,7 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     const [stepperLayout] = updatedFormBag.uischema.elements;
-    const [_layoutOne, _layoutTwo, _layoutThree, layoutFour] = (stepperLayout as StepperLayout).elements;
+    const layoutFour = (stepperLayout as StepperLayout).elements[3];
 
     expect(layoutFour.elements.length).toBe(4);
     expect((layoutFour.elements[0] as TitleElement).options.content)
@@ -393,6 +394,7 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
       .toBe('oie.enroll.okta_verify.setup.skipAuth.canBeClosed');
   });
 
+  /* eslint max-len: [2, 120] */
   it('should add Stepper elements when selectedChannel is devicebootstrap', () => {
     transaction.context = {
       // TODO: OKTA-503490 temporary sln access missing relatesTo obj
@@ -401,7 +403,7 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
           contextualData: {
             devicebootstrap: {
               platform: 'ios',
-              enrolledDevices: ['testDevice1', 'device2']
+              enrolledDevices: ['testDevice1', 'device2'],
             },
             selectedChannel: 'devicebootstrap',
           },
@@ -413,7 +415,7 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     const [stepperLayout] = updatedFormBag.uischema.elements;
-    const [_layoutOne, _layoutTwo, _layoutThree, _layoutFour, layoutFive] = (stepperLayout as StepperLayout).elements;
+    const layoutFive = (stepperLayout as StepperLayout).elements[3];
 
     expect(layoutFive.elements.length).toBe(4);
     expect((layoutFive.elements[0] as TitleElement).options.content)

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
@@ -21,6 +21,7 @@ import {
   StepperLayout,
   TextWithActionLinkElement,
   TitleElement,
+  UISchemaLayout,
   WidgetProps,
 } from 'src/types';
 
@@ -341,5 +342,98 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
       .toBe('select-enrollment-channel');
     expect((layoutThree.elements[2] as TextWithActionLinkElement).options.stepToRender)
       .toBe('select-enrollment-channel');
+  });
+
+  it('should add Stepper elements when selectedChannel is samedevice', () => {
+    transaction.context = {
+      // TODO: OKTA-503490 temporary sln access missing relatesTo obj
+      currentAuthenticator: {
+        value: {
+          contextualData: {
+            samedevice: {
+              orgUrl: 'okta.okta.com',
+              downloadHref: 'https://apps.apple.com/us/app/okta-verify/id490179405',
+              platform: 'ios'
+            },
+            selectedChannel: 'samedevice',
+          },
+        },
+      },
+    } as unknown as IdxContext;
+
+    const updatedFormBag = transformOktaVerifyEnrollPoll({ transaction, formBag, widgetProps });
+
+    expect(updatedFormBag).toMatchSnapshot();
+    const [stepperLayout] = updatedFormBag.uischema.elements;
+    const [_layoutOne, _layoutTwo, _layoutThree, layoutFour] = (stepperLayout as StepperLayout).elements;
+
+    expect(layoutFour.elements.length).toBe(4);
+    expect((layoutFour.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.title');
+    expect((layoutFour.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.subtitle');
+    expect(layoutFour.elements[2].type)
+      .toBe('List');
+    const listElement = layoutFour.elements[2] as ListElement;
+    expect(listElement.options.type)
+      .toBe('ol');
+    expect(((listElement.options.items[0] as UISchemaLayout).elements[0] as DescriptionElement).options.content)
+      .toBe('enroll.oda.without.account.step1');
+    expect(((listElement.options.items[1] as UISchemaLayout).elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.openOv');
+    expect(((listElement.options.items[2] as UISchemaLayout).elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.signInUrl');
+    expect(((listElement.options.items[2] as UISchemaLayout).elements[1] as DescriptionElement).options.content)
+      .toBe('<span class="strong no-translate">okta.okta.com</span>');
+    expect(((listElement.options.items[2] as UISchemaLayout).elements[2] as ButtonElement).label)
+      .toBe('enroll.oda.org.copyLink');
+    expect(((listElement.options.items[3] as UISchemaLayout).elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.skipAuth.followInstruction');
+    expect((layoutFour.elements[3] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.skipAuth.canBeClosed');
+  });
+
+  it('should add Stepper elements when selectedChannel is devicebootstrap', () => {
+    transaction.context = {
+      // TODO: OKTA-503490 temporary sln access missing relatesTo obj
+      currentAuthenticator: {
+        value: {
+          contextualData: {
+            devicebootstrap: {
+              platform: 'ios',
+              enrolledDevices: ['testDevice1', 'device2']
+            },
+            selectedChannel: 'devicebootstrap',
+          },
+        },
+      },
+    } as unknown as IdxContext;
+
+    const updatedFormBag = transformOktaVerifyEnrollPoll({ transaction, formBag, widgetProps });
+
+    expect(updatedFormBag).toMatchSnapshot();
+    const [stepperLayout] = updatedFormBag.uischema.elements;
+    const [_layoutOne, _layoutTwo, _layoutThree, _layoutFour, layoutFive] = (stepperLayout as StepperLayout).elements;
+
+    expect(layoutFive.elements.length).toBe(4);
+    expect((layoutFive.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.title');
+    expect((layoutFive.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.skipAuth.subtitle');
+    expect(layoutFive.elements[2].type)
+      .toBe('List');
+    const listElement = layoutFive.elements[2] as ListElement;
+    expect(listElement.options.type)
+      .toBe('ol');
+    expect(((listElement.options.items[0] as UISchemaLayout).elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.skipAuth.openOv.suchAs');
+    expect(((listElement.options.items[1] as UISchemaLayout).elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.skipAuth.selectAccount');
+    expect(((listElement.options.items[2] as UISchemaLayout).elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.skipAuth.addAccount');
+    expect(((listElement.options.items[3] as UISchemaLayout).elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.skipAuth.followInstruction');
+    expect((layoutFive.elements[3] as DescriptionElement).options.content)
+      .toBe('oie.enroll.okta_verify.setup.skipAuth.canBeClosed');
   });
 });

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
@@ -415,7 +415,7 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     const [stepperLayout] = updatedFormBag.uischema.elements;
-    const layoutFive = (stepperLayout as StepperLayout).elements[3];
+    const layoutFive = (stepperLayout as StepperLayout).elements[4];
 
     expect(layoutFive.elements.length).toBe(4);
     expect((layoutFive.elements[0] as TitleElement).options.content)

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-15"
+                    class="MuiBox-root emotion-0"
                   >
                     <div
                       class="MuiBox-root emotion-27"

--- a/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
@@ -165,22 +165,37 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
   }
 
   getSubHeader() {
+    if (userVariables.v3) {
+      return this.form.getSubtitle(0);
+    }
     return this.getTextContent(SUB_HEADER);
   }
   
   getCopyOrgLinkButtonLabel() {
+    if (userVariables.v3) {
+      return this.form.getButton('Copy sign-in URL to clipboard').innerText;
+    }
     return this.getTextContent(COPY_ORG_LINK_BUTTON_CLASS);
   }
 
   getCopiedOrgLinkValue() {
+    if (userVariables.v3) {
+      return this.form.getElement('[data-se=o-form-explain] > .no-translate').innerText;
+    }
     return this.body.find(COPY_ORG_LINK_BUTTON_CLASS).getAttribute(CLIPBOARD_TEXT);
   }
 
   getDownloadAppHref() {
+    if (userVariables.v3) {
+      return this.form.el.find(DOWNLOAD_OV_LINK_CLASS).getAttribute('href');
+    }
     return this.body.find(DOWNLOAD_OV_LINK_CLASS).getAttribute('href');
   }
 
   getClosingText() {
+    if (userVariables.v3) {
+      return this.form.getSubtitle(-1);
+    }
     return this.getTextContent(CLOSING_CLASS);
   }
 }

--- a/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
@@ -165,36 +165,30 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
   }
 
   getSubHeader() {
-    if (userVariables.v3) {
+    if (userVariables.gen3) {
       return this.form.getSubtitle(0);
     }
     return this.getTextContent(SUB_HEADER);
   }
   
   getCopyOrgLinkButtonLabel() {
-    if (userVariables.v3) {
+    if (userVariables.gen3) {
       return this.form.getButton('Copy sign-in URL to clipboard').innerText;
     }
     return this.getTextContent(COPY_ORG_LINK_BUTTON_CLASS);
   }
 
   getCopiedOrgLinkValue() {
-    if (userVariables.v3) {
-      return this.form.getElement('[data-se=o-form-explain] > .no-translate').innerText;
-    }
     return this.body.find(COPY_ORG_LINK_BUTTON_CLASS).getAttribute(CLIPBOARD_TEXT);
   }
 
   getDownloadAppHref() {
-    if (userVariables.v3) {
-      return this.form.el.find(DOWNLOAD_OV_LINK_CLASS).getAttribute('href');
-    }
-    return this.body.find(DOWNLOAD_OV_LINK_CLASS).getAttribute('href');
+    return this.form.el.find(DOWNLOAD_OV_LINK_CLASS).getAttribute('href');
   }
 
   getClosingText() {
-    if (userVariables.v3) {
-      return this.form.getSubtitle(-1);
+    if (userVariables.gen3) {
+      return this.form.getSubtitle(5);
     }
     return this.getTextContent(CLOSING_CLASS);
   }

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -57,7 +57,7 @@ const enrollViaQRcodeMocks2 = enrollViaQRcodeMocks(xhrSuccess);
 const enrollSameDeviceMocks = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorEnrollOktaVerifySameDevice);
-if (userVariables.v3) {
+if (userVariables.gen3) {
   enrollSameDeviceMocks
     .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
     .respond(xhrAuthenticatorEnrollOktaVerifySameDevice);
@@ -67,7 +67,7 @@ if (userVariables.v3) {
 const enrollDeviceBootstrapMocks = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrap);
-if (userVariables.v3) {
+if (userVariables.gen3) {
   enrollDeviceBootstrapMocks
     .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
     .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrap);
@@ -76,7 +76,7 @@ if (userVariables.v3) {
 const enrollDeviceBootstrapMocksMultipleDevices = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrapMultipleDevices);
-if (userVariables.v3) {
+if (userVariables.gen3) {
   enrollDeviceBootstrapMocksMultipleDevices
     .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
     .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrapMultipleDevices);
@@ -863,14 +863,16 @@ test
 
     await t.expect(enrollOktaVerifyPage.getDownloadAppHref()).eql(oktaVerifyAppStoreDownloadUrl);
     await t.expect(enrollOktaVerifyPage.getCopyOrgLinkButtonLabel()).eql(urlCopiedToClipboardMessage);
-    await t.expect(enrollOktaVerifyPage.getCopiedOrgLinkValue()).eql('okta.okta.com');
+    if (!userVariables.gen3) {
+      await t.expect(enrollOktaVerifyPage.getCopiedOrgLinkValue()).eql('okta.okta.com');
+    }
 
     await t.expect(enrollOktaVerifyPage.getTryDifferentWayText().exists).notOk();
     await t.expect(await enrollOktaVerifyPage.returnToAuthenticatorListLinkExists()).ok();
     await t.expect(await enrollOktaVerifyPage.signoutLinkExists()).ok();
 
     // expect no polling for same device page
-    if (!userVariables.v3) {
+    if (!userVariables.gen3) {
       await t.expect(logger.count(
         record => record.response.statusCode === 200 &&
         record.request.url.match(/poll/)
@@ -895,7 +897,7 @@ test
     await t.expect(await enrollOktaVerifyPage.signoutLinkExists()).ok();
 
     // expect no polling for device bootstrap page
-    if (!userVariables.v3) {
+    if (!userVariables.gen3) {
       await t.expect(logger.count(
         record => record.response.statusCode === 200 &&
         record.request.url.match(/poll/)
@@ -922,7 +924,7 @@ test
     await t.expect(await enrollOktaVerifyPage.signoutLinkExists()).ok();
 
     // expect no polling for device bootstrap page
-    if (!userVariables.v3) {
+    if (!userVariables.gen3) {
       await t.expect(logger.count(
         record => record.response.statusCode === 200 &&
         record.request.url.match(/poll/)

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -59,8 +59,8 @@ const enrollSameDeviceMocks = RequestMock()
   .respond(xhrAuthenticatorEnrollOktaVerifySameDevice);
 if (userVariables.v3) {
   enrollSameDeviceMocks
-  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
-  .respond(xhrAuthenticatorEnrollOktaVerifySameDevice);
+    .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+    .respond(xhrAuthenticatorEnrollOktaVerifySameDevice);
 }
 
 // this mock doesn't need poll to return successful response
@@ -69,8 +69,8 @@ const enrollDeviceBootstrapMocks = RequestMock()
   .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrap);
 if (userVariables.v3) {
   enrollDeviceBootstrapMocks
-  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
-  .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrap);
+    .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+    .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrap);
 }
 
 const enrollDeviceBootstrapMocksMultipleDevices = RequestMock()
@@ -78,8 +78,8 @@ const enrollDeviceBootstrapMocksMultipleDevices = RequestMock()
   .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrapMultipleDevices);
 if (userVariables.v3) {
   enrollDeviceBootstrapMocksMultipleDevices
-  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
-  .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrapMultipleDevices);
+    .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+    .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrapMultipleDevices);
 }
 
 const enrollViaEmailMocks = pollResponse => RequestMock()

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -57,15 +57,30 @@ const enrollViaQRcodeMocks2 = enrollViaQRcodeMocks(xhrSuccess);
 const enrollSameDeviceMocks = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorEnrollOktaVerifySameDevice);
+if (userVariables.v3) {
+  enrollSameDeviceMocks
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+  .respond(xhrAuthenticatorEnrollOktaVerifySameDevice);
+}
 
 // this mock doesn't need poll to return successful response
 const enrollDeviceBootstrapMocks = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrap);
+if (userVariables.v3) {
+  enrollDeviceBootstrapMocks
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+  .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrap);
+}
 
 const enrollDeviceBootstrapMocksMultipleDevices = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrapMultipleDevices);
+if (userVariables.v3) {
+  enrollDeviceBootstrapMocksMultipleDevices
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+  .respond(xhrAuthenticatorEnrollOktaVerifyDeviceBootstrapMultipleDevices);
+}
 
 const enrollViaEmailMocks = pollResponse => RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -835,7 +850,6 @@ test
 
 
 test
-  .meta('gen3', false)
   .requestHooks(logger, enrollSameDeviceMocks)('should be able to see OV same device enrollment instructions without polling', async t => {
     const enrollOktaVerifyPage = await setup(t);
     await checkA11y(t);
@@ -856,14 +870,15 @@ test
     await t.expect(await enrollOktaVerifyPage.signoutLinkExists()).ok();
 
     // expect no polling for same device page
-    await t.expect(logger.count(
-      record => record.response.statusCode === 200 &&
-      record.request.url.match(/poll/)
-    )).eql(0);
+    if (!userVariables.v3) {
+      await t.expect(logger.count(
+        record => record.response.statusCode === 200 &&
+        record.request.url.match(/poll/)
+      )).eql(0);
+    }
   });
 
 test
-  .meta('gen3', false)
   .requestHooks(logger, enrollDeviceBootstrapMocks)('should be able to see OV device bootstrap enrollment instructions without polling with one device', async t => {
     const enrollOktaVerifyPage = await setup(t);
     await checkA11y(t);
@@ -880,14 +895,15 @@ test
     await t.expect(await enrollOktaVerifyPage.signoutLinkExists()).ok();
 
     // expect no polling for device bootstrap page
-    await t.expect(logger.count(
-      record => record.response.statusCode === 200 &&
-      record.request.url.match(/poll/)
-    )).eql(0);
+    if (!userVariables.v3) {
+      await t.expect(logger.count(
+        record => record.response.statusCode === 200 &&
+        record.request.url.match(/poll/)
+      )).eql(0);
+    }
   });
 
 test
-  .meta('gen3', false)
   .requestHooks(logger, enrollDeviceBootstrapMocksMultipleDevices)('should be able to see OV device bootstrap enrollment instructions without polling with multiple devices', async t => {
     const enrollOktaVerifyPage = await setup(t);
     await checkA11y(t);
@@ -906,8 +922,10 @@ test
     await t.expect(await enrollOktaVerifyPage.signoutLinkExists()).ok();
 
     // expect no polling for device bootstrap page
-    await t.expect(logger.count(
-      record => record.response.statusCode === 200 &&
-      record.request.url.match(/poll/)
-    )).eql(0);
+    if (!userVariables.v3) {
+      await t.expect(logger.count(
+        record => record.response.statusCode === 200 &&
+        record.request.url.match(/poll/)
+      )).eql(0);
+    }
   });


### PR DESCRIPTION
## Description:

Follow-up for https://github.com/okta/okta-signin-widget/pull/3362

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-651065](https://oktainc.atlassian.net/browse/OKTA-651065)

### Reviewers:

### Screenshot/Video:

New page to enroll OV on same device ([mock](https://github.com/okta/okta-signin-widget/blob/master/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device.json)):
<img width="444" alt="authenticator-enroll-ov-same-device" src="https://github.com/okta/okta-signin-widget/assets/72614880/d7d69e0f-a6a1-4cb8-b871-62315d4d96e9">
Gen2:
<img width="416" alt="authenticator-enroll-ov-same-device (g2)" src="https://github.com/okta/okta-signin-widget/assets/72614880/7dc0f5e6-50bf-4c8e-96f5-24097550f413">

New page to enroll OV on another device ([mock](https://github.com/okta/okta-signin-widget/blob/master/playground/mocks/data/idp/idx/authenticator-enroll-ov-device-bootstrap.json)):
<img width="449" alt="authenticator-enroll-ov-device-bootstrap" src="https://github.com/okta/okta-signin-widget/assets/72614880/ef58c21a-588f-4d95-bf80-34da6d9831b9">
<img width="414" alt="authenticator-enroll-ov-device-bootstrap (g2)" src="https://github.com/okta/okta-signin-widget/assets/72614880/32d73910-4c7e-469a-8257-177eaa75a344">



### Downstream Monolith Build:



