### PR TITLE
Fix issue with CustomEvent in IE11

### DIFF
--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -350,7 +350,7 @@ fn.getFactorDescription = function(provider, factorType) {
 
     return brandName ? loc(key, 'login', [brandName]) : loc(key, 'login');
   } else {
-    return loc(descriptionKey, 'login');
+    return descriptionKey ? loc(descriptionKey, 'login') : '';
   }
 };
 

--- a/src/util/loc.ts
+++ b/src/util/loc.ts
@@ -25,6 +25,13 @@ type Bundles = {
   [key in BundleName]: Bundle;
 };
 
+interface L10nErrorDetail {
+  type: 'l10n-error';
+  key: string;
+  bundleName: string;
+  reason: string;
+}
+
 declare global {
   interface Window {
     okta?: {
@@ -126,13 +133,15 @@ function emitL10nError(key: string, bundleName: string, reason: string) {
       reason: reason
     }
   });
-  document.dispatchEvent(event);
+  if (event) {
+    document.dispatchEvent(event);
+  }
 }
 
-const createCustomEvent = function (event: string, params: CustomEventInit) {
+const createCustomEvent = function (event: string, params: CustomEventInit<L10nErrorDetail>) {
   if (typeof window.CustomEvent === 'function') {
     return new CustomEvent(event, params);
-  } else {
+  } else if (!window.CustomEvent) {
     /**
      * CustomEvent polyfill for IE
      * https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#polyfill

--- a/src/util/loc.ts
+++ b/src/util/loc.ts
@@ -130,7 +130,7 @@ function emitL10nError(key: string, bundleName: string, reason: string) {
 }
 
 const createCustomEvent = function (event: string, params: CustomEventInit) {
-  if (window.CustomEvent) {
+  if (typeof window.CustomEvent === 'function') {
     return new CustomEvent(event, params);
   } else {
     /**


### PR DESCRIPTION
## Description:

PR https://github.com/okta/okta-signin-widget/pull/3405 have introduced regression for IE11 for Gen1 if `features.passwordlessAuth` is enabled

### Bug description

Issue  with function [`createCustomEvent`](https://github.com/okta/okta-signin-widget/blob/16e7a4273858255e425c212ef2424fdf74a23b54/src/util/loc.ts#L132C1-L132C1) called from [`emitL10nError`](https://github.com/okta/okta-signin-widget/blob/16e7a4273858255e425c212ef2424fdf74a23b54/src/util/loc.ts#L120) (line 133):
https://github.com/okta/okta-signin-widget/blob/16e7a4273858255e425c212ef2424fdf74a23b54/src/util/loc.ts#L133-L137
For IE11 `CustomEvent` is an object, not a function. 
So trying to call `new CustomEvent(..)` triggers error `Object doesn't support this action`:
<img width="468" alt="Screenshot 2023-11-14 at 15 04 14" src="https://github.com/okta/okta-signin-widget/assets/72614880/e8720a12-97a2-4d7d-8f3c-eefb549020ac">

Fix - check that `CustomEvent` is a function before calling a constructor, as in original code from courage:
https://github.com/okta/okta-signin-widget/blob/16e7a4273858255e425c212ef2424fdf74a23b54/packages/%40okta/courage-dist/esm/src/courage/util/StringUtil.js#L90

### Why `emitL10nError` is called

 For `password` factor `FactorUtil.getFactorDescription()` is called from [`Factor`](https://github.com/okta/okta-signin-widget/blob/16e7a4273858255e425c212ef2424fdf74a23b54/src/v1/models/Factor.js#L110) model to compute `factorDescription` property.
But `password` factor has no description: 
https://github.com/okta/okta-signin-widget/blob/16e7a4273858255e425c212ef2424fdf74a23b54/src/util/FactorUtil.js#L140
So it can't be localized: https://github.com/okta/okta-signin-widget/blob/16e7a4273858255e425c212ef2424fdf74a23b54/src/util/FactorUtil.js#L363
Last line will [emit `okta-i18n-error`](https://github.com/okta/okta-signin-widget/blob/16e7a4273858255e425c212ef2424fdf74a23b54/src/util/loc.ts#L65) with empty `key` 

Proposing to not try to localize empty description: https://github.com/okta/okta-signin-widget/pull/3468/files#diff-99e80e48c63c1ecdbd265022ebb8c35d77e3033842f1e014cda08b25fa507aecR363



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-667106](https://oktainc.atlassian.net/browse/OKTA-667106)

### Reviewers:

### Screenshot/Video:

Before:

https://github.com/okta/okta-signin-widget/assets/72614880/82c592d0-65cf-4fa5-aaa5-52907d581216


After:

https://github.com/okta/okta-signin-widget/assets/72614880/51cac152-635f-452c-8837-d9555f6287cd



### Downstream Monolith Build:



