### PR TITLE
fix: Fixes L10N error when no app label is present

### DIFF
--- a/src/v2/view-builder/views/consent/EmailMagicLinkOTPTerminalView.js
+++ b/src/v2/view-builder/views/consent/EmailMagicLinkOTPTerminalView.js
@@ -29,7 +29,7 @@ const getTerminalOtpEmailMagicLinkContext = (settings, appState) => {
     ? loc(challengeIntentContentKey, 'login')
     : loc('idx.enter.otp.in.original.tab', 'login');
   let appName, browserOnOsString, isMobileDevice, geolocation;
-  if (app) {
+  if (app?.label) {
     appName = loc('idx.return.link.otponly.app', 'login', [app.label]);
   }
   if (client) {

--- a/test/testcafe/framework/page-objects/TerminalOtpOnlyPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalOtpOnlyPageObject.js
@@ -64,6 +64,11 @@ export default class TerminalOtpOnlyPageObject extends TerminalPageObject {
     return this.form.elementExist(APP_ICON_SELECTOR);
   }
 
+  doesAppNameElementExist() {
+    const appNameSelector = userVariables.gen3 ? APP_TEXT_SELECTOR_V3 : APP_TEXT_SELECTOR;
+    return Selector(appNameSelector).exists;
+  }
+
   getAppNameElement() {
     if (userVariables.gen3) {
       return this.form.getElement(APP_TEXT_SELECTOR_V3); 

--- a/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
+++ b/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
@@ -41,6 +41,13 @@ const terminalReturnOtpUnexpectedResponseyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(terminalReturnOtpUnexpectedResponse);
 
+const terminalReturnOtpOnlyNoAppLabel = JSON.parse(JSON.stringify(terminalReturnOtpOnlyFullLocation));
+terminalReturnOtpOnlyNoAppLabel.app.value.label = null;
+
+const terminalReturnOtpOnlyNoAppLabelMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(terminalReturnOtpOnlyNoAppLabel);
+
 fixture('Email Magic Link OTP Terminal view');
 
 async function setupOtpOnly(t) {
@@ -132,4 +139,15 @@ test.requestHooks(terminalReturnOtpUnexpectedResponseyMock)('should gracefully h
   const terminalOtpOnlyPage = await setupOtpOnly(t);
   await t.expect(await terminalOtpOnlyPage.doesEnterCodeOnPageExist()).ok();
   await t.expect(terminalOtpOnlyPage.getEnterCodeOnPageElement().innerText).notContains('L10N_ERROR');
+});
+
+test.requestHooks(terminalReturnOtpOnlyFullLocationMock)('should display the application label if it is present in the app state', async t => {
+  const terminalOtpOnlyPage = await setupOtpOnly(t);
+  await t.expect(terminalOtpOnlyPage.doesAppNameElementExist()).eql(true);
+  await t.expect(terminalOtpOnlyPage.getAppNameElement().textContent).eql('my 3rd magic link spa');
+});
+
+test.requestHooks(terminalReturnOtpOnlyNoAppLabelMock)('should not display the application label if it is not present in the app state', async t => {
+  const terminalOtpOnlyPage = await setupOtpOnly(t);
+  await t.expect(terminalOtpOnlyPage.doesAppNameElementExist()).eql(false);
 });


### PR DESCRIPTION
## Description:

When the IDX response does not contain the app label, it no longer displays the app line with the L10N error.

The issue was reproducible if we paste the password reset email link into a different browser, if the redirect url had a fromURI.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-649659](https://oktainc.atlassian.net/browse/OKTA-649659)
- [OKTA-541752](https://oktainc.atlassian.net/browse/OKTA-541752)

### Reviewers:

@TiffanyNg-okta 

### Screenshot/Video:

![image](https://github.com/okta/okta-signin-widget/assets/99218766/b053f3fe-6f58-41b5-b64d-ccfac99dd584)

### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-d8f3b45-6537fb09&page=1&pageSize=6&sha=732f698ae2e7cf1c097153651e81804a09a21a48&tab=main

