### PR TITLE
Add terminal screen if user requires WS1 to login, RESOLVES: OKTA-664541

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -108,6 +108,7 @@ const idx = {
     // 'oda-enrollment-ios',
     // 'oda-enrollment-android',
     // 'mdm-enrollment',
+    // 'ws1-device-integration-mobile-enrollment',
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-enroll-custom-app-push',
     // 'request-activation-email'    

--- a/playground/mocks/data/idp/idx/ws1-device-integration-mobile-enrollment.json
+++ b/playground/mocks/data/idp/idx/ws1-device-integration-mobile-enrollment.json
@@ -1,0 +1,42 @@
+{
+    "stateHandle": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+    "version": "1.0.0",
+    "expiresAt": "2023-11-27T22:15:50.000Z",
+    "intent": "LOGIN",
+    "deviceEnrollment": {
+      "type": "object",
+      "value": {
+        "name": "ws1",
+        "platform": "IOS",
+        "vendor": "VMWare Workspace ONE",
+        "enrollmentLink": "https://sampleEnrollmentlink.com"
+      }
+    },
+    "cancel": {
+        "rel": [
+            "create-form"
+        ],
+        "name": "cancel",
+        "href": "https://idx.okta1.com/idp/idx/cancel",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+            {
+                "name": "stateHandle",
+                "required": true,
+                "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+                "visible": false,
+                "mutable": false
+            }
+        ]
+    },
+    "app": {
+        "type": "object",
+        "value": {
+            "name": "oidc_client",
+            "label": "Native client",
+            "id": "0oa2lpzzzJHJy0E6q0g4"
+        }
+    }
+  }
+  

