### PR TITLE
Handle OAuth2 error 'The activation token is invalid' like OIE's 'idx.missing.activation.token'

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -12,6 +12,7 @@ const idx = {
     'interact'
     // 'error-feature-not-enabled'
     // 'error-recovery-token-invalid'
+    // 'error-activation-token-invalid'
   ],
   '/oauth2/default/v1/token': [
     'error-token-invalid-grant-pkce'

--- a/playground/mocks/data/oauth2/error-activation-token-invalid.json
+++ b/playground/mocks/data/oauth2/error-activation-token-invalid.json
@@ -1,0 +1,4 @@
+{
+  "error": "invalid_request",
+  "error_description": "The activation token is invalid"
+}

--- a/src/v2/client/formatError.ts
+++ b/src/v2/client/formatError.ts
@@ -33,6 +33,11 @@ export function isInvalidRecoveryTokenError(error): error is StandardApiError {
   return (error?.error === 'invalid_request' && error.error_description === 'The recovery token is invalid');
 }
 
+export function isInvalidActivationTokenError(error): error is StandardApiError {
+  // special case: error from interact when passing an (invalid) activation token
+  return (error?.error === 'invalid_request' && error.error_description === 'The activation token is invalid');
+}
+
 export function formatInvalidRecoveryTokenError(error: StandardApiError) {
   // This error comes from `oauth2/interact` so is not an IDX error.
   // simulate an IDX-JS error response
@@ -45,6 +50,28 @@ export function formatInvalidRecoveryTokenError(error: StandardApiError) {
         message: error.error_description,
         i18n: {
           key: 'oie.invalid.recovery.token'
+        },
+        class: 'ERROR'
+      }
+    ],
+  };
+  details.rawIdxState.messages = messages;
+  details.context.messages = messages;
+  return idxError;
+}
+
+export function formatInvalidActivationTokenError(error: StandardApiError) {
+  // This error comes from `oauth2/interact` so is not an IDX error.
+  // simulate an IDX-JS error response
+  const idxError = formatIDXError(error);
+  const { details } = idxError;
+  const messages: IdxMessages = {
+    type: 'array',
+    value: [
+      {
+        message: error.error_description,
+        i18n: {
+          key: 'idx.missing.activation.token'
         },
         class: 'ERROR'
       }
@@ -146,6 +173,11 @@ export function formatError(error: string | Error | LegacyIdxError | StandardApi
   // invalid reccovery token
   if (isInvalidRecoveryTokenError(error)) {
     return formatInvalidRecoveryTokenError(error);
+  }
+
+  // invalid activation token
+  if (isInvalidActivationTokenError(error)) {
+    return formatInvalidActivationTokenError(error);
   }
 
   // OIE is not enabled

--- a/src/v3/src/mocks/response/oauth2/default/v1/interact/error-activation-token-invalid.json
+++ b/src/v3/src/mocks/response/oauth2/default/v1/interact/error-activation-token-invalid.json
@@ -1,0 +1,4 @@
+{
+  "error": "invalid_request",
+  "error_description": "The activation token is invalid"
+}

--- a/src/v3/src/mocks/scenario/error-activation-token-invalid.ts
+++ b/src/v3/src/mocks/scenario/error-activation-token-invalid.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { scenario } from '../registry';
+
+scenario('error-activation-token-invalid', (rest) => ([
+  // bootstrap
+  rest.get('*/oauth2/default/.well-known/openid-configuration', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/well-known/openid-configuration/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // generic error from IDX
+  rest.post('*/oauth2/default/v1/interact', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/v1/interact/error-activation-token-invalid.json');
+    return res(
+      ctx.status(500),
+      ctx.json(body),
+    );
+  }),
+  rest.post('*/idp/idx/introspect', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/v1/interact/error-activation-token-invalid.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+]));

--- a/src/v3/src/mocks/scenario/index.ts
+++ b/src/v3/src/mocks/scenario/index.ts
@@ -31,6 +31,7 @@ import './error-400-unauthorized-client';
 import './error-401-invalid-otp-passcode';
 import './error-403-security-access-denied';
 import './error-account-creation';
+import './error-activation-token-invalid';
 import './error-feature-not-enabled';
 import './error-password-reset-failed';
 import './error-recovery-token-invalid';

--- a/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
+++ b/src/v3/src/transformer/terminal/__snapshots__/transformUnhandledErrors.test.ts.snap
@@ -142,6 +142,36 @@ Object {
 }
 `;
 
+exports[`Unhandled Error Transformer Tests When OAuthError is returned should add info box when response is invalid activation token error 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToValidate": Array [],
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "class": "ERROR",
+          "dataSe": "callout",
+          "message": Object {
+            "class": "ERROR",
+            "i18n": Object {
+              "key": "idx.missing.activation.token",
+            },
+            "message": "idx.missing.activation.token",
+            "title": "oie.activation.request.email.title.invalid",
+          },
+        },
+        "type": "InfoBox",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
 exports[`Unhandled Error Transformer Tests When OAuthError is returned should add info box when response is invalid recovery token error 1`] = `
 Object {
   "data": Object {},

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.test.ts
@@ -120,6 +120,30 @@ describe('Unhandled Error Transformer Tests', () => {
       ).options?.class).toBe('ERROR');
     });
 
+    it('should add info box when response is invalid activation token error', () => {
+      const mockErrorMessage = 'The activation token is invalid';
+      apiError = {
+        ...apiError,
+        error: 'invalid_request',
+        error_description: mockErrorMessage,
+      };
+      const formBag = transformUnhandledErrors(widgetProps, apiError);
+
+      expect(formBag).toMatchSnapshot();
+      expect(formBag.uischema.elements.length).toBe(1);
+      expect(formBag.uischema.elements[0].type).toBe('InfoBox');
+      expect((formBag.uischema.elements[0] as InfoboxElement).options?.message)
+        .toEqual({
+          class: 'ERROR',
+          i18n: { key: 'idx.missing.activation.token' },
+          message: 'idx.missing.activation.token',
+          title: 'oie.activation.request.email.title.invalid',
+        });
+      expect((
+        formBag.uischema.elements[0] as InfoboxElement
+      ).options?.class).toBe('ERROR');
+    });
+
     it('should add info box when oie is not enabled error', () => {
       const mockErrorMessage = 'A mocked error message';
       apiError = {

--- a/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
+++ b/src/v3/src/transformer/terminal/transformUnhandledErrors.ts
@@ -13,6 +13,7 @@
 import { AuthApiError, OAuthError } from '@okta/okta-auth-js';
 
 import { getMessage } from '../../../../v2/ion/i18nUtils';
+import { TERMINAL_KEY, TERMINAL_TITLE_KEY } from '../../constants';
 import {
   FormBag,
   InfoboxElement,
@@ -71,6 +72,15 @@ const getWidgetMessage = (
         class: 'ERROR',
         message: loc('oie.invalid.recovery.token', 'login'),
         i18n: { key: 'oie.invalid.recovery.token' },
+      }),
+    },
+    {
+      tester: (err?: OAuthError) => err?.error === 'invalid_request' && err?.error_description === 'The activation token is invalid',
+      message: () => ({
+        class: 'ERROR',
+        title: loc(TERMINAL_TITLE_KEY[TERMINAL_KEY.EMAIL_ACTIVATION_EMAIL_INVALID], 'login'),
+        message: loc(TERMINAL_KEY.EMAIL_ACTIVATION_EMAIL_INVALID, 'login'),
+        i18n: { key: TERMINAL_KEY.EMAIL_ACTIVATION_EMAIL_INVALID },
       }),
     },
     {

--- a/src/v3/test/integration/__snapshots__/error-activation-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-activation-token-invalid.test.tsx.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`error-activation-token-invalid should render form 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="auth-container main-container MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="MuiScopedCssBaseline-root emotion-2"
+      >
+        <div
+          class="MuiBox-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="okta-sign-in-header auth-header MuiBox-root emotion-5"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 emotion-6"
+              />
+            </div>
+            <div
+              class="MuiBox-root emotion-7"
+            >
+              <form
+                class="o-form MuiBox-root emotion-8"
+                data-se="o-form"
+                novalidate=""
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <div
+                      class="MuiBox-root emotion-11"
+                      data-se="message"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox infobox-error emotion-12"
+                        data-se="callout"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-icon emotion-13"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-14"
+                            fill="none"
+                            focusable="false"
+                            viewBox="0 0 16 16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M13.983 14.6471C13.4706 15 12.6329 15 10.9575 15H5.04248C3.36707 15 2.52937 15 2.01699 14.6471C1.56939 14.3387 1.26655 13.8615 1.17816 13.3252C1.07698 12.7114 1.43367 11.9534 2.14706 10.4374L5.10455 4.15277C6.02878 2.18879 6.49089 1.2068 7.12576 0.898255C7.6777 0.630012 8.32225 0.630012 8.87419 0.898255C9.50906 1.2068 9.97117 2.18879 10.8954 4.15277L13.8529 10.4374C14.5663 11.9534 14.923 12.7114 14.8218 13.3252C14.7334 13.8615 14.4306 14.3387 13.983 14.6471ZM7.99998 10C7.72383 10 7.49998 9.77614 7.49998 9.5L7.49998 5H8.49998L8.49998 9.5C8.49998 9.77614 8.27612 10 7.99998 10ZM7.99998 13C8.14831 13 8.29332 12.956 8.41665 12.8736C8.53999 12.7912 8.63612 12.6741 8.69288 12.537C8.74965 12.4 8.7645 12.2492 8.73556 12.1037C8.70662 11.9582 8.6352 11.8246 8.53031 11.7197C8.42542 11.6148 8.29178 11.5434 8.14629 11.5144C8.00081 11.4855 7.85001 11.5003 7.71296 11.5571C7.57592 11.6139 7.45878 11.71 7.37637 11.8333C7.29396 11.9567 7.24998 12.1017 7.24998 12.25C7.24998 12.4489 7.32899 12.6397 7.46964 12.7803C7.6103 12.921 7.80106 13 7.99998 13Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="MuiAlert-message emotion-15"
+                        >
+                          <h2
+                            class="MuiTypography-root MuiTypography-h6 emotion-16"
+                          >
+                            Activation link no longer valid
+                          </h2>
+                          This can happen if you have already activated your account, or if the URL you are trying to use is invalid. Contact your administrator for further assistance.
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;

--- a/src/v3/test/integration/error-activation-token-invalid.test.tsx
+++ b/src/v3/test/integration/error-activation-token-invalid.test.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { setup } from './util';
+
+import mockResponse from '../../src/mocks/response/oauth2/default/v1/interact/error-activation-token-invalid.json';
+
+describe('error-activation-token-invalid', () => {
+  it('should render form', async () => {
+    const { container, findByText } = await setup({ mockResponse });
+    // error title
+    await findByText(/Activation link no longer valid/);
+    // error description
+    await findByText(/This can happen if you have already activated your account, or if the URL you are trying to use is invalid. Contact your administrator for further assistance./);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -5,6 +5,7 @@ import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
 import { checkConsoleMessages } from '../framework/shared';
 import xhrErrorFeatureNotEnabled from '../../../playground/mocks/data/oauth2/error-feature-not-enabled';
 import xhrErrorInvalidRecoveryToken from '../../../playground/mocks/data/oauth2/error-recovery-token-invalid';
+import xhrErrorInvalidActivationToken from '../../../playground/mocks/data/oauth2/error-activation-token-invalid';
 import xhrWellKnownResponse from '../../../playground/mocks/data/oauth2/well-known-openid-configuration.json';
 import xhrInteractResponse from '../../../playground/mocks/data/oauth2/interact.json';
 import xhrIdentify from '../../../playground/mocks/data/idp/idx/identify';
@@ -266,6 +267,24 @@ test.requestHooks(requestLogger, errorInvalidRecoveryTokenMock)('shows an error 
   await t.expect(errors.isError()).ok();
   await t.expect(errors.getTextContent()).eql('The recovery token is invalid.');
 
+  await checkConsoleMessages([
+    'ready',
+    'afterRender',
+    expectTerminalView
+  ]);
+});
+
+test.requestHooks(requestLogger, xhrErrorInvalidActivationToken)('shows an error when activation token is invalid', async t => {
+  await setup(t);
+  await checkA11y(t);
+
+  const terminalPageObject = new TerminalPageObject(t);
+  const errors = terminalPageObject.getErrorMessages();
+  await t.expect(errors.isError()).ok();
+  // error title
+  await t.expect(errors.getTextContent()).contains('Activation link no longer valid');
+  // error description
+  await t.expect(errors.getTextContent()).contains('This can happen if you have already activated your account, or if the URL you are trying to use is invalid. Contact your administrator for further assistance');
   await checkConsoleMessages([
     'ready',
     'afterRender',

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -1,4 +1,4 @@
-import { ClientFunction, RequestMock, RequestLogger } from 'testcafe';
+import { ClientFunction, RequestMock, RequestLogger, userVariables } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import BasePageObject from '../framework/page-objects/BasePageObject';
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
@@ -288,9 +288,11 @@ test.requestHooks(requestLogger, errorInvalidActivationTokenMock)('shows an erro
   const terminalPageObject = new TerminalPageObject(t);
   const errors = terminalPageObject.getErrorMessages();
   await t.expect(errors.isError()).ok();
-  // error title
-  await t.expect(errors.getTextContent()).contains('Activation link no longer valid');
-  // error description
+  if (userVariables.gen3) {
+    await t.expect(errors.getTextContent()).contains('Activation link no longer valid');
+  } else {
+    await t.expect(terminalPageObject.getFormTitle()).eql('Activation link no longer valid');
+  }
   await t.expect(errors.getTextContent()).contains('This can happen if you have already activated your account, or if the URL you are trying to use is invalid. Contact your administrator for further assistance');
   await checkConsoleMessages([
     'ready',

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -63,6 +63,13 @@ const errorInvalidRecoveryTokenMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrIdentify);
 
+const errorInvalidActivationTokenMock = RequestMock()
+  .onRequestTo('http://localhost:3000/oauth2/default/.well-known/openid-configuration')
+  .respond(xhrWellKnownResponse, 200)
+  .onRequestTo('http://localhost:3000/oauth2/default/v1/interact')
+  .respond(xhrErrorInvalidActivationToken, 400)
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrIdentify);
 
 const cancelResetPasswordMock = RequestMock()
   .onRequestTo('http://localhost:3000/oauth2/default/.well-known/openid-configuration')
@@ -274,7 +281,7 @@ test.requestHooks(requestLogger, errorInvalidRecoveryTokenMock)('shows an error 
   ]);
 });
 
-test.requestHooks(requestLogger, xhrErrorInvalidActivationToken)('shows an error when activation token is invalid', async t => {
+test.requestHooks(requestLogger, errorInvalidActivationTokenMock)('shows an error when activation token is invalid', async t => {
   await setup(t);
   await checkA11y(t);
 


### PR DESCRIPTION
## Description:

This PR changes terminal error page when response to `/oauth2/default/v1/interact` results with the following error
```
{
  "error": "invalid_request",
  "error_description": "The activation token is invalid"
}
```
In this case error with key `idx.missing.activation.token` will be rendered, see screenshots.

Similar approach is already done for error with description `The recovery token is invalid` - it renders as error with i18n key `oie.invalid.recovery.token`

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-680179](https://oktainc.atlassian.net/browse/OKTA-680179)

### Reviewers:

### Screenshot/Video:

Before:

![Screenshot 2023-12-28 at 18 23 04](https://github.com/okta/okta-signin-widget/assets/72614880/cd289945-8b6b-4840-80ef-a05cb575dece)


<img width="455" alt="Screenshot 2024-01-22 at 10 59 55" src="https://github.com/okta/okta-signin-widget/assets/72614880/a72a77c5-eb96-4cfa-97bc-b3559ada5002">

After:

<img width="414" alt="Screenshot 2024-01-18 at 16 48 44" src="https://github.com/okta/okta-signin-widget/assets/72614880/72a5742c-5121-49fb-9af1-e3e4e05c4bf5">

<img width="457" alt="Screenshot 2024-01-18 at 16 54 26" src="https://github.com/okta/okta-signin-widget/assets/72614880/1ffb32f5-6e9c-4980-b9c9-cb606983973d">




### Downstream Monolith Build:



