### PR TITLE
fix gen3 loginpage title escape issue

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -60,7 +60,6 @@ import {
   areTransactionsEqual,
   buildAuthCoinProps,
   canBootstrapWidget,
-  escape,
   extractPageTitle,
   getLanguageCode,
   getLanguageDirection,
@@ -458,7 +457,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   }, [eventEmitter, toggleVisibility]);
 
   const getDocumentTitle = useCallback(() => (
-    escape(extractPageTitle(formBag.uischema, widgetProps, idxTransaction))
+    extractPageTitle(formBag.uischema, widgetProps, idxTransaction)
   ), [idxTransaction, widgetProps, formBag.uischema]);
 
   useEffect(() => {

--- a/src/v3/test/e2e/tests/pagetitle.spec.js
+++ b/src/v3/test/e2e/tests/pagetitle.spec.js
@@ -19,5 +19,5 @@ fixture('PageTitle')
 
 test('Page title applies correctly', async (t) => {
   // title should not inlcude escaped characters
-  await t.expect(getTitle()).eql(`Verify it's you with a security method`);
+  await t.expect(getTitle()).eql('Verify it\'s you with a security method');
 });

--- a/src/v3/test/e2e/tests/pagetitle.spec.js
+++ b/src/v3/test/e2e/tests/pagetitle.spec.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { fixture, ClientFunction } from 'testcafe';
+
+const getTitle = ClientFunction(() => document.title);
+
+fixture('PageTitle')
+  .page('http://localhost:3000/?siw-use-mocks=true&siw-mock-response=/idp/idx/identify/default');
+
+test('Page title applies correctly', async (t) => {
+  // title should not inlcude escaped characters
+  await t.expect(getTitle()).eql(`Verify it's you with a security method`);
+});

--- a/src/v3/test/integration/admin-consent.test.tsx
+++ b/src/v3/test/integration/admin-consent.test.tsx
@@ -28,7 +28,6 @@ describe('admin-consent', () => {
     expect(groupHeading.textContent).toBe('Resource and policies');
 
     expect(container).toMatchSnapshot();
-    expect(document.title).toBe('Native client');
   });
 
   it('should send correct payload when consent is given', async () => {

--- a/src/v3/test/integration/admin-consent.test.tsx
+++ b/src/v3/test/integration/admin-consent.test.tsx
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import adminConsentResponse from '../../../../playground/mocks/data/idp/idx/consent-admin.json';
@@ -30,24 +29,6 @@ describe('admin-consent', () => {
 
     expect(container).toMatchSnapshot();
     expect(document.title).toBe('Native client');
-  });
-
-  // disable for now as document is a global state, this test cannot be run in parallel
-  xit('should render correct page title with special character', async () => {
-    const mockResponse = {
-      ...adminConsentResponse,
-      app: {
-        ...adminConsentResponse.app,
-        value: {
-          ...adminConsentResponse.app.value,
-          label: 'Mock&label'
-        }
-      }
-    }
-    const { findByRole } = await setup({ mockResponse });
-    const appNameHeading = await findByRole('heading', { level: 2 });
-    expect(appNameHeading.textContent).toBe('Mock&amp;label');
-    await waitFor(() => expect(document.title).toBe('Mock&label'));
   });
 
   it('should send correct payload when consent is given', async () => {

--- a/src/v3/test/integration/admin-consent.test.tsx
+++ b/src/v3/test/integration/admin-consent.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import adminConsentResponse from '../../../../playground/mocks/data/idp/idx/consent-admin.json';
@@ -28,6 +29,25 @@ describe('admin-consent', () => {
     expect(groupHeading.textContent).toBe('Resource and policies');
 
     expect(container).toMatchSnapshot();
+    expect(document.title).toBe('Native client');
+  });
+
+  // disable for now as document is a global state, this test cannot be run in parallel
+  xit('should render correct page title with special character', async () => {
+    const mockResponse = {
+      ...adminConsentResponse,
+      app: {
+        ...adminConsentResponse.app,
+        value: {
+          ...adminConsentResponse.app.value,
+          label: 'Mock&label'
+        }
+      }
+    }
+    const { findByRole } = await setup({ mockResponse });
+    const appNameHeading = await findByRole('heading', { level: 2 });
+    expect(appNameHeading.textContent).toBe('Mock&amp;label');
+    await waitFor(() => expect(document.title).toBe('Mock&label'));
   });
 
   it('should send correct payload when consent is given', async () => {


### PR DESCRIPTION
## Description:

not escape chars in page title

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-678416](https://oktainc.atlassian.net/browse/OKTA-678416)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



