### PR TITLE
Added view for GA authenticator in reset-authenticator step

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-reset-google.json
+++ b/playground/mocks/data/idp/idx/authenticator-reset-google.json
@@ -1,0 +1,210 @@
+{
+  "stateHandle": "02U8D8oIqmFd3BE1XqjFexhopK6XYEglTNjV74mUFQ",
+  "version": "1.0.0",
+  "expiresAt": "2021-01-04T03:31:12.000Z",
+  "intent": "CREDENTIAL_RECOVERY",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "reset-authenticator",
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "href": "http://localhost:3000/idp/idx/challenge/answer",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter code",
+                  "required": true,
+                  "visible": true
+                }
+              ]
+            },
+            "required": true
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02U8D8oIqmFd3BE1XqjFexhopK6XYEglTNjV74mUFQ",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Google Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut11ceMaP0B0EzMI0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02U8D8oIqmFd3BE1XqjFexhopK6XYEglTNjV74mUFQ",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "contextualData": {
+        "qrcode": {
+          "method": "embedded",
+          "href": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAEjklEQVR42u3dQY7jOBBFQd//0l2LWjdqYWbmZzIeMCv32JasKICiRH3+SfpvH7tAAkQCRAJEAkQCRAJEAkQCRAJEEiASIBIgEiASIBIgEiASIBIgEiCSAJEAkQCRAJEAkQD5/aDPp/W/vz7/9PZUb++3+/f090v7fQEBBBBAAAEEEEAAAaT6AP32gD0N+vT2V4Pv/oOR/v6AAAIIIIAAAggggLwHpHoQ3n2AV3/+6UFs9f5JO8kCCCCAAAIIIIAAAggg00Bu+/+n9zcggAACCCCAAAIIIIAAkn1x3/RJgeqTGoAAAggggAACCCCAAHIbkHSA1cCqD9BpkOnHDyCAAAIIIIAAAggg+4GkLdrg9d5BuEUbAAEEEEC8DgggXgfk9W5blGF6ou+Z4wINQAABBBBAAAEEkLWD9NOD/G+/X/cBmbZ4d9oNVM+fxQIEEEAAAQQQQAABpBxI9Q7qBtW9sF3aoPyWG6QAAQQQQAABBBBAANkDJG3Q3g0wbWG47v0x/XmAAAIIIIAAAggggLwHpHsHpE0knj7A005ibL0YEhBAAAEEEEAAAQSQvYP06kH59PtVb//0SYXqh4g+t2gDIIAAAggggAACCCDjg+rbBqHbHiqadnEnIIAAAggggAACCCCAdAPpXuTgtkUUbntgj4lCQAABBBBAAAEEEEC2DdrTDoBpYKe3d8ugHBBAAAEEEEAAAQSQvUC2TXRVH0DVg97pP0CpN1QBAggggAACCCCAAHIvkOmF4aaBpw36p2+ISgEACCCAAAIIIIAAAoh5kJSLCW/7wadB3PqAHEAAAQQQQAABBBBA3hmkT09ETT/08vY/COkTu4AAAggggAACCCCAAFI9qOu+wej09leDS/u89JMegAACCCCAAAIIIIAAMv3+1YtJV39+9fudBmWQDggggAACCCCAAAJI9QGbdtN/9w1KaUC7H+iTGiCAAAIIIIAAAgggewfp1RNH1Qf09AOAbl/EwlksQAABBBBAAAEEEEDSQXQPIqcvHpxehGH6pMDzi1cDAggggAACCCCAAHJ8ENc9cXV6ENt9A9H0/u0etD83SAcEEEAAAQQQQAAB5HpAt02UpX+fLRcjAgIIIIAAAggggADyLpDuQWP169P/vvskw9aHfAICCCCAAAIIIIAAci+Q6cWN0wapty3GnXYDGCCAAAIIIIAAAggggMRP+DQ/xHMaXNpE660Ti4AAAggggAACCCCA7B2kdw/qqgf1rw3yty5uDQgggAACCCCAAALIHiDd73/bxGTaQzu3XowICCCAAAIIIIAAAsi7QLon8qonuroPiOmJvq2LQAACCCCAAAIIIIAAAsiWG4jSvt/p32t6/wECCCCAAAIIIIAAAshtD9ms3t7p/Vm9/7csZg0IIIAAAggggAACyF4g3QdM2gHZPQif/r1uAQYIIIAAAggggAACyB4g3Ys2TA9qpy/GrJ6onL6BDBBAAAEEEEAAAQQQQKQNASIBIgEiASIBIgEiASIBIgEiASIJEAkQCRAJEAkQCRAJEAkQCRAJEEmASIBIgEiASIBI4f0As/6SOQMO/ycAAAAASUVORK5CYII=",
+          "type": "image/png"
+        },
+        "sharedSecret": "ZR74DHZTG43NBULV"
+      },
+      "type": "app",
+      "key": "google_otp",
+      "id": "aut11ceMaP0B0EzMI0g4",
+      "displayName": "Google Authenticator",
+      "methods": [
+        {
+          "type": "otp"
+        }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "app",
+        "key": "google_otp",
+        "id": "aut11ceMaP0B0EzMI0g4",
+        "displayName": "Google Authenticator",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "type": "email",
+        "id": "eae11dkZe4pMeXpAy0g4",
+        "displayName": "Email",
+        "methods": [
+          {
+            "type": "email"
+          }
+        ]
+      },
+      {
+        "type": "password",
+        "id": "lae66mLs1g1Y5nRlA0g3",
+        "displayName": "Password",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
+      },
+      {
+        "type": "security_question",
+        "id": "qae1373hWZ8OKofXv0g4",
+        "displayName": "Security Question",
+        "methods": [
+          {
+            "type": "security_question"
+          }
+        ]
+      }
+    ]
+  },
+  "enrollmentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "app",
+      "key": "google_otp",
+      "id": "aut11ceMaP0B0EzMI0g4",
+      "displayName": "Google Authenticator",
+      "methods": [
+        {
+          "type": "otp"
+        }
+      ]
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u11djWuT63w8aHj0g4",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02U8D8oIqmFd3BE1XqjFexhopK6XYEglTNjV74mUFQ",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "TestApp",
+      "id": "0oa11ch8m94eTn0Qe0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/error-authenticator-reset-google-invalid-otp.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-reset-google-invalid-otp.json
@@ -1,0 +1,223 @@
+{
+  "stateHandle": "02U8D8oIqmFd3BE1XqjFexhopK6XYEglTNjV74mUFQ",
+  "version": "1.0.0",
+  "expiresAt": "2021-01-04T03:31:12.000Z",
+  "intent": "CREDENTIAL_RECOVERY",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "reset-authenticator",
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "href": "http://localhost:3000/idp/idx/challenge/answer",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter code",
+                  "messages": {
+                    "type": "array",
+                    "value": [
+                      {
+                        "message": "Invalid code. Try again.",
+                        "i18n": {
+                          "key": "api.authn.error.PASSCODE_INVALID",
+                          "params": []
+                        },
+                        "class": "ERROR"
+                      }
+                    ]
+                  },
+                  "required": true,
+                  "visible": true
+                }
+              ]
+            },
+            "required": true
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02U8D8oIqmFd3BE1XqjFexhopK6XYEglTNjV74mUFQ",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Google Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut11ceMaP0B0EzMI0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02U8D8oIqmFd3BE1XqjFexhopK6XYEglTNjV74mUFQ",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "contextualData": {
+        "qrcode": {
+          "method": "embedded",
+          "href": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAEjklEQVR42u3dQY7jOBBFQd//0l2LWjdqYWbmZzIeMCv32JasKICiRH3+SfpvH7tAAkQCRAJEAkQCRAJEAkQCRAJEEiASIBIgEiASIBIgEiASIBIgEiCSAJEAkQCRAJEAkQD5/aDPp/W/vz7/9PZUb++3+/f090v7fQEBBBBAAAEEEEAAAaT6AP32gD0N+vT2V4Pv/oOR/v6AAAIIIIAAAggggLwHpHoQ3n2AV3/+6UFs9f5JO8kCCCCAAAIIIIAAAggg00Bu+/+n9zcggAACCCCAAAIIIIAAkn1x3/RJgeqTGoAAAggggAACCCCAAHIbkHSA1cCqD9BpkOnHDyCAAAIIIIAAAggg+4GkLdrg9d5BuEUbAAEEEEC8DgggXgfk9W5blGF6ou+Z4wINQAABBBBAAAEEkLWD9NOD/G+/X/cBmbZ4d9oNVM+fxQIEEEAAAQQQQAABpBxI9Q7qBtW9sF3aoPyWG6QAAQQQQAABBBBAANkDJG3Q3g0wbWG47v0x/XmAAAIIIIAAAggggLwHpHsHpE0knj7A005ibL0YEhBAAAEEEEAAAQSQvYP06kH59PtVb//0SYXqh4g+t2gDIIAAAggggAACCCDjg+rbBqHbHiqadnEnIIAAAggggAACCCCAdAPpXuTgtkUUbntgj4lCQAABBBBAAAEEEEC2DdrTDoBpYKe3d8ugHBBAAAEEEEAAAQSQvUC2TXRVH0DVg97pP0CpN1QBAggggAACCCCAAHIvkOmF4aaBpw36p2+ISgEACCCAAAIIIIAAAoh5kJSLCW/7wadB3PqAHEAAAQQQQAABBBBA3hmkT09ETT/08vY/COkTu4AAAggggAACCCCAAFI9qOu+wej09leDS/u89JMegAACCCCAAAIIIIAAMv3+1YtJV39+9fudBmWQDggggAACCCCAAAJI9QGbdtN/9w1KaUC7H+iTGiCAAAIIIIAAAgggewfp1RNH1Qf09AOAbl/EwlksQAABBBBAAAEEEEDSQXQPIqcvHpxehGH6pMDzi1cDAggggAACCCCAAHJ8ENc9cXV6ENt9A9H0/u0etD83SAcEEEAAAQQQQAAB5HpAt02UpX+fLRcjAgIIIIAAAggggADyLpDuQWP169P/vvskw9aHfAICCCCAAAIIIIAAci+Q6cWN0wapty3GnXYDGCCAAAIIIIAAAggggMRP+DQ/xHMaXNpE660Ti4AAAggggAACCCCA7B2kdw/qqgf1rw3yty5uDQgggAACCCCAAALIHiDd73/bxGTaQzu3XowICCCAAAIIIIAAAsi7QLon8qonuroPiOmJvq2LQAACCCCAAAIIIIAAAsiWG4jSvt/p32t6/wECCCCAAAIIIIAAAshtD9ms3t7p/Vm9/7csZg0IIIAAAggggAACyF4g3QdM2gHZPQif/r1uAQYIIIAAAggggAACyB4g3Ys2TA9qpy/GrJ6onL6BDBBAAAEEEEAAAQQQQKQNASIBIgEiASIBIgEiASIBIgEiASIJEAkQCRAJEAkQCRAJEAkQCRAJEEmASIBIgEiASIBI4f0As/6SOQMO/ycAAAAASUVORK5CYII=",
+          "type": "image/png"
+        },
+        "sharedSecret": "ZR74DHZTG43NBULV"
+      },
+      "type": "app",
+      "key": "google_otp",
+      "id": "aut11ceMaP0B0EzMI0g4",
+      "displayName": "Google Authenticator",
+      "methods": [
+        {
+          "type": "otp"
+        }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "app",
+        "key": "google_otp",
+        "id": "aut11ceMaP0B0EzMI0g4",
+        "displayName": "Google Authenticator",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "type": "email",
+        "id": "eae11dkZe4pMeXpAy0g4",
+        "displayName": "Email",
+        "methods": [
+          {
+            "type": "email"
+          }
+        ]
+      },
+      {
+        "type": "password",
+        "id": "lae66mLs1g1Y5nRlA0g3",
+        "displayName": "Password",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
+      },
+      {
+        "type": "security_question",
+        "id": "qae1373hWZ8OKofXv0g4",
+        "displayName": "Security Question",
+        "methods": [
+          {
+            "type": "security_question"
+          }
+        ]
+      }
+    ]
+  },
+  "enrollmentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "app",
+      "key": "google_otp",
+      "id": "aut11ceMaP0B0EzMI0g4",
+      "displayName": "Google Authenticator",
+      "methods": [
+        {
+          "type": "otp"
+        }
+      ]
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u11djWuT63w8aHj0g4",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02U8D8oIqmFd3BE1XqjFexhopK6XYEglTNjV74mUFQ",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "TestApp",
+      "id": "0oa11ch8m94eTn0Qe0g4"
+    }
+  }
+}

