### PR TITLE
Enable Gen3 Device Fingerprinting

### DIFF
--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -20,6 +20,7 @@ import {
 } from '@okta/okta-auth-js';
 import { cloneDeep, merge, omit } from 'lodash';
 import { useCallback } from 'preact/hooks';
+import { generateDeviceFingerprint } from 'src/util/deviceFingerprintingUtils';
 
 import { IDX_STEP, ON_PREM_TOKEN_CHANGE_ERROR_KEY } from '../constants';
 import { useWidgetContext } from '../contexts';
@@ -27,6 +28,7 @@ import { MessageType } from '../types';
 import {
   areTransactionsEqual,
   containsMessageKey,
+  getBaseUrl,
   getErrorEventContext,
   getImmutableData,
   isConfigRecoverFlow,
@@ -208,6 +210,16 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     // This way the flow can maintain the latest state handle. For eg. Device probe calls
     if (step === IDX_STEP.CANCEL_TRANSACTION) {
       SessionStorage.removeStateHandle();
+    }
+    if (step === IDX_STEP.IDENTIFY && features?.deviceFingerprinting) {
+      const baseUrl = getBaseUrl(widgetProps);
+      if (baseUrl) {
+        // Proceeds with form submission even if device fingerprinting fails
+        const fingerprint = await generateDeviceFingerprint(baseUrl).catch(() => undefined);
+        if (fingerprint) {
+          authClient.http.setRequestHeader('X-Device-Fingerprint', fingerprint);
+        }
+      }
     }
     setMessage(undefined);
     try {

--- a/src/v3/src/util/browserUtils.ts
+++ b/src/v3/src/util/browserUtils.ts
@@ -24,3 +24,7 @@ export const isIOS = (): boolean => (
 );
 
 export const isAndroidOrIOS = (): boolean => isAndroid() || isIOS();
+
+export const getUserAgent = (): string => navigator.userAgent;
+
+export const isWindowsPhone = (userAgent: string): RegExpMatchArray | null => userAgent.match(/windows phone|iemobile|wpdesktop/i);

--- a/src/v3/src/util/browserUtils.ts
+++ b/src/v3/src/util/browserUtils.ts
@@ -27,4 +27,4 @@ export const isAndroidOrIOS = (): boolean => isAndroid() || isIOS();
 
 export const getUserAgent = (): string => navigator.userAgent;
 
-export const isWindowsPhone = (userAgent: string): RegExpMatchArray | null => userAgent.match(/windows phone|iemobile|wpdesktop/i);
+export const isWindowsPhone = (userAgent: string): boolean => /windows phone|iemobile|wpdesktop/i.test(userAgent);

--- a/src/v3/src/util/deviceFingerprintingUtils.test.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import * as DeviceFingerprintingUtils from './deviceFingerprintingUtils';
+
+describe('DeviceFingerprintingUtils', () => {
+  const oktaDomainUrl = '';
+
+  beforeAll(() => {
+    const mockForm = document.createElement('form');
+    mockForm.setAttribute('data-se', 'o-form');
+    document.body.append(mockForm);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockIFrameMessages = (success: boolean, errorMessage?: { type: string }) => {
+    const message = success
+      ? { type: 'FingerprintAvailable', fingerprint: 'thisIsTheFingerprint' }
+      : errorMessage;
+
+    // TODO (jest): event is missing `origin` property
+    window.postMessage(JSON.stringify(message), '*');
+  };
+
+  const mockUserAgent = (userAgent: string) => {
+    jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(userAgent);
+  };
+
+  const bypassMessageSourceCheck = () => {
+    jest.spyOn(DeviceFingerprintingUtils, 'isMessageFromCorrectSource').mockReturnValue(true);
+  };
+
+  it('creates hidden iframe during fingerprint generation', async () => {
+    mockIFrameMessages(true);
+    bypassMessageSourceCheck();
+    const fingerprintPromise = DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl);
+    let iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).not.toBeNull();
+    expect(iframe).not.toBeVisible();
+    expect(iframe?.getAttribute('src')).toBe('/auth/services/devicefingerprint');
+    await fingerprintPromise;
+    iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).toBeNull();
+  });
+
+  it('returns a fingerprint if the communication with the iframe is successful', async () => {
+    mockIFrameMessages(true);
+    bypassMessageSourceCheck();
+    const fingerprint = await DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl);
+    expect(fingerprint).toBe('thisIsTheFingerprint');
+  });
+
+  it('fails if there is a problem with communicating with the iframe', async () => {
+    mockIFrameMessages(false);
+    bypassMessageSourceCheck();
+
+    await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
+      .rejects
+      .toThrow('Service not available');
+    const iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).toBeNull();
+  });
+
+  it('fails if the iframe sends invalid message content', async () => {
+    mockIFrameMessages(false, { type: 'InvalidMessageType' });
+    bypassMessageSourceCheck();
+
+    await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
+      .rejects
+      .toThrow('Service not available');
+    const iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).toBeNull();
+  });
+
+  it('fails if user agent is not defined', async () => {
+    mockUserAgent('');
+    mockIFrameMessages(true);
+    bypassMessageSourceCheck();
+
+    await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
+      .rejects
+      .toThrow('User agent is not defined');
+    const iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).toBeNull();
+  });
+
+  it('fails if it is called from a Windows phone', async () => {
+    mockUserAgent('Windows Phone');
+    mockIFrameMessages(true);
+    bypassMessageSourceCheck();
+
+    await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
+      .rejects
+      .toThrow('Device fingerprint is not supported on Windows phones');
+    const iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).toBeNull();
+  });
+
+  it('fails if the iframe does not receive any messages', async () => {
+    // Not sending any mock messages should trigger a timeout
+    await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
+      .rejects
+      .toThrow('Service not available');
+    const iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).toBeNull();
+  });
+
+  it('fails if there is no form to attach the iframe to', async () => {
+    const form = document.querySelector('form[data-se="o-form"]');
+    expect(form).not.toBeNull();
+    document.body.removeChild(form!);
+    await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
+      .rejects
+      .toThrow('Form does not exist');
+    const iframe = document.getElementById('device-fingerprint-container');
+    expect(iframe).toBeNull();
+  });
+});

--- a/src/v3/src/util/deviceFingerprintingUtils.test.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.test.ts
@@ -68,7 +68,7 @@ describe('DeviceFingerprintingUtils', () => {
 
     await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
       .rejects
-      .toThrow('Device fingerprinting timed out');
+      .toThrow('No data');
     const iframe = document.getElementById('device-fingerprint-container');
     expect(iframe).toBeNull();
   });
@@ -79,7 +79,7 @@ describe('DeviceFingerprintingUtils', () => {
 
     await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
       .rejects
-      .toThrow('Device fingerprinting timed out');
+      .toThrow('No data');
     const iframe = document.getElementById('device-fingerprint-container');
     expect(iframe).toBeNull();
   });

--- a/src/v3/src/util/deviceFingerprintingUtils.test.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.test.ts
@@ -68,7 +68,7 @@ describe('DeviceFingerprintingUtils', () => {
 
     await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
       .rejects
-      .toThrow('Service not available');
+      .toThrow('Device fingerprinting timed out');
     const iframe = document.getElementById('device-fingerprint-container');
     expect(iframe).toBeNull();
   });
@@ -79,7 +79,7 @@ describe('DeviceFingerprintingUtils', () => {
 
     await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
       .rejects
-      .toThrow('Service not available');
+      .toThrow('Device fingerprinting timed out');
     const iframe = document.getElementById('device-fingerprint-container');
     expect(iframe).toBeNull();
   });
