### PR TITLE
OKTA-655063: wrap authenticator names

### DIFF
--- a/src/v3/src/components/Widget/style.css
+++ b/src/v3/src/components/Widget/style.css
@@ -176,6 +176,6 @@ span.strong {
   font-weight: 600;
   word-break: break-all;
 }
-.no-translate {
+span.no-translate {
   white-space: nowrap;
 }


### PR DESCRIPTION
## Description:

Actual:
Authenticator names in select-authenticator screens overflow the button boundary.

Expected:
Authenticator names should wrap on white space and NOT overflow the button boundary.

NOTE: green boxes in screenshots highlight `.no-translate`; these are **not** present in the PR

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-655063](https://oktainc.atlassian.net/browse/OKTA-655063)

### Reviewers:

### Screenshot/Video:

<img width="610" alt="wrap-authenticators-bug" src="https://github.com/okta/okta-signin-widget/assets/77294605/1b86ed31-35a7-48d3-a852-aef8ce9c1042">


<img width="450" alt="wrap-authenticators-bug" src="https://github.com/okta/okta-signin-widget/assets/77294605/5d504f91-8949-4c74-a32b-834d50dac50f">


### Downstream Monolith Build: