### PR TITLE
Print Lockfile Drift

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -42,7 +42,9 @@ npm config set @okta:registry ${INTERNAL_REGISTRY}
 
 if ! yarn_sync; then
   echo "yarn.lock file is not in sync, see diff below. Please make sure this file is up-to-date by running 'yarn install' at the repo root and checking in yarn.lock changes"
+  echo "############## yarn.lock diff starts here ##############"
   git diff *yarn.lock
+  echo "############## yarn.lock diff ends here ##############"
   exit ${FAILED_SETUP}
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,7 +41,8 @@ fi
 npm config set @okta:registry ${INTERNAL_REGISTRY}
 
 if ! yarn_sync; then
-  echo "yarn.lock file is not in sync. Please make sure this file is up-to-date by running 'yarn install' at the repo root and checking in yarn.lock changes"
+  echo "yarn.lock file is not in sync, see diff below. Please make sure this file is up-to-date by running 'yarn install' at the repo root and checking in yarn.lock changes"
+  git diff *yarn.lock
   exit ${FAILED_SETUP}
 fi
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3634,7 +3634,7 @@
     "@mui/utils" "^5.10.9"
     "@okta/odyssey-design-tokens" "^0.17.0"
 
-"@okta/okta-auth-js@^7.4.3":
+"@okta/okta-auth-js@^7.4.2":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.4.3.tgz#f4ff2f1cc93d6c27cb85e28d716259ef000547e5"
   integrity sha512-09uAdKF2k9lK45w82b5PZad1ARfaU9uoeXUvUsaYkZ2O8qInYJpNXANO04D4bISostQBnk1JRgsecxI8btVU/w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3634,7 +3634,7 @@
     "@mui/utils" "^5.10.9"
     "@okta/odyssey-design-tokens" "^0.17.0"
 
-"@okta/okta-auth-js@^7.4.2":
+"@okta/okta-auth-js@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.4.3.tgz#f4ff2f1cc93d6c27cb85e28d716259ef000547e5"
   integrity sha512-09uAdKF2k9lK45w82b5PZad1ARfaU9uoeXUvUsaYkZ2O8qInYJpNXANO04D4bISostQBnk1JRgsecxI8btVU/w==


### PR DESCRIPTION
## Description:
- Prints the lockfile diff when `yarn_sync()` detects differences in `yarn.lock` and throws an error 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-665609](https://oktainc.atlassian.net/browse/OKTA-665609)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-665609-print-lockfile-diff&page=1&pageSize=6&sha=980c100d60d81bc90e27734e435a69ac05f651dd&tab=main)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



