### PR TITLE
OKTA-654448 : Reenable test: Identify_spec 'should be able to submit identifier with rememberMe'

### DIFF
--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -15,6 +15,8 @@ import config from '../../../src/config/config.json';
 
 const baseIdentifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrIdentify)
+  .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(xhrIdentify);
 
 const identifyMockWithUnsupportedResponseError = RequestMock()
@@ -120,8 +122,7 @@ async function setup(t, widgetOptions) {
   return identityPage;
 }
 
-// Re-enable in OKTA-654448
-test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMock)('should be able to submit identifier with rememberMe', async t => {
+test.requestHooks(identifyRequestLogger, baseIdentifyMock)('should be able to submit identifier with rememberMe', async t => {
   const identityPage = await setup(t);
   await checkA11y(t);
 
@@ -140,7 +141,7 @@ test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMock)('shou
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
   await t.expect(reqHeaders['x-device-fingerprint']).notOk(); // only enabled if `features.deviceFingerprinting` is true
-  await t.expect(reqHeaders['x-okta-user-agent-extended']).contains(` okta-signin-widget-${config.version}`);
+  await t.expect(reqHeaders['x-okta-user-agent-extended']).contains(` okta-signin-widget-g3-${config.version}`);
 
   identifyRequestLogger.clear();
   await identityPage.fillIdentifierField('another foobar');

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -15,8 +15,6 @@ import config from '../../../src/config/config.json';
 
 const baseIdentifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(xhrIdentify)
-  .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(xhrIdentify);
 
 const identifyMockWithUnsupportedResponseError = RequestMock()
@@ -29,7 +27,16 @@ const identifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrIdentify)
   .onRequestTo('http://localhost:3000/idp/idx/identify')
-  .respond(xhrErrorIdentify, 403);
+  .respond((req, res) => {
+    res.headers['content-type'] = 'application/json';
+    if (userVariables.gen3) {
+      res.statusCode = '200';
+      res.setBody(xhrIdentify);
+    } else {
+      res.statusCode = '403';
+      res.setBody(xhrErrorIdentify);
+    }
+  });
 
 const identifyWithUnlockMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -122,7 +129,7 @@ async function setup(t, widgetOptions) {
   return identityPage;
 }
 
-test.requestHooks(identifyRequestLogger, baseIdentifyMock)('should be able to submit identifier with rememberMe', async t => {
+test.requestHooks(identifyRequestLogger, identifyMock)('should be able to submit identifier with rememberMe', async t => {
   const identityPage = await setup(t);
   await checkA11y(t);
 
@@ -141,7 +148,7 @@ test.requestHooks(identifyRequestLogger, baseIdentifyMock)('should be able to su
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
   await t.expect(reqHeaders['x-device-fingerprint']).notOk(); // only enabled if `features.deviceFingerprinting` is true
-  await t.expect(reqHeaders['x-okta-user-agent-extended']).contains(` okta-signin-widget-g3-${config.version}`);
+  await t.expect(reqHeaders['x-okta-user-agent-extended']).contains(` okta-signin-widget-${userVariables.gen3 ? 'g3-' : ''}${config.version}`);
 
   identifyRequestLogger.clear();
   await identityPage.fillIdentifierField('another foobar');


### PR DESCRIPTION
## Description:

This PR re-enables the test 'should be able to submit identifier with rememberMe' in the Identify_spec for SIW gen 3.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-654448](https://oktainc.atlassian.net/browse/OKTA-654448)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



