### PR TITLE
Show email as a description for email authenticator button

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-with-email.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-with-email.json
@@ -1,0 +1,648 @@
+{
+  "stateHandle": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+  "version": "1.0.0",
+  "expiresAt": "2020-05-05T23:34:09.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aidwboITrg4b4yAYd0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              },
+              {
+
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "fwftheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[1]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[2]"
+              },
+              {
+                "label": "Okta Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtm56L8gXXHI1SD0g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "email",
+                        "required": false,
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[3]"
+              },
+              {
+                "label":"Phone",
+                "value":{
+                  "form":{
+                    "value":[
+                      {
+                        "name":"id",
+                        "required":true,
+                        "value":"aut5v31Tb789KuCGY0g4",
+                        "mutable":false
+                      },
+                      {
+                        "name":"methodType",
+                        "type":"string",
+                        "required":false,
+                        "options":[
+                          {
+                            "label":"SMS",
+                            "value":"sms"
+                          },
+                          {
+                            "label":"Voice call",
+                            "value":"voice"
+                          }
+                        ]
+                      },
+                      {
+                        "name":"enrollmentId",
+                        "required":true,
+                        "value":"pae5ykx4eIvfslkO90g4",
+                        "mutable":false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo":"$.authenticatorEnrollments.value[4]"
+              },
+              {
+                "label":"Phone",
+                "value":{
+                  "form":{
+                    "value":[
+                      {
+                        "name":"id",
+                        "required":true,
+                        "value":"aut5v31Tb789KuCGY0g4",
+                        "mutable":false
+                      },
+                      {
+                        "name":"methodType",
+                        "type":"string",
+                        "required":false,
+                        "options":[
+                          {
+                            "label":"SMS",
+                            "value":"sms"
+                          },
+                          {
+                            "label":"Voice call",
+                            "value":"voice"
+                          }
+                        ]
+                      },
+                      {
+                        "name":"enrollmentId",
+                        "required":true,
+                        "value":"pae5ykzcnhmdfSMuQ0g4",
+                        "mutable":false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo":"$.authenticatorEnrollments.value[5]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0HHSLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[6]"
+              },
+              {
+                "label": "Okta Verify",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "auttheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "signed_nonce",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[7]"
+              },
+              {
+                "label": "Google Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut11ceMaP0B0EzMI0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[8]"
+              },
+              {
+                "label": "Atko Custom On-prem",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "autx7fdyRt87txnAs0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "enrollmentId",
+                        "required": true,
+                        "value": "paexaoLGpTBjbyhBF0g3",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[9]"
+              },
+              {
+                "label": "RSA SecurID",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "autx7fdyRt87txnAs0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "enrollmentId",
+                        "required": true,
+                        "value": "paexaoLGpTBjbyhBF0g3",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[10]"
+              },
+              {
+                "label": "Duo Security",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut32kl92UF8kfE4E0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "idp",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[11]"
+              },
+              {
+                "label": "IDP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "0oa69chx4bZyx8O7l0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[12]"
+              },
+              {
+                "label": "Atko Custom OTP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut32kl92UF8kfE4E0g5",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "idp",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[13]"
+              },
+              {
+                "label": "Symantec VIP",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut11ceMaP0B0EzMI0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[14]"
+              },
+              {
+                "label": "YubiKey Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut11ceMaP0B0EzMI0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[15]"
+              },
+              {
+                "label":"Custom Push App",
+                "value":{
+                   "form":{
+                      "value":[
+                         {
+                            "name":"id",
+                            "required":true,
+                            "value":"aut198w4v0f8dr8gT0g4",
+                            "mutable":false
+                         },
+                         {
+                            "name":"methodType",
+                            "type":"string",
+                            "required":false,
+                            "options":[
+                              {
+                                  "label":"Get a push notification",
+                                  "value":"push"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                },
+                "relatesTo":"$.authenticatorEnrollments.value[16]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "key": "okta_password",
+        "id": "autwa6eD9o02iBbtv0g1",
+        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "key": "webauthn",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "aidtheidkwh282hv8g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "key": "webauthn",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "fwftheidkwh282hv8g3"
+      },
+      {
+        "profile":{
+          "email":"t***r@okta.com"
+        },
+        "displayName": "Okta Email",
+        "type": "email",
+        "key": "okta_email",
+        "authenticatorId": "aidtm56L8gXXHI1SD0g3",
+        "id": "autwa6eD9o02iBbtv0g3",
+        "methods": [
+          {
+            "methodType": "email"
+          }
+        ]
+      },
+      {
+        "profile":{
+          "phoneNumber":"+1 XXX-XXX-5309"
+        },
+        "type":"phone",
+        "key": "phone_number",
+        "id":"pae5ykx4eIvfslkO90g4",
+        "displayName":"Phone Number",
+        "methods":[
+          {
+            "type":"sms"
+          },
+          {
+            "type":"voice"
+          }
+        ]
+      },
+      {
+        "profile":{
+          "phoneNumber":"+1 XXX-XXX-5310"
+        },
+        "type":"phone",
+        "key": "phone_number",
+        "id":"pae5ykzcnhmdfSMuQ0g4",
+        "displayName":"Phone Number",
+        "methods":[
+          {
+            "type":"sms"
+          },
+          {
+            "type":"voice"
+          }
+        ]
+      },
+      {
+        "displayName": "Okta Security Question",
+        "type": "security_question",
+        "key": "security_question",
+        "authenticatorId": "aid568g3mXgtID0HHSLH",
+        "id": "autwa6eD9o02iBbaaa82"
+      },
+      {
+        "displayName": "Okta Verify Device 1",
+        "type": "app",
+        "key": "okta_verify",
+        "id": "aen1mz5J4cuNoaR3l0g4",
+        "authenticatorId": "auttheidkwh282hv8g3",
+        "methods": [
+           {
+            "type":  "signed_nonce"
+           }
+        ]
+      },
+      {
+        "displayName": "Google Authenticator",
+        "key": "google_otp",
+        "type": "app",
+        "id": "aen1mz5J4cuNoaR3l0g3",
+        "authenticatorId": "aut11ceMaP0B0EzMI0g4",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      },
+      {
+        "type": "security_key",
+        "key": "onprem_mfa",
+        "id": "paexaoLGpTBjbyhBF0g3",
+        "displayName": "Atko Custom On-prem",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      },
+      {
+        "type": "security_key",
+        "key": "rsa_token",
+        "id": "paexaoLGpTBjbyhBF0g3",
+        "displayName": "RSA SecurID",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      },
+      {
+        "type": "app",
+        "key": "duo",
+        "id": "dsf36lrPqdONw2Xjv0g4",
+        "displayName": "Duo Security",
+        "credentialId": "",
+        "methods": [
+          {
+            "type": "idp"
+          }
+        ]
+      },
+      {
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "key": "external_idp",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          {
+            "type": "idp"
+          }
+        ]
+      },
+      {
+        "type": "security_key",
+        "key": "custom_otp",
+        "id": "dsf36lrPqdONw2Xjv0g5",
+        "displayName": "Atko Custom OTP Authenticator",
+        "credentialId": "",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      },
+      {
+        "type": "app",
+        "key": "symantec_vip",
+        "id": "aut11ceMaP0B0EzMI0g4",
+        "displayName": "Symantec VIP",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      },
+      {
+        "type": "security_key",
+        "key": "yubikey_token",
+        "id": "aut11ceMaP0B0EzMI0g4",
+        "displayName": "YubiKey Authenticator",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      },
+      {
+        "profile":{
+          "deviceName":"Todd’s iPhone"
+        },
+        "type":"app",
+        "key":"custom_app",
+        "id":"pfd1bmoy4nH6heq2v0g4",
+        "displayName":"Custom Push App",
+        "logoUri":"/img/logos/default.png",
+        "methods":[
+          {
+            "type":"push"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00uwb8GLwf1HED5Xs0g3",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "eyJ6aXAiOiJERUYiLCJhbGl",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  }
+}

--- a/src/v2/view-builder/utils/AuthenticatorUtil.js
+++ b/src/v2/view-builder/utils/AuthenticatorUtil.js
@@ -34,7 +34,7 @@ const getAuthenticatorData = function(authenticator, isVerifyAuthenticator) {
   case AUTHENTICATOR_KEY.EMAIL:
     Object.assign(authenticatorData, {
       description: isVerifyAuthenticator
-        ? ''
+        ? authenticator.relatesTo?.profile?.email
         : loc('oie.email.authenticator.description', 'login'),
       iconClassName: 'mfa-okta-email',
       buttonDataSeAttr: getButtonDataSeAttr(authenticator),

--- a/src/v2/view-builder/utils/AuthenticatorUtil.js
+++ b/src/v2/view-builder/utils/AuthenticatorUtil.js
@@ -34,7 +34,7 @@ const getAuthenticatorData = function(authenticator, isVerifyAuthenticator) {
   case AUTHENTICATOR_KEY.EMAIL:
     Object.assign(authenticatorData, {
       description: isVerifyAuthenticator
-        ? authenticator.relatesTo?.profile?.email
+        ? authenticator.relatesTo?.profile?.email || ''
         : loc('oie.email.authenticator.description', 'login'),
       iconClassName: 'mfa-okta-email',
       buttonDataSeAttr: getButtonDataSeAttr(authenticator),

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -267,12 +267,16 @@ describe('Select Authenticator Utility Tests', () => {
         expect(currentOption?.options.ctaLabel)
           .toBe('oie.verify.authenticator.button.text');
       });
-      options.filter(option => option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE).forEach((option) => {
+      options.filter((option) =>
+        option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE
+      ).forEach((option) => {
         const currentOption = authenticatorOptionValues
           .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
         expect(currentOption?.options.description).toBe(mockPhoneNumber);
       });
-      options.filter(option => option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL).forEach((option) => {
+      options.filter((option) =>
+        option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL
+      ).forEach((option) => {
         const currentOption = authenticatorOptionValues
           .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
         expect(currentOption?.options.description).toBe(mockEmail);

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -268,14 +268,14 @@ describe('Select Authenticator Utility Tests', () => {
           .toBe('oie.verify.authenticator.button.text');
       });
       options.filter((option) =>
-        option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE
+        option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE,
       ).forEach((option) => {
         const currentOption = authenticatorOptionValues
           .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
         expect(currentOption?.options.description).toBe(mockPhoneNumber);
       });
       options.filter((option) =>
-        option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL
+        option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL,
       ).forEach((option) => {
         const currentOption = authenticatorOptionValues
           .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -268,18 +268,14 @@ describe('Select Authenticator Utility Tests', () => {
           .toBe('oie.verify.authenticator.button.text');
       });
 
-      options.filter((option) =>
-        option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE,
-      )
+      options.filter((option) => option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE)
         .forEach((option) => {
           const currentOption = authenticatorOptionValues
             .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
           expect(currentOption?.options.description).toBe(mockPhoneNumber);
         });
 
-      options.filter((option) =>
-        option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL,
-      )
+      options.filter((option) => option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL)
         .forEach((option) => {
           const currentOption = authenticatorOptionValues
             .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -271,20 +271,20 @@ describe('Select Authenticator Utility Tests', () => {
       options.filter((option) =>
         option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE,
       )
-      .forEach((option) => {
-        const currentOption = authenticatorOptionValues
-          .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
-        expect(currentOption?.options.description).toBe(mockPhoneNumber);
-      });
+        .forEach((option) => {
+          const currentOption = authenticatorOptionValues
+            .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
+          expect(currentOption?.options.description).toBe(mockPhoneNumber);
+        });
 
       options.filter((option) =>
         option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL,
       )
-      .forEach((option) => {
-        const currentOption = authenticatorOptionValues
-          .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
-        expect(currentOption?.options.description).toBe(mockEmail);
-      });
+        .forEach((option) => {
+          const currentOption = authenticatorOptionValues
+            .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
+          expect(currentOption?.options.description).toBe(mockEmail);
+        });
     });
 
     it('should return authenticator buttons with multiple enrolled phone number security methods with correct description', () => {

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -267,16 +267,20 @@ describe('Select Authenticator Utility Tests', () => {
         expect(currentOption?.options.ctaLabel)
           .toBe('oie.verify.authenticator.button.text');
       });
+
       options.filter((option) =>
         option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE,
-      ).forEach((option) => {
+      )
+      .forEach((option) => {
         const currentOption = authenticatorOptionValues
           .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
         expect(currentOption?.options.description).toBe(mockPhoneNumber);
       });
+
       options.filter((option) =>
         option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL,
-      ).forEach((option) => {
+      )
+      .forEach((option) => {
         const currentOption = authenticatorOptionValues
           .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
         expect(currentOption?.options.description).toBe(mockEmail);

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -232,6 +232,7 @@ describe('Select Authenticator Utility Tests', () => {
 
     it('should return formatted authenticator options when raw options are provided', () => {
       const mockPhoneNumber = '2XXXXXX123';
+      const mockEmail = 't***r@okta.com';
       const options: IdxOption[] = Object.entries(AUTHENTICATOR_KEY)
         .filter(([, value]) => value !== AUTHENTICATOR_KEY.OV
           && value !== AUTHENTICATOR_KEY.DEFAULT)
@@ -250,6 +251,8 @@ describe('Select Authenticator Utility Tests', () => {
           };
           if (AUTHENTICATOR_KEY[key] === AUTHENTICATOR_KEY.PHONE) {
             option.relatesTo.profile = { phoneNumber: mockPhoneNumber };
+          } else if (AUTHENTICATOR_KEY[key] === AUTHENTICATOR_KEY.EMAIL) {
+            option.relatesTo.profile = { email: mockEmail };
           }
           return option;
         });
@@ -263,8 +266,13 @@ describe('Select Authenticator Utility Tests', () => {
         expect(currentOption?.label).toBe(option.label);
         expect(currentOption?.options.ctaLabel)
           .toBe('oie.verify.authenticator.button.text');
-        expect(currentOption?.options.description)
-          .toBe(option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE ? mockPhoneNumber : undefined);
+        let expeectedDescription;
+        if (option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE) {
+          expeectedDescription = mockPhoneNumber;
+        } else if (option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL) {
+          expeectedDescription = mockEmail;
+        }
+        expect(currentOption?.options.description).toBe(expeectedDescription);
       });
     });
 

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -266,13 +266,11 @@ describe('Select Authenticator Utility Tests', () => {
         expect(currentOption?.label).toBe(option.label);
         expect(currentOption?.options.ctaLabel)
           .toBe('oie.verify.authenticator.button.text');
-        let expeectedDescription;
         if (option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE) {
-          expeectedDescription = mockPhoneNumber;
+          expect(currentOption?.options.description).toBe(mockPhoneNumber);
         } else if (option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL) {
-          expeectedDescription = mockEmail;
+          expect(currentOption?.options.description).toBe(mockEmail);
         }
-        expect(currentOption?.options.description).toBe(expeectedDescription);
       });
     });
 

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -266,11 +266,16 @@ describe('Select Authenticator Utility Tests', () => {
         expect(currentOption?.label).toBe(option.label);
         expect(currentOption?.options.ctaLabel)
           .toBe('oie.verify.authenticator.button.text');
-        if (option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE) {
-          expect(currentOption?.options.description).toBe(mockPhoneNumber);
-        } else if (option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL) {
-          expect(currentOption?.options.description).toBe(mockEmail);
-        }
+      });
+      options.filter(option => option.relatesTo?.key === AUTHENTICATOR_KEY.PHONE).forEach((option) => {
+        const currentOption = authenticatorOptionValues
+          .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
+        expect(currentOption?.options.description).toBe(mockPhoneNumber);
+      });
+      options.filter(option => option.relatesTo?.key === AUTHENTICATOR_KEY.EMAIL).forEach((option) => {
+        const currentOption = authenticatorOptionValues
+          .find(({ options: { key: authKey } }) => authKey === option.relatesTo?.key);
+        expect(currentOption?.options.description).toBe(mockEmail);
       });
     });
 

--- a/src/v3/src/transformer/selectAuthenticator/utils.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.ts
@@ -169,6 +169,10 @@ const getAuthenticatorDescription = (
     return option.relatesTo?.profile?.phoneNumber as string || undefined;
   }
 
+  if (authenticatorKey === AUTHENTICATOR_KEY.EMAIL) {
+    return option.relatesTo?.profile?.email as string || undefined;
+  }
+
   if (authenticatorKey === AUTHENTICATOR_KEY.CUSTOM_APP) {
     return option.relatesTo?.displayName as string || undefined;
   }

--- a/src/v3/src/transformer/selectAuthenticator/utils.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.ts
@@ -165,22 +165,18 @@ const getAuthenticatorDescription = (
     return loc(AUTHENTICATOR_ENROLLMENT_DESCR_KEY_MAP[authenticatorKey], 'login', descrParams);
   }
 
-  if (authenticatorKey === AUTHENTICATOR_KEY.PHONE) {
-    return option.relatesTo?.profile?.phoneNumber as string || undefined;
+  switch (authenticatorKey) {
+    case AUTHENTICATOR_KEY.PHONE:
+      return option.relatesTo?.profile?.phoneNumber as string || undefined;
+    case AUTHENTICATOR_KEY.EMAIL:
+      return option.relatesTo?.profile?.email as string || undefined;
+    case AUTHENTICATOR_KEY.CUSTOM_APP:
+      return option.relatesTo?.displayName as string || undefined;
+    case AUTHENTICATOR_KEY.OV:
+      return loc('oie.okta_verify.label', 'login');
+    default:
+      return undefined;
   }
-
-  if (authenticatorKey === AUTHENTICATOR_KEY.EMAIL) {
-    return option.relatesTo?.profile?.email as string || undefined;
-  }
-
-  if (authenticatorKey === AUTHENTICATOR_KEY.CUSTOM_APP) {
-    return option.relatesTo?.displayName as string || undefined;
-  }
-
-  if (authenticatorKey === AUTHENTICATOR_KEY.OV) {
-    return loc('oie.okta_verify.label', 'login');
-  }
-  return undefined;
 };
 
 const getUsageDescription = (option: IdxOption): string | undefined => {

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
@@ -42,7 +42,7 @@ const getWidgetMessage = (
 
         // TODO: re-visit, handle side effects in hooks
         // If the session expired, this clears session to allow new transaction bootstrap
-        if (widgetProps && message.i18n.key === 'idx.session.expired') {
+        if (widgetProps && message?.i18n?.key === 'idx.session.expired') {
           const { authClient } = widgetProps;
           authClient?.transactionManager.clear();
           SessionStorage.removeStateHandle();

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -424,12 +424,8 @@ test.requestHooks(mockAuthenticatorListWithEmail)('should display email in descr
   await checkA11y(t);
   await t.expect(selectFactorPage.getIdentifier()).eql('testUser@okta.com');
   await t.expect(selectFactorPage.getFactorLabelByIndex(2)).eql('Email');
-  if (userVariables.gen3) {
-    await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(2)).eql(true);
-    await t.expect(selectFactorPage.getFactorDescriptionByIndex(2)).eql('t***r@okta.com');
-  } else {
-    await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(2)).eql(false);
-  }
+  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(2)).eql(true);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(2)).eql('t***r@okta.com');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('okta_email');
 });

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, RequestLogger, userVariables } from 'testcafe';
+import { RequestMock, RequestLogger } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 
 import { renderWidget } from '../framework/shared';


### PR DESCRIPTION
## Description:

If masked email is present in IDX response in `authenticatorEnrollments` (`profile.email` for email authenticator, same as `profile.phoneNumber` for phone authenticator), show it as description

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-620984](https://oktainc.atlassian.net/browse/OKTA-620984)

### Reviewers:

### Screenshot/Video:

Before:
<img width="445" alt="before" src="https://github.com/okta/okta-signin-widget/assets/72614880/13af248e-43fa-4bf1-8c92-d558b3d69c3b">

After:
<img width="446" alt="after" src="https://github.com/okta/okta-signin-widget/assets/72614880/73dff4b4-b8ee-463e-ad0c-b0f1ce0aab70">

Gen 2:
<img width="415" alt="Screenshot 2023-10-09 at 17 42 38" src="https://github.com/okta/okta-signin-widget/assets/72614880/70bc1292-5573-4623-b254-d00d12d11f6c">


### Downstream Monolith Build:



