### PR TITLE
Reenable autoFocus by default test in Identify_spec

### DIFF
--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -457,7 +457,7 @@ test.requestHooks(identifyRequestLogger, errorsIdentifyMock)('should render each
   await t.expect(await identityPage.form.getErrorBoxTextByIndex(2)).eql('Your session has expired. Please try to sign in again.');
 });
 
-// Re-enable in OKTA-654458
+// Leave disabled, product requests that autoFocus default to off in gen3
 test.meta('gen3', false).requestHooks(identifyRequestLogger, baseIdentifyMock)('should "autoFocus" form with config or by default', async t => {
   const identityPage = await setup(t, {
     features: {}

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -457,30 +457,28 @@ test.requestHooks(identifyRequestLogger, errorsIdentifyMock)('should render each
   await t.expect(await identityPage.form.getErrorBoxTextByIndex(2)).eql('Your session has expired. Please try to sign in again.');
 });
 
-// Leave disabled, product requests that autoFocus default to off in gen3
-test.meta('gen3', false).requestHooks(identifyRequestLogger, baseIdentifyMock)('should "autoFocus" form with config or by default', async t => {
+test.requestHooks(identifyRequestLogger, baseIdentifyMock)('should "autoFocus" form with config or by default in gen2 but not gen3', async t => {
   const identityPage = await setup(t, {
     features: {}
   });
   await checkA11y(t);
 
-  let doesFormHaveFocus = identityPage.form.getElement('[data-se="o-form-input-identifier"] input').focused;
-  await t.expect(doesFormHaveFocus).eql(true);
-
+  let doesFormHaveFocus = identityPage.form.getTextBox('Username', true).focused;
+  // Product requests that autoFocus default to off in gen3
+  await t.expect(doesFormHaveFocus).eql(userVariables.gen3 ? false : true);
 
   await rerenderWidget({
     features: { autoFocus: true }
   });
 
-  doesFormHaveFocus = identityPage.form.getElement('[data-se="o-form-input-identifier"] input').focused;
+  doesFormHaveFocus = identityPage.form.getTextBox('Username', true).focused;
   await t.expect(doesFormHaveFocus).eql(true);
-
 
   await rerenderWidget({
     features: { autoFocus: false }
   });
 
-  doesFormHaveFocus = identityPage.form.getElement('[data-se="o-form-input-identifier"] input').focused;
+  doesFormHaveFocus = identityPage.form.getTextBox('Username', true).focused;
   await t.expect(doesFormHaveFocus).eql(false);
 });
 


### PR DESCRIPTION
## Description:
- Product requested that autoFocus default to false in gen3 so test should stay disabled, left comment above disablement

See: https://okta.slack.com/archives/C04NYNLLRDL/p1680804626200699


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-654458](https://oktainc.atlassian.net/browse/OKTA-654458)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



