### PR TITLE
OKTA-652673 : Login page header h1 color fix

### DIFF
--- a/src/v3/src/components/Widget/style.css
+++ b/src/v3/src/components/Widget/style.css
@@ -126,6 +126,7 @@
   font-size: 24px;
   font-weight: lighter;
   line-height: 26px;
+  color: #6e6e78;
 }
 .okta-container .applogin-banner .applogin-app-logo {
   display: inline-block;


### PR DESCRIPTION
## Description:

This PR fixes the color of the login page header h1 so that the color contrast ratio is within WCAG AA spec.

Note: Axe devtools in the browser still fails on the login header due to Axe being unable to determine the background color due to an overlap issue.
<img width="1753" alt="Screenshot 2023-09-29 at 11 24 51 AM" src="https://github.com/okta/okta-signin-widget/assets/107433508/7c356aaa-1f48-484b-874a-066b0e00326b">


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-652673](https://oktainc.atlassian.net/browse/OKTA-652673)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



