### PR TITLE
CA-OKTA-649640 initial commit for password history text change.

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1107,11 +1107,7 @@ oie.enroll.okta_verify.channel.sms.description = Make sure you can access the te
 oie.enroll.okta_verify.channel.sms.description.updated = Make sure you can access the text on the receiving device
 oie.enroll.okta_verify.qrcode.title = Set up Okta Verify via QR code
 oie.enroll.okta_verify.qrcode.step1 = On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
-<<<<<<< HEAD
 oie.enroll.okta_verify.qrcode.step1.updated = On your other device, download the Okta Verify app from the App Store® (iPhone® and iPad®) or on Google Play (Android? devices).
-=======
-oie.enroll.okta_verify.qrcode.step1.updated = On your other device, download the Okta Verify app from the App Store� (iPhone� and iPad�) or on Google Play (Android? devices).
->>>>>>> b3ab32571 (CA-OKTA-649640 change the password policy history text property.)
 oie.enroll.okta_verify.qrcode.step2 = Open the app and follow the instructions to add your account
 oie.enroll.okta_verify.qrcode.step3.updated = When prompted, tap <$1>Scan a QR code</$1>, then scan the QR code below:
 oie.enroll.okta_verify.qrcode.step3 = When prompted, tap Scan a QR code, then scan the QR code below:

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -644,7 +644,7 @@ password.reset.title.specific = Reset your {0} password
 # {0} is a generated list of requirements, based on translations from the below keys.
 password.complexity.requirements = Password requirements: {0}.
 # {0} is a number
-password.complexity.history = Your password cannot be any of your last {0} passwords.
+password.complexity.history = Your password cannot be any of your last {0} password(s).
 # {0} is a number
 password.complexity.minAgeMinutes = At least {0} minute(s) must have elapsed since you last changed your password.
 # {0} is a number
@@ -1107,7 +1107,11 @@ oie.enroll.okta_verify.channel.sms.description = Make sure you can access the te
 oie.enroll.okta_verify.channel.sms.description.updated = Make sure you can access the text on the receiving device
 oie.enroll.okta_verify.qrcode.title = Set up Okta Verify via QR code
 oie.enroll.okta_verify.qrcode.step1 = On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
+<<<<<<< HEAD
 oie.enroll.okta_verify.qrcode.step1.updated = On your other device, download the Okta Verify app from the App Store® (iPhone® and iPad®) or on Google Play (Android? devices).
+=======
+oie.enroll.okta_verify.qrcode.step1.updated = On your other device, download the Okta Verify app from the App Store� (iPhone� and iPad�) or on Google Play (Android? devices).
+>>>>>>> b3ab32571 (CA-OKTA-649640 change the password policy history text property.)
 oie.enroll.okta_verify.qrcode.step2 = Open the app and follow the instructions to add your account
 oie.enroll.okta_verify.qrcode.step3.updated = When prompted, tap <$1>Scan a QR code</$1>, then scan the QR code below:
 oie.enroll.okta_verify.qrcode.step3 = When prompted, tap Scan a QR code, then scan the QR code below:

--- a/test/unit/spec/v1/PasswordReset_spec.js
+++ b/test/unit/spec/v1/PasswordReset_spec.js
@@ -267,7 +267,7 @@ Expect.describe('PasswordReset', function() {
 
   itp('has a valid subtitle if only password age "historyCount" defined', function() {
     return setup({ policyAge: 'historyCount' }).then(function(test) {
-      expect(test.form.subtitleText()).toEqual('Your password cannot be any of your last 7 passwords.');
+      expect(test.form.subtitleText()).toEqual('Your password cannot be any of your last 7 password(s).');
     });
   });
 
@@ -300,7 +300,7 @@ Expect.describe('PasswordReset', function() {
     function() {
       return setup({ policyComplexity: 'excludeUsername', policyAge: 'historyCount' }).then(function(test) {
         expect(test.form.subtitleText()).toEqual(
-          'Password requirements: no parts of your username.' + ' Your password cannot be any of your last 7 passwords.'
+          'Password requirements: no parts of your username.' + ' Your password cannot be any of your last 7 password(s).'
         );
       });
     }
@@ -319,7 +319,7 @@ Expect.describe('PasswordReset', function() {
   itp('has a valid subtitle in minutes if password age is defined with all options', function() {
     return setup({ policyAge: 'all' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual(
-        'Your password cannot be any of your last 7 passwords.' +
+        'Your password cannot be any of your last 7 password(s).' +
           ' At least 30 minute(s) must have elapsed since you last changed your password.'
       );
     });
@@ -333,7 +333,7 @@ Expect.describe('PasswordReset', function() {
           'Password requirements: at least 8 characters, a lowercase letter,' +
             ' an uppercase letter, a number, a symbol, no parts of your username,' +
             ' does not include your first name, does not include your last name.' +
-            ' Your password cannot be any of your last 7 passwords.'
+            ' Your password cannot be any of your last 7 password(s).'
         );
       });
     }
@@ -345,7 +345,7 @@ Expect.describe('PasswordReset', function() {
         'Password requirements: at least 8 characters, a lowercase letter,' +
           ' an uppercase letter, a number, a symbol, no parts of your username,' +
           ' does not include your first name, does not include your last name.' +
-          ' Your password cannot be any of your last 7 passwords.' +
+          ' Your password cannot be any of your last 7 password(s).' +
           ' At least 30 minute(s) must have elapsed since you last changed your password.'
       );
     });
@@ -484,7 +484,7 @@ Expect.describe('PasswordReset', function() {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual(
-          'Password can\'t be the same as your last 7 passwords'
+          'Password can\'t be the same as your last 7 password(s)'
         );
       });
     });
@@ -550,7 +550,7 @@ Expect.describe('PasswordReset', function() {
           expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
           expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('No parts of your username');
           expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual(
-            'Password can\'t be the same as your last 7 passwords'
+            'Password can\'t be the same as your last 7 password(s)'
           );
         });
       }
@@ -578,7 +578,7 @@ Expect.describe('PasswordReset', function() {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual(
-          'Password can\'t be the same as your last 7 passwords'
+          'Password can\'t be the same as your last 7 password(s)'
         );
         expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual(
           'At least 30 minute(s) must have elapsed since you last changed your password'
@@ -607,7 +607,7 @@ Expect.describe('PasswordReset', function() {
           );
           expect(test.form.passwordRequirementsHtmlListItems().eq(7).text()).toEqual('Does not include your last name');
           expect(test.form.passwordRequirementsHtmlListItems().eq(8).text()).toEqual(
-            'Password can\'t be the same as your last 7 passwords'
+            'Password can\'t be the same as your last 7 password(s)'
           );
         });
       }
@@ -630,7 +630,7 @@ Expect.describe('PasswordReset', function() {
         expect(test.form.passwordRequirementsHtmlListItems().eq(6).text()).toEqual('Does not include your first name');
         expect(test.form.passwordRequirementsHtmlListItems().eq(7).text()).toEqual('Does not include your last name');
         expect(test.form.passwordRequirementsHtmlListItems().eq(8).text()).toEqual(
-          'Password can\'t be the same as your last 7 passwords'
+          'Password can\'t be the same as your last 7 password(s)'
         );
         expect(test.form.passwordRequirementsHtmlListItems().eq(9).text()).toEqual(
           'At least 30 minute(s) must have elapsed since you last changed your password'

--- a/test/unit/spec/v1/PasswordReset_spec.js
+++ b/test/unit/spec/v1/PasswordReset_spec.js
@@ -484,7 +484,7 @@ Expect.describe('PasswordReset', function() {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual(
-          'Password can\'t be the same as your last 7 password(s)'
+          'Password can\'t be the same as your last 7 passwords'
         );
       });
     });
@@ -550,7 +550,7 @@ Expect.describe('PasswordReset', function() {
           expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
           expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('No parts of your username');
           expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual(
-            'Password can\'t be the same as your last 7 password(s)'
+            'Password can\'t be the same as your last 7 passwords'
           );
         });
       }
@@ -578,7 +578,7 @@ Expect.describe('PasswordReset', function() {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual(
-          'Password can\'t be the same as your last 7 password(s)'
+          'Password can\'t be the same as your last 7 passwords'
         );
         expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual(
           'At least 30 minute(s) must have elapsed since you last changed your password'
@@ -607,7 +607,7 @@ Expect.describe('PasswordReset', function() {
           );
           expect(test.form.passwordRequirementsHtmlListItems().eq(7).text()).toEqual('Does not include your last name');
           expect(test.form.passwordRequirementsHtmlListItems().eq(8).text()).toEqual(
-            'Password can\'t be the same as your last 7 password(s)'
+            'Password can\'t be the same as your last 7 passwords'
           );
         });
       }
@@ -630,7 +630,7 @@ Expect.describe('PasswordReset', function() {
         expect(test.form.passwordRequirementsHtmlListItems().eq(6).text()).toEqual('Does not include your first name');
         expect(test.form.passwordRequirementsHtmlListItems().eq(7).text()).toEqual('Does not include your last name');
         expect(test.form.passwordRequirementsHtmlListItems().eq(8).text()).toEqual(
-          'Password can\'t be the same as your last 7 password(s)'
+          'Password can\'t be the same as your last 7 passwords'
         );
         expect(test.form.passwordRequirementsHtmlListItems().eq(9).text()).toEqual(
           'At least 30 minute(s) must have elapsed since you last changed your password'


### PR DESCRIPTION
## Description:
* Fix issue with english grammar in password policy error msg and description.


## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-649640](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:
@glenfannin-okta 

### Screenshot/Video:


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-1b2bd47-65a8076c&page=1&pageSize=6&tab=main