--- a/src/v2/view-builder/ViewFactory.ts
+++ b/src/v2/view-builder/ViewFactory.ts
@@ -229,6 +229,7 @@ const VIEWS_MAPPING = {
   [RemediationForms.RESET_AUTHENTICATOR]: {
     // Admin driven password reset..
     [AUTHENTICATOR_KEY.PASSWORD]: ResetAuthenticatorPasswordView,
+    [AUTHENTICATOR_KEY.GOOGLE_OTP]: EnrollAuthenticatorGoogleAuthenticatorView,
   },
   [RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE]: {
     [DEFAULT]: SelectAuthenticatorVerifyView,

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
@@ -32,6 +32,54 @@ describe('Google Authenticator Enroll Transformer Tests', () => {
   const widgetProps: WidgetProps = {};
   const formBag = getStubFormBag();
 
+  function validateForm(updatedFormBag) {
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(2);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.enroll.google_authenticator.setup.title');
+
+    const stepperLayout = updatedFormBag.uischema.elements[1] as StepperLayout;
+    const [layoutOne, layoutTwo, layoutThree] = stepperLayout.elements;
+
+    expect(layoutOne.elements.length).toBe(5);
+    expect((layoutOne.elements[0] as HeadingElement).options.content)
+      .toBe('oie.enroll.google_authenticator.scanBarcode.title');
+    expect((layoutOne.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.enroll.google_authenticator.scanBarcode.description');
+    expect((layoutOne.elements[2] as QRCodeElement).options.data)
+      .toBe('#mockhref');
+    expect((layoutOne.elements[3] as StepperButtonElement).label)
+      .toBe('oie.enroll.google_authenticator.scanBarcode.cannotScan');
+    expect((layoutOne.elements[3] as StepperButtonElement).options.nextStepIndex)
+      .toBe(1);
+    expect((layoutOne.elements[4] as StepperButtonElement).label)
+      .toBe('oform.next');
+    expect((layoutOne.elements[4] as StepperButtonElement).options.nextStepIndex)
+      .toBe(2);
+
+    expect(layoutTwo.elements.length).toBe(4);
+    expect((layoutTwo.elements[0] as HeadingElement).options.content)
+      .toBe('oie.enroll.google_authenticator.cannotScanBarcode.title');
+    expect((layoutTwo.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.enroll.google_authenticator.manualSetupInstructions');
+    expect((layoutTwo.elements[2] as DescriptionElement).options.content)
+      .toBe('A B C 1 2 3 D E F 4 5 6');
+    expect((layoutTwo.elements[3] as StepperButtonElement).label)
+      .toBe('oform.next');
+    expect((layoutTwo.elements[3] as StepperButtonElement).options.nextStepIndex)
+      .toBe(2);
+
+    expect(layoutThree.elements.length).toBe(3);
+    expect((layoutThree.elements[0] as DescriptionElement).options.content)
+      .toBe('oie.enroll.google_authenticator.enterCode.title');
+    expect((layoutThree.elements[1] as FieldElement).options.inputMeta.name)
+      .toBe('credentials.passcode');
+    expect((layoutThree.elements[2] as ButtonElement).label)
+      .toBe('oform.verify');
+    expect((layoutThree.elements[2] as ButtonElement).options.type)
+      .toBe(ButtonType.SUBMIT);
+  }
+
   beforeEach(() => {
     formBag.uischema.elements = [
       {
@@ -105,52 +153,4 @@ describe('Google Authenticator Enroll Transformer Tests', () => {
 
     validateForm(updatedFormBag);
   });
-
-  function validateForm(updatedFormBag) {
-    expect(updatedFormBag).toMatchSnapshot();
-    expect(updatedFormBag.uischema.elements.length).toBe(2);
-    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.enroll.google_authenticator.setup.title');
-
-    const stepperLayout = updatedFormBag.uischema.elements[1] as StepperLayout;
-    const [layoutOne, layoutTwo, layoutThree] = stepperLayout.elements;
-
-    expect(layoutOne.elements.length).toBe(5);
-    expect((layoutOne.elements[0] as HeadingElement).options.content)
-      .toBe('oie.enroll.google_authenticator.scanBarcode.title');
-    expect((layoutOne.elements[1] as DescriptionElement).options.content)
-      .toBe('oie.enroll.google_authenticator.scanBarcode.description');
-    expect((layoutOne.elements[2] as QRCodeElement).options.data)
-      .toBe('#mockhref');
-    expect((layoutOne.elements[3] as StepperButtonElement).label)
-      .toBe('oie.enroll.google_authenticator.scanBarcode.cannotScan');
-    expect((layoutOne.elements[3] as StepperButtonElement).options.nextStepIndex)
-      .toBe(1);
-    expect((layoutOne.elements[4] as StepperButtonElement).label)
-      .toBe('oform.next');
-    expect((layoutOne.elements[4] as StepperButtonElement).options.nextStepIndex)
-      .toBe(2);
-
-    expect(layoutTwo.elements.length).toBe(4);
-    expect((layoutTwo.elements[0] as HeadingElement).options.content)
-      .toBe('oie.enroll.google_authenticator.cannotScanBarcode.title');
-    expect((layoutTwo.elements[1] as DescriptionElement).options.content)
-      .toBe('oie.enroll.google_authenticator.manualSetupInstructions');
-    expect((layoutTwo.elements[2] as DescriptionElement).options.content)
-      .toBe('A B C 1 2 3 D E F 4 5 6');
-    expect((layoutTwo.elements[3] as StepperButtonElement).label)
-      .toBe('oform.next');
-    expect((layoutTwo.elements[3] as StepperButtonElement).options.nextStepIndex)
-      .toBe(2);
-
-    expect(layoutThree.elements.length).toBe(3);
-    expect((layoutThree.elements[0] as DescriptionElement).options.content)
-      .toBe('oie.enroll.google_authenticator.enterCode.title');
-    expect((layoutThree.elements[1] as FieldElement).options.inputMeta.name)
-      .toBe('credentials.passcode');
-    expect((layoutThree.elements[2] as ButtonElement).label)
-      .toBe('oform.verify');
-    expect((layoutThree.elements[2] as ButtonElement).options.type)
-      .toBe(ButtonType.SUBMIT);
-  }
 });

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
@@ -73,6 +73,40 @@ describe('Google Authenticator Enroll Transformer Tests', () => {
     const updatedFormBag = transformGoogleAuthenticatorEnroll({
       transaction, formBag, widgetProps,
     });
+
+    validateForm(updatedFormBag);
+  });
+
+  it('should add Stepper layout to UI Schema elements '
+    + 'when GA Reset params exists in Idx response', () => {
+    transaction.nextStep = {
+      name: IDX_STEP.RESET_AUTHENTICATOR,
+      relatesTo: {
+        value: {
+          displayName: 'google auth',
+          id: '',
+          key: 'google_otp',
+          methods: [],
+          type: '',
+          contextualData: {
+            sharedSecret: 'ABC123DEF456',
+            qrcode: {
+              href: '#mockhref',
+              method: 'mockmethod',
+              type: 'mocktype',
+            },
+          },
+        },
+      },
+    };
+    const updatedFormBag = transformGoogleAuthenticatorEnroll({
+      transaction, formBag, widgetProps,
+    });
+
+    validateForm(updatedFormBag);
+  });
+
+  function validateForm(updatedFormBag) {
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(2);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
@@ -118,5 +152,5 @@ describe('Google Authenticator Enroll Transformer Tests', () => {
       .toBe('oform.verify');
     expect((layoutThree.elements[2] as ButtonElement).options.type)
       .toBe(ButtonType.SUBMIT);
-  });
+  }
 });

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -491,6 +491,10 @@ const TransformerMap: {
       transform: transformResetPasswordAuthenticator,
       buttonConfig: { showDefaultSubmit: false },
     },
+    [AUTHENTICATOR_KEY.GOOGLE_OTP]: {
+      transform: transformGoogleAuthenticatorVerify,
+      buttonConfig: { showDefaultSubmit: false },
+    },
   },
   [IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE]: {
     [AUTHENTICATOR_KEY.DEFAULT]: {

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -492,7 +492,7 @@ const TransformerMap: {
       buttonConfig: { showDefaultSubmit: false },
     },
     [AUTHENTICATOR_KEY.GOOGLE_OTP]: {
-      transform: transformGoogleAuthenticatorVerify,
+      transform: transformGoogleAuthenticatorEnroll,
       buttonConfig: { showDefaultSubmit: false },
     },
   },

--- a/test/testcafe/spec/ResetAuthenticatorGoogleView_spec.js
+++ b/test/testcafe/spec/ResetAuthenticatorGoogleView_spec.js
@@ -1,0 +1,156 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import { checkA11y } from '../framework/a11y';
+import { oktaDashboardContent } from '../framework/shared';
+import FactorEnrollGoogleAuthenticatorPageObject from '../framework/page-objects/EnrollGoogleAuthenticatorPageObject.js';
+import { checkConsoleMessages } from '../framework/shared';
+import xhrAuthenticatorResetGoogle from '../../../playground/mocks/data/idp/idx/authenticator-reset-google';
+import success from '@okta/mocks/data/idp/idx/success.json';
+import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
+import xhrInvalidOTP from '@okta/mocks/data/idp/idx/error-authenticator-enroll-google-invalid-otp.json';
+
+const logger = RequestLogger(/challenge\/answer/,
+  {
+    logRequestBody: true,
+    stringifyRequestBody: true,
+  }
+);
+
+const validOTPmock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrAuthenticatorResetGoogle)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
+  .respond(success)
+  .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
+  .respond(oktaDashboardContent);
+
+const invalidOTPMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrAuthenticatorResetGoogle)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
+  .respond(xhrInvalidOTP, 403);
+
+fixture('Reset Google Authenticator');
+
+async function setup(t) {
+  const resetGAPage = new FactorEnrollGoogleAuthenticatorPageObject(t);
+  await resetGAPage.navigateToPage();
+  await t.expect(resetGAPage.formExists()).eql(true);
+  await checkConsoleMessages({
+    controller: null,
+    formName: 'reset-authenticator',
+    authenticatorKey: 'google_otp',
+    methodType:'otp',
+  });
+
+  return resetGAPage;
+}
+
+test
+  .requestHooks(invalidOTPMock)('enroll with Barcode with invalid OTP', async t => {
+    const enrollGoogleAuthenticatorPageObject = await setup(t);
+    await checkA11y(t);
+
+    await t.expect(enrollGoogleAuthenticatorPageObject.form.getTitle()).eql('Set up Google Authenticator');
+    await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
+    await t.expect(enrollGoogleAuthenticatorPageObject.getBarcodeSubtitle()).eql('Scan barcode');
+    await t.expect(enrollGoogleAuthenticatorPageObject.getSetUpDescription())
+      .eql('Launch Google Authenticator, tap the "+" icon, then select "Scan barcode".');
+    await t.expect(enrollGoogleAuthenticatorPageObject.hasQRcode).ok();
+    await t.expect(enrollGoogleAuthenticatorPageObject.getNextButton().exists).eql(true);
+    await enrollGoogleAuthenticatorPageObject.goToNextPage();
+
+    await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.getOtpLabel()).contains('Enter code');
+    await enrollGoogleAuthenticatorPageObject.enterCode('123456');
+    await enrollGoogleAuthenticatorPageObject.submit();
+
+    await t.expect(enrollGoogleAuthenticatorPageObject.getCodeFieldError()).contains('Invalid code. Try again.');
+    await t.expect(enrollGoogleAuthenticatorPageObject.form.getErrorBoxText()).contains('We found some errors.');
+  });
+
+test
+  .requestHooks(invalidOTPMock)('enroll with manual setup with invalid OTP', async t => {
+    const enrollGoogleAuthenticatorPageObject = await setup(t);
+    await checkA11y(t);
+
+    await enrollGoogleAuthenticatorPageObject.goTomanualSetup();
+    await t.expect(enrollGoogleAuthenticatorPageObject.form.getTitle()).eql('Set up Google Authenticator');
+    await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
+    await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).contains('Can\'t scan');
+
+    const sharedSecret = await enrollGoogleAuthenticatorPageObject.getSharedSecret();
+    // Remove white spaces in string
+    await t.expect(sharedSecret.toString().replace(/\s/g, '')).eql('ZR74DHZTG43NBULV');
+
+    await t.expect(enrollGoogleAuthenticatorPageObject.getNextButton().exists).eql(true);
+    await enrollGoogleAuthenticatorPageObject.goToNextPage();
+
+    await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.getOtpLabel()).contains('Enter code');
+    await enrollGoogleAuthenticatorPageObject.enterCode('123456');
+    await enrollGoogleAuthenticatorPageObject.submit();
+
+    await t.expect(enrollGoogleAuthenticatorPageObject.getCodeFieldError()).contains('Invalid code. Try again.');
+    await t.expect(enrollGoogleAuthenticatorPageObject.form.getErrorBoxText()).contains('We found some errors.');
+  });
+
+test
+  .requestHooks(logger, validOTPmock)('enroll with Barcode with valid OTP', async t => {
+    const enrollGoogleAuthenticatorPageObject = await setup(t);
+    await checkA11y(t);
+
+    await t.expect(enrollGoogleAuthenticatorPageObject.form.getTitle()).eql('Set up Google Authenticator');
+    await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
+    await t.expect(enrollGoogleAuthenticatorPageObject.getBarcodeSubtitle()).eql('Scan barcode');
+    await t.expect(enrollGoogleAuthenticatorPageObject.hasQRcode).ok();
+
+    // Verify links (switch authenticator link is present even if there is just one authenticator available))
+    await t.expect(await enrollGoogleAuthenticatorPageObject.returnToAuthenticatorListLinkExists()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.signoutLinkExists()).ok();
+    await t.expect(enrollGoogleAuthenticatorPageObject.getNextButton().getStyleProperty('display')).eql('block');
+    await t.expect(enrollGoogleAuthenticatorPageObject.getNextButton().exists).eql(true);
+
+    await enrollGoogleAuthenticatorPageObject.goToNextPage();
+
+    await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.getOtpLabel()).contains('Enter code');
+    await enrollGoogleAuthenticatorPageObject.enterCode('123456');
+    await enrollGoogleAuthenticatorPageObject.submit();
+
+    const successPage = new SuccessPageObject(t);
+    const pageUrl = await successPage.getPageUrl();
+    await t.expect(pageUrl)
+      .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+  });
+
+test
+  .requestHooks(logger, validOTPmock)('enroll with manual setup with valid OTP', async t => {
+    const enrollGoogleAuthenticatorPageObject = await setup(t);
+    await checkA11y(t);
+
+    await enrollGoogleAuthenticatorPageObject.goTomanualSetup();
+    await t.expect(enrollGoogleAuthenticatorPageObject.form.getTitle()).eql('Set up Google Authenticator');
+    await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
+    await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
+    const sharedSecret = await enrollGoogleAuthenticatorPageObject.getSharedSecret();
+    // Remove white spaces in string
+    await t.expect(sharedSecret.toString().replace(/\s/g, '')).eql('ZR74DHZTG43NBULV');
+    await t.expect(enrollGoogleAuthenticatorPageObject.getNextButton().exists).eql(true);
+    await enrollGoogleAuthenticatorPageObject.goToNextPage();
+
+    // Verify links (switch authenticator link is present even if there is just one authenticator available))
+    await t.expect(await enrollGoogleAuthenticatorPageObject.returnToAuthenticatorListLinkExists()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.signoutLinkExists()).ok();
+
+    await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.getOtpLabel()).contains('Enter code');
+    await enrollGoogleAuthenticatorPageObject.enterCode('123456');
+    await enrollGoogleAuthenticatorPageObject.submit();
+
+    const successPage = new SuccessPageObject(t);
+    const pageUrl = await successPage.getPageUrl();
+    await t.expect(pageUrl)
+      .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+  });
+
+


### PR DESCRIPTION
## Description:

Fixed issue with `RESET_AUTHENTICATOR` form missing for Google Authenticator when running through the password reset flow. If a user had their GA authenticator and Password reset, after setting a new password, the setup GA authenticator form would default to the base form and the user could not proceed.

Updated SIW v2 and v3

**BEFORE**

![image](https://github.com/okta/okta-signin-widget/assets/59570785/3a02ee7f-510c-4f98-a63f-741c72cd4b85)


**AFTER**

![image](https://github.com/okta/okta-signin-widget/assets/59570785/137870fe-a719-495b-8820-bee988649573)


## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-644131](https://oktainc.atlassian.net/browse/OKTA-644131)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



