### PR TITLE
OKTA-654445 & OKTA-654446 : Resend reminder timestamp fix

### DIFF
--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -73,7 +73,6 @@ const ReminderPrompt: UISchemaElementComponent<{
 
     return () => {
       window.clearInterval(timerRef.current);
-      SessionStorage.removeResendTimestamp();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -249,11 +249,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       return createForm();
     }
 
-    // clear the resend reminder time stamp in session storage if current transaction does not have resend option
-    if (SessionStorage.getResendTimestamp() && !idxTransaction.nextStep?.canResend) {
-      SessionStorage.removeResendTimestamp();
-    }
-
     // clear the loginHint value when returning to the identify flow
     if (idxTransaction?.nextStep?.name === IDX_STEP.IDENTIFY) {
       setloginHint(null);
@@ -412,6 +407,11 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   }, [interactionCodeFlowFormBag]);
 
   useEffect(() => {
+    // clear the resend reminder time stamp in session storage if current transaction does not have resend option
+    if (idxTransaction && !idxTransaction.nextStep?.canResend) {
+      SessionStorage.removeResendTimestamp();
+    }
+
     const asyncEffect = async () => {
       if (isClientTransaction) {
         return;

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -249,6 +249,11 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       return createForm();
     }
 
+    // clear the resend reminder time stamp in session storage if current transaction does not have resend option
+    if (SessionStorage.getResendTimestamp() && !idxTransaction.nextStep?.canResend) {
+      SessionStorage.removeResendTimestamp();
+    }
+
     // clear the loginHint value when returning to the identify flow
     if (idxTransaction?.nextStep?.name === IDX_STEP.IDENTIFY) {
       setloginHint(null);

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -307,6 +307,10 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   // track previous idxTransaction
   useEffect(() => {
     prevIdxTransactionRef.current = idxTransaction;
+    // clear the resend reminder time stamp in session storage if current transaction does not have resend option
+    if (idxTransaction && !idxTransaction.nextStep?.canResend) {
+      SessionStorage.removeResendTimestamp();
+    }
   }, [idxTransaction]);
 
   // update dataSchemaRef in context
@@ -407,11 +411,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   }, [interactionCodeFlowFormBag]);
 
   useEffect(() => {
-    // clear the resend reminder time stamp in session storage if current transaction does not have resend option
-    if (idxTransaction && !idxTransaction.nextStep?.canResend) {
-      SessionStorage.removeResendTimestamp();
-    }
-
     const asyncEffect = async () => {
       if (isClientTransaction) {
         return;

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -556,8 +556,7 @@ test
     await t.expect(answerRequestUrl).eql('http://localhost:3000/idp/idx/challenge/answer');
   });
 
-// Re-enable in OKTA-654445
-test.meta('gen3', false)
+test
   .requestHooks(stopPollLogger, stopPollMock)('no polling if session has expired', async t => {
     const challengeEmailPageObject = await setup(t);
     await checkA11y(t);
@@ -677,9 +676,7 @@ test
     await t.expect(lastRequestUrl).eql('http://localhost:3000/idp/idx/challenge/resend');
   });
 
-// Test fails in v3. After re-render we still have to wait for 30 seconds
-// Re-enable in OKTA-654446
-test.meta('gen3', false)
+test
   .requestHooks(validOTPmock)('resend after at most 30 seconds even after re-render', async t => {
     const challengeEmailPageObject = await setup(t);
     await checkA11y(t);

--- a/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
@@ -188,9 +188,7 @@ test
     await t.expect(resendCodeText).contains('Call again');
   });
 
-// Test fails in v3. After re-render we still have to wait for 30 seconds
-// Re-enable in OKTA-654446
-test.meta('gen3', false)
+test
   .requestHooks(smsMock)('Callout appears after 30 seconds at most even after re-render', async t => {
     const enrollPhonePageObject = await setup(t);
     await checkA11y(t);


### PR DESCRIPTION
## Description:

This PR fixes the issue of the resend reminder element clearing the timestamp in session storage after a page refresh.  Tests for this scenario were re-enabled in ChallengeAuthenticatorEmail_spec and EnrollAuthenticatorPhoneView_spec.

The 'no polling if session has expired' test in ChallengeAuthenticatorEmail_spec for [OKTA-654445](https://oktainc.atlassian.net/browse/OKTA-654445) was also enabled, and did not need any extra work done to pass.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-654446](https://oktainc.atlassian.net/browse/OKTA-654446)
- [OKTA-654445](https://oktainc.atlassian.net/browse/OKTA-654445)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



