### PR TITLE
fix: Addresses an XSS vuln on the identifier element

### DIFF
--- a/src/v2/view-builder/internals/BaseForm.ts
+++ b/src/v2/view-builder/internals/BaseForm.ts
@@ -104,7 +104,7 @@ export default Form.extend({
 
     const header = this.$el.find('[data-se="o-form-head"]');
     const identifierHTMLString = hbs('<div class="identifier-container">\
-        <span class="identifier no-translate" data-se="identifier" title={{identifier}}>{{identifier}}</span>\
+        <span class="identifier no-translate" data-se="identifier" title="{{identifier}}">{{identifier}}</span>\
       </div>')({identifier});
 
     if (header.length) {

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -80,6 +80,14 @@ export default class BasePageObject {
     return this.getTextContent('[data-se="identifier"]');
   }
 
+  getIdentifierTitle() {
+    return Selector('[data-se="identifier"]').getAttribute('title');
+  }
+
+  identifierHasContenteditable() {
+    return Selector('[data-se="identifier"]').hasAttribute('contenteditable');
+  }
+
   getFormFieldLabel(field) {
     return this.form.getFormFieldLabel(field);
   }


### PR DESCRIPTION
## Description:

The injected HTML was not being escaped properly for the title attribute, as it was missing quotes. This allowed a malicious user to inject a script. Since the CSP headers were rolled out, this was no longer an issue as far as JS execution goes, but I addressed the HTML injection anyways.

I made sure that the test was failing without the fix in place.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-633280](https://oktainc.atlassian.net/browse/OKTA-633280)

### Reviewers:

### Screenshot/Video:

https://drive.google.com/file/d/1m_LeCaE_vBh58ZZFf998FgBsha5t9uvc/view?usp=sharing

![image](https://github.com/okta/okta-signin-widget/assets/99218766/6cb8d710-ecfa-4fea-bc30-d1aecba4c9d0)


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=705f1c263623b2cec4984c2c85062b7d1d78375d&tab=main

