### PR TITLE
Migrate Spinner to Odyssey CircularProgress

### DIFF
--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -10,8 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { CircularProgress } from '@okta/odyssey-react-mui';
 import { Box } from '@mui/material';
+import { CircularProgress } from '@okta/odyssey-react-mui';
 import { FunctionComponent, h } from 'preact';
 
 import { SpinnerElement } from '../../types';

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -10,17 +10,18 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box, CircularProgress } from '@okta/odyssey-react-mui-legacy';
+import { CircularProgress } from '@okta/odyssey-react-mui';
+import { Box } from '@mui/material';
 import { FunctionComponent, h } from 'preact';
 
 import { SpinnerElement } from '../../types';
 import { loc } from '../../util';
 
-type SpinnerProps = { dataSe?: string; color?: string; };
+type SpinnerProps = { dataSe?: string; };
 const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
   props,
 ) => {
-  const { dataSe = undefined, color = undefined } = 'type' in props
+  const { dataSe = undefined } = 'type' in props
     ? {}
     : props as SpinnerProps;
   return (
@@ -31,13 +32,10 @@ const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
       alignItems="center"
     >
       <CircularProgress
-        id={dataSe}
-        data-se={dataSe}
+        testId={dataSe}
         // Using loc here because this component is not only used by transformers
         // but also directly in widget component
-        aria-label={loc('processing.alt.text', 'login')}
-        aria-valuetext={loc('processing.alt.text', 'login')}
-        sx={{ color }}
+        ariaLabel={loc('processing.alt.text', 'login')}
       />
     </Box>
   );

--- a/src/v3/src/util/theme.ts
+++ b/src/v3/src/util/theme.ts
@@ -123,16 +123,6 @@ export const createThemeAndTokens = (
   // Merge default Odyssey 1.x theme with component overrides
   const themeOverride = mergeThemes(baseOdysseyTheme, {
     components: {
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            whiteSpace: 'normal',
-          },
-        },
-      },
       MuiAlert: {
         styleOverrides: {
           root: {
@@ -142,6 +132,23 @@ export const createThemeAndTokens = (
             paddingInlineEnd: mergedTokens.Spacing5,
             flexShrink: 0,
           },
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: ({ ownerState }) => ({
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            whiteSpace: 'normal',
+            // Odyssey CircularProgress does not allow color change but SIW needs a white spinner
+            // when rendering it as the startIcon for primary buttons
+            ...(ownerState.variant === "primary" && {
+              '& .MuiCircularProgress-root': {
+                color: 'white'
+              },
+            }),
+          }),
         },
       },
       MuiInputBase: {

--- a/src/v3/src/util/theme.ts
+++ b/src/v3/src/util/theme.ts
@@ -143,9 +143,9 @@ export const createThemeAndTokens = (
             whiteSpace: 'normal',
             // Odyssey CircularProgress does not allow color change but SIW needs a white spinner
             // when rendering it as the startIcon for primary buttons
-            ...(ownerState.variant === "primary" && {
+            ...(ownerState.variant === 'primary' && {
               '& .MuiCircularProgress-root': {
-                color: 'white'
+                color: 'white',
               },
             }),
           }),

--- a/src/v3/src/util/theme.ts
+++ b/src/v3/src/util/theme.ts
@@ -145,7 +145,7 @@ export const createThemeAndTokens = (
             // when rendering it as the startIcon for primary buttons
             ...(ownerState.variant === 'primary' && {
               '& .MuiCircularProgress-root': {
-                color: 'white',
+                color: mergedTokens.HueNeutralWhite,
               },
             }),
           }),

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -1280,7 +1280,6 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           >
                             <span
                               aria-label="Processing..."
-                              aria-valuetext="Processing..."
                               class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-52"
                               role="progressbar"
                               style="width: 1.71428571rem; height: 1.71428571rem;"

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -1020,10 +1020,8 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
                       >
                         <span
                           aria-label="Processing..."
-                          aria-valuetext="Processing..."
                           class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-20"
                           data-se="okta-spinner"
-                          id="okta-spinner"
                           role="progressbar"
                           style="width: 1.71428571rem; height: 1.71428571rem;"
                         >

--- a/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
@@ -58,7 +58,6 @@ exports[`enduser-consent-without-logo should render form 1`] = `
               >
                 <span
                   aria-label="Processing..."
-                  aria-valuetext="Processing..."
                   class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-14"
                   role="progressbar"
                   style="width: 1.71428571rem; height: 1.71428571rem;"

--- a/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
@@ -77,7 +77,6 @@ exports[`enduser-consent should render form with logo 1`] = `
               >
                 <span
                   aria-label="Processing..."
-                  aria-valuetext="Processing..."
                   class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-17"
                   role="progressbar"
                   style="width: 1.71428571rem; height: 1.71428571rem;"

--- a/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
@@ -76,7 +76,6 @@ exports[`granular-consent should render form with logo 1`] = `
               >
                 <span
                   aria-label="Processing..."
-                  aria-valuetext="Processing..."
                   class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-16"
                   role="progressbar"
                   style="width: 1.71428571rem; height: 1.71428571rem;"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -1519,7 +1519,6 @@ exports[`identify-with-password renders the loading state first 1`] = `
               >
                 <span
                   aria-label="Processing..."
-                  aria-valuetext="Processing..."
                   class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-9"
                   role="progressbar"
                   style="width: 1.71428571rem; height: 1.71428571rem;"


### PR DESCRIPTION
## Description:
- Migrate SIW `Spinner` to Odyssey `CircularProgress`
- Add theme override for rendering a white spinner when it is rendered as a child of a primary button because Odyssey `CircularProgress` does not support changing the color since they don't expect that a spinner would be used as the icon for a button
    - This theme override is guaranteed to be safe from an accessibility POV because the primary palette token (`PalettePrimaryMain`) is generated by the Leonardo package which always ensures that it adheres to WCAG contrast ratios with white text

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-678806](https://oktainc.atlassian.net/browse/OKTA-678806)

### Reviewers:

### Screenshot/Video:
#### Spinner only renders as white on a primary button, otherwise it renders as `PrimaryPaletteMain`
https://github.com/okta/okta-signin-widget/assets/106110543/58b9aaff-eb67-488c-91c1-3f9928d29163



### Downstream Monolith Build:



