### PR TITLE
Reenable ReEnrollAuthenticatorPasswordView spec

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-expired-password.json
+++ b/playground/mocks/data/idp/idx/authenticator-expired-password.json
@@ -52,7 +52,22 @@
         {
           "type":"password"
         }
-      ]
+      ],
+      "settings": {
+				"complexity": {
+					"minLength": 8,
+					"minLowerCase": 1,
+					"minUpperCase": 1,
+					"minNumber": 1,
+					"minSymbol": 0,
+					"excludeUsername": true,
+					"excludeAttributes": []
+				},
+				"age": {
+					"minAgeMinutes": 0,
+					"historyCount": 0
+				}
+			}
     }
   },
   "authenticators":{


### PR DESCRIPTION
## Description:
- Reenables `ReEnrollAuthenticatorPasswordView_spec.js` for gen3. Spec was disabled because the password requirements settings object was missing from the `authenticator-expired-password` mock, so they weren't being rendered and enforced


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-654484](https://oktainc.atlassian.net/browse/OKTA-654484)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-654484-reenable-authpwview-test&page=1&pageSize=6&sha=a6a92fbf012c27e4c781183235ddfdca0773d46a&tab=main)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



