### PR TITLE
SIW Gen 3: Enable Chrome DTC view and spec

### DIFF
--- a/src/v3/src/components/AuthCoin/authCoinConfigUtil.ts
+++ b/src/v3/src/components/AuthCoin/authCoinConfigUtil.ts
@@ -169,6 +169,13 @@ export const getAuthCoinConfiguration = (): Record<string, AuthCoinConfig> => ({
     description: loc('factor.totpSoft.oktaVerify', 'login'),
     iconClassName: 'mfa-okta-verify',
   },
+  [CHALLENGE_METHOD.CHROME_DTC]: {
+    icon: OktaVerifyIcon,
+    name: 'mfa-okta-verify',
+    customizable: false,
+    description: loc('factor.totpSoft.oktaVerify', 'login'),
+    iconClassName: 'mfa-okta-verify',
+  },
   [CHALLENGE_METHOD.CUSTOM_URI]: {
     icon: OktaVerifyIcon,
     name: 'mfa-okta-verify',

--- a/src/v3/src/components/ChromeDtcContainer/ChromeDtcContainer.tsx
+++ b/src/v3/src/components/ChromeDtcContainer/ChromeDtcContainer.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { h } from 'preact';
+
+import { useWidgetContext } from '../../contexts';
+import {
+  ChromeDtcContainerElement, UISchemaElementComponent,
+} from '../../types';
+import { getBaseUrl } from '../../util';
+import HiddenIFrame from '../HiddenIFrame';
+
+const ChromeDtcContainer: UISchemaElementComponent<{
+  uischema: ChromeDtcContainerElement
+}> = ({ uischema }) => {
+  const {
+    options: {
+      href,
+    },
+  } = uischema;
+  const { widgetProps } = useWidgetContext();
+  const deviceChallengeUrl = new URL(href as string, getBaseUrl(widgetProps)).toString();
+
+  return (
+    <HiddenIFrame
+      id="chrome-dtc-container"
+      src={deviceChallengeUrl}
+    />
+  );
+};
+
+export default ChromeDtcContainer;

--- a/src/v3/src/components/ChromeDtcContainer/ChromeDtcContainer.tsx
+++ b/src/v3/src/components/ChromeDtcContainer/ChromeDtcContainer.tsx
@@ -28,7 +28,7 @@ const ChromeDtcContainer: UISchemaElementComponent<{
     },
   } = uischema;
   const { widgetProps } = useWidgetContext();
-  const deviceChallengeUrl = new URL(href as string, getBaseUrl(widgetProps)).toString();
+  const deviceChallengeUrl = new URL(href, getBaseUrl(widgetProps)).toString();
 
   return (
     <HiddenIFrame

--- a/src/v3/src/components/ChromeDtcContainer/index.tsx
+++ b/src/v3/src/components/ChromeDtcContainer/index.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import ChromeDtcContainer from './ChromeDtcContainer';
+
+export default ChromeDtcContainer;

--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -25,6 +25,7 @@ import AutoSubmit from '../AutoSubmit';
 import Button from '../Button';
 import CaptchaContainer from '../CaptchaContainer';
 import Checkbox from '../Checkbox';
+import ChromeDtcContainer from '../ChromeDtcContainer';
 import Divider from '../Divider';
 import DuoWindow from '../DuoWindow';
 import Heading from '../Heading';
@@ -124,6 +125,10 @@ export default [
   {
     tester: ({ type }) => type === 'OpenOktaVerifyFPButton',
     renderer: OpenOktaVerifyFPButton,
+  },
+  {
+    tester: ({ type }) => type === 'ChromeDtcContainer',
+    renderer: ChromeDtcContainer,
   },
   {
     tester: ({ type }) => type === 'WebAuthNSubmitButton',

--- a/src/v3/src/components/HiddenIFrame/HiddenIFrame.tsx
+++ b/src/v3/src/components/HiddenIFrame/HiddenIFrame.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Box } from '@mui/material';
+import { FunctionComponent, h } from 'preact';
+
+type HiddenIFrameProps = {
+  id?: string;
+  src: string;
+};
+const HiddenIFrame: FunctionComponent<HiddenIFrameProps> = ({ id, src }) => (
+  <Box
+    id={id}
+    component="iframe"
+    src={src}
+    sx={{
+      display: 'none',
+    }}
+  />
+);
+
+export default HiddenIFrame;

--- a/src/v3/src/components/HiddenIFrame/index.tsx
+++ b/src/v3/src/components/HiddenIFrame/index.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import HiddenIFrame from './HiddenIFrame';
+
+export default HiddenIFrame;

--- a/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
+++ b/src/v3/src/components/OpenOktaVerifyFPButton/OpenOktaVerifyFPButton.tsx
@@ -10,8 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box } from '@mui/material';
-import { FunctionComponent, h } from 'preact';
+import { h } from 'preact';
 import React from 'preact/compat';
 import { useState } from 'preact/hooks';
 
@@ -28,19 +27,7 @@ import {
   getBaseUrl, getTranslation, isAndroid, setUrlQueryParams,
 } from '../../util';
 import Button from '../Button';
-
-type IFrameProps = {
-  src: string;
-};
-const IFrame: FunctionComponent<IFrameProps> = ({ src }) => (
-  <Box
-    component="iframe"
-    src={src}
-    sx={{
-      display: 'none',
-    }}
-  />
-);
+import HiddenIFrame from '../HiddenIFrame';
 
 const OpenOktaVerifyFPButton: UISchemaElementComponent<{
   uischema: OpenOktaVerifyFPButtonElement
@@ -96,8 +83,9 @@ const OpenOktaVerifyFPButton: UISchemaElementComponent<{
     <React.Fragment>
       <Button uischema={buttonUiSchema} />
       {(href && challengeMethod === CHALLENGE_METHOD.CUSTOM_URI) && (
-        <IFrame
+        <HiddenIFrame
           key={key}
+          id="custom-uri-container"
           src={deviceChallengeUrl}
         />
       )}

--- a/src/v3/src/constants/idxConstants.ts
+++ b/src/v3/src/constants/idxConstants.ts
@@ -89,6 +89,7 @@ export const IDX_STEP: Record<string, string> = {
 
 export const CHALLENGE_METHOD: Record<string, string> = {
   APP_LINK: 'APP_LINK',
+  CHROME_DTC: 'CHROME_DTC',
   CUSTOM_URI: 'CUSTOM_URI',
   LOOPBACK: 'LOOPBACK',
   UNIVERSAL_LINK: 'UNIVERSAL_LINK',

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -268,6 +268,13 @@ const TransformerMap: {
         showDefaultCancel: false,
       },
     },
+    [CHALLENGE_METHOD.CHROME_DTC]: {
+      transform: transformOktaVerifyDeviceChallengePoll,
+      buttonConfig: {
+        showDefaultSubmit: false,
+        showDefaultCancel: false,
+      },
+    },
     [CHALLENGE_METHOD.CUSTOM_URI]: {
       transform: transformOktaVerifyDeviceChallengePoll,
       buttonConfig: {

--- a/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyDeviceChallengePoll.test.ts.snap
+++ b/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyDeviceChallengePoll.test.ts.snap
@@ -310,6 +310,50 @@ Object {
 }
 `;
 
+exports[`Transform Okta Verify Device Challenge Poll Tests where remediation is device-challenge-poll should transform elements when challengeMethod is CHROME_DTC 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "chrome_dtc.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "type": "Spinner",
+      },
+      Object {
+        "options": Object {
+          "href": "okta-verify.html",
+        },
+        "type": "ChromeDtcContainer",
+      },
+      Object {
+        "contentType": "footer",
+        "options": Object {
+          "isActionStep": true,
+          "label": "goback",
+          "step": "cancel",
+        },
+        "type": "Link",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
 exports[`Transform Okta Verify Device Challenge Poll Tests where remediation is device-challenge-poll should transform elements when challengeMethod is CUSTOM_URI 1`] = `
 Object {
   "data": Object {},

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.test.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.test.ts
@@ -13,6 +13,7 @@
 import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
+  ChromeDtcContainerElement,
   DescriptionElement,
   LinkElement,
   OpenOktaVerifyFPButtonElement,
@@ -144,6 +145,30 @@ describe('Transform Okta Verify Device Challenge Poll Tests', () => {
       expect((updatedFormBag.uischema.elements[5] as LinkElement).type)
         .toBe('Link');
       expect((updatedFormBag.uischema.elements[5] as LinkElement).options.step)
+        .toBe('cancel');
+    });
+
+    it('should transform elements when challengeMethod is CHROME_DTC', () => {
+      // @ts-expect-error Property 'challengeMethod' does not exist on type 'IdxAuthenticator'.
+      transaction.nextStep?.relatesTo.value.challengeMethod = 'CHROME_DTC';
+      transaction.availableSteps = undefined;
+      const updatedFormBag = transformOktaVerifyDeviceChallengePoll({
+        transaction,
+        formBag,
+        widgetProps,
+      });
+
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+        .toBe('chrome_dtc.title');
+      expect((updatedFormBag.uischema.elements[1] as SpinnerElement).type)
+        .toBe('Spinner');
+      expect((updatedFormBag.uischema.elements[2] as ChromeDtcContainerElement).options.href)
+        .toBe('okta-verify.html');
+      expect((updatedFormBag.uischema.elements[3] as LinkElement).type)
+        .toBe('Link');
+      expect((updatedFormBag.uischema.elements[3] as LinkElement).options.step)
         .toBe('cancel');
     });
   });

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyDeviceChallengePoll.ts
@@ -30,23 +30,35 @@ import {
 import { hasMinAuthenticatorOptions, loc, updateTransactionWithNextStep } from '../../../util';
 
 const getTitleText = (challengeMethod: string) => {
-  if (challengeMethod === CHALLENGE_METHOD.APP_LINK) {
-    return loc('appLink.title', 'login');
+  switch (challengeMethod) {
+    case CHALLENGE_METHOD.APP_LINK:
+      return loc('appLink.title', 'login');
+
+    case CHALLENGE_METHOD.CHROME_DTC:
+      return loc('chrome_dtc.title', 'login');
+
+    case CHALLENGE_METHOD.UNIVERSAL_LINK:
+      return loc('universalLink.title', 'login');
+
+    default:
+      return loc('customUri.title', 'login');
   }
-  if (challengeMethod === CHALLENGE_METHOD.UNIVERSAL_LINK) {
-    return loc('universalLink.title', 'login');
-  }
-  return loc('customUri.title', 'login');
 };
 
 const getDescriptionText = (challengeMethod: string) => {
-  if (challengeMethod === CHALLENGE_METHOD.APP_LINK) {
-    return loc('appLink.content', 'login');
+  switch (challengeMethod) {
+    case CHALLENGE_METHOD.APP_LINK:
+      return loc('appLink.content', 'login');
+
+    case CHALLENGE_METHOD.UNIVERSAL_LINK:
+      return loc('universalLink.content', 'login');
+
+    case CHALLENGE_METHOD.CHROME_DTC:
+      return '';
+
+    default:
+      return loc('customUri.required.content.prompt', 'login');
   }
-  if (challengeMethod === CHALLENGE_METHOD.UNIVERSAL_LINK) {
-    return loc('universalLink.content', 'login');
-  }
-  return loc('customUri.required.content.prompt', 'login');
 };
 
 export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
@@ -180,12 +192,14 @@ export const transformOktaVerifyDeviceChallengePoll: IdxStepTransformer = ({
     return formBag;
   }
 
-  if (challengeMethod === CHALLENGE_METHOD.APP_LINK
-    || challengeMethod === CHALLENGE_METHOD.UNIVERSAL_LINK) {
+  if (challengeMethod !== CHALLENGE_METHOD.CUSTOM_URI) {
     uischema.elements.push(spinnerElement);
   }
-  uischema.elements.push(descriptionElement);
-  uischema.elements.push(openOktaVerifyButton);
+
+  if (challengeMethod !== CHALLENGE_METHOD.CHROME_DTC) {
+    uischema.elements.push(descriptionElement);
+    uischema.elements.push(openOktaVerifyButton);
+  }
 
   if (challengeMethod === CHALLENGE_METHOD.CUSTOM_URI) {
     uischema.elements.push({

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -385,6 +385,13 @@ export interface LoopbackProbeElement extends UISchemaElement {
   };
 }
 
+export interface ChromeDtcContainerElement extends UISchemaElement {
+  type: 'ChromeDtcContainer';
+  options: {
+    href: string;
+  };
+}
+
 export interface TitleElement extends UISchemaElement {
   type: 'Title';
   options: {

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -14,7 +14,7 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
   }
 
   getCustomUriIframeAttributes() {
-    return this.getIframe().attributes;
+    return Selector('#custom-uri-container').attributes;
   }
 
   getChromeDTCIframeAttributes() {

--- a/test/testcafe/spec/DeviceProbingChromeDTC_spec.js
+++ b/test/testcafe/spec/DeviceProbingChromeDTC_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, userVariables } from 'testcafe';
+import { RequestMock } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import DeviceChallengePollPageObject from '../framework/page-objects/DeviceChallengePollPageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
@@ -64,12 +64,7 @@ const mockChromeProbingThenCancel = RequestMock()
     res.setBody(identify);
   });
 
-<<<<<<< HEAD
-fixture('Device Challenge Polling View for Chrome DTC').meta('v3', true);
-=======
-// TODO: OKTA-616189 - implement this view in Gen3
-fixture('Device Challenge Polling View for Chrome DTC').meta('gen3', false);
->>>>>>> master
+fixture('Device Challenge Polling View for Chrome DTC');
 
 async function setup(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
@@ -108,6 +103,7 @@ async function assertChromeDTCView(t) {
   await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().exists).eql(false);
   await t.expect(await deviceChallengePollPageObject.hasSpinner()).eql(true);
   let iframe = await deviceChallengePollPageObject.getIframe();
+  await t.expect(iframe.exists).ok({ timeout: 100 });
   let attributes = await deviceChallengePollPageObject.getChromeDTCIframeAttributes();
   await t.expect(attributes.src).eql('http://localhost:3000/idp/device/dinkm9q0dV4tsEdkz0g4/challenge?transactionHandle=dit2ChhQiZ7xRpQfED8H9hXnw1NrKcE8VCq');
   await t.expect(iframe.visible).eql(false);

--- a/test/testcafe/spec/DeviceProbingChromeDTC_spec.js
+++ b/test/testcafe/spec/DeviceProbingChromeDTC_spec.js
@@ -64,7 +64,7 @@ const mockChromeProbingThenCancel = RequestMock()
     res.setBody(identify);
   });
 
-fixture('Device Challenge Polling View for Chrome DTC').meta('v3', false);
+fixture('Device Challenge Polling View for Chrome DTC').meta('v3', true);
 
 async function setup(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);

--- a/test/testcafe/spec/DeviceProbingChromeDTC_spec.js
+++ b/test/testcafe/spec/DeviceProbingChromeDTC_spec.js
@@ -101,10 +101,6 @@ async function assertChromeDTCView(t) {
   await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Collecting device signals');
   await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(true);
   await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().exists).eql(false);
-  // In v3 all cancel buttons are the same so skip this assertion
-  if (userVariables.v3) {
-    await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().exists).eql(false);
-  }
   await t.expect(await deviceChallengePollPageObject.hasSpinner()).eql(true);
   let iframe = await deviceChallengePollPageObject.getIframe();
   let attributes = await deviceChallengePollPageObject.getChromeDTCIframeAttributes();


### PR DESCRIPTION
## Description:
- Implements the Chrome DTC polling view for gen 3
- Enables and updates the corresponding spec tests (one sidenote is that none of the tests in this spec were actually running since this spec got created because we were missing `await` before calling `assertChromeDTCView()`)


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-616189](https://oktainc.atlassian.net/browse/OKTA-616189)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-616189-dtc-view&page=1&pageSize=6&sha=ab44c49962e1f782a035b223f185f0b6ff7c6120&tab=main)

### Reviewers:

### Screenshot/Video:
![Screenshot 2023-09-27 at 5 35 22 PM](https://github.com/okta/okta-signin-widget/assets/106110543/8825e0c1-fff2-4903-849a-084702ee274c)

### Downstream Monolith Build:



