### PR TITLE
Addition to the existing insecure enrollments block tests

### DIFF
--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -1,6 +1,7 @@
 import { RequestMock, RequestLogger, userVariables } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import EnrollOktaVerifyPageObject from '../framework/page-objects/EnrollOktaVerifyPageObject';
+import SelectFactorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
 import SwitchOVEnrollChannelPageObject from '../framework/page-objects/SwitchOVEnrollChannelPageObject';
 import EnrollOVViaEmailPageObject from '../framework/page-objects/EnrollOVViaEmailPageObject';
 import EnrollOVViaSMSPageObject from '../framework/page-objects/EnrollOVViaSMSPageObject';
@@ -878,6 +879,14 @@ test
         record.request.url.match(/poll/)
       )).eql(0);
     }
+    await enrollOktaVerifyPage.clickReturnToAuthenticatorListLink();
+    const selectFactorPageObject = new SelectFactorPageObject(t);
+
+    await t.expect(selectFactorPageObject.getFormTitle()).eql('Set up security methods');
+    await t.expect(selectFactorPageObject.getFormSubtitle()).eql(
+      'Security methods help protect your account by ensuring only you have access.');
+    await t.expect(await selectFactorPageObject.getCancelLink().exists).ok();
+
   });
 
 test


### PR DESCRIPTION
## Description:

Addition to the existing insecure enrollments block tests

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-646768](https://oktainc.atlassian.net/browse/OKTA-646768)

### Reviewers:

@yannongli-okta , @helenchen-okta 

### Screenshot/Video:


### Downstream Monolith Build:



