### PR TITLE
Processes loginpage CSS with `postcss-logical`

### DIFF
--- a/src/v3/.postcssrc.js
+++ b/src/v3/.postcssrc.js
@@ -1,8 +1,16 @@
+const postcssLogical = require('postcss-logical');
 const { default: postcssOdyssey } = require("@okta/odyssey-postcss-preset");
 
 module.exports = (ctx) => {
   if (!ctx.odyssey) {
-    return {};
+    return {
+      plugins: [
+        postcssLogical({
+          blockDirection: 'top-to-bottom',
+          inlineDirection: 'left-to-right',
+        }),
+      ],
+    };
   }
 
   const options = Object.assign(

--- a/src/v3/.postcssrc.js
+++ b/src/v3/.postcssrc.js
@@ -6,8 +6,8 @@ module.exports = (ctx) => {
     return {
       plugins: [
         postcssLogical({
-          blockDirection: 'top-to-bottom',
-          inlineDirection: 'left-to-right',
+          // https://github.com/csstools/postcss-logical#options
+          preserve: true,
         }),
       ],
     };

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -115,6 +115,7 @@
     "nodemon": "^3.0.1",
     "postcss": "^8.4.13",
     "postcss-loader": "^7.3.3",
+    "postcss-logical": "^7.0.0",
     "postcss-preset-env": "^8.4.1",
     "properties": "^1.2.1",
     "rimraf": "^4.3.0",

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -115,7 +115,7 @@
     "nodemon": "^3.0.1",
     "postcss": "^8.4.13",
     "postcss-loader": "^7.3.3",
-    "postcss-logical": "^7.0.0",
+    "postcss-logical": "^5.0.0",
     "postcss-preset-env": "^8.4.1",
     "properties": "^1.2.1",
     "rimraf": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16342,13 +16342,6 @@ postcss-logical@^6.2.0:
   dependencies:
     postcss-value-parser "^4.2.0"
 
-postcss-logical@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-logical/-/postcss-logical-7.0.0.tgz#9a83426e716e3c8f957dda3fd874edbcf22c754e"
-  integrity sha512-zYf3vHkoW82f5UZTEXChTJvH49Yl9X37axTZsJGxrCG2kOUwtaAoz9E7tqYg0lsIoJLybaL8fk/2mOi81zVIUw==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
 postcss-media-query-parser@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16342,6 +16342,13 @@ postcss-logical@^6.2.0:
   dependencies:
     postcss-value-parser "^4.2.0"
 
+postcss-logical@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-logical/-/postcss-logical-7.0.0.tgz#9a83426e716e3c8f957dda3fd874edbcf22c754e"
+  integrity sha512-zYf3vHkoW82f5UZTEXChTJvH49Yl9X37axTZsJGxrCG2kOUwtaAoz9E7tqYg0lsIoJLybaL8fk/2mOi81zVIUw==
+  dependencies:
+    postcss-value-parser "^4.2.0"
+
 postcss-media-query-parser@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"


### PR DESCRIPTION
## Description:

* Processes loginpage CSS so it transforms logical properties to LTR physical property fallbacks
* NOTE: We will only get LTR in IE11 but both RTL and LTR will work for the login page banner in newer browsers.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-653655](https://oktainc.atlassian.net/browse/OKTA-653655)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



