### PR TITLE
Fixing lockfile drift

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -8,13 +8,13 @@ yarn global add @okta/ci-pkginfo
 
 export PATH="${PATH}:$(yarn global bin)"
 export TEST_SUITE_TYPE="build"
+export PUBLISH_REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-topic"
 
 # Append a SHA to the version in package.json 
 if ! ci-append-sha; then
   echo "ci-append-sha failed! Exiting..."
   exit $FAILED_SETUP
 fi
-
 
 # Build
 if ! yarn build:release; then
@@ -26,7 +26,7 @@ pushd ./dist
 ### Not able to use 'yarn publish' which failed at
 ### publish alpha version.
 ### Didn't figure out root cause but keep using npm.
-npm config set @okta:registry ${REGISTRY}
+npm config set @okta:registry ${PUBLISH_REGISTRY}
 if ! npm publish --unsafe-perm; then
   echo "npm publish failed! Exiting..."
   exit $PUBLISH_ARTIFACTORY_FAILURE

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,7 +28,7 @@ if ! setup_service yarn 1.22.19 &> /dev/null; then
   exit ${FAILED_SETUP}
 fi
 
-cd "${OKTA_HOME}"/"${REPO}" || exit
+cd ${OKTA_HOME}/${REPO}
 
 npm config set @okta:registry ${PUBLIC_REGISTRY}
 npm config set registry ${PUBLIC_REGISTRY}

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -2,7 +2,7 @@
 
 # NOTE: MUST BE RAN *AFTER* THE PUBLISH SUITE
 
-export PUBLISHED_REGISTRY="${ARTIFACTORY_URL}/npm-topic"
+export PUBLISH_REGISTRY="${ARTIFACTORY_URL}/npm-topic"
 
 cd ${OKTA_HOME}/${REPO}
 
@@ -25,7 +25,7 @@ fi
 
 # NOTE: hyphen rather than '@'
 artifact_version="$(ci-pkginfo -t pkgname)-$(ci-pkginfo -t pkgsemver)"
-published_tarball=${PUBLISHED_REGISTRY}/@okta/okta-signin-widget/-/${artifact_version}.tgz
+published_tarball=${PUBLISH_REGISTRY}/@okta/okta-signin-widget/-/${artifact_version}.tgz
 
 # clone angular sample, using angular sample because angular toolchain is *very* opinionated about modules
 git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/angular-sample

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -2,7 +2,7 @@
 
 # NOTE: MUST BE RAN *AFTER* THE PUBLISH SUITE
 
-export REGISTRY="${ARTIFACTORY_URL}/npm-topic"
+export PUBLISHED_REGISTRY="${ARTIFACTORY_URL}/npm-topic"
 
 cd ${OKTA_HOME}/${REPO}
 
@@ -25,7 +25,7 @@ fi
 
 # NOTE: hyphen rather than '@'
 artifact_version="$(ci-pkginfo -t pkgname)-$(ci-pkginfo -t pkgsemver)"
-published_tarball=${REGISTRY}/@okta/okta-signin-widget/-/${artifact_version}.tgz
+published_tarball=${PUBLISHED_REGISTRY}/@okta/okta-signin-widget/-/${artifact_version}.tgz
 
 # clone angular sample, using angular sample because angular toolchain is *very* opinionated about modules
 git clone --depth 1 https://github.com/okta/samples-js-angular.git test/package/angular-sample

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@okta/okta-signin-widget": "link:../../dist"
+    "@okta/okta-signin-widget": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",

--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -97,7 +97,7 @@ test
   });
 
 // Re-enable in OKTA-594821
-test
+test.meta('gen3', false)
   .requestHooks(pushAutoChallengeMock)('challenge ov push screen has right labels and a checkbox', async t => {
     const challengeOktaVerifyPushPageObject = await setup(t);
     await checkA11y(t);

--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -97,7 +97,7 @@ test
   });
 
 // Re-enable in OKTA-594821
-test.meta('gen3', false)
+test
   .requestHooks(pushAutoChallengeMock)('challenge ov push screen has right labels and a checkbox', async t => {
     const challengeOktaVerifyPushPageObject = await setup(t);
     await checkA11y(t);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,30 +3716,6 @@
     rasha "^1.2.5"
     safe-flat "^2.0.2"
 
-"@okta/okta-signin-widget@link:dist":
-  version "7.12.0"
-  dependencies:
-    "@okta/okta-auth-js" "~7.0.0"
-    "@sindresorhus/to-milliseconds" "^1.0.0"
-    "@types/backbone" "^1.4.15"
-    "@types/eslint-scope" "^3.7.3"
-    "@types/jquery" "^3.5.14"
-    "@types/jqueryui" "^1.12.16"
-    "@types/q" "^1.5.5"
-    "@types/selectize" "^0.12.35"
-    "@types/underscore" "^1.11.4"
-    chokidar "^3.5.1"
-    clipboard "^1.5.16"
-    cross-fetch "^3.1.5"
-    handlebars "^4.7.7"
-    jquery "^3.6.0"
-    parse-ms "^2.0.0"
-    q "1.4.1"
-    u2f-api-polyfill "0.4.3"
-    underscore "1.13.1"
-  optionalDependencies:
-    fsevents "*"
-
 "@open-draft/until@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"


### PR DESCRIPTION
## Description:
- Adds `yarn_sync()` in `setup.sh` to check for changes to `yarn.lock` in CI and force users to check in an updated lockfile
- Removes `@okta/okta-signin-widget: "link:../../dist"` in test app `package.json` because it was leading to an empty resolution in the lockfile on every `yarn install`, which would raise a false positive for the `yarn_sync()` logic
- Ensures that `yarn install` in `setup` uses public yarn registry and then reverts to internal artifactory for `@okta:registry` for all following scripts
- Cleans up naming of different registries used for `setup`, `publish`, and `verify-registry-install` scripts


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-653621](https://oktainc.atlassian.net/browse/OKTA-653621)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-653621-fix-lockfile-drift&page=1&pageSize=12&sha=8faa60bdc0f49018cb90c18f75af49d3a3e516bc&tab=main)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



