### PR TITLE
OKTA-654389 : success-redirect remediation fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,7 +46,7 @@
       "program": "${workspaceRoot}/node_modules/testcafe/bin/testcafe.js",
       "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v14.18.3/bin/node",
       "env": {
-        "OKTA_SIW_V3": "true"
+        "OKTA_SIW_GEN3": "true"
       },
       "args": [
           "chrome",

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -90,6 +90,8 @@ const idx = {
     // 'identify-with-universal-link',
     // 'identify-with-app-link',
     // 'success',
+    // 'success-redirect-remediation',
+    // 'failure-redirect-remediation',
     // 'success-with-app-user',
     // 'success-with-interaction-code'
     // 'terminal-return-email',

--- a/playground/mocks/data/idp/idx/failure-redirect-remediation.json
+++ b/playground/mocks/data/idp/idx/failure-redirect-remediation.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02.id.H-AFRAeLKsKv9zE5wpyMQviMh1pN8Wl2H-UUrwad~drd",
+  "expiresAt": "2023-09-28T10:39:54.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+      "type": "array",
+      "value": [
+          {
+              "name": "failure-redirect",
+              "href": "http://localhost:3000/app/UserHome?stateToken=mockedStateToken123",
+              "method": "GET"
+          }
+      ]
+  },
+  "user": {
+      "type": "object",
+      "value": {
+          "id": "00u8nvxf8gxuIqW7F5d7",
+          "identifier": "test@test.com",
+          "profile": {
+              "firstName": "MF",
+              "lastName": "Test",
+              "timeZone": "America/Los_Angeles",
+              "locale": "en_US"
+          }
+      }
+  },
+  "cancel": {
+      "rel": [
+          "create-form"
+      ],
+      "name": "cancel",
+      "href": "https://test.test.com/idp/idx/cancel",
+      "method": "POST",
+      "produces": "application/ion+json; okta-version=1.0.0",
+      "value": [
+          {
+              "name": "stateHandle",
+              "required": true,
+              "value": "02.id.H-AFRAeLKsKv9zE5wpyMQviMh1pN8Wl2H-UUrwad~drd",
+              "visible": false,
+              "mutable": false
+          }
+      ],
+      "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+      "type": "object",
+      "value": {
+          "name": "testApp",
+          "label": "Help Desk",
+          "id": "0oaadb734Og45jJEU5d6"
+      }
+  },
+  "authentication": {
+      "type": "object",
+      "value": {
+          "protocol": "SAML2.0",
+          "request": {}
+      }
+  }
+}

--- a/playground/mocks/data/idp/idx/success-redirect-remediation.json
+++ b/playground/mocks/data/idp/idx/success-redirect-remediation.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02.id.H-AFRAeLKsKv9zE5wpyMQviMh1pN8Wl2H-UUrwad~drd",
+  "expiresAt": "2023-09-28T10:39:54.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+      "type": "array",
+      "value": [
+          {
+              "name": "success-redirect",
+              "href": "http://localhost:3000/app/UserHome?stateToken=mockedStateToken123",
+              "method": "GET"
+          }
+      ]
+  },
+  "user": {
+      "type": "object",
+      "value": {
+          "id": "00u8nvxf8gxuIqW7F5d7",
+          "identifier": "test@test.com",
+          "profile": {
+              "firstName": "MF",
+              "lastName": "Test",
+              "timeZone": "America/Los_Angeles",
+              "locale": "en_US"
+          }
+      }
+  },
+  "cancel": {
+      "rel": [
+          "create-form"
+      ],
+      "name": "cancel",
+      "href": "https://test.test.com/idp/idx/cancel",
+      "method": "POST",
+      "produces": "application/ion+json; okta-version=1.0.0",
+      "value": [
+          {
+              "name": "stateHandle",
+              "required": true,
+              "value": "02.id.H-AFRAeLKsKv9zE5wpyMQviMh1pN8Wl2H-UUrwad~drd",
+              "visible": false,
+              "mutable": false
+          }
+      ],
+      "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+      "type": "object",
+      "value": {
+          "name": "testApp",
+          "label": "Help Desk",
+          "id": "0oaadb734Og45jJEU5d6"
+      }
+  },
+  "authentication": {
+      "type": "object",
+      "value": {
+          "protocol": "SAML2.0",
+          "request": {}
+      }
+  }
+}

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -41,6 +41,7 @@ import {
 } from '../phone';
 import { transformEnrollProfile } from '../profile';
 import { transformEnrollProfileUpdate } from '../profile/transformEnrollProfileUpdate';
+import { transformAutoRedirect } from '../redirect';
 import {
   transformSelectAuthenticatorEnroll,
   transformSelectAuthenticatorUnlockVerify,
@@ -381,6 +382,15 @@ const TransformerMap: {
       buttonConfig: { showDefaultSubmit: false },
     },
   },
