### PR TITLE
Reenable SelectAuthenticatorForVerification_spec

### DIFF
--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -678,8 +678,7 @@ test.requestHooks(requestLogger, mockChallengeOVPush)('should navigate to okta v
   });
 });
 
-// Re-enable in OKTA-654488
-test.meta('gen3', false).requestHooks(requestLogger, mockChallengeOVFastPass)('should navigate to okta verify fast pass page', async t => {
+test.requestHooks(requestLogger, mockChallengeOVFastPass)('should navigate to okta verify fast pass page', async t => {
   const selectFactorPage = await setup(t);
   await checkA11y(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
@@ -706,8 +705,7 @@ test.meta('gen3', false).requestHooks(requestLogger, mockChallengeOVFastPass)('s
   });
 });
 
-// Re-enable in OKTA-654488
-test.meta('gen3', false).requestHooks(mockChallengeOnPremMFA)('should navigate to on prem mfa challenge page', async t => {
+test.requestHooks(mockChallengeOnPremMFA)('should navigate to on prem mfa challenge page', async t => {
   const selectFactorPage = await setup(t);
   await checkA11y(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
@@ -717,8 +715,7 @@ test.meta('gen3', false).requestHooks(mockChallengeOnPremMFA)('should navigate t
   await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with Atko Custom On-prem');
 });
 
-// Re-enable in OKTA-654488
-test.meta('gen3', false).requestHooks(mockChallengeRsa)('should navigate to RSA challenge page', async t => {
+test.requestHooks(mockChallengeRsa)('should navigate to RSA challenge page', async t => {
   const selectFactorPage = await setup(t);
   await checkA11y(t);
   await t.expect(selectFactorPage.getIdentifier()).eql('testUser@okta.com');
@@ -729,8 +726,7 @@ test.meta('gen3', false).requestHooks(mockChallengeRsa)('should navigate to RSA 
   await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with RSA SecurID');
 });
 
-// Re-enable in OKTA-654488
-test.meta('gen3', false).requestHooks(mockChallengeDuo)('should navigate to Duo challenge page', async t => {
+test.requestHooks(mockChallengeDuo)('should navigate to Duo challenge page', async t => {
   const selectFactorPage = await setup(t);
   await checkA11y(t);
   await t.expect(selectFactorPage.getIdentifier()).eql('testUser@okta.com');
@@ -741,8 +737,7 @@ test.meta('gen3', false).requestHooks(mockChallengeDuo)('should navigate to Duo 
   await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with Duo Security');
 });
 
-// Re-enable in OKTA-654488
-test.meta('gen3', false).requestHooks(mockChallengeCustomOTP)('should navigate to Custom OTP challenge page', async t => {
+test.requestHooks(mockChallengeCustomOTP)('should navigate to Custom OTP challenge page', async t => {
   const selectFactorPage = await setup(t);
   await checkA11y(t);
   await t.expect(selectFactorPage.getIdentifier()).eql('testUser@okta.com');
@@ -782,8 +777,7 @@ test.requestHooks(mockSelectAuthenticatorForRecovery)('should not show custom fa
   await t.expect(await pageObject.factorPageHelpLinksExists()).notOk();
 });
 
-// Re-enable in OKTA-654488
-test.meta('gen3', false).requestHooks(mockChallengeCustomApp)('should navigate to Custom App challenge page', async t => {
+test.requestHooks(mockChallengeCustomApp)('should navigate to Custom App challenge page', async t => {
   const selectFactorPage = await setup(t);
   await checkA11y(t);
   await t.expect(selectFactorPage.getIdentifier()).eql('testUser@okta.com');


### PR DESCRIPTION
## Description:
- Reenabling this spec was essentially a no-op, the tests passed without requiring any other changes


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-654488](https://oktainc.atlassian.net/browse/OKTA-654488)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-654488-reenable-select-authenticator-spec&page=1&pageSize=6&sha=b24357cc304cb143588bf957427de5f5e4439733&tab=main)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



