### PR TITLE
fix: Allows legacy ref to css exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "default": "./target/js/okta-sign-in.oie.js"
     },
     "./polyfill": "./target/js/okta-sign-in.polyfill.js",
-    "./css/": "./target/css/"
+    "./css/": "./target/css/",
+    "./target/css/": "./target/css/"
   },
   "scripts": {
     "clean": "rimraf target && rimraf dist && rimraf build2",


### PR DESCRIPTION
## Description:

This PR allows users to upgrade to the latest version without experiencing css export path issues.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- No current Issue to reference

### Reviewers:

### Screenshot/Video:

**Before the Change, a user would see the below error**

<img width="468" alt="image" src="https://github.com/okta/okta-signin-widget/assets/17281152/66829961-0f30-4847-a66a-c9f6d3e2a897">

![image](https://github.com/okta/okta-signin-widget/assets/17281152/68ffdcc1-2e36-448a-8342-2f1cba022944)

<img width="1253" alt="Screenshot 2024-01-17 at 6 45 42 PM" src="https://github.com/okta/okta-signin-widget/assets/17281152/ad857799-91a4-4d50-a337-d732babd8f54">

> IME, the error would manifest itself when referencing the legacy path from a `*.css` file

**SO**
To fix user from potentially breaking when upgrading, i recommend the below change to allow for the legacy reference path to be covered as well. Maybe this could be better explained or referenced in the [Migration Guide](https://github.com/okta/okta-signin-widget/blob/master/MIGRATING.md)

<img width="1243" alt="Screenshot 2024-01-17 at 6 47 30 PM" src="https://github.com/okta/okta-signin-widget/assets/17281152/bed11f3b-00e8-42d9-a1ae-81046db8d839">


### Downstream Monolith Build:



