### PR TITLE
Reenable Device Fingerprinting Tests in Identify_spec

### DIFF
--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -203,7 +203,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       const baseUrl = getBaseUrl(widgetProps);
       if (baseUrl) {
         // Proceeds with form submission even if device fingerprinting fails
-        const fingerprint = await generateDeviceFingerprint(baseUrl);
+        const fingerprint = await generateDeviceFingerprint(baseUrl).catch(() => undefined);
         if (fingerprint) {
           authClient.http.setRequestHeader('X-Device-Fingerprint', fingerprint);
         }

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -202,7 +202,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     if (step === IDX_STEP.IDENTIFY && features?.deviceFingerprinting) {
       const baseUrl = getBaseUrl(widgetProps);
       if (baseUrl) {
-        // function should catch any errors and return undefined to avoid crashing here
+        // Proceeds with form submission even if device fingerprinting fails
         const fingerprint = await generateDeviceFingerprint(baseUrl);
         if (fingerprint) {
           authClient.http.setRequestHeader('X-Device-Fingerprint', fingerprint);

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -20,6 +20,7 @@ import {
 } from '@okta/okta-auth-js';
 import { cloneDeep, merge, omit } from 'lodash';
 import { useCallback } from 'preact/hooks';
+import { generateDeviceFingerprint } from 'src/util/deviceFingerprintingUtils';
 
 import { IDX_STEP, ON_PREM_TOKEN_CHANGE_ERROR_KEY } from '../constants';
 import { useWidgetContext } from '../contexts';
@@ -41,7 +42,6 @@ import {
   triggerRegistrationErrorMessages,
 } from '../util';
 import { getEventContext } from '../util/getEventContext';
-import DeviceFingerprintingUtils from 'src/util/deviceFingerprintingUtils';
 
 type OnSubmitHandlerOptions = {
   includeData?: boolean;
@@ -194,7 +194,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       }
     }
     // Login flows that mimic step up (moving forward in login pipeline) via internal api calls,
-    // need to clear stored stateHandles. 
+    // need to clear stored stateHandles.
     // This way the flow can maintain the latest state handle. For eg. Device probe calls
     if (step === IDX_STEP.CANCEL_TRANSACTION) {
       SessionStorage.removeStateHandle();
@@ -203,7 +203,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       const baseUrl = getBaseUrl(widgetProps);
       if (baseUrl) {
         // function should catch any errors and return undefined to avoid crashing here
-        const fingerprint = await DeviceFingerprintingUtils.generateDeviceFingerprint(baseUrl);
+        const fingerprint = await generateDeviceFingerprint(baseUrl);
         if (fingerprint) {
           authClient.http.setRequestHeader('X-Device-Fingerprint', fingerprint);
         }

--- a/src/v3/src/util/browserUtils.ts
+++ b/src/v3/src/util/browserUtils.ts
@@ -24,3 +24,7 @@ export const isIOS = (): boolean => (
 );
 
 export const isAndroidOrIOS = (): boolean => isAndroid() || isIOS();
+
+export const getUserAgent = (): string => navigator.userAgent;
+
+export const isWindowsPhone = (userAgent: string): RegExpMatchArray | null => userAgent.match(/windows phone|iemobile|wpdesktop/i);

--- a/src/v3/src/util/deviceFingerprintingUtils.test.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.test.ts
@@ -130,4 +130,15 @@ describe('DeviceFingerprintingUtils', () => {
     const iframe = document.getElementById('device-fingerprint-container');
     expect(iframe).toBeNull();
   });
+
+  it('fails if it there is no form to attach the iframe to', async () => {
+    const form = document.querySelector('form[data-se="o-form"]');
+    expect(form).not.toBeNull();
+    document.body.removeChild(form!);
+    await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
+      .rejects
+      .toThrow('Form does not exist');
+    const iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).toBeNull();
+  });
 });

--- a/src/v3/src/util/deviceFingerprintingUtils.test.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.test.ts
@@ -1,0 +1,125 @@
+import DeviceFingerprintingUtils from './deviceFingerprintingUtils';
+
+describe('DeviceFingerprintingUtils', () => {
+  const oktaDomainUrl = '';
+
+  beforeAll(() => {
+    const mockForm = document.createElement('form');
+    mockForm.setAttribute('data-se', 'o-form');
+    document.body.append(mockForm);
+  })
+
+  function mockIFrameMessages(success: boolean, errorMessage?: { type: string }) {
+    const message = success
+      ? { type: 'FingerprintAvailable', fingerprint: 'thisIsTheFingerprint' }
+      : errorMessage;
+
+    // TODO (jest): event is missing `origin` property
+    window.postMessage(JSON.stringify(message), '*');
+  }
+
+  function mockUserAgent(userAgent: string) {
+    jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(userAgent);
+  }
+
+  function bypassMessageSourceCheck() {
+    jest.spyOn(DeviceFingerprintingUtils, 'isMessageFromCorrectSource').mockReturnValue(true);
+  }
+
+  it('creates hidden iframe during fingerprint generation', async () => {
+    mockIFrameMessages(true);
+    bypassMessageSourceCheck();
+    const fingerprintPromise = DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl);
+    let iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).not.toBeNull();
+    expect(iframe).not.toBeVisible();
+    expect(iframe?.getAttribute('src')).toBe('/auth/services/devicefingerprint');
+    await fingerprintPromise;
+    iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).toBeNull();
+  });
+
+  it('returns a fingerprint if the communication with the iframe is successful', async () => {
+    mockIFrameMessages(true);
+    bypassMessageSourceCheck();
+    const fingerprint = await DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl);
+    expect(fingerprint).toBe('thisIsTheFingerprint');
+  });
+
+  it('fails if the iframe does not load', async () => {
+    try {
+      await DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl);
+      fail('Fingerprint promise should have been rejected');
+    } catch (reason) {
+      expect(reason).toBe('Service not available');
+      const iframe = document.getElementById('device-fingerprint-container');
+      expect(iframe).toBeNull();
+    }
+  });
+
+  it('clears iframe timeout once the iframe loads', async () => {
+    mockIFrameMessages(true);
+    bypassMessageSourceCheck();
+
+    const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+
+    return DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl)
+      .then(fingerprint => {
+        expect(fingerprint).toBe('thisIsTheFingerprint');
+        expect(clearTimeoutSpy).toHaveBeenCalled();
+      });
+  });
+
+  it('fails if there is a problem with communicating with the iframe', async () => {
+    mockIFrameMessages(false);
+    bypassMessageSourceCheck();
+    try {
+      await DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl);
+      fail('Fingerprint promise should have been rejected');
+    } catch (reason) {
+      expect(reason).toBe('No data');
+      const iframe = document.getElementById('device-fingerprint-container');
+      expect(iframe).toBeNull();
+    }
+  });
+
+  it('fails if there iframe sends and invalid message content', async () => {
+    mockIFrameMessages(false, { type: 'InvalidMessageType' });
+    bypassMessageSourceCheck();
+
+    try {
+      await DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl);
+      fail('Fingerprint promise should have been rejected');
+    } catch (reason) {
+      expect(reason).toBe('No data');
+      const iframe = document.getElementById('device-fingerprint-container');
+      expect(iframe).toBeNull();
+    }
+  });
+
+  it('fails if user agent is not defined', async () => {
+    mockUserAgent('');
+    mockIFrameMessages(true);
+    try {
+      await DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl);
+      fail('Fingerprint promise should have been rejected');
+    } catch (reason) {
+      expect(reason).toBe('User agent is not defined');
+      const iframe = document.getElementById('device-fingerprint-container');
+      expect(iframe).toBeNull();
+    }
+  });
+
+  it('fails if it is called from a Windows phone', async () => {
+    mockUserAgent('Windows Phone');
+    mockIFrameMessages(true);
+    try {
+      await DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl);
+      fail('Fingerprint promise should have been rejected');
+    } catch (reason) {
+      expect(reason).toBe('Device fingerprint is not supported on Windows phones');
+      const iframe = document.getElementById('device-fingerprint-container');
+      expect(iframe).toBeNull();
+    }
+  });
+});