+  [IDX_STEP.FAILURE_REDIRECT]: {
+    [AUTHENTICATOR_KEY.DEFAULT]: {
+      transform: transformAutoRedirect,
+      buttonConfig: {
+        showDefaultSubmit: false,
+        showDefaultCancel: false,
+      },
+    },
+  },
   [IDX_STEP.IDENTIFY]: {
     [AUTHENTICATOR_KEY.DEFAULT]: {
       transform: transformIdentify,
@@ -507,6 +517,15 @@ const TransformerMap: {
     [AUTHENTICATOR_KEY.OV]: {
       transform: transformOktaVerifyChannelSelection,
       buttonConfig: { showDefaultSubmit: false },
+    },
+  },
+  [IDX_STEP.SUCCESS_REDIRECT]: {
+    [AUTHENTICATOR_KEY.DEFAULT]: {
+      transform: transformAutoRedirect,
+      buttonConfig: {
+        showDefaultSubmit: false,
+        showDefaultCancel: false,
+      },
     },
   },
   [IDX_STEP.POLL]: {

--- a/src/v3/src/transformer/redirect/transformAutoRedirect.ts
+++ b/src/v3/src/transformer/redirect/transformAutoRedirect.ts
@@ -10,5 +10,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export * from './redirectTransformer';
-export * from './transformAutoRedirect';
+import {
+  IdxStepTransformer,
+} from '../../types';
+import { redirectTransformer } from './redirectTransformer';
+
+export const transformAutoRedirect: IdxStepTransformer = ({ transaction, widgetProps }) => {
+  const { nextStep } = transaction;
+  return redirectTransformer(transaction, nextStep!.href!, widgetProps);
+};

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -1,6 +1,6 @@
 import BasePageObject from './BasePageObject';
 import CalloutObject from './components/CalloutObject';
-import { userVariables } from 'testcafe';
+import { userVariables, Selector, ClientFunction } from 'testcafe';
 import { within } from '@testing-library/testcafe';
 
 const TERMINAL_VIEW = '.siw-main-view.terminal';
@@ -47,5 +47,12 @@ export default class TerminalPageObject extends BasePageObject {
       return this.goBackLinkExists();
     }
     return false;
+  }
+
+  async getPageUrl() {
+    await this.t.expect(Selector('#mock-user-dashboard-title', { timeout: 10000 }).innerText).eql('Mock User Dashboard');
+
+    const pageUrl = await ClientFunction(() => window.location.href)();
+    return pageUrl;
   }
 }

--- a/test/testcafe/spec/FailureRedirect_spec.js
+++ b/test/testcafe/spec/FailureRedirect_spec.js
@@ -3,13 +3,21 @@ import { renderWidget } from '../framework/shared';
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
 import PlaygroundErrorPageObject from '../framework/page-objects/PlaygroundErrorPageObject';
 import xhrErrorWithFailureRedirect from '../../../playground/mocks/data/idp/idx/error-with-failure-redirect';
+import failureRedirectRemediation from '../../../playground/mocks/data/idp/idx/failure-redirect-remediation';
 import interact from '../../../playground/mocks/data/oauth2/interact';
+import { oktaDashboardContent } from '../framework/shared';
 
 const userNotAssignedMock = RequestMock()
   .onRequestTo('http://localhost:3000/oauth2/default/v1/interact')
   .respond(interact)
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrErrorWithFailureRedirect);
+
+const failureRedirectRemediationMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(failureRedirectRemediation)
+  .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
+  .respond(oktaDashboardContent);
 
 fixture('Failure with redirect');
 
@@ -52,4 +60,12 @@ test.requestHooks(userNotAssignedMock)('oauth: will redirect if `redirect === "a
   });
   const errorPage = new PlaygroundErrorPageObject(t);
   await t.expect(errorPage.hasTitle()).eql(true);
+});
+
+test.requestHooks(failureRedirectRemediationMock)('should navigate to redirect link when there is a failure-redirect remediation', async t => {
+  const terminalPage = new TerminalPageObject(t);
+  terminalPage.navigateToPage();
+  const pageUrl = await terminalPage.getPageUrl();
+  await t.expect(pageUrl)
+    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });

--- a/test/testcafe/spec/Success_spec.js
+++ b/test/testcafe/spec/Success_spec.js
@@ -3,6 +3,7 @@ import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import { RequestMock } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import success from '../../../playground/mocks/data/idp/idx/success';
+import successRedirectRemediation from '../../../playground/mocks/data/idp/idx/success-redirect-remediation';
 import identify from '../../../playground/mocks/data/idp/idx/identify';
 import { oktaDashboardContent } from '../framework/shared';
 
@@ -14,8 +15,13 @@ const mock = RequestMock()
   .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
   .respond(oktaDashboardContent);
 
-fixture('Success Form')
-  .requestHooks(mock);
+const successRedirectRemediationMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(successRedirectRemediation)
+  .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
+  .respond(oktaDashboardContent);
+
+fixture('Success Form');
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
@@ -24,12 +30,20 @@ async function setup(t) {
   return identityPage;
 }
 
-test('should navigate to redirect link google.com after success', async t => {
+test.requestHooks(mock)('should navigate to redirect link google.com after success', async t => {
   const identityPage = await setup(t);
   await checkA11y(t);
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.clickNextButton();
   const successPage = new SuccessPageObject(t);
+  const pageUrl = await successPage.getPageUrl();
+  await t.expect(pageUrl)
+    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+});
+
+test.requestHooks(successRedirectRemediationMock)('should navigate to redirect link when there is a success-redirect remediation', async t => {
+  const successPage = new SuccessPageObject(t);
+  successPage.navigateToPage();
   const pageUrl = await successPage.getPageUrl();
   await t.expect(pageUrl)
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');

--- a/test/testcafe/spec/Success_spec.js
+++ b/test/testcafe/spec/Success_spec.js
@@ -48,4 +48,3 @@ test.requestHooks(successRedirectRemediationMock)('should navigate to redirect l
   await t.expect(pageUrl)
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
-


### PR DESCRIPTION
## Description:

This PR fixes an issue where in some cases when trying to access an app, the user is presented with a blank view with only a "Next" button that has no functionality.  This was happening because the `success-redirect` remediation did not have a transformer mapped to it in the transformer mapping file.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-654389](https://oktainc.atlassian.net/browse/OKTA-654389)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



