### PR TITLE
Reenable IdentifyWithRememberUsername_spec

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -110,7 +110,7 @@ const idx = {
     // 'mdm-enrollment',
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-enroll-custom-app-push',
-    // 'request-activation-email',
+    // 'request-activation-email'
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -110,7 +110,7 @@ const idx = {
     // 'mdm-enrollment',
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-enroll-custom-app-push',
-    // 'request-activation-email'    
+    // 'request-activation-email'
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -110,7 +110,7 @@ const idx = {
     // 'mdm-enrollment',
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-enroll-custom-app-push',
-    // 'request-activation-email'    
+    // 'request-activation-email',
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -110,7 +110,7 @@ const idx = {
     // 'mdm-enrollment',
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-enroll-custom-app-push',
-    // 'request-activation-email'
+    // 'request-activation-email'    
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -141,15 +141,13 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     // Allow username transformation if applicable
     if ('identifier' in payload) {
       payload.identifier = transformIdentifier(widgetProps, step, payload.identifier as string);
-    }
 
-    // Widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
-    if (features?.rememberMe) {
-      if (payload.identifier) {
+      // Widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
+      if (features?.rememberMe) {
         setUsernameCookie(payload.identifier as string);
+      } else {
+        removeUsernameCookie();
       }
-    } else {
-      removeUsernameCookie();
     }
 
     // For Granular Consent remediation, scopes within the `optedScopes`

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -310,6 +310,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     widgetProps,
     eventEmitter,
     widgetHooks,
+    features,
     setResponseError,
     setIdxTransaction,
     setIsClientTransaction,

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -34,7 +34,9 @@ import {
   loc,
   postRegistrationSubmit,
   preRegistrationSubmit,
+  removeUsernameCookie,
   SessionStorage,
+  setUsernameCookie,
   toNestedObject,
   transformIdentifier,
   triggerRegistrationErrorMessages,
@@ -64,7 +66,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setStepToRender,
     widgetProps,
   } = useWidgetContext();
-  const { eventEmitter, widgetHooks } = widgetProps;
+  const { eventEmitter, widgetHooks, features } = widgetProps;
 
   return useCallback(async (options: OnSubmitHandlerOptions) => {
     setLoading(true);
@@ -139,6 +141,15 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     // Allow username transformation if applicable
     if ('identifier' in payload) {
       payload.identifier = transformIdentifier(widgetProps, step, payload.identifier as string);
+    }
+
+    // Widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
+    if (features?.rememberMe) {
+      if (payload.identifier) {
+        setUsernameCookie(payload.identifier as string);
+      }
+    } else {
+      removeUsernameCookie();
     }
 
     // For Granular Consent remediation, scopes within the `optedScopes`

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
@@ -20,7 +20,6 @@ import {
 
 import { TERMINAL_KEY, TERMINAL_TITLE_KEY } from '../../constants';
 import { getStubTransaction } from '../../mocks/utils/utils';
-import { removeUsernameCookie, setUsernameCookie } from '../../util';
 import { redirectTransformer } from '../redirect';
 import { transformTerminalTransaction } from '.';
 import { transformOdaEnrollment } from './odaEnrollment/transformOdaEnrollment';

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.test.ts
@@ -254,43 +254,6 @@ describe('Terminal Transaction Transformer Tests', () => {
     expect((formBag.uischema.elements[0] as LinkElement).options?.href).toBe('/');
   });
 
-  it('should set username cookie when successful authentication and rememberMe feature is set', () => {
-    const mockIdentifier = 'testUser';
-    transaction.context = {
-      success: { name: 'success' },
-      user: {
-        type: 'object',
-        value: {
-          identifier: mockIdentifier,
-        },
-      },
-    } as unknown as IdxContext;
-    widgetProps = {
-      features: { rememberMe: true },
-    };
-    transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
-
-    expect(setUsernameCookie).toHaveBeenCalledWith(mockIdentifier);
-  });
-
-  it('should remove username cookie when successful authentication and rememberMe feature is false', () => {
-    transaction.context = {
-      success: { name: 'success' },
-      user: {
-        type: 'object',
-        value: {
-          identifier: 'testUser',
-        },
-      },
-    } as unknown as IdxContext;
-    widgetProps = {
-      features: { rememberMe: false },
-    };
-    transformTerminalTransaction(transaction, widgetProps, mockBootstrapFn);
-
-    expect(removeUsernameCookie).toHaveBeenCalled();
-  });
-
   it('should invoke oda enrollment terminal transformer when device enrollment data is present', () => {
     transaction.context = {
       deviceEnrollment: {

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -136,27 +136,12 @@ const isSuccessfulAuthentication = (
 ): boolean => !!(transction.context.success
   || transction.rawIdxState.successWithInteractionCode);
 
-const updateIdentifierCookie = (transaction: IdxTransaction, rememberMe?: boolean): void => {
-  if (rememberMe) {
-    const userInfo = getUserInfo(transaction);
-    if (userInfo.identifier) {
-      setUsernameCookie(userInfo.identifier);
-    }
-  } else {
-    removeUsernameCookie();
-  }
-};
-
 export const transformTerminalTransaction = (
   transaction: IdxTransaction,
   widgetProps: WidgetProps,
   bootstrapFn: () => Promise<void>,
 ): FormBag => {
-  const { authClient, features } = widgetProps;
-  if (isSuccessfulAuthentication(transaction)) {
-    // TODO: OKTA-506358 This identifier cookie can be removed once implemented in auth-js
-    updateIdentifierCookie(transaction, features?.rememberMe);
-  }
+  const { authClient } = widgetProps;
 
   if (isOauth2Enabled(widgetProps) && transaction.interactionCode) {
     // Interaction code flow handled by useInteractionCodeFlow hook

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -35,12 +35,9 @@ import {
   containsOneOfMessageKeys,
   getBackToSignInUri,
   getBaseUrl,
-  getUserInfo,
   isOauth2Enabled,
   loc,
-  removeUsernameCookie,
   SessionStorage,
-  setUsernameCookie,
   shouldShowCancelLink,
 } from '../../util';
 import { redirectTransformer } from '../redirect';
@@ -130,11 +127,6 @@ const appendViewLinks = (
     uischema.elements.push(cancelLink);
   }
 };
-
-const isSuccessfulAuthentication = (
-  transction: IdxTransaction,
-): boolean => !!(transction.context.success
-  || transction.rawIdxState.successWithInteractionCode);
 
 export const transformTerminalTransaction = (
   transaction: IdxTransaction,

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -55,6 +55,7 @@ describe('identify-with-password-error-flow', () => {
   });
 
   it('should display warning message when invalid identifier is entered and should allow user to resubmit same information without showing client-side errors', async () => {
+    jest.spyOn(cookieUtils, 'getUsernameCookie').mockReturnValue('');
     const {
       authClient,
       user,

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -71,6 +71,7 @@ describe('identify-with-password-error-flow', () => {
           status: 200,
         },
       },
+      widgetOptions: { features: { rememberMe: false } },
     });
 
     const titleElement = await findByText('Sign In', { selector: 'h2' });

--- a/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
+++ b/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
@@ -225,9 +225,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should pre-fill identifi
   await t.expect(identifier).eql('testUsername@okta.com');
 });
 
-
-// OKTA-585939 Cookie is not updated in gen 3 widget
-test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMock)('should store identifier in ln cookie when updated', async t => {
+test.requestHooks(identifyRequestLogger, identifyMock)('should store identifier in ln cookie when updated', async t => {
   const identityPage = await setup(t, { render: false });
 
   await t.setCookies({name: 'ln', value: 'PREFILL VALUE', httpOnly: false});


### PR DESCRIPTION
## Description:
- Gen3 version of [OKTA-552341](https://oktainc.atlassian.net/browse/OKTA-552341), which was fixed in #3063
- Reenables IdentifyWithRememberUsername_spec by storing identifier in `ln` username cookie on form submission


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-585939](https://oktainc.atlassian.net/browse/OKTA-585939)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-585939-reenable-identify-cookie-spec&page=1&pageSize=6&sha=ead268860e18edc00e9b9e3eb060e085d792e42c&tab=main)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



