### PR TITLE
Reenable Interact_spec Clear Recovery Token

### DIFF
--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -194,9 +194,10 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     // Required to prevent auth-js from clearing sessionStorage and breaking interaction code flow
     payload.exchangeCodeForTokens = false;
     if (step === 'cancel') {
-      authClient?.transactionManager.clear();
+      authClient?.transactionManager.clear({ clearIdxResponse: false });
       SessionStorage.removeStateHandle();
       if (isOauth2Enabled(widgetProps)) {
+        authClient?.transactionManager.clear();
         // We have to directly delete the recoveryToken since it is set once upon authClient instantiation
         delete authClient.options.recoveryToken;
         // In this case we need to restart login flow and recreate transaction meta

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -67,6 +67,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setMessage,
     setStepToRender,
     widgetProps,
+    bootstrap,
   } = useWidgetContext();
   const { eventEmitter, widgetHooks, features } = widgetProps;
 
@@ -197,6 +198,8 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       authClient?.transactionManager.clear({ clearIdxResponse: false });
       SessionStorage.removeStateHandle();
       if (isOauth2Enabled(widgetProps)) {
+        // We have to directly delete the recoveryToken since it is set once upon authClient instantiation
+        delete authClient.options['recoveryToken'];
         // In this case we need to restart login flow and recreate transaction meta
         fn = authClient.idx.start;
         payload = {};

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -67,7 +67,6 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setMessage,
     setStepToRender,
     widgetProps,
-    bootstrap,
   } = useWidgetContext();
   const { eventEmitter, widgetHooks, features } = widgetProps;
 
@@ -199,7 +198,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       SessionStorage.removeStateHandle();
       if (isOauth2Enabled(widgetProps)) {
         // We have to directly delete the recoveryToken since it is set once upon authClient instantiation
-        delete authClient.options['recoveryToken'];
+        delete authClient.options.recoveryToken;
         // In this case we need to restart login flow and recreate transaction meta
         fn = authClient.idx.start;
         payload = {};

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -194,7 +194,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     // Required to prevent auth-js from clearing sessionStorage and breaking interaction code flow
     payload.exchangeCodeForTokens = false;
     if (step === 'cancel') {
-      authClient?.transactionManager.clear({ clearIdxResponse: false });
+      authClient?.transactionManager.clear();
       SessionStorage.removeStateHandle();
       if (isOauth2Enabled(widgetProps)) {
         // We have to directly delete the recoveryToken since it is set once upon authClient instantiation

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -79,7 +79,7 @@ const appendViewLinks = (
   widgetProps: WidgetProps,
   bootstrapFn: () => Promise<void>,
 ): void => {
-  const { features } = widgetProps;
+  const { features, authClient } = widgetProps;
   const isCancelAvailable = shouldShowCancelLink(features);
   const cancelStep = transaction?.availableSteps?.find(({ name }) => name === 'cancel');
   const skipStep = transaction?.availableSteps?.find(({ name }) => name.includes('skip'));
@@ -119,6 +119,8 @@ const appendViewLinks = (
       cancelLink.options.href = backToSigninUri;
     } else if (isOauth2Enabled(widgetProps)) {
       cancelLink.options.onClick = async () => {
+        // We have to directly delete the recoveryToken since it is set once upon authClient instantiation
+        delete authClient?.options.recoveryToken;
         await bootstrapFn();
       };
     } else {

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -119,6 +119,7 @@ const appendViewLinks = (
       cancelLink.options.href = backToSigninUri;
     } else if (isOauth2Enabled(widgetProps)) {
       cancelLink.options.onClick = async () => {
+        authClient?.transactionManager.clear();
         // We have to directly delete the recoveryToken since it is set once upon authClient instantiation
         delete authClient?.options.recoveryToken;
         await bootstrapFn();

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -114,6 +114,7 @@ async function setup(t, options = {}) {
     recoveryToken: options.recoveryToken,
     clientId: 'fake',
     redirectUri: 'http://doesnot-matter',
+    authScheme: 'oauth2',
     authParams: {
       pkce: true,
       state: 'mock-state'
@@ -250,10 +251,8 @@ test.requestHooks(requestLogger, cancelResetPasswordMock)('clears recovery_token
   ]);
   requestLogger.clear();
   await pageObject.clickSignOutLink();
-  await t.wait(5000);
   req = requestLogger.requests[0].request; // interact
   params = decodeUrlEncodedRequestBody(req.body);
-  console.log(req);
   await t.expect(req.url).eql('http://localhost:3000/oauth2/default/v1/interact');
   await t.expect(params['recovery_token']).eql(undefined);
 });

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -250,6 +250,7 @@ test.requestHooks(requestLogger, cancelResetPasswordMock)('clears recovery_token
   ]);
   requestLogger.clear();
   await pageObject.clickSignOutLink();
+  await t.wait(5000);
   req = requestLogger.requests[0].request; // interact
   params = decodeUrlEncodedRequestBody(req.body);
   await t.expect(req.url).eql('http://localhost:3000/oauth2/default/v1/interact');

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -232,11 +232,7 @@ test.requestHooks(requestLogger, interactMock)('passes recovery_token to interac
   ]);
 });
 
-// TODO this is calling /cancel but not also /interact in v3. Might be good but
-// not sure if it _should_ call interact actually when there is
-// a recovery token
-// OKTA-654463
-test.meta('gen3', false).requestHooks(requestLogger, cancelResetPasswordMock)('clears recovery_token and does not pass it to interact after clicking "back to signin"', async t => {
+test.requestHooks(requestLogger, cancelResetPasswordMock)('clears recovery_token and does not pass it to interact after clicking "back to signin"', async t => {
   const recoveryToken = 'abcdef';
   const pageObject = await setup(t, {
     recoveryToken

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -253,6 +253,7 @@ test.requestHooks(requestLogger, cancelResetPasswordMock)('clears recovery_token
   await t.wait(5000);
   req = requestLogger.requests[0].request; // interact
   params = decodeUrlEncodedRequestBody(req.body);
+  console.log(req);
   await t.expect(req.url).eql('http://localhost:3000/oauth2/default/v1/interact');
   await t.expect(params['recovery_token']).eql(undefined);
 });


### PR DESCRIPTION
## Description:
- Reenables test in `Interact_spec` that expected gen3 to meet parity with gen2 and clear the `recoveryToken` config option used by embedded widgets for password reset
- `recoveryToken` has to be directly deleted from `authClient.options`, currently `auth-js` does not support an alternative way to clear this option 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-654463](https://oktainc.atlassian.net/browse/OKTA-654463)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-654463-reenable-interact-clear-token&page=1&pageSize=6&sha=5ac690487b3b33bfb61fbd303b1d1af22ae09dba&tab=main)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