--- a/src/v3/src/util/deviceFingerprintingUtils.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+const getUserAgent = () => {
+  return navigator.userAgent;
+}
+
+const isWindowsPhone = (userAgent: string) => {
+  return userAgent.match(/windows phone|iemobile|wpdesktop/i);
+}
+
+export default {
+  isMessageFromCorrectSource: (iframe: HTMLIFrameElement, event: MessageEvent) => {
+    return event.source === iframe.contentWindow;
+  },
+
+  // NOTE: This utility is similar to the DeviceFingerprinting.js file used for V2 authentication flows.
+  generateDeviceFingerprint(oktaDomainUrl: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const userAgent = getUserAgent();
+      if (!userAgent) {
+        return reject('User agent is not defined');
+      } else if (isWindowsPhone(userAgent)) {
+        return reject('Device fingerprint is not supported on Windows phones');
+      }
+
+      let iframe: HTMLIFrameElement;
+      let iframeTimeout: NodeJS.Timeout;
+      const self = this;
+
+      const removeIframe = () => {
+        iframe.remove();
+        window.removeEventListener('message', onMessageReceivedFromOkta, false);
+      }
+
+      const handleError = (reason: string) => {
+        removeIframe();
+        reject(reason);
+      }
+      
+      const onMessageReceivedFromOkta = (event: MessageEvent) => {
+        if (!self.isMessageFromCorrectSource(iframe, event)) {
+          return;
+        }
+        // deviceFingerprint service is available, clear timeout
+        clearTimeout(iframeTimeout);
+        if (!event || !event.data || event.origin !== oktaDomainUrl) {
+          handleError('No data');
+          return;
+        }
+        try {
+          const message = JSON.parse(event.data);
+
+          if (message && message.type === 'FingerprintServiceReady') {
+            sendMessageToOkta({
+              type: 'GetFingerprint',
+            });
+          } else if (message && message.type === 'FingerprintAvailable') {
+            removeIframe();
+            resolve(message.fingerprint);
+          } else {
+            handleError('No data');
+          }
+        } catch (error) {
+          //Ignore any errors since we could get other messages too
+        }
+      }
+
+      const sendMessageToOkta = (message: { type: string }) => {
+        const win = iframe.contentWindow;
+
+        if (win) {
+          win.postMessage(JSON.stringify(message), oktaDomainUrl);
+        }
+      }
+
+      // Attach listener
+      window.addEventListener('message', onMessageReceivedFromOkta, false);
+      iframe = document.createElement('iframe');
+      iframe.id = 'device-fingerprint-container'
+      iframe.style.display = 'none';
+      // Create and load devicefingerprint page inside the iframe
+      iframe.src = oktaDomainUrl + '/auth/services/devicefingerprint';
+
+      const formElement = document.querySelector('form[data-se="o-form"]');
+      if (formElement === null) {
+        handleError('Form does not exist');
+      }
+      formElement!.appendChild(iframe);
+
+      iframeTimeout = setTimeout(() => {
+        // If the iframe does not load or there is a slow connection, throw an error
+        handleError('Service not available');
+      }, 2000);
+    });
+  }
+}; 

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -344,8 +344,7 @@ test.requestHooks(identifyMock)('should not render custom forgot password link',
   await t.expect(await identityPage.hasForgotPasswordLinkText()).notOk();
 });
 
-// Re-enable in OKTA-654456
-test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMockWithFingerprint)('should compute device fingerprint and add to header', async t => {
+test.requestHooks(identifyRequestLogger, identifyMockWithFingerprint)('should compute device fingerprint and add to header', async t => {
   const identityPage = await setup(t, {
     features: {
       deviceFingerprinting: true,
@@ -373,8 +372,7 @@ test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMockWithFin
   await t.expect(factorReqHeaders['x-device-fingerprint']).eql('mock-device-fingerprint');
 });
 
-// Re-enable in OKTA-654456
-test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMockWithFingerprintError)('should continue to compute device fingerprint and add to header when there are API errors', async t => {
+test.requestHooks(identifyRequestLogger, identifyMockWithFingerprintError)('should continue to compute device fingerprint and add to header when there are API errors', async t => {
   const identityPage = await setup(t, {
     features: {
       deviceFingerprinting: true,
@@ -393,7 +391,10 @@ test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMockWithFin
 
   // Validate that there is an error message
   await identityPage.waitForErrorBox();
-  await t.expect(identityPage.getNextButton().exists).eql(true);
+  // Gen 3 does not merge transactions together to show error while staying on identify page
+  if (!userVariables.gen3) {
+    await t.expect(identityPage.getNextButton().exists).eql(true);
+  }
   await t.expect(identityPage.getGlobalErrors()).contains('You do not have permission to perform the requested action');
 });
 


### PR DESCRIPTION
## Description:
- Reenables device fingerprinting tests within `Identify_spec`
- Adds `deviceFingerprintingUtils` temporarily to gen3 utils folder until `auth-js` implements device fingerprinting
- Refer to [gen2 version of utility](https://github.com/okta/okta-signin-widget/blob/master/src/v2/view-builder/utils/DeviceFingerprinting.js) for comparison with `deviceFingerprintingUtils`. Core logic stayed the same, changes were mainly modernization of syntax and removing jQuery code.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-654456](https://oktainc.atlassian.net/browse/OKTA-654456)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



