### PR TITLE
Reenable ChallengeOktaVerifyPush_spec

### DIFF
--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -94,8 +94,7 @@ test
     await t.expect(challengeOktaVerifyPushPageObject.getSignoutLinkText()).eql('Back to sign in');
   });
 
-// eslint-disable-next-line testcafe-extended/no-only-statements, no-only-tests/no-only-tests
-test.only
+test
   .requestHooks(pushAutoChallengeMock)('challenge ov push screen has right labels and a checkbox', async t => {
     const challengeOktaVerifyPushPageObject = await setup(t);
     await checkA11y(t);

--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -45,8 +45,6 @@ const pushWaitMock = RequestMock()
 
 const pushAutoChallengeMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(pushPollAutoChallenge)
-  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
   .respond(pushPollAutoChallenge);
 
 const pushWaitAutoChallengeMock = RequestMock()
@@ -96,8 +94,8 @@ test
     await t.expect(challengeOktaVerifyPushPageObject.getSignoutLinkText()).eql('Back to sign in');
   });
 
-// Re-enable in OKTA-594821
-test.meta('gen3', false)
+// eslint-disable-next-line testcafe-extended/no-only-statements, no-only-tests/no-only-tests
+test.only
   .requestHooks(pushAutoChallengeMock)('challenge ov push screen has right labels and a checkbox', async t => {
     const challengeOktaVerifyPushPageObject = await setup(t);
     await checkA11y(t);

--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -45,10 +45,6 @@ const pushWaitMock = RequestMock()
 
 const pushAutoChallengeMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(pushPollAutoChallenge);
-
-const pushWaitAutoChallengeMock = RequestMock()
-  .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(pushPollAutoChallenge)
   .onRequestTo('http://localhost:3000/idp/idx/authenticators/poll')
   .respond(pushPollAutoChallenge);
@@ -133,7 +129,7 @@ test
 
 // V3 - Polling fails with AssertionError: expected 8 to deeply equal 1
 test
-  .requestHooks(logger, pushWaitAutoChallengeMock)('should call polling API and checkbox should be clickable after polling started', async t => {
+  .requestHooks(logger, pushAutoChallengeMock)('should call polling API and checkbox should be clickable after polling started', async t => {
     const challengeOktaVerifyPushPageObject = await setup(t);
     await checkA11y(t);
     const checkbox = challengeOktaVerifyPushPageObject.getAutoChallengeCheckbox();

--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -127,7 +127,6 @@ test
     await t.expect(challengeOktaVerifyPushPageObject.getSignoutLinkText()).eql('Back to sign in');
   });
 
-// V3 - Polling fails with AssertionError: expected 8 to deeply equal 1
 test
   .requestHooks(logger, pushAutoChallengeMock)('should call polling API and checkbox should be clickable after polling started', async t => {
     const challengeOktaVerifyPushPageObject = await setup(t);


### PR DESCRIPTION
## Description:
- Test was failing because `pushAutoChallengeMock` was attempting to hit `idp/idx/authenticators/poll` but the mock sequence had been configured to use `idp/idx/challenge/poll`
- Adding `idp/idx/authenticators/poll` to the `pushAutoChallengeMock` made it identical to `pushWaitAutoChallengeMock`, so these were combined into a single mock sequence


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-594821](https://oktainc.atlassian.net/browse/OKTA-594821)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-594821-reenable-challenge-ov-push-spec&page=1&pageSize=6&sha=7bf865156dba21e5fdec8afc5007d4554cfa0261&tab=main)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