--- a/src/util/Enums.js
+++ b/src/util/Enums.js
@@ -30,6 +30,7 @@ export default {
 
   ODA: 'oda',
   MDM: 'mdm',
+  WS1: 'ws1',
 
   // Global success messages
   SUCCESS: 'SUCCESS',

--- a/src/v2/view-builder/views/device/DeviceEnrollmentTerminalView.js
+++ b/src/v2/view-builder/views/device/DeviceEnrollmentTerminalView.js
@@ -113,6 +113,8 @@ export default BaseView.extend({
     case Enums.MDM:
       this.Body = MdmTerminalForm;
       break;
+    case Enums.WS1:
+      this.Body = MdmTerminalForm;
     }
   },
 

--- a/src/v3/src/constants/idxConstants.ts
+++ b/src/v3/src/constants/idxConstants.ts
@@ -105,6 +105,7 @@ export const AUTHENTICATOR_ALLOWED_FOR_OPTIONS: Record<string, string> = {
 export const DEVICE_ENROLLMENT_TYPE: Record<string, string> = {
   ODA: 'oda',
   MDM: 'mdm',
+  WS1: 'ws1',
 };
 
 export const TERMINAL_KEY: Record<string, string> = {

--- a/src/v3/src/transformer/terminal/__snapshots__/transformMdmTerminalView.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformMdmTerminalView.test.ts.snap
@@ -1,6 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Terminal MDM enrollment transformer adds UI elements appropriately 1`] = `
+exports[`Terminal MDM enrollment transformer adds UI elements appropriately when name is mdm 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "enroll.title.mdm",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "enroll.explanation.mdm",
+        },
+        "type": "Description",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "items": Array [
+            Object {
+              "elements": Array [
+                Object {
+                  "noMargin": true,
+                  "options": Object {
+                    "content": "enroll.mdm.step.copyLink",
+                  },
+                  "type": "Description",
+                },
+                Object {
+                  "label": "enroll.mdm.copyLink",
+                  "options": Object {
+                    "onClick": [Function],
+                    "step": "",
+                    "type": "button",
+                    "variant": "secondary",
+                  },
+                  "type": "Button",
+                },
+              ],
+              "type": "VerticalLayout",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "noMargin": true,
+                  "options": Object {
+                    "content": "enroll.mdm.step.pasteLink",
+                  },
+                  "type": "Description",
+                },
+              ],
+              "type": "VerticalLayout",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "noMargin": true,
+                  "options": Object {
+                    "content": "enroll.mdm.step.followInstructions",
+                  },
+                  "type": "Description",
+                },
+              ],
+              "type": "VerticalLayout",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "noMargin": true,
+                  "options": Object {
+                    "content": "enroll.mdm.step.relogin",
+                  },
+                  "type": "Description",
+                },
+              ],
+              "type": "VerticalLayout",
+            },
+          ],
+          "type": "ol",
+        },
+        "type": "List",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`Terminal MDM enrollment transformer adds UI elements appropriately when name is ws1 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -180,7 +180,8 @@ export const transformTerminalTransaction = (
   if (typeof deviceEnrollment !== 'undefined') {
     if (deviceEnrollment.name === DEVICE_ENROLLMENT_TYPE.ODA) {
       return transformOdaEnrollment({ transaction, formBag, widgetProps });
-    } if (deviceEnrollment.name === DEVICE_ENROLLMENT_TYPE.MDM) {
+    } if (deviceEnrollment.name === DEVICE_ENROLLMENT_TYPE.MDM
+            || deviceEnrollment.name === DEVICE_ENROLLMENT_TYPE.WS1) {
       return transformMdmTerminalView({ transaction, formBag, widgetProps });
     }
   }

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -2,9 +2,10 @@ import {RequestLogger, RequestMock, userVariables} from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import { renderWidget } from '../framework/shared';
 import DeviceEnrollmentTerminalPageObject from '../framework/page-objects/DeviceEnrollmentTerminalPageObject';
-import IOSOdaEnrollment from '../../../playground/mocks/data/idp/idx/oda-enrollment-ios';
-import AndroidOdaEnrollmentLoopback from '../../../playground/mocks/data/idp/idx/oda-enrollment-android';
-import MdmEnrollment from '../../../playground/mocks/data/idp/idx/mdm-enrollment';
+import IOSOdaEnrollment from '../../../playground/mocks/data/idp/idx/oda-enrollment-ios.json';
+import AndroidOdaEnrollmentLoopback from '../../../playground/mocks/data/idp/idx/oda-enrollment-android.json';
+import MdmEnrollment from '../../../playground/mocks/data/idp/idx/mdm-enrollment.json';
+import Ws1Enrollment from '../../../playground/mocks/data/idp/idx/ws1-device-integration-mobile-enrollment.json';
 
 const logger = RequestLogger(/introspect/);
 
@@ -17,6 +18,9 @@ const androidOdaLoopbackMock = RequestMock()
 const mdmMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(MdmEnrollment);
+const ws1Mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(Ws1Enrollment);
 
 fixture('Device enrollment terminal view for ODA and MDM');
 
@@ -81,6 +85,24 @@ test
     await t.expect(content).contains('Tap the Copy Link button below.');
     await t.expect(content).contains('On this device, open your browser, then paste the copied link into the address bar.');
     await t.expect(content).contains('Follow the instructions in your browser to set up Airwatch.');
+    await t.expect(content).contains('Logout and re-login and then try accessing the app again.');
+    await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
+    if (!userVariables.gen3) {
+      await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://sampleEnrollmentlink.com');
+    }
+  });
+
+test
+  .requestHooks(logger, ws1Mock)('shows the correct content in WS1 mobile device integration terminal view', async t => {
+    const deviceEnrollmentTerminalPage = await setup(t);
+    await checkA11y(t);
+    await t.expect(deviceEnrollmentTerminalPage.getFormTitle()).eql('Additional setup required');
+    const content = deviceEnrollmentTerminalPage.getContentText();
+    await t.expect(content).contains('To access this app, your device needs to meet your organization');
+    await t.expect(content).contains('s security requirements. Follow the instructions below to continue.');
+    await t.expect(content).contains('Tap the Copy Link button below.');
+    await t.expect(content).contains('On this device, open your browser, then paste the copied link into the address bar.');
+    await t.expect(content).contains('Follow the instructions in your browser to set up VMWare Workspace ONE.');
     await t.expect(content).contains('Logout and re-login and then try accessing the app again.');
     await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
     if (!userVariables.gen3) {


### PR DESCRIPTION
## Description:
- Add a terminal screen if the enduser is required to enroll in VMWare Workspace ONE to get access to their apps
  - Use the existing deviceEnrollment object and support another enum `ws1` to indicate code path is coming from WS1 

- Context: There are classic customers that are using a mobile SAML IdP-based solution via VMWare Workspace ONE to evaluate device trust. They currently cannot upgrade to OIE since OIE in general does not support mobile device trust. We are now supporting a migration path for this mobile SAML IdP-based device trust solution one OIE. This is merely to unblock their OIE upgrade and the goal is to eventually offboard this feature and onboard onto FastPass. While the feature is still enabled on OIE, in case customers are not enrolled into the vendor, we need to display this remediation screen so they can enroll accordingly.
- [UI Mock](https://www.figma.com/file/XqYJIxrMpmlboNShcL6cNn/Device-Posture-Provider?type=design&node-id=3365-2275&mode=design&t=qvE63hSRBq2Q9BZL-0)

Sample `deviceEnrollment` object in response json:
```
"deviceEnrollment": {
      "type": "object",
      "value": {
        "name": "ws1",
        "platform": "IOS",
        "vendor": "VMWare Workspace ONE",
        "enrollmentLink": "https://sampleEnrollmentlink.com"
      }
}
```

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-664541](https://oktainc.atlassian.net/browse/OKTA-664541)

### Reviewers:
@okta/device-platform 

### Screenshot/Video:
Mocking the /introspect endpoint to point to the ws1 .json response

https://github.com/okta/okta-signin-widget/assets/68347527/d05f16ce-76db-4600-a940-e19d886037b7


### Downstream Monolith Build:



