### PR TITLE
Fix test flakiness

### DIFF
--- a/.testcaferc.js
+++ b/.testcaferc.js
@@ -78,6 +78,12 @@ const config = {
   // limit concurrency when running flaky tests
   concurrency: OKTA_SIW_ONLY_FLAKY ? 1 : undefined,
 
+  // retry failed tests
+  quarantineMode: {
+    successThreshold: 1,
+    attemptLimit: 3,
+  },
+
   filter: (_testName, _fixtureName, fixturePath, testMeta, fixtureMeta) => {
     // only check one of {gen3 | gen2} conditionals. without this guard, a
     // fixture or test will always get skipped in both testcafe runs

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "copy:types": "grunt copy:types",
     "build:types": "yarn clean:types && yarn generate:types && yarn copy:types",
     "test:parity-setup": "mkdir -p test-reports/testcafe && yarn generate-config && yarn workspace v3 dev",
-    "test:parity-run": "OKTA_SIW_GEN3=true yarn testcafe -c 2 chrome:headless --reporter spec,xunit:build2/reports/junit/testcafe-results.xml",
+    "test:parity-run": "OKTA_SIW_GEN3=true yarn testcafe -c 4 chrome:headless --reporter spec,xunit:build2/reports/junit/testcafe-results.xml",
     "test:parity-ci": "OKTA_SIW_SKIP_FLAKY=true yarn codegen && run-p -r test:parity-setup test:parity-run",
     "test:parity-ci-flaky": "OKTA_SIW_GEN3=true OKTA_SIW_ONLY_FLAKY=true yarn test:parity-ci"
   },

--- a/test/unit/spec/v1/PrimaryAuth_spec.js
+++ b/test/unit/spec/v1/PrimaryAuth_spec.js
@@ -1495,6 +1495,12 @@ Expect.describe('PrimaryAuth', function() {
           });
       });
       itp('shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)', function() {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
+          const deferred = Q.defer();
+  
+          deferred.resolve('thisIsTheDeviceFingerprint');
+          return deferred.promise;
+        });
         return setup({
           features: { securityImage: true, deviceFingerprinting: true, useDeviceFingerprintForSecurityImage: false },
         })
@@ -1703,6 +1709,12 @@ Expect.describe('PrimaryAuth', function() {
       });
     });
     itp('shows beacon-loading animation while loading security image (with deviceFingerprint)', function() {
+      spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
+        const deferred = Q.defer();
+
+        deferred.resolve('thisIsTheDeviceFingerprint');
+        return deferred.promise;
+      });
       return setup({ features: { securityImage: true, deviceFingerprinting: true } })
         .then(function(test) {
           test.securityBeacon = test.router.header.currentBeacon.$el;


### PR DESCRIPTION
## Description:

Changes:
1) Use [quarantine mode](https://testcafe.io/documentation/403841/guides/intermediate-guides/quarantine-mode#quarantine-mode-options) to retry failed flaky tests (up to 2 times, total 3 tries per test)
2) Use TestCafe concurrency `4` instead of `2` for Gen3 to decrease testing time from 40+ to 28 mins
3) Fix [flaky test](https://github.com/okta/okta-signin-widget/pull/3486#discussion_r1427807531) `PrimaryAuth events beacon loading shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)` in `unit-jest` test suite




## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-575629](https://oktainc.atlassian.net/browse/OKTA-575629)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



