### PR TITLE
OKTA 673876 a11y loading state

### DIFF
--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -29,6 +29,7 @@ const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
       flexDirection="column"
       justifyContent="center"
       alignItems="center"
+      aria-live="polite"
     >
       <CircularProgress
         id={dataSe}

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -1,8 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`authenticator-enroll-security-question-error custom question should show field level character count error message when invalid number of characters are sent and field should retain characters 1`] = `<div />`;
-
-exports[`authenticator-enroll-security-question-error custom question should show field level character count error message when invalid number of characters are sent and field should retain characters 2`] = `
+exports[`authenticator-enroll-security-question-error custom question should show field level character count error message when invalid number of characters are sent and field should retain characters 1`] = `
 <div>
   <div
     class="MuiScopedCssBaseline-root emotion-0"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`authenticator-enroll-security-question-error custom question should show field level character count error message when invalid number of characters are sent and field should retain characters 1`] = `
+exports[`authenticator-enroll-security-question-error custom question should show field level character count error message when invalid number of characters are sent and field should retain characters 1`] = `<div />`;
+
+exports[`authenticator-enroll-security-question-error custom question should show field level character count error message when invalid number of characters are sent and field should retain characters 2`] = `
 <div>
   <div
     class="MuiScopedCssBaseline-root emotion-0"
@@ -1438,6 +1440,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-56"
                         >
                           <div
+                            aria-live="polite"
                             class="MuiBox-root emotion-57"
                           >
                             <span

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -1080,6 +1080,7 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
                       class="MuiBox-root emotion-18"
                     >
                       <div
+                        aria-live="polite"
                         class="MuiBox-root emotion-19"
                       >
                         <span

--- a/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`enduser-consent-without-lgoo should render form 1`] = `
                 </span>
               </div>
               <div
+                aria-live="polite"
                 class="MuiBox-root emotion-13"
               >
                 <span

--- a/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`enduser-consent should render form with logo 1`] = `
                 </span>
               </div>
               <div
+                aria-live="polite"
                 class="MuiBox-root emotion-16"
               >
                 <span

--- a/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`granular-consent should render form with logo 1`] = `
                 </div>
               </div>
               <div
+                aria-live="polite"
                 class="MuiBox-root emotion-15"
               >
                 <span

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -1570,6 +1570,7 @@ exports[`identify-with-password renders the loading state first 1`] = `
               class="MuiBox-root emotion-7"
             >
               <div
+                aria-live="polite"
                 class="MuiBox-root emotion-8"
               >
                 <span


### PR DESCRIPTION
## Description:
- fix(a11y): add aria-live to loading animation


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-673876](https://oktainc.atlassian.net/browse/OKTA-673876)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



