### PR TITLE
OKTA-654455 : re-enable tests for identify spec

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -411,9 +411,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
   useEffect(() => {
     const asyncEffect = async () => {
-      const isEndOfAuthentication = idxTransaction?.status === IdxStatus.TERMINAL
-          && idxTransaction.neededToProceed.length === 0;
-      if (isClientTransaction || isEndOfAuthentication) {
+      if (isClientTransaction) {
         return;
       }
       if (widgetRendered) {

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -411,7 +411,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
 
   useEffect(() => {
     const asyncEffect = async () => {
-      if (isClientTransaction) {
+      const isEndOfAuthentication = idxTransaction?.status === IdxStatus.TERMINAL
+          && idxTransaction.neededToProceed.length === 0;
+      if (isClientTransaction || isEndOfAuthentication) {
         return;
       }
       if (widgetRendered) {

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -225,9 +225,9 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
         (message) => message.class === MessageType.WARNING.toString(),
       );
       const isClientTransaction = (!newTransaction.requestDidSucceed
-        // do not preserve field data on token change errors
-        && !containsMessageKey(ON_PREM_TOKEN_CHANGE_ERROR_KEY, newTransaction.messages))
-      || (areTransactionsEqual(currTransaction, newTransaction) && transactionHasWarning);
+          // do not preserve field data on token change errors
+          && !containsMessageKey(ON_PREM_TOKEN_CHANGE_ERROR_KEY, newTransaction.messages))
+        || (areTransactionsEqual(currTransaction, newTransaction) && transactionHasWarning);
 
       const onSuccess = (resolve?: (val: unknown) => void) => {
         setIdxTransaction(newTransaction);

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -284,8 +284,11 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       }
 
       // Don't execute hooks in the end of authentication flow and if request did not succeed
-      if (!isClientTransaction && newTransaction?.status !== IdxStatus.SUCCESS) {
-        await widgetHooks.callHooks('before', newTransaction);
+      if (!isClientTransaction
+        && newTransaction?.status !== IdxStatus.SUCCESS
+        // when remediations are missing, this indicates the end of auth flow
+        && newTransaction.neededToProceed.length > 0) {
+          await widgetHooks.callHooks('before', newTransaction);
       }
 
       onSuccess();

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -224,10 +224,13 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       const transactionHasWarning = (newTransaction.messages || []).some(
         (message) => message.class === MessageType.WARNING.toString(),
       );
-      const isClientTransaction = (!newTransaction.requestDidSucceed
-          // do not preserve field data on token change errors
-          && !containsMessageKey(ON_PREM_TOKEN_CHANGE_ERROR_KEY, newTransaction.messages))
-        || (areTransactionsEqual(currTransaction, newTransaction) && transactionHasWarning);
+      const isClientTransaction = (
+        !newTransaction.requestDidSucceed
+        // Not a client transaction if remediations do not exist
+        && newTransaction.neededToProceed.length > 0
+        // do not preserve field data on token change errors
+        && !containsMessageKey(ON_PREM_TOKEN_CHANGE_ERROR_KEY, newTransaction.messages)
+      ) || (areTransactionsEqual(currTransaction, newTransaction) && transactionHasWarning);
 
       const onSuccess = (resolve?: (val: unknown) => void) => {
         setIdxTransaction(newTransaction);

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -176,8 +176,7 @@ test.requestHooks(identifyMock)('should show errors if required fields are empty
   await t.expect(identityPage.getIdentifierErrorMessage()).eql('This field cannot be left blank');
 });
 
-// Re-enable in OKTA-654453
-test.meta('gen3', false).requestHooks(identifyMockWithUnsupportedResponseError)('should show error if server response is unsupported', async t => {
+test.requestHooks(identifyMockWithUnsupportedResponseError)('should show error if server response is unsupported', async t => {
   const identityPage = await setup(t);
   await checkA11y(t);
   await identityPage.fillIdentifierField('test');
@@ -290,8 +289,7 @@ test.requestHooks(identifyThenSelectAuthenticatorMock)('navigate to other screen
   ]);
 });
 
-// Re-enable in OKTA-654455
-test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMock)('should transform identifier using settings.transformUsername', async t => {
+test.requestHooks(identifyRequestLogger, identifyMock)('should transform identifier using settings.transformUsername', async t => {
   const identityPage = await setup(t, {
     transformUsername: function(username, operation) {
       if (operation === 'PRIMARY_AUTH') {

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -258,7 +258,6 @@ test.requestHooks(identifyLockedUserMock)('should show global error for invalid 
   if (userVariables.gen3) {
     // Gen3 follows the IDX response, this response is terminal and does not have remediations
     // hence why it will not display a button or fields, only the error message
-    // See thread: https://okta.slack.com/archives/CCA77QVL2/p1698345162710659?thread_ts=1698344174.752619&cid=CCA77QVL2
     await t.expect(identityPage.form.queryButton('Next').exists).eql(false);
   } else {
     await t.expect(identityPage.getNextButton().exists).eql(true);

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -246,8 +246,7 @@ test.requestHooks(identifyMock)('should have correct display text', async t => {
   await t.expect(await identityPage.hasForgotPasswordLinkText()).notOk();
 });
 
-// Re-enable in OKTA-654453
-test.meta('gen3', false).requestHooks(identifyLockedUserMock)('should show global error for invalid user', async t => {
+test.requestHooks(identifyLockedUserMock)('should show global error for invalid user', async t => {
   const identityPage = await setup(t);
   await checkA11y(t);
 
@@ -256,8 +255,14 @@ test.meta('gen3', false).requestHooks(identifyLockedUserMock)('should show globa
   await identityPage.clickNextButton();
 
   await identityPage.waitForErrorBox();
-
-  await t.expect(identityPage.getNextButton().exists).eql(true);
+  if (userVariables.gen3) {
+    // Gen3 follows the IDX response, this response is terminal and does not have remediations
+    // hence why it will not display a button or fields, only the error message
+    // See thread: https://okta.slack.com/archives/CCA77QVL2/p1698345162710659?thread_ts=1698344174.752619&cid=CCA77QVL2
+    await t.expect(identityPage.form.queryButton('Next').exists).eql(false);
+  } else {
+    await t.expect(identityPage.getNextButton().exists).eql(true);
+  }
 
   await t.expect(identityPage.getGlobalErrors()).contains('You do not have permission to perform the requested action');
 });


### PR DESCRIPTION
## Description:
The purpose of this PR is to re-enable tests within the Identify_spec test. 

- https://oktainc.atlassian.net/browse/OKTA-654453 - Re-enables displaying proper error message when server response is unsupported and should show global error for invalid user
- https://oktainc.atlassian.net/browse/OKTA-654455 - Re-enables Transform username


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-654455](https://oktainc.atlassian.net/browse/OKTA-654455)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



