### PR TITLE
Changes useragent string to use version instead of hash

### DIFF
--- a/src/v3/src/OktaSignIn/index.ts
+++ b/src/v3/src/OktaSignIn/index.ts
@@ -120,8 +120,7 @@ export default class OktaSignIn {
       // eslint-disable-next-line no-underscore-dangle
       const userAgent = this.authClient._oktaUserAgent;
       if (userAgent) {
-        userAgent.addEnvironment('okta-signin-widget-next');
-        userAgent.addEnvironment(OKTA_SIW_COMMIT_HASH);
+        userAgent.addEnvironment(`okta-signin-widget-next-${this.version}`);
       }
 
       if (options.el) {

--- a/src/v3/src/OktaSignIn/index.ts
+++ b/src/v3/src/OktaSignIn/index.ts
@@ -120,7 +120,7 @@ export default class OktaSignIn {
       // eslint-disable-next-line no-underscore-dangle
       const userAgent = this.authClient._oktaUserAgent;
       if (userAgent) {
-        userAgent.addEnvironment(`okta-signin-widget-next-${this.version}`);
+        userAgent.addEnvironment(`okta-signin-widget-g3-${this.version}`);
       }
 
       if (options.el) {


### PR DESCRIPTION
## Description:

* Updates Gen3 userAgent environment value to use the package version to be consistent with Gen2

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-653523](https://oktainc.atlassian.net/browse/OKTA-653523)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



