### PR TITLE
SIW Gen 3: Unlock Account Back to Sign In Error

### DIFF
--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -65,6 +65,8 @@ const Link: UISchemaElementComponent<{
     typeof href === 'undefined' ? (
       <LinkMui
         component="button"
+        // Fixes OKTA-653788 (see comments) - Currently we treat all links as buttons
+        type="button"
         variant="body1"
         role="link"
         onClick={onClick}

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -180,6 +180,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>
@@ -375,6 +376,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>
@@ -570,6 +572,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -162,6 +162,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -1572,6 +1572,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -1583,6 +1584,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -3169,6 +3171,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -3180,6 +3183,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -4793,6 +4797,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -4804,6 +4809,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -203,6 +203,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -214,6 +215,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -174,6 +174,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -185,6 +186,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -224,6 +224,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -235,6 +236,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -467,6 +469,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -478,6 +481,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -707,6 +711,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -718,6 +723,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -950,6 +956,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -961,6 +968,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -646,6 +646,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-96"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -657,6 +658,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-96"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -598,6 +598,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-66"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -834,6 +835,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -845,6 +847,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -222,6 +222,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -233,6 +234,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -389,6 +389,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -400,6 +401,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -914,6 +916,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -925,6 +928,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1444,6 +1448,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -1455,6 +1460,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1969,6 +1975,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -1980,6 +1987,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -389,6 +389,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -400,6 +401,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -757,6 +759,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -768,6 +771,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1236,6 +1240,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-53"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -1247,6 +1252,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-53"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1715,6 +1721,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-53"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -1726,6 +1733,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-53"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -490,6 +490,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -1578,6 +1578,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-156"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -265,6 +265,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -276,6 +277,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -332,6 +332,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-48"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -638,6 +638,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-97"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -649,6 +650,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-97"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1217,6 +1219,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-82"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -1228,6 +1231,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-82"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -638,6 +638,7 @@ exports[`authenticator-expired-password should present field level error message
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-97"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1206,6 +1207,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-82"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -778,6 +778,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-119"
                     data-se="skip"
                     role="link"
+                    type="button"
                   >
                     Remind me later
                   </button>
@@ -789,6 +790,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-119"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1492,6 +1494,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-103"
                     data-se="skip"
                     role="link"
+                    type="button"
                   >
                     Remind me later
                   </button>
@@ -1503,6 +1506,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-103"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -239,6 +239,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="forgot-password"
                     role="link"
+                    type="button"
                   >
                     Forgot password?
                   </button>
@@ -250,6 +251,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="unlock"
                     role="link"
+                    type="button"
                   >
                     Unlock account?
                   </button>
@@ -297,6 +299,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>
@@ -551,6 +554,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="forgot-password"
                     role="link"
+                    type="button"
                   >
                     Forgot password?
                   </button>
@@ -562,6 +566,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="unlock"
                     role="link"
+                    type="button"
                   >
                     Unlock account?
                   </button>
@@ -609,6 +614,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>
@@ -863,6 +869,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="forgot-password"
                     role="link"
+                    type="button"
                   >
                     Forgot password?
                   </button>
@@ -874,6 +881,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="unlock"
                     role="link"
+                    type="button"
                   >
                     Unlock account?
                   </button>
@@ -921,6 +929,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -675,6 +675,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -554,6 +554,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-82"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1122,6 +1123,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-82"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
@@ -199,6 +199,7 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -455,6 +455,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -455,6 +455,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -192,6 +192,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -203,6 +204,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -168,6 +168,7 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-24"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -203,6 +203,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -174,6 +174,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -406,6 +407,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -627,6 +629,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -894,6 +897,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -905,6 +909,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1216,6 +1221,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-45"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -1227,6 +1233,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-45"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1324,6 +1331,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-16"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -1545,6 +1553,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -214,6 +214,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -225,6 +226,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -292,6 +292,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -303,6 +304,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -564,6 +566,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -575,6 +578,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -187,6 +187,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -198,6 +199,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -184,6 +184,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -195,6 +196,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -174,6 +174,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -185,6 +186,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -174,6 +174,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -185,6 +186,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -373,6 +375,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -384,6 +387,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
@@ -143,6 +143,7 @@ exports[`authenticator-verification-ov-resend-push-notification renders form 1`]
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-21"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -154,6 +155,7 @@ exports[`authenticator-verification-ov-resend-push-notification renders form 1`]
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-21"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -245,6 +245,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -256,6 +257,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -228,6 +228,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -239,6 +240,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -206,6 +206,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -1774,6 +1774,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-172"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -256,6 +256,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                     data-se="forgot-password"
                     role="link"
+                    type="button"
                   >
                     Forgot password?
                   </button>
@@ -267,6 +268,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -316,6 +316,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -327,6 +328,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -649,6 +651,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -660,6 +663,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -982,6 +986,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -993,6 +998,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -224,6 +224,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -1572,6 +1572,7 @@ exports[`byol loading custom language should load custom language with "language
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -1583,6 +1584,7 @@ exports[`byol loading custom language should load custom language with "language
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -3169,6 +3171,7 @@ exports[`byol loading custom language should load custom language with assets.ba
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -3180,6 +3183,7 @@ exports[`byol loading custom language should load custom language with assets.ba
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -4766,6 +4770,7 @@ exports[`byol loading default language should not load custom language when the 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -4777,6 +4782,7 @@ exports[`byol loading default language should not load custom language when the 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -6363,6 +6369,7 @@ exports[`byol loading default language should not load custom language with "lan
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -6374,6 +6381,7 @@ exports[`byol loading default language should not load custom language with "lan
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -1839,6 +1839,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-79"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>
@@ -3582,6 +3583,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-62"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -221,6 +221,7 @@ exports[`enroll-profile-new should render form 1`] = `
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -256,6 +256,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-48"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>
@@ -538,6 +539,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-49"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>
@@ -820,6 +822,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-49"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>
@@ -1089,6 +1092,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-47"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>
@@ -1445,6 +1449,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-61"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -240,6 +240,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="skip"
                     role="link"
+                    type="button"
                   >
                     Skip Profile
                   </button>
@@ -251,6 +252,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -287,6 +287,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-49"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -542,6 +543,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -575,6 +575,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-97"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>
@@ -1143,6 +1144,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-92"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>
@@ -1666,6 +1668,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
                       data-se="back"
                       role="link"
+                      type="button"
                     >
                       Sign In
                     </button>

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -83,6 +83,7 @@ exports[`error-account-creation should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-16"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -120,6 +120,7 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-21"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -83,6 +83,7 @@ exports[`error-session-expired should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-16"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -316,6 +316,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button Mui-focusVisible emotion-50"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -327,6 +328,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/flow-verify-with-piv-as-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-verify-with-piv-as-authenticator.test.tsx.snap
@@ -170,6 +170,7 @@ exports[`flow-verify-with-piv-as-authenticator should render select authenticato
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-25"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Verify with something else
                   </button>
@@ -181,6 +182,7 @@ exports[`flow-verify-with-piv-as-authenticator should render select authenticato
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-25"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`identify-recovery renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-20"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -263,6 +263,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                     data-se="forgot-password"
                     role="link"
+                    type="button"
                   >
                     Forgot password?
                   </button>
@@ -310,6 +311,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>
@@ -588,6 +590,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                     data-se="forgot-password"
                     role="link"
+                    type="button"
                   >
                     Forgot password?
                   </button>
@@ -635,6 +638,7 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>
@@ -913,6 +917,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                     data-se="forgot-password"
                     role="link"
+                    type="button"
                   >
                     Forgot password?
                   </button>
@@ -960,6 +965,7 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>
@@ -1179,6 +1185,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                     data-se="forgot-password"
                     role="link"
+                    type="button"
                   >
                     Forgot password?
                   </button>
@@ -1226,6 +1233,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>
@@ -1445,6 +1453,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                     data-se="forgot-password"
                     role="link"
+                    type="button"
                   >
                     Forgot password?
                   </button>
@@ -1492,6 +1501,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                       class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="enroll"
                       role="link"
+                      type="button"
                     >
                       Sign up
                     </button>

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -205,6 +205,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -216,6 +217,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -231,6 +231,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -242,6 +243,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1466,6 +1466,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -1477,6 +1478,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -2957,6 +2959,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -2968,6 +2971,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -121,6 +121,7 @@ exports[`terminal-return-email-error should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-17"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -110,6 +110,7 @@ exports[`unlock-account-success renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-21"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -304,6 +304,7 @@ exports[`user-unlock-account renders form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -186,6 +186,7 @@ exports[`webauthn-enroll should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-25"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -197,6 +198,7 @@ exports[`webauthn-enroll should render form 1`] = `
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-25"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -405,6 +407,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-25"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -416,6 +419,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-25"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>
@@ -631,6 +635,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                     data-se="switchAuthenticator"
                     role="link"
+                    type="button"
                   >
                     Return to authenticator list
                   </button>
@@ -642,6 +647,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
                     class="MuiTypography-root MuiTypography-body1 MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                     data-se="cancel"
                     role="link"
+                    type="button"
                   >
                     Back to sign in
                   </button>


### PR DESCRIPTION
## Description:
- In gen3, we changed our `Link` component to be an HTML `button` under the hood but omitted an explicit `type="button"`, so the default value for `type` ended up being `type="submit"`. This was causing an error where the user was being sent back to the sign in screen when pressing Enter in the input of the unlock account screen because it was targeting the "Back to sign in" link as the only valid submit button in the form
- This small fix is pre-GA and doesn't fully replicate the gen2 UX, which also raises an error on pressing Enter (see [#3083](https://github.com/okta/okta-signin-widget/pull/3083)), but we will do a post-GA fast follow to meet parity here 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-653788](https://oktainc.atlassian.net/browse/OKTA-653788)

### Reviewers:

### Screenshot/Video:
#### Back to sign in error
https://github.com/okta/okta-signin-widget/assets/106110543/761cf629-51fc-4cff-a4bb-2564418e1179



### Downstream Monolith Build:



