### PR TITLE
Support AD Password Complexity

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -668,6 +668,7 @@ password.complexity.symbol = a symbol
 password.complexity.no_username = no parts of your username
 password.complexity.no_first_name = does not include your first name
 password.complexity.no_last_name = does not include your last name
+password.complexity.adRequirements = at least 3 of the following: lowercase letter, uppercase letter, number, symbol
 
 # Requirements as HTML list.
 # These are copy of existing strings, but we need them since in a list, the starting letter has to be in CAPS and no period at the end.
@@ -682,6 +683,7 @@ password.complexity.no_username.description = No parts of your username
 password.complexity.no_first_name.description = Does not include your first name
 password.complexity.no_last_name.description = Does not include your last name
 password.complexity.history.one.description = Password can't be the same as your last password
+password.complexity.adRequirements.description = At least 3 of the following: lowercase letter, uppercase letter, number, symbol
 # {0} is a number
 password.complexity.history.description = Password can't be the same as your last {0} passwords
 # {0} is a number

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    // 'identify',
+    'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -33,7 +33,7 @@ const idx = {
     // 'error-identify-with-only-one-third-party-idp',
     // 'authenticator-enroll-email',
     // 'error-internal-server-error',
-    'authenticator-enroll-password-with-ad-req',
+    // 'authenticator-enroll-password',
     // 'authenticator-enroll-phone',
     // 'authenticator-enroll-phone-voice',
     // 'authenticator-enroll-data-phone',

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    'identify',
+    // 'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -33,7 +33,7 @@ const idx = {
     // 'error-identify-with-only-one-third-party-idp',
     // 'authenticator-enroll-email',
     // 'error-internal-server-error',
-    // 'authenticator-enroll-password',
+    'authenticator-enroll-password-with-ad-req',
     // 'authenticator-enroll-phone',
     // 'authenticator-enroll-phone-voice',
     // 'authenticator-enroll-data-phone',

--- a/playground/mocks/data/idp/idx/authenticator-enroll-password-with-ad-req.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-password-with-ad-req.json
@@ -1,0 +1,253 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "expiresAt": "2018-09-17T23:08:56.000Z",
+  "intent": "login",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-authenticator",
+        "href": "http://localhost:3000/idp/idx/challenge/answer",
+        "method": "POST",
+        "value": [
+          {
+            "name": "credentials",
+            "required": true,
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter password",
+                  "secret": true
+                }
+              ]
+            }
+          },
+          {
+            "name": "stateHandle",
+            "value": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+            "visible": false
+          }
+        ],
+        "relatesTo": ["$.currentAuthenticator"]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "required": true,
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "autwa6eD9o02iBbtv0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              },
+              {
+                "label": "Okta Phone",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1SLH",
+                        "mutable": false,
+                        "required": true
+                    },
+                    {
+                        "name": "methodType",
+                        "required": false,
+                        "options": [
+                            { "label": "SMS", "value": "sms" },
+                            { "label": "VOICE", "value": "voice" }
+                        ]
+                    },
+                    {
+                        "name": "phoneNumber",
+                        "required": false,
+                        "type": "string"
+                    }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[2]"
+              },
+              {
+                "label": "Security Key or Biometric Authenticator (FIDO2)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[1]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1GGG",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[3]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02CqFbzJ_zMGCqXut-1CNXfafiTkh9wGlbFqi9Xupt",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value":{
+      "type":"password",
+      "key": "okta_password",
+      "id":"aut1kaiLIbyUwwGBS0g4",
+      "displayName":"Okta Password",
+      "methods":[
+        {
+          "type":"password"
+        }
+      ],
+      "settings":{
+        "complexity":{
+          "minLength":8,
+          "minLowerCase":1,
+          "minUpperCase":1,
+          "minNumber":1,
+          "minSymbol":1,
+          "excludeUsername":true,
+          "excludeAttributes": [
+            "firstName",
+            "lastName"
+          ],
+          "useADComplexityRequirements": true
+        },
+        "age":{
+          "minAgeMinutes":120,
+          "historyCount":4
+        }
+      }
+   }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "I9bvFiq01cRFgbn",
+      "identifier": "testUser@okta.com",
+      "passwordChanged": "2019-05-03T19:00:00.000Z",
+      "profile": {
+        "login": "foo@example.com",
+        "firstName": "Foo",
+        "lastName": "Bar",
+        "locale": "en-us",
+        "timeZone": "UTC"
+      }
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "key": "okta_password",
+        "authenticatorId": "autwa6eD9o02iBbtv0g3",
+        "id": "password-enroll-id-123"
+      },
+      {
+        "displayName": "Security Key or Biometric Authenticator (FIDO2)",
+        "type": "security_key",
+        "key": "webauthn",
+        "authenticatorid": "aidtheidkwh282hv8g3",
+        "id": "webauthn-enroll-id-123"
+      },
+      {
+        "displayName": "Okta Phone",
+        "type": "phone",
+        "key": "phone_number",
+        "authenticatorId": "aid568g3mXgtID0X1SLH",
+        "id": "phone-enroll-id-123"
+      },
+      {
+        "displayName": "Okta Security Question",
+        "type": "security_question",
+        "key": "security_question",
+        "authenticatorId": "aid568g3mXgtID0X1GGG",
+        "id": "security-question-enroll-id-123"
+      }
+    ]
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "value": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+        "visible": false
+      }
+    ]
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-expired-password-with-ad-req.json
+++ b/playground/mocks/data/idp/idx/authenticator-expired-password-with-ad-req.json
@@ -59,12 +59,9 @@
 					"minLowerCase": 1,
 					"minUpperCase": 1,
 					"minNumber": 1,
-					"minSymbol": 1,
+					"minSymbol": 0,
 					"excludeUsername": true,
-          "excludeAttributes": [
-            "firstName",
-            "lastName"
-          ],
+          "excludeAttributes": ["firstName", "lastName"],
           "useADComplexityRequirements": true
 				},
 				"age": {
@@ -116,10 +113,10 @@
           "minLowerCase":1,
           "minUpperCase":1,
           "minNumber":1,
-          "minSymbol":0,
+          "minSymbol":1,
           "excludeUsername":true,
-          "excludeFirstName":true,
-          "excludeLastName":true
+          "excludeAttributes": ["firstName", "lastName"],
+          "useADComplexityRequirements": true
         },
         "age":{
           "minAgeMinutes":10,

--- a/playground/mocks/data/idp/idx/authenticator-expired-password-with-ad-req.json
+++ b/playground/mocks/data/idp/idx/authenticator-expired-password-with-ad-req.json
@@ -1,0 +1,154 @@
+{
+  "stateHandle":"01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "version":"1.0.0",
+  "expiresAt":"2018-09-17T23:08:56.000Z",
+  "intent":"login",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"reenroll-authenticator",
+        "relatesTo":[
+          "$.currentAuthenticator"
+        ],
+        "href":"http://localhost:3000/idp/idx/challenge/answer",
+        "method":"POST",
+        "accepts":"application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "value":[
+          {
+            "name":"credentials",
+            "type":"object",
+            "form":{
+              "value":[
+                {
+                  "name":"passcode",
+                  "label":"New password",
+                  "secret":true
+                }
+              ]
+            },
+            "required":true
+          },
+          {
+            "name":"stateHandle",
+            "value":"01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+            "visible":false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator":{
+    "type":"object",
+    "value":{
+      "type":"password",
+      "key": "okta_password",
+      "id":"autwa6eD9o02iBbtv0g3",
+      "displayName":"Okta Password",
+      "methods":[
+        {
+          "type":"password"
+        }
+      ],
+      "settings": {
+				"complexity": {
+					"minLength": 8,
+					"minLowerCase": 1,
+					"minUpperCase": 1,
+					"minNumber": 1,
+					"minSymbol": 1,
+					"excludeUsername": true,
+          "excludeAttributes": [
+            "firstName",
+            "lastName"
+          ],
+          "useADComplexityRequirements": true
+				},
+				"age": {
+					"minAgeMinutes": 0,
+					"historyCount": 0
+				}
+			}
+    }
+  },
+  "authenticators":{
+    "type":"array",
+    "value":[
+
+    ]
+  },
+  "authenticatorEnrollments":{
+    "type":"array",
+    "value":[
+      {
+        "type":"password",
+        "key": "okta_password",
+        "id":"autwa6eD9o02iBbtv0g3",
+        "displayName":"Okta Password",
+        "methods":[
+          {
+            "type":"password"
+          }
+        ]
+      }
+    ]
+  },
+  "user":{
+    "type":"object",
+    "value":{
+      "id":"00u1d4o00DWrRfc5u0g4",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "recoveryAuthenticator":{
+    "type":"object",
+    "value":{
+      "displayName":"Okta Password",
+      "type":"password",
+      "key": "okta_password",
+      "id":"autwa6eD9o02iBbtv0g3",
+      "settings":{
+        "complexity":{
+          "minLength":8,
+          "minLowerCase":1,
+          "minUpperCase":1,
+          "minNumber":1,
+          "minSymbol":0,
+          "excludeUsername":true,
+          "excludeFirstName":true,
+          "excludeLastName":true
+        },
+        "age":{
+          "minAgeMinutes":10,
+          "historyCount":4
+        }
+      }
+    }
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "value":[
+      {
+        "name":"stateHandle",
+        "value":"01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+        "visible":false
+      }
+    ]
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"oidc_client",
+      "label":"Native client",
+      "id":"0oa1bowRUq4I8pIfd0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-expiry-warning-password-with-ad-req.json
+++ b/playground/mocks/data/idp/idx/authenticator-expiry-warning-password-with-ad-req.json
@@ -1,0 +1,168 @@
+{
+  "stateHandle":"022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+  "version":"1.0.0",
+  "expiresAt":"2020-06-30T20:53:44.000Z",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"reenroll-authenticator-warning",
+        "relatesTo":[
+          "$.currentAuthenticator"
+        ],
+        "href":"http://localhost:3000/idp/idx/challenge/answer",
+        "method":"POST",
+        "value":[
+          {
+            "name":"credentials",
+            "type":"object",
+            "form":{
+              "value":[
+                {
+                  "name":"passcode",
+                  "label":"New password",
+                  "secret":true
+                }
+              ]
+            },
+            "required":true
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/ion+json; okta-version=1.0.0"
+      },
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"skip",
+        "href":"http://localhost:3000/idp/idx/skip",
+        "method":"POST",
+        "accepts":"application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator":{
+    "type":"object",
+    "value":{
+      "type":"password",
+      "key": "okta_password",
+      "id":"aut6ci0ZJwJCQ5v6f0g4",
+      "displayName":"Okta Password",
+      "methods":[
+        {
+          "type":"password"
+        }
+      ],
+      "settings":{
+        "complexity":{
+          "minLength":8,
+          "minLowerCase":1,
+          "minUpperCase":1,
+          "minNumber":1,
+          "minSymbol":1,
+          "excludeUsername":true,
+          "excludeAttributes": [
+            "firstName",
+            "lastName"
+          ],
+          "useADComplexityRequirements": true
+        },
+        "age":{
+          "minAgeMinutes":0,
+          "historyCount":4
+        },
+        "daysToExpiry":4
+      }
+    }
+  },
+  "authenticators":{
+    "type":"array",
+    "value":[
+
+    ]
+  },
+  "authenticatorEnrollments":{
+    "type":"array",
+    "value":[
+      {
+        "type":"password",
+        "key": "okta_password",
+        "id":"laeh5oe8s68GfRKkf0g3",
+        "displayName":"Okta Password",
+        "methods":[
+          {
+            "type":"password"
+          }
+        ]
+      }
+    ]
+  },
+  "user":{
+    "type":"object",
+    "value":{
+      "id": "00u6ci9LYMwaOkjBL0g4",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "value":[
+      {
+        "name":"stateHandle",
+        "required":true,
+        "value":"022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+        "visible":false,
+        "mutable":false
+      }
+    ],
+    "accepts":"application/ion+json; okta-version=1.0.0"
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"oidc_client",
+      "label":"myApp",
+      "id":"0oa6ch0s7dCszUFz00g4"
+    }
+  },
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "When your password expires, you will have to change your password before you can login to your Localhost account.",
+        "i18n": {
+          "key": "idx.password.expiring.message",
+          "params": [
+            "Localhost"
+          ]
+        },
+        "class": "INFO"
+      }
+    ]
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-reset-password-with-ad-req.json
+++ b/playground/mocks/data/idp/idx/authenticator-reset-password-with-ad-req.json
@@ -66,8 +66,7 @@
           "minNumber":1,
           "minSymbol":1,
           "excludeUsername":true,
-          "excludeFirstName":true,
-          "excludeLastName":true,
+          "excludeAttributes": ["firstName", "lastName"],
           "useADComplexityRequirements": true
         },
         "age":{

--- a/playground/mocks/data/idp/idx/authenticator-reset-password-with-ad-req.json
+++ b/playground/mocks/data/idp/idx/authenticator-reset-password-with-ad-req.json
@@ -1,0 +1,139 @@
+{
+  "stateHandle":"01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "version":"1.0.0",
+  "expiresAt":"DATE",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"reset-authenticator",
+        "href":"http://localhost:3000/idp/idx/challenge/answer",
+        "relatesTo":[
+          "$.currentAuthenticator"
+        ],
+        "method":"POST",
+        "accepts":"application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "value":[
+          {
+            "name":"credentials",
+            "type":"object",
+            "required":true,
+            "form":{
+              "value":[
+                {
+                  "name":"passcode",
+                  "label":"New password",
+                  "secret":true
+                },
+                {
+                  "name": "revokeSessions",
+                  "type": "boolean",
+                  "label": "Sign me out of all other devices"
+                }
+              ]
+            }
+          },
+          {
+            "name": "stateHandle",
+            "value": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+            "visible": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator":{
+    "type":"object",
+    "value":{
+      "type":"password",
+      "key": "okta_password",
+      "id":"autwa6eD9o02iBbtv0g3",
+      "displayName":"Okta Password",
+      "methods":[
+        {
+          "type":"password"
+        }
+      ],
+      "settings":{
+        "complexity":{
+          "minLength":8,
+          "minLowerCase":1,
+          "minUpperCase":1,
+          "minNumber":1,
+          "minSymbol":1,
+          "excludeUsername":true,
+          "excludeFirstName":true,
+          "excludeLastName":true,
+          "useADComplexityRequirements": true
+        },
+        "age":{
+          "minAgeMinutes":10,
+          "historyCount":4
+        }
+      }
+    }
+  },
+  "enrollmentAuthenticator":{
+    "__embeddedContract":"idx/partials/authenticator_simple_enroll.json"
+  },
+  "authenticators":{
+    "type":"array",
+    "value":[
+      {
+        "type":"password",
+        "key": "okta_password",
+        "id":"laeh5oe8s68GfRKkf0g3",
+        "displayName":"Okta Password",
+        "methods":[
+          {
+            "type":"password"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments":{
+    "type":"array",
+    "value":[
+      "​"
+    ]
+  },
+  "user":{
+    "type":"object",
+    "value":{
+      "id":"00u1d4o00DWrRfc5u0g4",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"oidc_client",
+      "label":"Native client",
+      "id":"0oa1bowRUq4I8pIfd0g4"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  }
+}

--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -178,9 +178,19 @@ const getPasswordComplexityRequirementsAsArray = function(policy, i18nKeys) {
 
   if (policy.complexity) {
     const complexityFields = i18nKeys.complexity;
-    const policyComplexity = setExcludeAttributes(policy.complexity);
 
-    const requirements = _.map(policyComplexity, function(complexityValue, complexityType) {
+    const policyComplexity = setExcludeAttributes(policy.complexity);
+    let filteredPolicyComplexity = policyComplexity;
+
+    // If useADComplexityRequirements is true, ignore casing, number, and symbol rules since
+    // AD validator handles those requirements
+    if (policyComplexity.useADComplexityRequirements) {
+      const allowed = ['minLength', 'useADComplexityRequirements', 'excludeUsername', 'excludeFirstName',
+        'excludeLastName', 'excludeAttributes'];
+      filteredPolicyComplexity = _.pick(policyComplexity, allowed);
+    }
+
+    const requirements = _.map(filteredPolicyComplexity, function(complexityValue, complexityType) {
       if (complexityValue <= 0) {
         // to skip 0 and -1
         return;
@@ -397,6 +407,7 @@ fn.getPasswordComplexityDescriptionForHtmlList = function(policy) {
       excludeUsername: { i18n: 'password.complexity.no_username.description' },
       excludeFirstName: { i18n: 'password.complexity.no_first_name.description' },
       excludeLastName: { i18n: 'password.complexity.no_last_name.description' },
+      useADComplexityRequirements: { i18n: 'password.complexity.adRequirements.description' },
     },
     history: {
       one: { i18n: 'password.complexity.history.one.description' },
@@ -424,6 +435,7 @@ fn.getPasswordComplexityDescription = function(policy) {
       excludeUsername: { i18n: 'password.complexity.no_username' },
       excludeFirstName: { i18n: 'password.complexity.no_first_name' },
       excludeLastName: { i18n: 'password.complexity.no_last_name' },
+      useADComplexityRequirements: { i18n: 'password.complexity.adRequirements' },
     },
     history: { i18n: 'password.complexity.history' },
     age: {

--- a/src/v3/src/constants/passwordConstants.ts
+++ b/src/v3/src/constants/passwordConstants.ts
@@ -20,6 +20,7 @@ export const PASSWORD_REQUIREMENTS_KEYS: Record<'complexity' | 'age', { [key: st
     excludeUsername: 'password.complexity.no_username.description',
     excludeFirstName: 'password.complexity.no_first_name.description',
     excludeLastName: 'password.complexity.no_last_name.description',
+    useADComplexityRequirements: 'password.complexity.adRequirements.description',
   },
   age: {
     minAgeMinutes: 'password.complexity.minAgeMinutes.description',

--- a/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
@@ -92,7 +92,7 @@ describe('getComplexityItems', () => {
       excludeUsername: true,
       excludeFirstName: true,
       excludeLastName: true,
-      useADComplexityRequirements: true
+      useADComplexityRequirements: true,
     } as unknown as ComplexityRequirements;
 
     const result = getComplexityItems(complexity);

--- a/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
@@ -93,7 +93,7 @@ describe('getComplexityItems', () => {
       excludeFirstName: true,
       excludeLastName: true,
       useADComplexityRequirements: true,
-    } as unknown as ComplexityRequirements;
+    };
 
     const result = getComplexityItems(complexity);
     expect(result).toEqual([

--- a/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
@@ -81,4 +81,27 @@ describe('getComplexityItems', () => {
       { ruleKey: 'minSymbol', label: PASSWORD_REQUIREMENTS_KEYS.complexity.minSymbol },
     ]);
   });
+
+  it('should return filtered items when useADComplexityRequirements is true', () => {
+    const complexity = {
+      minLength: 8,
+      minLowerCase: 1,
+      minUpperCase: 1,
+      minNumber: 1,
+      minSymbol: 1,
+      excludeUsername: true,
+      excludeFirstName: true,
+      excludeLastName: true,
+      useADComplexityRequirements: true
+    } as unknown as ComplexityRequirements;
+
+    const result = getComplexityItems(complexity);
+    expect(result).toEqual([
+      { ruleKey: 'minLength', label: PASSWORD_REQUIREMENTS_KEYS.complexity.minLength },
+      { ruleKey: 'useADComplexityRequirements', label: PASSWORD_REQUIREMENTS_KEYS.complexity.useADComplexityRequirements },
+      { ruleKey: 'excludeUsername', label: PASSWORD_REQUIREMENTS_KEYS.complexity.excludeUsername },
+      { ruleKey: 'excludeFirstName', label: PASSWORD_REQUIREMENTS_KEYS.complexity.excludeFirstName },
+      { ruleKey: 'excludeLastName', label: PASSWORD_REQUIREMENTS_KEYS.complexity.excludeLastName },
+    ]);
+  });
 });

--- a/src/v3/src/transformer/password/passwordSettingsUtils.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.ts
@@ -43,9 +43,14 @@ export const getComplexityItems = (complexity?: ComplexityRequirements): ListIte
 
   // If useADComplexityRequirements is true, ignore casing, number, and symbol rules since AD validator handles those requirements
   if (complexity.useADComplexityRequirements) {
-    const allowed = ['minLength', 'useADComplexityRequirements', 'excludeUsername', 'excludeFirstName',
-      'excludeLastName', 'excludeAttributes'];
-    filteredComplexity = Object.fromEntries(allowed.map((key) => [key, complexity[key]]));
+    filteredComplexity = {
+      minLength: complexity.minLength,
+      useADComplexityRequirements: complexity.useADComplexityRequirements,
+      excludeUsername: complexity.excludeUsername,
+      excludeFirstName: complexity.excludeFirstName,
+      excludeLastName: complexity.excludeLastName,
+      excludeAttributes: complexity.excludeAttributes,
+    };
   }
 
   Object.entries(filteredComplexity).forEach(([key, value]) => {

--- a/src/v3/src/transformer/password/passwordSettingsUtils.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.ts
@@ -45,7 +45,7 @@ export const getComplexityItems = (complexity?: ComplexityRequirements): ListIte
   if (complexity.useADComplexityRequirements) {
     const allowed = ['minLength', 'useADComplexityRequirements', 'excludeUsername', 'excludeFirstName',
       'excludeLastName', 'excludeAttributes'];
-    filteredComplexity = Object.fromEntries(allowed.map(key => [key, complexity[key]]));
+    filteredComplexity = Object.fromEntries(allowed.map((key) => [key, complexity[key]]));
   }
 
   Object.entries(filteredComplexity).forEach(([key, value]) => {

--- a/src/v3/src/transformer/password/passwordSettingsUtils.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.ts
@@ -39,7 +39,16 @@ export const getComplexityItems = (complexity?: ComplexityRequirements): ListIte
     return items;
   }
 
-  Object.entries(complexity).forEach(([key, value]) => {
+  let filteredComplexity: ComplexityRequirements = complexity;
+
+  // If useADComplexityRequirements is true, ignore casing, number, and symbol rules since AD validator handles those requirements
+  if (complexity.useADComplexityRequirements) {
+    const allowed = ['minLength', 'useADComplexityRequirements', 'excludeUsername', 'excludeFirstName',
+      'excludeLastName', 'excludeAttributes'];
+    filteredComplexity = Object.fromEntries(allowed.map(key => [key, complexity[key]]));
+  }
+
+  Object.entries(filteredComplexity).forEach(([key, value]) => {
     if (key === 'excludeAttributes' && Array.isArray(value) && value.length > 0) {
       value
         .filter((rule) => ['username', 'firstName', 'lastName'].includes(rule))

--- a/src/v3/src/types/password.ts
+++ b/src/v3/src/types/password.ts
@@ -50,6 +50,7 @@ export interface PasswordSettings {
     excludeFirstName?: boolean;
     excludeLastName?: boolean;
     excludeAttributes?: string[];
+    useADComplexityRequirements?: boolean;
   };
   age?: {
     historyCount?: number;

--- a/src/v3/src/util/passwordUtils.test.ts
+++ b/src/v3/src/util/passwordUtils.test.ts
@@ -305,7 +305,7 @@ describe('PasswordUtils Tests', () => {
         ?.useADComplexityRequirements)
         .toEqual(true);
     });
-    
+
     it('should ignore existing minLowerCase, minUpperCase, minNumber, and minSymbol requirements', () => {
       expect(validatePassword('aBCD1234', userInfo, { complexity: { useADComplexityRequirements: true, minLowerCase: 2 } })
         ?.useADComplexityRequirements)
@@ -333,12 +333,15 @@ describe('PasswordUtils Tests', () => {
       expect(validatePassword('User1234', userInfo, { complexity: { useADComplexityRequirements: true, excludeLastName: true } })
         ?.excludeLastName)
         .toEqual(false);
-      expect(validatePassword('Test_User_testUser', userInfo, { 
-        complexity: { 
+      expect(validatePassword('Test_User_testUser', userInfo, {
+        complexity: {
           useADComplexityRequirements: true,
-          excludeAttributes: ['username', 'firstName', 'lastName'] 
-        } 
-      })).toEqual({ firstName: false, lastName: false, username: false, useADComplexityRequirements: true });
+          excludeAttributes: ['username', 'firstName', 'lastName'],
+        },
+      }))
+        .toEqual({
+          firstName: false, lastName: false, username: false, useADComplexityRequirements: true,
+        });
     });
   });
 

--- a/src/v3/src/util/passwordUtils.test.ts
+++ b/src/v3/src/util/passwordUtils.test.ts
@@ -278,6 +278,70 @@ describe('PasswordUtils Tests', () => {
       .toEqual(true);
   });
 
+  describe('Validate useADComplexityRequirements', () => {
+    it('should validate password for at least 3 of the following: lowercase letter, uppercase letter, number, symbol', () => {
+      expect(validatePassword('abcd1234', userInfo, { complexity: { useADComplexityRequirements: true } })
+        ?.useADComplexityRequirements)
+        .toEqual(false);
+      expect(validatePassword('aaaaaaaa', userInfo, { complexity: { useADComplexityRequirements: true } })
+        ?.useADComplexityRequirements)
+        .toEqual(false);
+      expect(validatePassword(' ', userInfo, { complexity: { useADComplexityRequirements: true } })
+        ?.useADComplexityRequirements)
+        .toEqual(false);
+      expect(validatePassword('abcd1234$', userInfo, { complexity: { useADComplexityRequirements: true } })
+        ?.useADComplexityRequirements)
+        .toEqual(true);
+      expect(validatePassword('ABCD1234$', userInfo, { complexity: { useADComplexityRequirements: true } })
+        ?.useADComplexityRequirements)
+        .toEqual(true);
+      expect(validatePassword('abCD$$$$', userInfo, { complexity: { useADComplexityRequirements: true } })
+        ?.useADComplexityRequirements)
+        .toEqual(true);
+      expect(validatePassword('abCD1234', userInfo, { complexity: { useADComplexityRequirements: true } })
+        ?.useADComplexityRequirements)
+        .toEqual(true);
+      expect(validatePassword('abCD1234$', userInfo, { complexity: { useADComplexityRequirements: true } })
+        ?.useADComplexityRequirements)
+        .toEqual(true);
+    });
+    
+    it('should ignore existing minLowerCase, minUpperCase, minNumber, and minSymbol requirements', () => {
+      expect(validatePassword('aBCD1234', userInfo, { complexity: { useADComplexityRequirements: true, minLowerCase: 2 } })
+        ?.useADComplexityRequirements)
+        .toEqual(true);
+      expect(validatePassword('abcD1234', userInfo, { complexity: { useADComplexityRequirements: true, minUpperCase: 2 } })
+        ?.useADComplexityRequirements)
+        .toEqual(true);
+      expect(validatePassword('abcdefG1', userInfo, { complexity: { useADComplexityRequirements: true, minNumber: 2 } })
+        ?.useADComplexityRequirements)
+        .toEqual(true);
+      expect(validatePassword('abcd123$', userInfo, { complexity: { useADComplexityRequirements: true, minSymbol: 2 } })
+        ?.useADComplexityRequirements)
+        .toEqual(true);
+    });
+
+    it('should enforce excludeUsername, excludeFirstName, excludeLastName, and excludeAttributes requirements', () => {
+      userInfo = { identifier: 'testUser', profile: { firstName: 'Test', lastName: 'User' } };
+
+      expect(validatePassword('testUser1', userInfo, { complexity: { useADComplexityRequirements: true, excludeUsername: true } })
+        ?.excludeUsername)
+        .toEqual(false);
+      expect(validatePassword('Test1234', userInfo, { complexity: { useADComplexityRequirements: true, excludeFirstName: true } })
+        ?.excludeFirstName)
+        .toEqual(false);
+      expect(validatePassword('User1234', userInfo, { complexity: { useADComplexityRequirements: true, excludeLastName: true } })
+        ?.excludeLastName)
+        .toEqual(false);
+      expect(validatePassword('Test_User_testUser', userInfo, { 
+        complexity: { 
+          useADComplexityRequirements: true,
+          excludeAttributes: ['username', 'firstName', 'lastName'] 
+        } 
+      })).toEqual({ firstName: false, lastName: false, username: false, useADComplexityRequirements: true });
+    });
+  });
+
   describe('Validate combined password settings', () => {
     it('should validate password against minLength, minUpperCase & excludeLastName requirements', () => {
       userInfo = { profile: { lastName: 'Test' } };

--- a/src/v3/src/util/passwordUtils.ts
+++ b/src/v3/src/util/passwordUtils.ts
@@ -139,17 +139,19 @@ const excludeLastNameValidator = (
 
 const useADComplexityRequirementsValidator = (
   password: string,
-  ruleVal: unknown,
 ): boolean => {
-  // AD password policy requires that at least 3 of the following validators are satisfied
-  const requiredValidators: ((password: string, limit: unknown) => boolean)[] = 
-    [minLowerCaseValidator, minUpperCaseValidator, minNumberValidator, minSymbolValidator];
-  
-  let numRequirementsMet: number = 0;
-  requiredValidators.map(validator => {
-    if (validator(password, ruleVal)) { numRequirementsMet += 1; }
-  })
+  const requiredValidators: ((password: string, limit: unknown) => boolean)[] = [
+    minLowerCaseValidator,
+    minUpperCaseValidator,
+    minNumberValidator,
+    minSymbolValidator,
+  ];
 
+  // Runs the 4 validation functions and returns the number that passed
+  const numRequirementsMet = requiredValidators.reduce((num, validator) => (
+    validator(password, 1) ? num + 1 : num), 0);
+
+  // AD password policy requires that at least 3 of the following validators are satisfied
   return numRequirementsMet >= 3;
 };
 
@@ -162,7 +164,8 @@ const ValidatorFunctions = {
   [PasswordValidatorFunctionNames.ExcludeUsernameValidator]: excludeUsernameValidator,
   [PasswordValidatorFunctionNames.ExcludeFirstNameValidator]: excludeFirstNameValidator,
   [PasswordValidatorFunctionNames.ExcludeLastNameValidator]: excludeLastNameValidator,
-  [PasswordValidatorFunctionNames.UseADComplexityRequirementsValidator]: useADComplexityRequirementsValidator,
+  [PasswordValidatorFunctionNames.UseADComplexityRequirementsValidator]:
+    useADComplexityRequirementsValidator,
 };
 
 const excludeAttributes = (
@@ -206,7 +209,7 @@ export const validatePassword = (
         };
         return;
       }
-      
+
       const validationFn = ValidatorFunctions[`${rule}Validator`];
       if (!validationFn) {
         return;

--- a/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
@@ -104,8 +104,7 @@ async function setup(t) {
   });
 });
 
-// eslint-disable-next-line testcafe-extended/no-only-statements, no-only-tests/no-only-tests
-test.only.requestHooks(wthADReqMock)('should have the correct requirements when enforcing useADComplexityRequirements', async t => {
+test.requestHooks(wthADReqMock)('should have the correct requirements when enforcing useADComplexityRequirements', async t => {
   const expiredPasswordPage = await setup(t);
   await checkA11y(t);
   await t.expect(expiredPasswordPage.getRequirements()).contains('Password requirements:');

--- a/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
@@ -104,7 +104,8 @@ async function setup(t) {
   });
 });
 
-test.requestHooks(wthADReqMock)('should have the correct requirements when enforcing useADComplexityRequirements', async t => {
+// eslint-disable-next-line testcafe-extended/no-only-statements, no-only-tests/no-only-tests
+test.only.requestHooks(wthADReqMock)('should have the correct requirements when enforcing useADComplexityRequirements', async t => {
   const expiredPasswordPage = await setup(t);
   await checkA11y(t);
   await t.expect(expiredPasswordPage.getRequirements()).contains('Password requirements:');


### PR DESCRIPTION
## Description:
- SIW-side changes for supporting AD password complexity, which is a new password requirement that forces users to have 3 out of 4 of the following: lowercase letter, uppercase letter, number, symbol
- Enforces the AD complexity requirements in gen 3's client-side validation logic (gen 2's password validation is only server-side)
- Adds new mocks that contain the `useADComplexityRequirements` option for all e2e flows that display password requirements


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-637006](https://oktainc.atlassian.net/browse/OKTA-637006)
- [Corresponding backend/admin UI ticket](https://oktainc.atlassian.net/browse/OKTA-625930)
- [Corresponding backend/admin UI PR](https://github.com/atko-eng/okta-core/pull/83514)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-637006-ad-pw-complexity&page=1&pageSize=6&sha=155ceef0377ef71578e5341a079bccc2afd154b2&tab=main)

### Reviewers:

### Screenshot/Video:
#### Gen 2 AD Complexity Displayed as Password Requirement
https://github.com/okta/okta-signin-widget/assets/106110543/dbfbf8e2-b2eb-4d31-ad52-34a0ba214de1


#### Gen 3 AD Complexity Displayed as Password Requirement and Validated
https://github.com/okta/okta-signin-widget/assets/106110543/c0771bc0-5421-48eb-926c-7034121f8827


### Downstream Monolith Build:
- [Downstream Link](https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=656aaf133be21c3b73f3492301f5d3683f53f0d7&tab=main)