@@ -110,9 +110,9 @@ describe('DeviceFingerprintingUtils', () => {
 
   it('fails if the iframe does not receive any messages', async () => {
     // Not sending any mock messages should trigger a timeout
-    await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl))
+    await expect(DeviceFingerprintingUtils.generateDeviceFingerprint(oktaDomainUrl, 1000))
       .rejects
-      .toThrow('Service not available');
+      .toThrow('Device fingerprinting timed out');
     const iframe = document.getElementById('device-fingerprint-container');
     expect(iframe).toBeNull();
   });

--- a/src/v3/src/util/deviceFingerprintingUtils.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.ts
@@ -27,7 +27,7 @@ export const generateDeviceFingerprint = (oktaDomainUrl: string): Promise<string
 
   let timeout: NodeJS.Timeout;
   let iframe: HTMLIFrameElement;
-  let listener: (this: Window, ev: MessageEvent<any>) => any;
+  let listener: (this: Window, ev: MessageEvent) => void;
   let msg;
   const formElement = document.querySelector('form[data-se="o-form"]');
   const promise = new Promise((resolve, reject) => {
@@ -35,7 +35,7 @@ export const generateDeviceFingerprint = (oktaDomainUrl: string): Promise<string
     iframe.style.display = 'none';
     iframe.id = 'device-fingerprint-container';
 
-    listener = (event: MessageEvent<any>) => {
+    listener = (event: MessageEvent) => {
       if (!isMessageFromCorrectSource(iframe, event)) {
         return undefined;
       }

--- a/src/v3/src/util/deviceFingerprintingUtils.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.ts
@@ -30,7 +30,7 @@ export const generateDeviceFingerprint = (oktaDomainUrl: string, timeoutDuration
   let listener: (this: Window, ev: MessageEvent) => void;
   let msg;
   const formElement = document.querySelector('form[data-se="o-form"]');
-  const promise = new Promise<string>((resolve, reject) => {
+  return new Promise<string>((resolve, reject) => {
     iframe = document.createElement('iframe');
     iframe.style.display = 'none';
     iframe.id = 'device-fingerprint-container';
@@ -76,9 +76,7 @@ export const generateDeviceFingerprint = (oktaDomainUrl: string, timeoutDuration
       // If the iframe does not load, receive the right message type, or there is a slow connection, throw an error
       reject(new Error('Device fingerprinting timed out'));
     }, timeoutDuration || 2000);
-  });
-
-  return promise.finally(() => {
+  }).finally(() => {
     clearTimeout(timeout);
     window.removeEventListener('message', listener);
     if (formElement?.contains(iframe)) {

--- a/src/v3/src/util/deviceFingerprintingUtils.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.ts
@@ -47,8 +47,8 @@ export const generateDeviceFingerprint = (oktaDomainUrl: string): Promise<string
       try {
         msg = JSON.parse(event.data);
       } catch (err) {
-        // iframe messages should all be parsable
-        // skip not parsable messages come from other sources in same origin (browser extensions)
+        // iframe messages should all be parsable, skip not parsable messages that come from other
+        // sources in the same origin (browser extensions)
         return undefined;
       }
 
@@ -57,11 +57,10 @@ export const generateDeviceFingerprint = (oktaDomainUrl: string): Promise<string
         return resolve(msg.fingerprint as string);
       }
       if (msg.type === 'FingerprintServiceReady') {
-        event.source?.postMessage(JSON.stringify({
+        const win = iframe.contentWindow;
+        win?.postMessage(JSON.stringify({
           type: 'GetFingerprint',
-        }), {
-          targetOrigin: event.origin
-        });
+        }), event.origin );
       }
       return undefined;
     };
@@ -74,7 +73,7 @@ export const generateDeviceFingerprint = (oktaDomainUrl: string): Promise<string
     formElement!.appendChild(iframe);
 
     timeout = setTimeout(() => {
-      // If the iframe does not load, receive the right message, or there is a slow connection, throw an error
+      // If the iframe does not load, receive the right message type, or there is a slow connection, throw an error
       reject(new Error('Service not available'));
     }, 2000);
   });

--- a/src/v3/src/util/deviceFingerprintingUtils.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.ts
@@ -16,7 +16,10 @@ export const isMessageFromCorrectSource = (iframe: HTMLIFrameElement, event: Mes
 : boolean => event.source === iframe.contentWindow;
 
 // NOTE: This utility is similar to the DeviceFingerprinting.js file used for V2 authentication flows.
-export const generateDeviceFingerprint = (oktaDomainUrl: string, timeoutDuration?: number): Promise<string> => {
+export const generateDeviceFingerprint = (
+  oktaDomainUrl: string,
+  timeoutDuration?: number,
+): Promise<string> => {
   const userAgent = getUserAgent();
   if (!userAgent) {
     return Promise.reject(new Error('User agent is not defined'));
@@ -41,7 +44,7 @@ export const generateDeviceFingerprint = (oktaDomainUrl: string, timeoutDuration
       }
 
       if (!event || !event.data || event.origin !== oktaDomainUrl) {
-        return reject('No data');
+        return reject(new Error('No data'));
       }
 
       try {
@@ -55,14 +58,15 @@ export const generateDeviceFingerprint = (oktaDomainUrl: string, timeoutDuration
       if (!msg) { return undefined; }
       if (msg.type === 'FingerprintAvailable') {
         return resolve(msg.fingerprint as string);
-      } else if (msg.type === 'FingerprintServiceReady') {
+      } if (msg.type === 'FingerprintServiceReady') {
         const win = iframe.contentWindow;
         win?.postMessage(JSON.stringify({
           type: 'GetFingerprint',
         }), event.origin );
       } else {
-        return reject('No data')
+        return reject(new Error('No data'));
       }
+      return undefined;
     };
     window.addEventListener('message', listener, false);
 

--- a/src/v3/src/util/deviceFingerprintingUtils.ts
+++ b/src/v3/src/util/deviceFingerprintingUtils.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { getUserAgent, isWindowsPhone } from './browserUtils';
+
+export const isMessageFromCorrectSource = (iframe: HTMLIFrameElement, event: MessageEvent)
+: boolean => event.source === iframe.contentWindow;
+
+// NOTE: This utility is similar to the DeviceFingerprinting.js file used for V2 authentication flows.
+export const generateDeviceFingerprint = (oktaDomainUrl: string): Promise<string> => {
+  const userAgent = getUserAgent();
+  if (!userAgent) {
+    return Promise.reject(new Error('User agent is not defined'));
+  }
+  if (isWindowsPhone(userAgent)) {
+    return Promise.reject(new Error('Device fingerprint is not supported on Windows phones'));
+  }
+
+  let timeout: NodeJS.Timeout;
+  let iframe: HTMLIFrameElement;
+  let listener: (this: Window, ev: MessageEvent<any>) => any;
+  let msg;
+  const formElement = document.querySelector('form[data-se="o-form"]');
+  const promise = new Promise((resolve, reject) => {
+    iframe = document.createElement('iframe');
+    iframe.style.display = 'none';
+    iframe.id = 'device-fingerprint-container';
+
+    listener = (event: MessageEvent<any>) => {
+      if (!isMessageFromCorrectSource(iframe, event)) {
+        return undefined;
+      }
+
+      if (!event || !event.data || event.origin !== oktaDomainUrl) {
+        return undefined;
+      }
+
+      try {
+        msg = JSON.parse(event.data);
+      } catch (err) {
+        // iframe messages should all be parsable
+        // skip not parsable messages come from other sources in same origin (browser extensions)
+        return undefined;
+      }
+
+      if (!msg) { return undefined; }
+      if (msg.type === 'FingerprintAvailable') {
+        return resolve(msg.fingerprint as string);
+      }
+      if (msg.type === 'FingerprintServiceReady') {
+        event.source?.postMessage(JSON.stringify({
+          type: 'GetFingerprint',
+        }), {
+          targetOrigin: event.origin
+        });
+      }
+      return undefined;
+    };
+    window.addEventListener('message', listener, false);
+
+    iframe.src = `${oktaDomainUrl}/auth/services/devicefingerprint`;
+    if (formElement === null) {
+      reject(new Error('Form does not exist'));
+    }
+    formElement!.appendChild(iframe);
+
+    timeout = setTimeout(() => {
+      // If the iframe does not load, receive the right message, or there is a slow connection, throw an error
+      reject(new Error('Service not available'));
+    }, 2000);
+  });
+
+  return promise.finally(() => {
+    clearTimeout(timeout);
+    window.removeEventListener('message', listener);
+    if (formElement?.contains(iframe)) {
+      iframe.parentElement?.removeChild(iframe);
+    }
+  }) as Promise<string>;
+};

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -344,8 +344,7 @@ test.requestHooks(identifyMock)('should not render custom forgot password link',
   await t.expect(await identityPage.hasForgotPasswordLinkText()).notOk();
 });
 
-// Re-enable in OKTA-654456
-test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMockWithFingerprint)('should compute device fingerprint and add to header', async t => {
+test.requestHooks(identifyRequestLogger, identifyMockWithFingerprint)('should compute device fingerprint and add to header', async t => {
   const identityPage = await setup(t, {
     features: {
       deviceFingerprinting: true,
@@ -373,8 +372,7 @@ test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMockWithFin
   await t.expect(factorReqHeaders['x-device-fingerprint']).eql('mock-device-fingerprint');
 });
 
-// Re-enable in OKTA-654456
-test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMockWithFingerprintError)('should continue to compute device fingerprint and add to header when there are API errors', async t => {
+test.requestHooks(identifyRequestLogger, identifyMockWithFingerprintError)('should continue to compute device fingerprint and add to header when there are API errors', async t => {
   const identityPage = await setup(t, {
     features: {
       deviceFingerprinting: true,
@@ -393,7 +391,10 @@ test.meta('gen3', false).requestHooks(identifyRequestLogger, identifyMockWithFin
 
   // Validate that there is an error message
   await identityPage.waitForErrorBox();
-  await t.expect(identityPage.getNextButton().exists).eql(true);
+  // Gen 3 does not merge transactions together to show error while staying on identify page
+  if (!userVariables.gen3) {
+    await t.expect(identityPage.getNextButton().exists).eql(true);
+  }
   await t.expect(identityPage.getGlobalErrors()).contains('You do not have permission to perform the requested action');
 });
 


### PR DESCRIPTION
## Description:
- Enables device fingerprinting in gen3 to meet parity with gen2 fingerprinting behavior
- Rewrites fingerprinting utility to remove jQuery, enforce type safety, and clean up logic
    - New logic more closely mirrors auth-js implementation of device fingerprinting: https://github.com/okta/okta-auth-js/blob/master/lib/browser/fingerprint.ts
    - Old PR with IE11 regression, for comparison: https://github.com/okta/okta-signin-widget/pull/3449/files#diff-e1279c643ed9af1d0e83c4a1140a7fbb107b1dab0ba73391dfb037528618bf47
- See video below for manual IE11 testing to ensure that updated logic does not use unsupported methods (since this reenablement originally caused IE11 regression)
    - Manual testing was also done in Chrome, Firefox, Safari, and Edge

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-674340](https://oktainc.atlassian.net/browse/OKTA-674340)
- [Bacon Link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=ti-OKTA-674340-gen3-device-fingerprinting&page=1&pageSize=6&sha=fe271c0c3d2fcf41a3ed3a55fd44e06a69850449&tab=main)
- [Downstream](https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=4fea7e0a3beaefe2311eb00e98bc489799a88fe4&tab=main)

### Reviewers:

### Screenshot/Video:
#### SauceLabs IE11 demo
https://github.com/okta/okta-signin-widget/assets/106110543/bfbdb6e5-1803-4aa0-9950-1b4ff818724d

### Downstream Monolith Build:



