### PR TITLE
Gen2: Fix ARIA label for authenticator CTA buttons

### DIFF
--- a/src/v2/view-builder/components/AuthenticatorEnrollOptions.js
+++ b/src/v2/view-builder/components/AuthenticatorEnrollOptions.js
@@ -14,6 +14,7 @@ import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 import skipAll from './SkipOptionalEnrollmentButton';
 import hbs from '@okta/handlebars-inline-precompile';
 import { AUTHENTICATOR_ALLOWED_FOR_OPTIONS } from '../utils/Constants';
+import { getEnrollAuthenticatorAriaLabel } from '../utils/AuthenticatorUtil';
 
 const AuthenticatorRow = View.extend({
   className: 'authenticator-row clearfix',
@@ -49,6 +50,9 @@ const AuthenticatorRow = View.extend({
       className: 'button select-factor',
       title: function() {
         return loc('oie.enroll.authenticator.button.text', 'login');
+      },
+      attributes: {
+        'aria-label': getEnrollAuthenticatorAriaLabel(this.model),
       },
       click: function() {
         this.model.trigger('selectAuthenticator', this.model.get('value'));

--- a/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
+++ b/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
@@ -11,6 +11,7 @@
  */
 import { ListView, View, createButton, loc } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
+import { getVerifyAuthenticatorAriaLabel } from '../utils/AuthenticatorUtil';
 
 const AuthenticatorRow = View.extend({
   className: 'authenticator-row clearfix',
@@ -49,6 +50,9 @@ const AuthenticatorRow = View.extend({
       className: 'button select-factor',
       title: function() {
         return loc('oie.verify.authenticator.button.text', 'login');
+      },
+      attributes: {
+        'aria-label': getVerifyAuthenticatorAriaLabel(this.model, true),
       },
       click: function() {
         this.model.trigger('selectAuthenticator', this.model.get('value'));

--- a/src/v2/view-builder/utils/AuthenticatorUtil.js
+++ b/src/v2/view-builder/utils/AuthenticatorUtil.js
@@ -249,5 +249,35 @@ export function getAuthenticatorDisplayName(remediation) {
   return remediation.relatesTo?.value?.displayName;
 }
 
+export function getVerifyAuthenticatorAriaLabel(authenticatorModel) {
+  // For Custom App: label is "Get a push notification", description is the app name
+  // For Okta Verify: label is "Use Okta FastPass" / "Get a push notification" / "Enter a code",
+  //   description is "Okta Verify"
+  // ARIA label should be eg. "Select Okta Verify. Use Okta FastPass"
+  const isNameInDescription = [
+    AUTHENTICATOR_KEY.CUSTOM_APP,
+    AUTHENTICATOR_KEY.OV,
+  ].includes(authenticatorModel.get('authenticatorKey'));
+  let name = authenticatorModel.get('label');
+  let description = authenticatorModel.get('description');
+  if (description && isNameInDescription) {
+    [name, description] = [description, name];
+  }
+  return [
+    [
+      loc('oie.verify.authenticator.button.text', 'login'),
+      name,
+    ].join(' '),
+    description,
+  ].filter(v => v).join('. ');
+}
+
+export function getEnrollAuthenticatorAriaLabel(authenticatorModel) {
+  return [
+    loc('oie.enroll.authenticator.button.text', 'login'),
+    authenticatorModel.get('label'),
+  ].join(' ');
+}
+
 // Re-export function from FactorUtil
 export { getPasswordComplexityDescriptionForHtmlList };

--- a/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
@@ -57,6 +57,10 @@ export default class SelectFactorPageObject extends BasePageObject {
     return this.getFactorNicknameElementByIndex(index).textContent;
   }
 
+  getFactorButtonAriaLabelByIndex(index) {
+    return this.getFactorCTAButtonByIndex(index).getAttribute('aria-label');
+  }
+
   getFactorAriaDescriptionByIndex(index) {
     return this.getAriaDescription(this.getFactorButtons().nth(index));
   }

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -216,6 +216,10 @@ test.requestHooks(mockEnrollAuthenticatorWithUsageInfo)('should load select auth
     await t.expect(await selectFactorPage.getFactorAriaDescriptionByIndex(0)).eql(
       'Choose a password for your account. Used for access. Set up'
     );
+  } else {
+    await t.expect(await selectFactorPage.getFactorButtonAriaLabelByIndex(0)).eql(
+      'Set up Password'
+    );
   }
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(1)).eql('Phone');

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -302,6 +302,11 @@ test.requestHooks(mockChallengeWithNickname)('should load select authenticator l
   await t.expect(await selectFactorPage.factorCustomLogoExist(2)).eql(false);
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('okta_email');
+  if (!userVariables.gen3) {
+    await t.expect(await selectFactorPage.getFactorButtonAriaLabelByIndex(2)).eql(
+      'Select Email'
+    );
+  }
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql('Phone');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(3)).eql(true);
@@ -315,6 +320,10 @@ test.requestHooks(mockChallengeWithNickname)('should load select authenticator l
   if (userVariables.gen3) {
     await t.expect(await selectFactorPage.getFactorAriaDescriptionByIndex(3)).eql(
       '+1 XXX-XXX-5309. ph-nn. Select'
+    );
+  } else {
+    await t.expect(await selectFactorPage.getFactorButtonAriaLabelByIndex(3)).eql(
+      'Select Phone. +1 XXX-XXX-5309'
     );
   }
 
@@ -340,6 +349,11 @@ test.requestHooks(mockChallengeWithNickname)('should load select authenticator l
   await t.expect(await selectFactorPage.factorCustomLogoExist(6)).eql(false);
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(6)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(6)).eql('okta_verify-signed_nonce');
+  if (!userVariables.gen3) {
+    await t.expect(await selectFactorPage.getFactorButtonAriaLabelByIndex(6)).eql(
+      'Select Okta Verify. Use Okta FastPass'
+    );
+  }
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(7)).eql('Google Authenticator');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(7)).eql(false);
@@ -405,6 +419,11 @@ test.requestHooks(mockChallengeWithNickname)('should load select authenticator l
   await t.expect(selectFactorPage.getFactorIconBgImageByIndex(15)).match(/.*\/img\/logos\/default\.png/);
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(15)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(15)).eql('custom_app');
+  if (!userVariables.gen3) {
+    await t.expect(await selectFactorPage.getFactorButtonAriaLabelByIndex(15)).eql(
+      'Select Custom Push App. Get a push notification'
+    );
+  }
 
   // signout link at enroll page
   await t.expect(await selectFactorPage.signoutLinkExists()).eql(true);


### PR DESCRIPTION
## Description:

For Gen2 CTA buttons for authenticators  are being read by screen reader apps just as "Select" (for verify page) and "Set up" (for enroll page) for any authenticator.

Change:
- for verify page "Select" button has `aria-label` with value `Select <authenticator name>. <description>`. Examples: "Select Okta Verify. Use Okta FastPass", "Select Phone. +1 XXX-XXX-5309", "Select Email"
- for enroll page "Set up" button has `aria-label` with value `Set up <authenticator name>`. Example: "Set up Email"

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-678692](https://oktainc.atlassian.net/browse/OKTA-678692)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



