### PR TITLE
Add no-transalte to shared secret on google authenticator enroll screen

### DIFF
--- a/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
@@ -76,7 +76,7 @@ const Body = BaseForm.extend({
         }
       }, {
         label: false,
-        className: 'shared-secret',
+        className: 'shared-secret no-translate',
         type: 'text',
         placeholder: this.options.appState.get('currentAuthenticator').contextualData.sharedSecret,
         disabled: true,

--- a/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorEnroll.test.ts.snap
+++ b/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorEnroll.test.ts.snap
@@ -100,6 +100,7 @@ Object {
               },
               Object {
                 "contentType": "subtitle",
+                "noTranslate": true,
                 "options": Object {
                   "content": "A B C 1 2 3 D E F 4 5 6",
                 },

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.ts
@@ -56,6 +56,7 @@ export const transformGoogleAuthenticatorEnroll: IdxStepTransformer = ({
   const manualKeyElement: DescriptionElement = {
     type: 'Description',
     contentType: 'subtitle',
+    noTranslate: true,
     options: {
       // spacing out the code so Screen reader can speak each letter individually
       content: relatesTo.value.contextualData.sharedSecret?.split('').join(' ') || '',

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                         class="MuiBox-root emotion-18"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-26"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph no-translate emotion-26"
                           data-se="google-authenticator-setup-info"
                           id="enroll-authenticator_Description_Launch_Google_Authenticator,_tap_the__icon,_then_select_Scan_barcode_google_otp_aut2m5drzzUlo4Bn81d7_4_1"
                         >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                         class="MuiBox-root emotion-18"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph no-translate emotion-26"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-26"
                           data-se="google-authenticator-setup-info"
                           id="enroll-authenticator_Description_Launch_Google_Authenticator,_tap_the__icon,_then_select_Scan_barcode_google_otp_aut2m5drzzUlo4Bn81d7_4_1"
                         >
@@ -707,7 +707,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                         class="MuiBox-root emotion-18"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-26"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph no-translate emotion-26"
                           data-se="o-form-explain"
                           id="enroll-authenticator_Description_K_A_G_W_B_I_X_A_K_O_L_P_E_F_M_Y_google_otp_aut2m5drzzUlo4Bn81d7_10_2"
                         >


### PR DESCRIPTION
Resolves: OKTA-658304

## Description:

- Add no-translate class to shared secret on google authenticator enroll screen to bypass english leak checks for placeholder elements


<img width="417" alt="google_authenticator" src="https://github.com/okta/okta-signin-widget/assets/23267876/1788b383-bfea-4788-be0d-bcd9ea9f8f59">


## PR Checklist

- [x] Have you verified the basic functionality for this change?



### Issue:

- [OKTA-658304](https://oktainc.atlassian.net/browse/OKTA-658304)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



