### PR TITLE
Migrate `InputText` to `TextField`

### DIFF
--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -10,15 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { useOdysseyDesignTokens } from '@okta/odyssey-react-mui';
-import {
-  Box,
-  FormHelperText,
-  InputBase,
-  InputLabel,
-  Typography,
-} from '@okta/odyssey-react-mui-legacy';
+import { Box } from '@mui/material';
+import { TextField } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
+import { buildFieldLevelErrorMessages } from 'src/util/buildFieldLevelErrorMessages';
 
 import { useWidgetContext } from '../../contexts';
 import {
@@ -31,16 +26,13 @@ import {
   UISchemaElementComponent, UISchemaElementComponentWithValidationProps,
 } from '../../types';
 import { getTranslation } from '../../util';
-import FieldLevelMessageContainer from '../FieldLevelMessageContainer';
 import { withFormValidationState } from '../hocs';
 
 const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidationProps> = ({
-  type,
   uischema,
   errors,
   handleChange,
   handleBlur,
-  describedByIds,
 }) => {
   const value = useValue(uischema);
   const { loading } = useWidgetContext();
@@ -48,112 +40,46 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
     translations = [],
     focus,
     parserOptions,
-    showAsterisk,
     dir,
   } = uischema;
   const label = getTranslation(translations, 'label');
   const hint = getTranslation(translations, 'hint');
   const explain = getTranslation(translations, 'bottomExplain');
-  const optionalLabel = getTranslation(translations, 'optionalLabel');
   const {
     attributes,
     inputMeta: { name, required },
     dataSe,
   } = uischema.options;
+  const { autocomplete, inputmode } = attributes || {};
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
   const parsedExplainContent = useHtmlContentParser(explain, parserOptions);
-  const hasErrors = typeof errors !== 'undefined';
-  // TODO: OKTA-569647 - refactor logic
-  const hintId = hint && `${name}-hint`;
-  const explainId = explain && `${name}-explain`;
-  const ariaDescribedByIds = [describedByIds, hintId, explainId].filter(Boolean).join(' ')
-    || undefined;
-  const tokens = useOdysseyDesignTokens();
+  const { errorMessage, errorMessageList } = buildFieldLevelErrorMessages(errors);
 
   return (
-    <Box>
-      <InputLabel
-        htmlFor={name}
-        // To prevent asterisk from shifting far right
-        sx={{ justifyContent: showAsterisk ? 'flex-start' : undefined }}
-      >
-        {label}
-        {showAsterisk && (
-          <Box
-            component="span"
-            sx={{
-              marginInlineStart: tokens.Spacing2,
-              marginInlineEnd: tokens.Spacing2,
-            }}
-            className="no-translate"
-            aria-hidden
-          >
-            *
-          </Box>
-        )}
-        {required === false && (
-          <Typography
-            variant="subtitle1"
-            sx={{ whiteSpace: 'nowrap' }}
-          >
-            {optionalLabel}
-          </Typography>
-        )}
-      </InputLabel>
-      {
-        hint && (
-          <FormHelperText
-            id={hintId}
-            className="o-form-explain"
-            data-se={hintId}
-            // TODO: OKTA-577905 - Temporary fix until we can upgrade to the latest version of Odyssey
-            sx={{ textAlign: 'start' }}
-          >
-            {hint}
-          </FormHelperText>
-        )
-      }
-      <InputBase
-        value={value}
-        type={type || 'text'}
+    <Box dir={dir}>
+      <TextField
+        autoCompleteType={autocomplete}
+        errorMessage={errorMessage}
+        errorMessageList={errorMessageList}
+        hint={hint ?? parsedExplainContent as string}
         id={name}
+        inputFocusRef={focusRef}
+        inputMode={inputmode}
+        isDisabled={loading}
+        isFullWidth
+        isOptional={!required}
         name={name}
-        error={hasErrors}
+        label={label ?? ''}
         onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
           handleChange?.(e.currentTarget.value);
         }}
         onBlur={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
           handleBlur?.(e?.currentTarget?.value);
         }}
-        disabled={loading}
-        fullWidth
-        inputProps={{
-          'data-se': dataSe,
-          'aria-describedby': ariaDescribedByIds,
-          ...attributes,
-        }}
-        inputRef={focusRef}
-        dir={dir}
+        testId={dataSe}
+        type="text"
+        value={value as string | undefined}
       />
-      {hasErrors && (
-        <FieldLevelMessageContainer
-          messages={errors}
-          fieldName={name}
-        />
-      )}
-      {
-        explain && (
-          <FormHelperText
-            id={explainId}
-            className="o-form-explain"
-            data-se={explainId}
-            // TODO: OKTA-577905 - Temporary fix until we can upgrade to the latest version of Odyssey
-            sx={{ textAlign: 'start' }}
-          >
-            {parsedExplainContent}
-          </FormHelperText>
-        )
-      }
     </Box>
   );
 };

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -60,7 +60,7 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
       errorMessageList={errorMessageList}
       hint={hint ?? parsedExplainContent as string}
       id={name}
-      inputFocusRef={focusRef}
+      inputRef={focusRef}
       inputMode={inputmode}
       isDisabled={loading}
       isFullWidth
@@ -75,7 +75,7 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
       }}
       testId={dataSe}
       type="text"
-      value={value as string | undefined}
+      value={value as string ?? ''}
     />
   );
 };

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box } from '@mui/material';
 import { TextField } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 import { buildFieldLevelErrorMessages } from 'src/util/buildFieldLevelErrorMessages';
@@ -40,7 +39,6 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
     translations = [],
     focus,
     parserOptions,
-    dir,
   } = uischema;
   const label = getTranslation(translations, 'label');
   const hint = getTranslation(translations, 'hint');
@@ -56,31 +54,29 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
   const { errorMessage, errorMessageList } = buildFieldLevelErrorMessages(errors);
 
   return (
-    <Box dir={dir}>
-      <TextField
-        autoCompleteType={autocomplete}
-        errorMessage={errorMessage}
-        errorMessageList={errorMessageList}
-        hint={hint ?? parsedExplainContent as string}
-        id={name}
-        inputFocusRef={focusRef}
-        inputMode={inputmode}
-        isDisabled={loading}
-        isFullWidth
-        isOptional={!required}
-        name={name}
-        label={label ?? ''}
-        onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-          handleChange?.(e.currentTarget.value);
-        }}
-        onBlur={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-          handleBlur?.(e?.currentTarget?.value);
-        }}
-        testId={dataSe}
-        type="text"
-        value={value as string | undefined}
-      />
-    </Box>
+    <TextField
+      autoCompleteType={autocomplete}
+      errorMessage={errorMessage}
+      errorMessageList={errorMessageList}
+      hint={hint ?? parsedExplainContent as string}
+      id={name}
+      inputFocusRef={focusRef}
+      inputMode={inputmode}
+      isDisabled={loading}
+      isFullWidth
+      isOptional={!required}
+      name={name}
+      label={label ?? ''}
+      onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        handleChange?.(e.currentTarget.value);
+      }}
+      onBlur={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        handleBlur?.(e?.currentTarget?.value);
+      }}
+      testId={dataSe}
+      type="text"
+      value={value as string | undefined}
+    />
   );
 };
 

--- a/src/v3/src/util/buildFieldLevelErrorMessages.ts
+++ b/src/v3/src/util/buildFieldLevelErrorMessages.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { WidgetMessage } from '../types';
+
+type FieldLevelErrorMessages = {
+  errorMessage?: string;
+  errorMessageList?: string[];
+};
+
+export const buildFieldLevelErrorMessages = (
+  errors: WidgetMessage[] | undefined,
+) : FieldLevelErrorMessages => {
+  const hasErrors = typeof errors !== 'undefined' && errors.length > 0;
+
+  if (hasErrors) {
+    if (errors.length === 1) {
+      const error = errors[0];
+      // Covers nested messages, e.g. password requirements not met
+      if (Array.isArray(error.message)) {
+        return {
+          errorMessage: error.description,
+          errorMessageList: error.message
+            .filter((msg) => typeof msg.message === 'string')
+            .map((msg) => msg.message as string),
+        };
+      }
+      return { errorMessage: error.message };
+    }
+    return {
+      errorMessageList: errors
+        .filter((error) => typeof error.message === 'string')
+        .map((error) => error.message as string),
+    };
+  }
+
+  return {};
+};

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -12,6 +12,7 @@
 
 export * from './browserUtils';
 export * from './buildErrorMessageIds';
+export * from './buildFieldLevelErrorMessages';
 export * from './buildPasswordRequirementNotMetErrorList';
 export * from './clipboard';
 export * from './configuredFlowUtils';

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -36,6 +36,7 @@ export * from './htmlContentParserUtils';
 export * from './idpIconMap';
 export * from './idxUtils';
 export * from './isInteractiveElement';
+export * from './isLtrField';
 export * from './isPasswordRecovery';
 export * from './isPollingStep';
 export * from './languageUtils';

--- a/src/v3/src/util/isLtrField.ts
+++ b/src/v3/src/util/isLtrField.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+// fields with these names should stay LTR by default
+const ltrOnlyFieldNames = [
+  'credentials.passcode',
+  'identifier',
+  'credentials.newPassword',
+  'confirmPassword',
+  'extension',
+];
+
+export const isLtrField = (fieldName: string) => ltrOnlyFieldNames.includes(fieldName) || fieldName.endsWith('phoneNumber');

--- a/src/v3/src/util/theme.ts
+++ b/src/v3/src/util/theme.ts
@@ -18,6 +18,7 @@ import * as Tokens from '@okta/odyssey-design-tokens';
 import { createOdysseyMuiTheme, DesignTokensOverride, ThemeOptions } from '@okta/odyssey-react-mui';
 
 import { BrandColors } from '../types';
+import { isLtrField } from '.';
 import { mergeThemes } from './mergeThemes';
 
 const WHITE_HEX = '#ffffff';
@@ -166,9 +167,12 @@ export const createThemeAndTokens = (
       },
       MuiInputBase: {
         styleOverrides: {
-          root: {
+          root: ({ ownerState }) => ({
             width: '100%',
-          },
+            ...(ownerState.name && isLtrField(ownerState.name) && {
+              direction: 'ltr',
+            }),
+          }),
           input: {
             '::-ms-reveal': {
               display: 'none',

--- a/src/v3/src/util/theme.ts
+++ b/src/v3/src/util/theme.ts
@@ -157,6 +157,13 @@ export const createThemeAndTokens = (
           }),
         },
       },
+      MuiFormHelperText: {
+        styleOverrides: {
+          root: {
+            display: 'block',
+          },
+        },
+      },
       MuiInputBase: {
         styleOverrides: {
           root: {

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -74,7 +74,6 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -82,6 +81,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-17"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""
@@ -265,7 +265,6 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -273,6 +272,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-17"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""
@@ -456,7 +456,6 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -464,6 +463,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-17"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -60,38 +60,33 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-14"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-18"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-17"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -99,16 +94,16 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-20"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-19"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-22"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-21"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-23"
+                            class="PrivateSwitchBase-input emotion-22"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -118,7 +113,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
                         >
                           Keep me signed in
                         </span>
@@ -129,7 +124,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-25"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -141,7 +136,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -152,20 +147,20 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-30"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-29"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-31"
+                    class="MuiBox-root emotion-30"
                   >
                     <div
-                      class="MuiBox-root emotion-32"
+                      class="MuiBox-root emotion-31"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-34"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_8"
                         >
@@ -174,10 +169,10 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-32"
+                      class="MuiBox-root emotion-31"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                         data-se="enroll"
                         href=""
                       >
@@ -256,38 +251,33 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-14"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-18"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-17"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -295,16 +285,16 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-20"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-19"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-22"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-21"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-23"
+                            class="PrivateSwitchBase-input emotion-22"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -314,7 +304,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
                         >
                           Keep me signed in
                         </span>
@@ -325,7 +315,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-25"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -337,7 +327,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -348,20 +338,20 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-30"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-29"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-31"
+                    class="MuiBox-root emotion-30"
                   >
                     <div
-                      class="MuiBox-root emotion-32"
+                      class="MuiBox-root emotion-31"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-34"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_8"
                         >
@@ -370,10 +360,10 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-32"
+                      class="MuiBox-root emotion-31"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                         data-se="enroll"
                         href=""
                       >
@@ -452,38 +442,33 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-14"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-18"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-17"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -491,16 +476,16 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-20"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-19"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-22"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-21"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-23"
+                            class="PrivateSwitchBase-input emotion-22"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -510,7 +495,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
                         >
                           Keep me signed in
                         </span>
@@ -521,7 +506,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-25"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -533,7 +518,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -544,20 +529,20 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-30"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-29"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-31"
+                    class="MuiBox-root emotion-30"
                   >
                     <div
-                      class="MuiBox-root emotion-32"
+                      class="MuiBox-root emotion-31"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-34"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_8"
                         >
@@ -566,10 +551,10 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-32"
+                      class="MuiBox-root emotion-31"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                         data-se="enroll"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -61,27 +61,37 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-17"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
                           data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-18"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -89,16 +99,16 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-19"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-20"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-21"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-22"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-22"
+                            class="PrivateSwitchBase-input emotion-23"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -108,7 +118,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
                         >
                           Keep me signed in
                         </span>
@@ -119,7 +129,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-25"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -131,7 +141,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -142,20 +152,20 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-29"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-30"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-30"
+                    class="MuiBox-root emotion-31"
                   >
                     <div
-                      class="MuiBox-root emotion-31"
+                      class="MuiBox-root emotion-32"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-34"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_8"
                         >
@@ -164,10 +174,10 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-31"
+                      class="MuiBox-root emotion-32"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                         data-se="enroll"
                         href=""
                       >
@@ -247,27 +257,37 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-17"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
                           data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-18"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -275,16 +295,16 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-19"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-20"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-21"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-22"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-22"
+                            class="PrivateSwitchBase-input emotion-23"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -294,7 +314,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
                         >
                           Keep me signed in
                         </span>
@@ -305,7 +325,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-25"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -317,7 +337,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -328,20 +348,20 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-29"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-30"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-30"
+                    class="MuiBox-root emotion-31"
                   >
                     <div
-                      class="MuiBox-root emotion-31"
+                      class="MuiBox-root emotion-32"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-34"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_8"
                         >
@@ -350,10 +370,10 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-31"
+                      class="MuiBox-root emotion-32"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                         data-se="enroll"
                         href=""
                       >
@@ -433,27 +453,37 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-17"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
                           data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-18"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -461,16 +491,16 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-19"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-20"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-21"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-21"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-22"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-22"
+                            class="PrivateSwitchBase-input emotion-23"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -480,7 +510,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
                         >
                           Keep me signed in
                         </span>
@@ -491,7 +521,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-25"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -503,7 +533,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -514,20 +544,20 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-29"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-30"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-30"
+                    class="MuiBox-root emotion-31"
                   >
                     <div
-                      class="MuiBox-root emotion-31"
+                      class="MuiBox-root emotion-32"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-34"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_8"
                         >
@@ -536,10 +566,10 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-31"
+                      class="MuiBox-root emotion-32"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                         data-se="enroll"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -158,39 +158,34 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                          id="credentials.passcode-label"
-                        >
-                          <span>
-                            Enter Code
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.passcode-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-29"
-                            id="credentials.passcode"
-                            name="credentials.passcode"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter Code
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
+                        data-se="credentials.passcode"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-28"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -198,7 +193,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -210,7 +205,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -221,7 +216,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -159,28 +159,38 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-26"
-                        data-shrink="false"
-                        for="credentials.passcode"
-                      >
-                        Enter Code
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
+                        >
+                          <span>
+                            Enter Code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
                           data-se="credentials.passcode"
-                          id="credentials.passcode"
                           inputmode="numeric"
-                          name="credentials.passcode"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-29"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -188,7 +198,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -200,7 +210,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -211,7 +221,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -172,8 +172,6 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                        data-se="credentials.passcode"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -181,7 +179,9 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-28"
+                          data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -430,28 +430,38 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                     >
                       <div
                         class="MuiBox-root emotion-1"
+                        dir="ltr"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-26"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                        >
-                          Enter code
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
-                          dir="ltr"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
                         >
-                          <input
-                            aria-invalid="false"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-28"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
+                            data-shrink="false"
+                            for="credentials.passcode"
+                            id="credentials.passcode-label"
+                          >
+                            <span>
+                              Enter code
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
                             data-se="credentials.passcode"
-                            id="credentials.passcode"
                             inputmode="numeric"
-                            name="credentials.passcode"
-                            type="text"
-                          />
+                            required="true"
+                          >
+                            <input
+                              aria-invalid="false"
+                              aria-labelledby="credentials.passcode-label"
+                              autocomplete="off"
+                              class="MuiInputBase-input emotion-29"
+                              id="credentials.passcode"
+                              name="credentials.passcode"
+                              required=""
+                              type="text"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -459,7 +469,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -472,7 +482,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -483,7 +493,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                       data-se="cancel"
                       href=""
                     >
@@ -917,28 +927,38 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     >
                       <div
                         class="MuiBox-root emotion-1"
+                        dir="ltr"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-26"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                        >
-                          Enter code
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
-                          dir="ltr"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
                         >
-                          <input
-                            aria-invalid="false"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-28"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
+                            data-shrink="false"
+                            for="credentials.passcode"
+                            id="credentials.passcode-label"
+                          >
+                            <span>
+                              Enter code
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
                             data-se="credentials.passcode"
-                            id="credentials.passcode"
                             inputmode="numeric"
-                            name="credentials.passcode"
-                            type="text"
-                          />
+                            required="true"
+                          >
+                            <input
+                              aria-invalid="false"
+                              aria-labelledby="credentials.passcode-label"
+                              autocomplete="off"
+                              class="MuiInputBase-input emotion-29"
+                              id="credentials.passcode"
+                              name="credentials.passcode"
+                              required=""
+                              type="text"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -946,7 +966,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -959,7 +979,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -970,7 +990,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -443,8 +443,6 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
                           required="true"
                         >
                           <input
@@ -452,7 +450,9 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
                             class="MuiInputBase-input emotion-28"
+                            data-se="credentials.passcode"
                             id="credentials.passcode"
+                            inputmode="numeric"
                             name="credentials.passcode"
                             required=""
                             type="text"
@@ -935,8 +935,6 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
                           required="true"
                         >
                           <input
@@ -944,7 +942,9 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
                             class="MuiInputBase-input emotion-28"
+                            data-se="credentials.passcode"
                             id="credentials.passcode"
+                            inputmode="numeric"
                             name="credentials.passcode"
                             required=""
                             type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -429,39 +429,34 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
-                            data-shrink="false"
-                            for="credentials.passcode"
-                            id="credentials.passcode-label"
-                          >
-                            <span>
-                              Enter code
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
-                            data-se="credentials.passcode"
-                            inputmode="numeric"
-                            required="true"
-                          >
-                            <input
-                              aria-invalid="false"
-                              aria-labelledby="credentials.passcode-label"
-                              autocomplete="off"
-                              class="MuiInputBase-input emotion-29"
-                              id="credentials.passcode"
-                              name="credentials.passcode"
-                              required=""
-                              type="text"
-                            />
-                          </div>
+                          <span>
+                            Enter code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
+                          data-se="credentials.passcode"
+                          inputmode="numeric"
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-28"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
                         </div>
                       </div>
                     </div>
@@ -469,7 +464,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -482,7 +477,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -493,7 +488,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="cancel"
                       href=""
                     >
@@ -926,39 +921,34 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
-                            data-shrink="false"
-                            for="credentials.passcode"
-                            id="credentials.passcode-label"
-                          >
-                            <span>
-                              Enter code
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
-                            data-se="credentials.passcode"
-                            inputmode="numeric"
-                            required="true"
-                          >
-                            <input
-                              aria-invalid="false"
-                              aria-labelledby="credentials.passcode-label"
-                              autocomplete="off"
-                              class="MuiInputBase-input emotion-29"
-                              id="credentials.passcode"
-                              name="credentials.passcode"
-                              required=""
-                              type="text"
-                            />
-                          </div>
+                          <span>
+                            Enter code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
+                          data-se="credentials.passcode"
+                          inputmode="numeric"
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-28"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
                         </div>
                       </div>
                     </div>
@@ -966,7 +956,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -979,7 +969,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -990,7 +980,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -799,28 +799,38 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-29"
-                        data-shrink="false"
-                        for="credentials.passcode"
-                      >
-                        Enter Code
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-30"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-31"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
+                        >
+                          <span>
+                            Enter Code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
                           data-se="credentials.passcode"
-                          id="credentials.passcode"
                           inputmode="numeric"
-                          name="credentials.passcode"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-32"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -828,7 +838,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -840,7 +850,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -851,7 +861,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -798,39 +798,34 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-28"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-29"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                          id="credentials.passcode-label"
-                        >
-                          <span>
-                            Enter Code
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.passcode-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-32"
-                            id="credentials.passcode"
-                            name="credentials.passcode"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter Code
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-30"
+                        data-se="credentials.passcode"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-31"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -838,7 +833,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -850,7 +845,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -861,7 +856,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -812,8 +812,6 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-30"
-                        data-se="credentials.passcode"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -821,7 +819,9 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-31"
+                          data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -178,28 +178,38 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-29"
-                        data-shrink="false"
-                        for="credentials.passcode"
-                      >
-                        Enter Code
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-30"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-31"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
+                        >
+                          <span>
+                            Enter Code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
                           data-se="credentials.passcode"
-                          id="credentials.passcode"
                           inputmode="numeric"
-                          name="credentials.passcode"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-32"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -207,7 +217,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -219,7 +229,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -230,7 +240,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -177,39 +177,34 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-28"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-29"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                          id="credentials.passcode-label"
-                        >
-                          <span>
-                            Enter Code
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.passcode-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-32"
-                            id="credentials.passcode"
-                            name="credentials.passcode"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter Code
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-30"
+                        data-se="credentials.passcode"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-31"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -217,7 +212,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -229,7 +224,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -240,7 +235,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -191,8 +191,6 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-30"
-                        data-se="credentials.passcode"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -200,7 +198,9 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-31"
+                          data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -234,25 +234,35 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                       <div
                         class="MuiBox-root emotion-1"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-41"
-                          data-shrink="false"
-                          for="credentials.question"
-                        >
-                          Create my own security question
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-42"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-41"
                         >
-                          <input
-                            aria-invalid="false"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-43"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
+                            data-shrink="false"
+                            for="credentials.question"
+                            id="credentials.question-label"
+                          >
+                            <span>
+                              Create my own security question
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-43"
                             data-se="credentials.question"
-                            id="credentials.question"
-                            name="credentials.question"
-                            type="text"
-                          />
+                            required="true"
+                          >
+                            <input
+                              aria-invalid="false"
+                              aria-labelledby="credentials.question-label"
+                              autocomplete="off"
+                              class="MuiInputBase-input emotion-44"
+                              id="credentials.question"
+                              name="credentials.question"
+                              required=""
+                              type="text"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -263,32 +273,32 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                         class="MuiBox-root emotion-1"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-41"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-47"
                           data-shrink="false"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-42"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-48"
                         >
                           <input
                             aria-describedby=" credentials.answer-error  "
                             aria-invalid="true"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-43"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-49"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-50"
                           >
                             <button
                               aria-controls="credentials.answer"
                               aria-label="Show answer"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-50"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-51"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
@@ -315,7 +325,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                           class="MuiBox-root emotion-1"
                         >
                           <p
-                            class="MuiFormHelperText-root Mui-error emotion-53"
+                            class="MuiFormHelperText-root Mui-error emotion-54"
                             data-se="credentials.answer-error"
                             id="credentials.answer-error"
                             role="alert"
@@ -329,7 +339,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-55"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-56"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -342,7 +352,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -353,7 +363,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -246,7 +246,6 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-42"
-                          data-se="credentials.question"
                           required="true"
                         >
                           <input
@@ -254,6 +253,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                             aria-labelledby="credentials.question-label"
                             autocomplete="off"
                             class="MuiInputBase-input emotion-43"
+                            data-se="credentials.question"
                             id="credentials.question"
                             name="credentials.question"
                             required=""

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -232,37 +232,33 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                       class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-40"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-41"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-41"
+                          data-shrink="false"
+                          for="credentials.question"
+                          id="credentials.question-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
-                            data-shrink="false"
-                            for="credentials.question"
-                            id="credentials.question-label"
-                          >
-                            <span>
-                              Create my own security question
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-43"
-                            data-se="credentials.question"
-                            required="true"
-                          >
-                            <input
-                              aria-invalid="false"
-                              aria-labelledby="credentials.question-label"
-                              autocomplete="off"
-                              class="MuiInputBase-input emotion-44"
-                              id="credentials.question"
-                              name="credentials.question"
-                              required=""
-                              type="text"
-                            />
-                          </div>
+                          <span>
+                            Create my own security question
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-42"
+                          data-se="credentials.question"
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.question-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-43"
+                            id="credentials.question"
+                            name="credentials.question"
+                            required=""
+                            type="text"
+                          />
                         </div>
                       </div>
                     </div>
@@ -273,32 +269,32 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                         class="MuiBox-root emotion-1"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-47"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-46"
                           data-shrink="false"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-48"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-47"
                         >
                           <input
                             aria-describedby=" credentials.answer-error  "
                             aria-invalid="true"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-43"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-50"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-49"
                           >
                             <button
                               aria-controls="credentials.answer"
                               aria-label="Show answer"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-51"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-50"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
@@ -325,7 +321,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                           class="MuiBox-root emotion-1"
                         >
                           <p
-                            class="MuiFormHelperText-root Mui-error emotion-54"
+                            class="MuiFormHelperText-root Mui-error emotion-53"
                             data-se="credentials.answer-error"
                             id="credentials.answer-error"
                             role="alert"
@@ -339,7 +335,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-56"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-55"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -352,7 +348,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -363,7 +359,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -246,7 +246,6 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-42"
-                          data-se="credentials.question"
                           required="true"
                         >
                           <input
@@ -256,6 +255,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                             aria-labelledby="credentials.question-label"
                             autocomplete="off"
                             class="MuiInputBase-input emotion-43"
+                            data-se="credentials.question"
                             id="credentials.question"
                             name="credentials.question"
                             required=""
@@ -584,7 +584,6 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-35"
-                          data-se="credentials.question"
                           required="true"
                         >
                           <input
@@ -592,6 +591,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                             aria-labelledby="credentials.question-label"
                             autocomplete="off"
                             class="MuiInputBase-input emotion-36"
+                            data-se="credentials.question"
                             id="credentials.question"
                             name="credentials.question"
                             required=""

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -234,37 +234,51 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                       <div
                         class="MuiBox-root emotion-1"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-41"
-                          data-shrink="false"
-                          for="credentials.question"
-                        >
-                          Create my own security question
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-42"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-41"
                         >
-                          <input
-                            aria-describedby=" credentials.question-error  "
-                            aria-invalid="true"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-43"
-                            data-se="credentials.question"
-                            id="credentials.question"
-                            name="credentials.question"
-                            type="text"
-                          />
-                        </div>
-                        <div
-                          class="MuiBox-root emotion-1"
-                        >
-                          <p
-                            class="MuiFormHelperText-root Mui-error emotion-45"
-                            data-se="credentials.question-error"
-                            id="credentials.question-error"
-                            role="alert"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
+                            data-shrink="false"
+                            for="credentials.question"
+                            id="credentials.question-label"
                           >
-                            This field cannot be left blank
+                            <span>
+                              Create my own security question
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-43"
+                            data-se="credentials.question"
+                            required="true"
+                          >
+                            <input
+                              aria-describedby="credentials.question-error"
+                              aria-errormessage="credentials.question-error"
+                              aria-invalid="true"
+                              aria-labelledby="credentials.question-label"
+                              autocomplete="off"
+                              class="MuiInputBase-input emotion-44"
+                              id="credentials.question"
+                              name="credentials.question"
+                              required=""
+                              type="text"
+                            />
+                          </div>
+                          <p
+                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-45"
+                            id="credentials.question-error"
+                          >
+                            <span
+                              class="MuiBox-root emotion-15"
+                            >
+                              Error:
+                            </span>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              This field cannot be left blank
+                            </div>
                           </p>
                         </div>
                       </div>
@@ -276,31 +290,31 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                         class="MuiBox-root emotion-1"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-41"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-50"
                           data-shrink="false"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-42"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-51"
                         >
                           <input
                             aria-invalid="false"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-43"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-51"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-53"
                           >
                             <button
                               aria-controls="credentials.answer"
                               aria-label="Show answer"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-52"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-54"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
@@ -329,7 +343,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-55"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-57"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -342,7 +356,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -353,7 +367,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
                       data-se="cancel"
                       href=""
                     >
@@ -562,25 +576,35 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       <div
                         class="MuiBox-root emotion-1"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-34"
-                          data-shrink="false"
-                          for="credentials.question"
-                        >
-                          Create my own security question
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-35"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-34"
                         >
-                          <input
-                            aria-invalid="false"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-36"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
+                            data-shrink="false"
+                            for="credentials.question"
+                            id="credentials.question-label"
+                          >
+                            <span>
+                              Create my own security question
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-36"
                             data-se="credentials.question"
-                            id="credentials.question"
-                            name="credentials.question"
-                            type="text"
-                          />
+                            required="true"
+                          >
+                            <input
+                              aria-invalid="false"
+                              aria-labelledby="credentials.question-label"
+                              autocomplete="off"
+                              class="MuiInputBase-input emotion-37"
+                              id="credentials.question"
+                              name="credentials.question"
+                              required=""
+                              type="text"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -591,38 +615,38 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                         class="MuiBox-root emotion-1"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-34"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
                           data-shrink="false"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-35"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-41"
                         >
                           <input
                             aria-invalid="false"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-36"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-42"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
                           >
                             <button
                               aria-controls="credentials.answer"
                               aria-label="Show answer"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-43"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-44"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-44"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -644,7 +668,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-47"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -657,7 +681,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -668,7 +692,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -232,55 +232,51 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                       class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-40"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-41"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-41"
+                          data-shrink="false"
+                          for="credentials.question"
+                          id="credentials.question-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
-                            data-shrink="false"
-                            for="credentials.question"
-                            id="credentials.question-label"
-                          >
-                            <span>
-                              Create my own security question
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-43"
-                            data-se="credentials.question"
-                            required="true"
-                          >
-                            <input
-                              aria-describedby="credentials.question-error"
-                              aria-errormessage="credentials.question-error"
-                              aria-invalid="true"
-                              aria-labelledby="credentials.question-label"
-                              autocomplete="off"
-                              class="MuiInputBase-input emotion-44"
-                              id="credentials.question"
-                              name="credentials.question"
-                              required=""
-                              type="text"
-                            />
-                          </div>
-                          <p
-                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-45"
-                            id="credentials.question-error"
-                          >
-                            <span
-                              class="MuiBox-root emotion-15"
-                            >
-                              Error:
-                            </span>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              This field cannot be left blank
-                            </div>
-                          </p>
+                          <span>
+                            Create my own security question
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-42"
+                          data-se="credentials.question"
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="credentials.question-error"
+                            aria-errormessage="credentials.question-error"
+                            aria-invalid="true"
+                            aria-labelledby="credentials.question-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-43"
+                            id="credentials.question"
+                            name="credentials.question"
+                            required=""
+                            type="text"
+                          />
                         </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-44"
+                          id="credentials.question-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-15"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
+                        </p>
                       </div>
                     </div>
                     <div
@@ -290,31 +286,31 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                         class="MuiBox-root emotion-1"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-50"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-49"
                           data-shrink="false"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-51"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-50"
                         >
                           <input
                             aria-invalid="false"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-43"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-53"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-52"
                           >
                             <button
                               aria-controls="credentials.answer"
                               aria-label="Show answer"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-54"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-53"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
@@ -343,7 +339,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-57"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-56"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -356,7 +352,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -367,7 +363,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                       data-se="cancel"
                       href=""
                     >
@@ -574,37 +570,33 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-33"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-34"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-34"
+                          data-shrink="false"
+                          for="credentials.question"
+                          id="credentials.question-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
-                            data-shrink="false"
-                            for="credentials.question"
-                            id="credentials.question-label"
-                          >
-                            <span>
-                              Create my own security question
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-36"
-                            data-se="credentials.question"
-                            required="true"
-                          >
-                            <input
-                              aria-invalid="false"
-                              aria-labelledby="credentials.question-label"
-                              autocomplete="off"
-                              class="MuiInputBase-input emotion-37"
-                              id="credentials.question"
-                              name="credentials.question"
-                              required=""
-                              type="text"
-                            />
-                          </div>
+                          <span>
+                            Create my own security question
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-35"
+                          data-se="credentials.question"
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.question-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-36"
+                            id="credentials.question"
+                            name="credentials.question"
+                            required=""
+                            type="text"
+                          />
                         </div>
                       </div>
                     </div>
@@ -615,38 +607,38 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                         class="MuiBox-root emotion-1"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-40"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-39"
                           data-shrink="false"
                           for="credentials.answer"
                         >
                           Answer
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-41"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd no-translate emotion-40"
                         >
                           <input
                             aria-invalid="false"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-36"
                             data-se="credentials.answer"
                             id="credentials.answer"
                             name="credentials.answer"
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-42"
                           >
                             <button
                               aria-controls="credentials.answer"
                               aria-label="Show answer"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-44"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-43"
                               data-mui-internal-clone-element="true"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-44"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -668,7 +660,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-47"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -681,7 +673,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -692,7 +684,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -96,27 +96,37 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-24"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
                           data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-25"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -127,40 +137,40 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-28"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-23"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-29"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-30"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-31"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-31"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-32"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-32"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-33"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -182,16 +192,16 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-34"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-35"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-35"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-36"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-36"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-37"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-37"
+                            class="PrivateSwitchBase-input emotion-38"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -201,7 +211,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-38"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-39"
                         >
                           Keep me signed in
                         </span>
@@ -212,7 +222,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-40"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-41"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -224,7 +234,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="forgot-password"
                       href=""
                     >
@@ -235,7 +245,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="unlock"
                       href=""
                     >
@@ -246,7 +256,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -257,20 +267,20 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-48"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-49"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-49"
+                    class="MuiBox-root emotion-50"
                   >
                     <div
-                      class="MuiBox-root emotion-50"
+                      class="MuiBox-root emotion-51"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-52"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-53"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut2h3ffszv3me6O31d7_13"
                         >
@@ -279,10 +289,10 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-50"
+                      class="MuiBox-root emotion-51"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                         data-se="enroll"
                         href=""
                       >
@@ -397,27 +407,37 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-24"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
                           data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-25"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -428,40 +448,40 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-28"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-23"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-29"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-30"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-31"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-31"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-32"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-32"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-33"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -483,16 +503,16 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-34"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-35"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-35"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-36"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-36"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-37"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-37"
+                            class="PrivateSwitchBase-input emotion-38"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -502,7 +522,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-38"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-39"
                         >
                           Keep me signed in
                         </span>
@@ -513,7 +533,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-40"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-41"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -525,7 +545,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="forgot-password"
                       href=""
                     >
@@ -536,7 +556,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="unlock"
                       href=""
                     >
@@ -547,7 +567,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -558,20 +578,20 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-48"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-49"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-49"
+                    class="MuiBox-root emotion-50"
                   >
                     <div
-                      class="MuiBox-root emotion-50"
+                      class="MuiBox-root emotion-51"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-52"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-53"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut2h3ffszv3me6O31d7_13"
                         >
@@ -580,10 +600,10 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-50"
+                      class="MuiBox-root emotion-51"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                         data-se="enroll"
                         href=""
                       >
@@ -663,27 +683,37 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-17"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
                           data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-18"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -694,40 +724,40 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-21"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-16"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-22"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-17"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-18"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-23"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-24"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-24"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-25"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-25"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -749,16 +779,16 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-27"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-28"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-28"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-29"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-29"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-30"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-30"
+                            class="PrivateSwitchBase-input emotion-31"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -768,7 +798,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-31"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-32"
                         >
                           Keep me signed in
                         </span>
@@ -779,7 +809,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -791,11 +821,11 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren separation-line emotion-35"
+                      class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren separation-line emotion-36"
                       role="separator"
                     >
                       <span
-                        class="MuiDivider-wrapper emotion-36"
+                        class="MuiDivider-wrapper emotion-37"
                       >
                         OR
                       </span>
@@ -805,12 +835,12 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-38"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-39"
                       tabindex="0"
                       type="button"
                     >
                       <span
-                        class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-39"
+                        class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-40"
                       >
                         <img
                           alt="PIV Card"
@@ -826,7 +856,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="forgot-password"
                       href=""
                     >
@@ -837,7 +867,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="unlock"
                       href=""
                     >
@@ -848,7 +878,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -859,20 +889,20 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-48"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-49"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-49"
+                    class="MuiBox-root emotion-50"
                   >
                     <div
-                      class="MuiBox-root emotion-50"
+                      class="MuiBox-root emotion-51"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-52"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-53"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut2h3ffszv3me6O31d7_13"
                         >
@@ -881,10 +911,10 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-50"
+                      class="MuiBox-root emotion-51"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                         data-se="enroll"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -95,38 +95,33 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-25"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-24"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -137,40 +132,40 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-28"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-27"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-29"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-28"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-31"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-30"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-32"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-31"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-33"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -192,16 +187,16 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-35"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-34"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-36"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-35"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-37"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-36"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-38"
+                            class="PrivateSwitchBase-input emotion-37"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -211,7 +206,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-39"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-38"
                         >
                           Keep me signed in
                         </span>
@@ -222,7 +217,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-41"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-40"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -234,7 +229,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="forgot-password"
                       href=""
                     >
@@ -245,7 +240,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="unlock"
                       href=""
                     >
@@ -256,7 +251,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -267,20 +262,20 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-49"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-48"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-50"
+                    class="MuiBox-root emotion-49"
                   >
                     <div
-                      class="MuiBox-root emotion-51"
+                      class="MuiBox-root emotion-50"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-53"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-52"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut2h3ffszv3me6O31d7_13"
                         >
@@ -289,10 +284,10 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-51"
+                      class="MuiBox-root emotion-50"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                         data-se="enroll"
                         href=""
                       >
@@ -406,38 +401,33 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-25"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-24"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -448,40 +438,40 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-28"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-27"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-29"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-28"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-31"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-30"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-32"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-31"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-33"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-32"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -503,16 +493,16 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-35"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-34"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-36"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-35"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-37"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-36"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-38"
+                            class="PrivateSwitchBase-input emotion-37"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -522,7 +512,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-39"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-38"
                         >
                           Keep me signed in
                         </span>
@@ -533,7 +523,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-41"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-40"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -545,7 +535,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="forgot-password"
                       href=""
                     >
@@ -556,7 +546,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="unlock"
                       href=""
                     >
@@ -567,7 +557,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -578,20 +568,20 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-49"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-48"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-50"
+                    class="MuiBox-root emotion-49"
                   >
                     <div
-                      class="MuiBox-root emotion-51"
+                      class="MuiBox-root emotion-50"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-53"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-52"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut2h3ffszv3me6O31d7_13"
                         >
@@ -600,10 +590,10 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-51"
+                      class="MuiBox-root emotion-50"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                         data-se="enroll"
                         href=""
                       >
@@ -682,38 +672,33 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-14"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-18"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-17"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -724,40 +709,40 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-21"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-22"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-21"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-18"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-17"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-24"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-23"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-25"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-24"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-26"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-25"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -779,16 +764,16 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-28"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-27"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-29"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-28"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-30"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-29"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-31"
+                            class="PrivateSwitchBase-input emotion-30"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -798,7 +783,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-32"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-31"
                         >
                           Keep me signed in
                         </span>
@@ -809,7 +794,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -821,11 +806,11 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren separation-line emotion-36"
+                      class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren separation-line emotion-35"
                       role="separator"
                     >
                       <span
-                        class="MuiDivider-wrapper emotion-37"
+                        class="MuiDivider-wrapper emotion-36"
                       >
                         OR
                       </span>
@@ -835,12 +820,12 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-39"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-38"
                       tabindex="0"
                       type="button"
                     >
                       <span
-                        class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-40"
+                        class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-39"
                       >
                         <img
                           alt="PIV Card"
@@ -856,7 +841,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="forgot-password"
                       href=""
                     >
@@ -867,7 +852,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="unlock"
                       href=""
                     >
@@ -878,7 +863,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -889,20 +874,20 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-49"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-48"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-50"
+                    class="MuiBox-root emotion-49"
                   >
                     <div
-                      class="MuiBox-root emotion-51"
+                      class="MuiBox-root emotion-50"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-53"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-52"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut2h3ffszv3me6O31d7_13"
                         >
@@ -911,10 +896,10 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-51"
+                      class="MuiBox-root emotion-50"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                         data-se="enroll"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -109,7 +109,6 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -117,6 +116,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-24"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""
@@ -415,7 +415,6 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -423,6 +422,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-24"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""
@@ -686,7 +686,6 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -694,6 +693,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-17"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
@@ -155,28 +155,38 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="credentials.passcode"
-                      >
-                        Enter code
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
+                        >
+                          <span>
+                            Enter code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="credentials.passcode"
-                          id="credentials.passcode"
                           inputmode="numeric"
-                          name="credentials.passcode"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-28"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -184,7 +194,7 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-29"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -196,7 +206,7 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
@@ -168,8 +168,6 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="credentials.passcode"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -177,7 +175,9 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-27"
+                          data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
@@ -154,39 +154,34 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                          id="credentials.passcode-label"
-                        >
-                          <span>
-                            Enter code
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.passcode-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-28"
-                            id="credentials.passcode"
-                            name="credentials.passcode"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter code
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="credentials.passcode"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-27"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -194,7 +189,7 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-29"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -206,7 +201,7 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -158,39 +158,34 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                          id="credentials.passcode-label"
-                        >
-                          <span>
-                            Enter Code
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.passcode-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-29"
-                            id="credentials.passcode"
-                            name="credentials.passcode"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter Code
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
+                        data-se="credentials.passcode"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-28"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -198,7 +193,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -210,7 +205,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -172,8 +172,6 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                        data-se="credentials.passcode"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -181,7 +179,9 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-28"
+                          data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -159,28 +159,38 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-26"
-                        data-shrink="false"
-                        for="credentials.passcode"
-                      >
-                        Enter Code
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
+                        >
+                          <span>
+                            Enter Code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
                           data-se="credentials.passcode"
-                          id="credentials.passcode"
                           inputmode="numeric"
-                          name="credentials.passcode"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-29"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -188,7 +198,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -200,7 +210,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -597,39 +597,34 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-28"
-                            data-shrink="false"
-                            for="credentials.passcode"
-                            id="credentials.passcode-label"
-                          >
-                            <span>
-                              Enter Code
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-29"
-                            data-se="credentials.passcode"
-                            inputmode="numeric"
-                            required="true"
-                          >
-                            <input
-                              aria-invalid="false"
-                              aria-labelledby="credentials.passcode-label"
-                              autocomplete="off"
-                              class="MuiInputBase-input emotion-30"
-                              id="credentials.passcode"
-                              name="credentials.passcode"
-                              required=""
-                              type="text"
-                            />
-                          </div>
+                          <span>
+                            Enter Code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-28"
+                          data-se="credentials.passcode"
+                          inputmode="numeric"
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-29"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
                         </div>
                       </div>
                     </div>
@@ -637,7 +632,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-32"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -650,7 +645,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                       data-se="cancel"
                       href=""
                     >
@@ -872,64 +867,59 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-33"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-34"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-34"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
-                            data-shrink="false"
-                            for="credentials.passcode"
-                            id="credentials.passcode-label"
-                          >
-                            <span>
-                              Enter Code
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-36"
-                            data-se="credentials.passcode"
-                            inputmode="numeric"
-                            required="true"
-                          >
-                            <input
-                              aria-describedby="credentials.passcode-error"
-                              aria-errormessage="credentials.passcode-error"
-                              aria-invalid="true"
-                              aria-labelledby="credentials.passcode-label"
-                              autocomplete="off"
-                              class="MuiInputBase-input emotion-37"
-                              id="credentials.passcode"
-                              name="credentials.passcode"
-                              required=""
-                              type="text"
-                            />
-                          </div>
-                          <p
-                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-38"
-                            id="credentials.passcode-error"
-                          >
-                            <span
-                              class="MuiBox-root emotion-15"
-                            >
-                              Error:
-                            </span>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              Invalid code. Try again.
-                            </div>
-                          </p>
+                          <span>
+                            Enter Code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-35"
+                          data-se="credentials.passcode"
+                          inputmode="numeric"
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="credentials.passcode-error"
+                            aria-errormessage="credentials.passcode-error"
+                            aria-invalid="true"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-36"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
                         </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-37"
+                          id="credentials.passcode-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-15"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            Invalid code. Try again.
+                          </div>
+                        </p>
                       </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-42"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-41"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -942,7 +932,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -953,7 +943,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="cancel"
                       href=""
                     >
@@ -1229,64 +1219,59 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-42"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-43"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-43"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-44"
-                            data-shrink="false"
-                            for="credentials.passcode"
-                            id="credentials.passcode-label"
-                          >
-                            <span>
-                              Enter Code
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-45"
-                            data-se="credentials.passcode"
-                            inputmode="numeric"
-                            required="true"
-                          >
-                            <input
-                              aria-describedby="credentials.passcode-error"
-                              aria-errormessage="credentials.passcode-error"
-                              aria-invalid="true"
-                              aria-labelledby="credentials.passcode-label"
-                              autocomplete="off"
-                              class="MuiInputBase-input emotion-46"
-                              id="credentials.passcode"
-                              name="credentials.passcode"
-                              required=""
-                              type="text"
-                            />
-                          </div>
-                          <p
-                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-47"
-                            id="credentials.passcode-error"
-                          >
-                            <span
-                              class="MuiBox-root emotion-15"
-                            >
-                              Error:
-                            </span>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              Invalid code. Try again.
-                            </div>
-                          </p>
+                          <span>
+                            Enter Code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-44"
+                          data-se="credentials.passcode"
+                          inputmode="numeric"
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="credentials.passcode-error"
+                            aria-errormessage="credentials.passcode-error"
+                            aria-invalid="true"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-45"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
                         </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-46"
+                          id="credentials.passcode-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-15"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            Invalid code. Try again.
+                          </div>
+                        </p>
                       </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-50"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1299,7 +1284,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-53"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-52"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -1310,7 +1295,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-53"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-52"
                       data-se="cancel"
                       href=""
                     >
@@ -1600,39 +1585,34 @@ exports[`Email authenticator verification when email magic link = undefined shou
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-28"
-                            data-shrink="false"
-                            for="credentials.passcode"
-                            id="credentials.passcode-label"
-                          >
-                            <span>
-                              Enter Code
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-29"
-                            data-se="credentials.passcode"
-                            inputmode="numeric"
-                            required="true"
-                          >
-                            <input
-                              aria-invalid="false"
-                              aria-labelledby="credentials.passcode-label"
-                              autocomplete="one-time-code"
-                              class="MuiInputBase-input emotion-30"
-                              id="credentials.passcode"
-                              name="credentials.passcode"
-                              required=""
-                              type="text"
-                            />
-                          </div>
+                          <span>
+                            Enter Code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-28"
+                          data-se="credentials.passcode"
+                          inputmode="numeric"
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="one-time-code"
+                            class="MuiInputBase-input emotion-29"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
                         </div>
                       </div>
                     </div>
@@ -1640,7 +1620,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-32"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1653,7 +1633,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -598,28 +598,38 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     >
                       <div
                         class="MuiBox-root emotion-1"
+                        dir="ltr"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-27"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                        >
-                          Enter Code
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused emotion-28"
-                          dir="ltr"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-27"
                         >
-                          <input
-                            aria-invalid="false"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-29"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-28"
+                            data-shrink="false"
+                            for="credentials.passcode"
+                            id="credentials.passcode-label"
+                          >
+                            <span>
+                              Enter Code
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-29"
                             data-se="credentials.passcode"
-                            id="credentials.passcode"
                             inputmode="numeric"
-                            name="credentials.passcode"
-                            type="text"
-                          />
+                            required="true"
+                          >
+                            <input
+                              aria-invalid="false"
+                              aria-labelledby="credentials.passcode-label"
+                              autocomplete="off"
+                              class="MuiInputBase-input emotion-30"
+                              id="credentials.passcode"
+                              name="credentials.passcode"
+                              required=""
+                              type="text"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -627,7 +637,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-32"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -640,7 +650,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
                       data-se="cancel"
                       href=""
                     >
@@ -863,40 +873,54 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     >
                       <div
                         class="MuiBox-root emotion-1"
+                        dir="ltr"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-34"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                        >
-                          Enter Code
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-35"
-                          dir="ltr"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-34"
                         >
-                          <input
-                            aria-describedby=" credentials.passcode-error  "
-                            aria-invalid="true"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-36"
-                            data-se="credentials.passcode"
-                            id="credentials.passcode"
-                            inputmode="numeric"
-                            name="credentials.passcode"
-                            type="text"
-                          />
-                        </div>
-                        <div
-                          class="MuiBox-root emotion-1"
-                        >
-                          <p
-                            class="MuiFormHelperText-root Mui-error emotion-38"
-                            data-se="credentials.passcode-error"
-                            id="credentials.passcode-error"
-                            role="alert"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
+                            data-shrink="false"
+                            for="credentials.passcode"
+                            id="credentials.passcode-label"
                           >
-                            Invalid code. Try again.
+                            <span>
+                              Enter Code
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-36"
+                            data-se="credentials.passcode"
+                            inputmode="numeric"
+                            required="true"
+                          >
+                            <input
+                              aria-describedby="credentials.passcode-error"
+                              aria-errormessage="credentials.passcode-error"
+                              aria-invalid="true"
+                              aria-labelledby="credentials.passcode-label"
+                              autocomplete="off"
+                              class="MuiInputBase-input emotion-37"
+                              id="credentials.passcode"
+                              name="credentials.passcode"
+                              required=""
+                              type="text"
+                            />
+                          </div>
+                          <p
+                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-38"
+                            id="credentials.passcode-error"
+                          >
+                            <span
+                              class="MuiBox-root emotion-15"
+                            >
+                              Error:
+                            </span>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              Invalid code. Try again.
+                            </div>
                           </p>
                         </div>
                       </div>
@@ -905,7 +929,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-40"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-42"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -918,7 +942,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -929,7 +953,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
                       data-se="cancel"
                       href=""
                     >
@@ -1206,40 +1230,54 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     >
                       <div
                         class="MuiBox-root emotion-1"
+                        dir="ltr"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-43"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                        >
-                          Enter Code
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-44"
-                          dir="ltr"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-43"
                         >
-                          <input
-                            aria-describedby=" credentials.passcode-error  "
-                            aria-invalid="true"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-45"
-                            data-se="credentials.passcode"
-                            id="credentials.passcode"
-                            inputmode="numeric"
-                            name="credentials.passcode"
-                            type="text"
-                          />
-                        </div>
-                        <div
-                          class="MuiBox-root emotion-1"
-                        >
-                          <p
-                            class="MuiFormHelperText-root Mui-error emotion-47"
-                            data-se="credentials.passcode-error"
-                            id="credentials.passcode-error"
-                            role="alert"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-44"
+                            data-shrink="false"
+                            for="credentials.passcode"
+                            id="credentials.passcode-label"
                           >
-                            Invalid code. Try again.
+                            <span>
+                              Enter Code
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-45"
+                            data-se="credentials.passcode"
+                            inputmode="numeric"
+                            required="true"
+                          >
+                            <input
+                              aria-describedby="credentials.passcode-error"
+                              aria-errormessage="credentials.passcode-error"
+                              aria-invalid="true"
+                              aria-labelledby="credentials.passcode-label"
+                              autocomplete="off"
+                              class="MuiInputBase-input emotion-46"
+                              id="credentials.passcode"
+                              name="credentials.passcode"
+                              required=""
+                              type="text"
+                            />
+                          </div>
+                          <p
+                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-47"
+                            id="credentials.passcode-error"
+                          >
+                            <span
+                              class="MuiBox-root emotion-15"
+                            >
+                              Error:
+                            </span>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              Invalid code. Try again.
+                            </div>
                           </p>
                         </div>
                       </div>
@@ -1248,7 +1286,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-49"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1261,7 +1299,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-51"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-53"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -1272,7 +1310,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     class="MuiBox-root emotion-18"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-51"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-53"
                       data-se="cancel"
                       href=""
                     >
@@ -1563,28 +1601,38 @@ exports[`Email authenticator verification when email magic link = undefined shou
                     >
                       <div
                         class="MuiBox-root emotion-1"
+                        dir="ltr"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-27"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                        >
-                          Enter Code
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused emotion-28"
-                          dir="ltr"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-27"
                         >
-                          <input
-                            aria-invalid="false"
-                            autocomplete="one-time-code"
-                            class="MuiInputBase-input emotion-29"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-28"
+                            data-shrink="false"
+                            for="credentials.passcode"
+                            id="credentials.passcode-label"
+                          >
+                            <span>
+                              Enter Code
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-29"
                             data-se="credentials.passcode"
-                            id="credentials.passcode"
                             inputmode="numeric"
-                            name="credentials.passcode"
-                            type="text"
-                          />
+                            required="true"
+                          >
+                            <input
+                              aria-invalid="false"
+                              aria-labelledby="credentials.passcode-label"
+                              autocomplete="one-time-code"
+                              class="MuiInputBase-input emotion-30"
+                              id="credentials.passcode"
+                              name="credentials.passcode"
+                              required=""
+                              type="text"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1592,7 +1640,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-31"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-32"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1605,7 +1653,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -611,8 +611,6 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-28"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
                           required="true"
                         >
                           <input
@@ -620,7 +618,9 @@ exports[`Email authenticator verification when email magic link = undefined rend
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
                             class="MuiInputBase-input emotion-29"
+                            data-se="credentials.passcode"
                             id="credentials.passcode"
+                            inputmode="numeric"
                             name="credentials.passcode"
                             required=""
                             type="text"
@@ -881,8 +881,6 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-35"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
                           required="true"
                         >
                           <input
@@ -892,7 +890,9 @@ exports[`Email authenticator verification when email magic link = undefined rend
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
                             class="MuiInputBase-input emotion-36"
+                            data-se="credentials.passcode"
                             id="credentials.passcode"
+                            inputmode="numeric"
                             name="credentials.passcode"
                             required=""
                             type="text"
@@ -1233,8 +1233,6 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-44"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
                           required="true"
                         >
                           <input
@@ -1244,7 +1242,9 @@ exports[`Email authenticator verification when email magic link = undefined rend
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
                             class="MuiInputBase-input emotion-45"
+                            data-se="credentials.passcode"
                             id="credentials.passcode"
+                            inputmode="numeric"
                             name="credentials.passcode"
                             required=""
                             type="text"
@@ -1599,8 +1599,6 @@ exports[`Email authenticator verification when email magic link = undefined shou
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-28"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
                           required="true"
                         >
                           <input
@@ -1608,7 +1606,9 @@ exports[`Email authenticator verification when email magic link = undefined shou
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="one-time-code"
                             class="MuiInputBase-input emotion-29"
+                            data-se="credentials.passcode"
                             id="credentials.passcode"
+                            inputmode="numeric"
                             name="credentials.passcode"
                             required=""
                             type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -183,8 +183,6 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="credentials.passcode"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -192,7 +190,9 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-27"
+                          data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -170,28 +170,38 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="credentials.passcode"
-                      >
-                        Enter code
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
+                        >
+                          <span>
+                            Enter code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="credentials.passcode"
-                          id="credentials.passcode"
                           inputmode="numeric"
-                          name="credentials.passcode"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-28"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -199,7 +209,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-29"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -211,7 +221,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -222,7 +232,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -169,39 +169,34 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                          id="credentials.passcode-label"
-                        >
-                          <span>
-                            Enter code
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.passcode-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-28"
-                            id="credentials.passcode"
-                            name="credentials.passcode"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter code
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="credentials.passcode"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-27"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -209,7 +204,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-29"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -221,7 +216,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -232,7 +227,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -132,26 +132,36 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
-                        data-shrink="false"
-                        for="credentials.totp"
-                      >
-                        Enter code from Okta Verify app
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-24"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
+                          data-shrink="false"
+                          for="credentials.totp"
+                          id="credentials.totp-label"
+                        >
+                          <span>
+                            Enter code from Okta Verify app
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
                           data-se="credentials.totp"
-                          id="credentials.totp"
                           inputmode="numeric"
-                          name="credentials.totp"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.totp-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-25"
+                            id="credentials.totp"
+                            name="credentials.totp"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -159,7 +169,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-27"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -171,7 +181,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -182,7 +192,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -130,38 +130,34 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="credentials.totp"
+                        id="credentials.totp-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
-                          data-shrink="false"
-                          for="credentials.totp"
-                          id="credentials.totp-label"
-                        >
-                          <span>
-                            Enter code from Okta Verify app
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
-                          data-se="credentials.totp"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.totp-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-25"
-                            id="credentials.totp"
-                            name="credentials.totp"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter code from Okta Verify app
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
+                        data-se="credentials.totp"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.totp-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-24"
+                          id="credentials.totp"
+                          name="credentials.totp"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -169,7 +165,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-27"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -181,7 +177,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -192,7 +188,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -144,8 +144,6 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
-                        data-se="credentials.totp"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -153,7 +151,9 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                           aria-labelledby="credentials.totp-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-24"
+                          data-se="credentials.totp"
                           id="credentials.totp"
+                          inputmode="numeric"
                           name="credentials.totp"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -132,26 +132,36 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
-                        data-shrink="false"
-                        for="credentials.totp"
-                      >
-                        Enter code from Okta Verify app
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="one-time-code"
-                          class="MuiInputBase-input emotion-24"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
+                          data-shrink="false"
+                          for="credentials.totp"
+                          id="credentials.totp-label"
+                        >
+                          <span>
+                            Enter code from Okta Verify app
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
                           data-se="credentials.totp"
-                          id="credentials.totp"
                           inputmode="numeric"
-                          name="credentials.totp"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.totp-label"
+                            autocomplete="one-time-code"
+                            class="MuiInputBase-input emotion-25"
+                            id="credentials.totp"
+                            name="credentials.totp"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -159,7 +169,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-27"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -171,7 +181,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -182,7 +192,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                       data-se="cancel"
                       href=""
                     >
@@ -332,26 +342,36 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
-                        data-shrink="false"
-                        for="credentials.totp"
-                      >
-                        Enter code from Okta Verify app
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-24"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
+                          data-shrink="false"
+                          for="credentials.totp"
+                          id="credentials.totp-label"
+                        >
+                          <span>
+                            Enter code from Okta Verify app
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
                           data-se="credentials.totp"
-                          id="credentials.totp"
                           inputmode="numeric"
-                          name="credentials.totp"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.totp-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-25"
+                            id="credentials.totp"
+                            name="credentials.totp"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -359,7 +379,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-27"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -371,7 +391,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -382,7 +402,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -130,38 +130,34 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="credentials.totp"
+                        id="credentials.totp-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
-                          data-shrink="false"
-                          for="credentials.totp"
-                          id="credentials.totp-label"
-                        >
-                          <span>
-                            Enter code from Okta Verify app
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
-                          data-se="credentials.totp"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.totp-label"
-                            autocomplete="one-time-code"
-                            class="MuiInputBase-input emotion-25"
-                            id="credentials.totp"
-                            name="credentials.totp"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter code from Okta Verify app
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
+                        data-se="credentials.totp"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.totp-label"
+                          autocomplete="one-time-code"
+                          class="MuiInputBase-input emotion-24"
+                          id="credentials.totp"
+                          name="credentials.totp"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -169,7 +165,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-27"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -181,7 +177,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -192,7 +188,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="cancel"
                       href=""
                     >
@@ -340,38 +336,34 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="credentials.totp"
+                        id="credentials.totp-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
-                          data-shrink="false"
-                          for="credentials.totp"
-                          id="credentials.totp-label"
-                        >
-                          <span>
-                            Enter code from Okta Verify app
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
-                          data-se="credentials.totp"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.totp-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-25"
-                            id="credentials.totp"
-                            name="credentials.totp"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter code from Okta Verify app
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
+                        data-se="credentials.totp"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.totp-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-24"
+                          id="credentials.totp"
+                          name="credentials.totp"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -379,7 +371,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-27"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-26"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -391,7 +383,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -402,7 +394,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -144,8 +144,6 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
-                        data-se="credentials.totp"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -153,7 +151,9 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                           aria-labelledby="credentials.totp-label"
                           autocomplete="one-time-code"
                           class="MuiInputBase-input emotion-24"
+                          data-se="credentials.totp"
                           id="credentials.totp"
+                          inputmode="numeric"
                           name="credentials.totp"
                           required=""
                           type="text"
@@ -350,8 +350,6 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
-                        data-se="credentials.totp"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -359,7 +357,9 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                           aria-labelledby="credentials.totp-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-24"
+                          data-se="credentials.totp"
                           id="credentials.totp"
+                          inputmode="numeric"
                           name="credentials.totp"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -213,26 +213,36 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-37"
-                        data-shrink="false"
-                        for="credentials.totp"
-                      >
-                        Enter code from Okta Verify app
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-38"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-37"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-39"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-38"
+                          data-shrink="false"
+                          for="credentials.totp"
+                          id="credentials.totp-label"
+                        >
+                          <span>
+                            Enter code from Okta Verify app
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-39"
                           data-se="credentials.totp"
-                          id="credentials.totp"
                           inputmode="numeric"
-                          name="credentials.totp"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.totp-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-40"
+                            id="credentials.totp"
+                            name="credentials.totp"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -240,7 +250,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-41"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-42"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -252,7 +262,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -263,7 +273,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -211,38 +211,34 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-36"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-37"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-37"
+                        data-shrink="false"
+                        for="credentials.totp"
+                        id="credentials.totp-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-38"
-                          data-shrink="false"
-                          for="credentials.totp"
-                          id="credentials.totp-label"
-                        >
-                          <span>
-                            Enter code from Okta Verify app
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-39"
-                          data-se="credentials.totp"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.totp-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-40"
-                            id="credentials.totp"
-                            name="credentials.totp"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter code from Okta Verify app
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-38"
+                        data-se="credentials.totp"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.totp-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-39"
+                          id="credentials.totp"
+                          name="credentials.totp"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -250,7 +246,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-42"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-41"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -262,7 +258,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -273,7 +269,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -225,8 +225,6 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-38"
-                        data-se="credentials.totp"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -234,7 +232,9 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                           aria-labelledby="credentials.totp-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-39"
+                          data-se="credentials.totp"
                           id="credentials.totp"
+                          inputmode="numeric"
                           name="credentials.totp"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -197,8 +197,6 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-30"
-                        data-se="credentials.passcode"
-                        inputmode="numeric"
                         required="true"
                       >
                         <input
@@ -206,7 +204,9 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="off"
                           class="MuiInputBase-input emotion-31"
+                          data-se="credentials.passcode"
                           id="credentials.passcode"
+                          inputmode="numeric"
                           name="credentials.passcode"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -184,28 +184,38 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-29"
-                        data-shrink="false"
-                        for="credentials.passcode"
-                      >
-                        Enter Code
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-30"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="off"
-                          class="MuiInputBase-input emotion-31"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
+                          data-shrink="false"
+                          for="credentials.passcode"
+                          id="credentials.passcode-label"
+                        >
+                          <span>
+                            Enter Code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
                           data-se="credentials.passcode"
-                          id="credentials.passcode"
                           inputmode="numeric"
-                          name="credentials.passcode"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="credentials.passcode-label"
+                            autocomplete="off"
+                            class="MuiInputBase-input emotion-32"
+                            id="credentials.passcode"
+                            name="credentials.passcode"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -213,7 +223,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -225,7 +235,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -236,7 +246,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -183,39 +183,34 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-28"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-29"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
-                          data-shrink="false"
-                          for="credentials.passcode"
-                          id="credentials.passcode-label"
-                        >
-                          <span>
-                            Enter Code
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
-                          data-se="credentials.passcode"
-                          inputmode="numeric"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="credentials.passcode-label"
-                            autocomplete="off"
-                            class="MuiInputBase-input emotion-32"
-                            id="credentials.passcode"
-                            name="credentials.passcode"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Enter Code
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-30"
+                        data-se="credentials.passcode"
+                        inputmode="numeric"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input emotion-31"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -223,7 +218,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -235,7 +230,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -246,7 +241,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/device-code-activate.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/device-code-activate.test.tsx.snap
@@ -95,12 +95,12 @@ exports[`device-code-activate should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                        data-se="userCode"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userCode-label"
                           class="MuiInputBase-input emotion-21"
+                          data-se="userCode"
                           id="userCode"
                           name="userCode"
                           type="text"

--- a/src/v3/test/integration/__snapshots__/device-code-activate.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/device-code-activate.test.tsx.snap
@@ -75,40 +75,36 @@ exports[`device-code-activate should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userCode"
+                        id="userCode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userCode"
-                          id="userCode-label"
+                        <span>
+                          Activation Code
+                        </span>
+                        <p
+                          class="MuiTypography-root MuiTypography-subtitle1 emotion-19"
+                          tabindex="-1"
                         >
-                          <span>
-                            Activation Code
-                          </span>
-                          <p
-                            class="MuiTypography-root MuiTypography-subtitle1 emotion-20"
-                            tabindex="-1"
-                          >
-                            Optional
-                          </p>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-21"
-                          data-se="userCode"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userCode-label"
-                            class="MuiInputBase-input emotion-22"
-                            id="userCode"
-                            name="userCode"
-                            type="text"
-                          />
-                        </div>
+                          Optional
+                        </p>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
+                        data-se="userCode"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userCode-label"
+                          class="MuiInputBase-input emotion-21"
+                          id="userCode"
+                          name="userCode"
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -116,7 +112,7 @@ exports[`device-code-activate should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-24"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-23"
                       data-se="save"
                       tabindex="0"
                       type="submit"

--- a/src/v3/test/integration/__snapshots__/device-code-activate.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/device-code-activate.test.tsx.snap
@@ -77,24 +77,38 @@ exports[`device-code-activate should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userCode"
-                      >
-                        Activation Code
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-20"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userCode"
+                          id="userCode-label"
+                        >
+                          <span>
+                            Activation Code
+                          </span>
+                          <p
+                            class="MuiTypography-root MuiTypography-subtitle1 emotion-20"
+                            tabindex="-1"
+                          >
+                            Optional
+                          </p>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-21"
                           data-se="userCode"
-                          id="userCode"
-                          name="userCode"
-                          type="text"
-                        />
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userCode-label"
+                            class="MuiInputBase-input emotion-22"
+                            id="userCode"
+                            name="userCode"
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -102,7 +116,7 @@ exports[`device-code-activate should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-22"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-24"
                       data-se="save"
                       tabindex="0"
                       type="submit"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -120,43 +120,51 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.firstName-error  "
-                          aria-invalid="true"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-27"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="userProfile.firstName-error"
+                            aria-errormessage="userProfile.firstName-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.firstName-error"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-29"
                           id="userProfile.firstName-error"
-                          role="alert"
                         >
-                          This field cannot be left blank
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -167,43 +175,51 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.lastName-error  "
-                          aria-invalid="true"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.lastName-error"
-                          id="userProfile.lastName-error"
-                          role="alert"
+                          required="true"
                         >
-                          This field cannot be left blank
+                          <input
+                            aria-describedby="userProfile.lastName-error"
+                            aria-errormessage="userProfile.lastName-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
+                          id="userProfile.lastName-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -214,44 +230,52 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.email-error  "
-                          aria-invalid="true"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.email-error"
-                          id="userProfile.email-error"
-                          role="alert"
+                          required="true"
                         >
-                          This field cannot be left blank
+                          <input
+                            aria-describedby="userProfile.email-error"
+                            aria-errormessage="userProfile.email-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
+                          id="userProfile.email-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -260,28 +284,28 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-48"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-51"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-49"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-52"
                         data-shrink="false"
                         for="userProfile.country"
                       >
                         Country
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
+                          class="no-translate MuiBox-root emotion-53"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-51"
+                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-54"
                       >
                         <select
                           aria-describedby=" userProfile.country-error  "
                           aria-invalid="true"
-                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-52"
+                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-55"
                           data-se="userProfile.country"
                           id="userProfile.country"
                           name="userProfile.country"
@@ -1499,7 +1523,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                         </select>
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-53"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-56"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -1517,7 +1541,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-30"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-58"
                           data-se="userProfile.country-error"
                           id="userProfile.country-error"
                           role="alert"
@@ -1533,42 +1557,50 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.countryCode"
-                      >
-                        Country code
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.countryCode-error  "
-                          aria-invalid="true"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.countryCode"
+                          id="userProfile.countryCode-label"
+                        >
+                          <span>
+                            Country code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.countryCode"
-                          id="userProfile.countryCode"
-                          name="userProfile.countryCode"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.countryCode-error"
-                          id="userProfile.countryCode-error"
-                          role="alert"
+                          required="true"
                         >
-                          This field cannot be left blank
+                          <input
+                            aria-describedby="userProfile.countryCode-error"
+                            aria-errormessage="userProfile.countryCode-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.countryCode-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.countryCode"
+                            name="userProfile.countryCode"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
+                          id="userProfile.countryCode-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -1577,28 +1609,28 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-48"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-51"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-49"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-52"
                         data-shrink="false"
                         for="userProfile.timezone"
                       >
                         Time zone
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
+                          class="no-translate MuiBox-root emotion-53"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-51"
+                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-54"
                       >
                         <select
                           aria-describedby=" userProfile.timezone-error  "
                           aria-invalid="true"
-                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-52"
+                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-55"
                           data-se="userProfile.timezone"
                           id="userProfile.timezone"
                           name="userProfile.timezone"
@@ -1776,7 +1808,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                         </select>
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-53"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-56"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -1794,7 +1826,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-30"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-58"
                           data-se="userProfile.timezone-error"
                           id="userProfile.timezone-error"
                           role="alert"
@@ -1808,7 +1840,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-74"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-78"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1820,14 +1852,14 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-76"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-80"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-77"
+                    class="MuiBox-root emotion-81"
                   >
                     <div
-                      class="MuiBox-root emotion-78"
+                      class="MuiBox-root emotion-82"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -1842,10 +1874,10 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-78"
+                      class="MuiBox-root emotion-82"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-82"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-86"
                         data-se="back"
                         href=""
                       >
@@ -1941,31 +1973,35 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1975,31 +2011,35 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2009,32 +2049,36 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2052,7 +2096,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                         Country
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
+                          class="no-translate MuiBox-root emotion-37"
                         >
                           *
                         </span>
@@ -3302,30 +3346,34 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.countryCode"
-                      >
-                        Country code
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.countryCode"
+                          id="userProfile.countryCode-label"
+                        >
+                          <span>
+                            Country code
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.countryCode"
-                          id="userProfile.countryCode"
-                          name="userProfile.countryCode"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.countryCode-label"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.countryCode"
+                            name="userProfile.countryCode"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -3343,7 +3391,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                         Time zone
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
+                          class="no-translate MuiBox-root emotion-37"
                         >
                           *
                         </span>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -118,194 +118,182 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.firstName-error"
-                            aria-errormessage="userProfile.firstName-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-29"
-                          id="userProfile.firstName-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
-                        >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.lastName"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.lastName-error"
-                            aria-errormessage="userProfile.lastName-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
-                          id="userProfile.lastName-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.email-error"
-                            aria-errormessage="userProfile.email-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
-                          id="userProfile.email-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-51"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-52"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.firstName-error"
+                          aria-errormessage="userProfile.firstName-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-28"
+                        id="userProfile.firstName-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
+                      >
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.lastName-error"
+                          aria-errormessage="userProfile.lastName-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-28"
+                        id="userProfile.lastName-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
+                      >
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.email-error"
+                          aria-errormessage="userProfile.email-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-28"
+                        id="userProfile.email-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-48"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-49"
                         data-shrink="false"
                         for="userProfile.country"
                       >
                         Country
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-53"
+                          class="no-translate MuiBox-root emotion-50"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-54"
+                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-51"
                       >
                         <select
                           aria-describedby=" userProfile.country-error  "
                           aria-invalid="true"
-                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-55"
+                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-52"
                           data-se="userProfile.country"
                           id="userProfile.country"
                           name="userProfile.country"
@@ -1523,7 +1511,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                         </select>
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-56"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-53"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -1541,7 +1529,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-58"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-55"
                           data-se="userProfile.country-error"
                           id="userProfile.country-error"
                           role="alert"
@@ -1555,82 +1543,78 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.countryCode"
+                        id="userProfile.countryCode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.countryCode"
-                          id="userProfile.countryCode-label"
-                        >
-                          <span>
-                            Country code
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.countryCode"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.countryCode-error"
-                            aria-errormessage="userProfile.countryCode-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.countryCode-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.countryCode"
-                            name="userProfile.countryCode"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
-                          id="userProfile.countryCode-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Country code
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.countryCode"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.countryCode-error"
+                          aria-errormessage="userProfile.countryCode-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.countryCode-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.countryCode"
+                          name="userProfile.countryCode"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-28"
+                        id="userProfile.countryCode-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-51"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-48"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-52"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-49"
                         data-shrink="false"
                         for="userProfile.timezone"
                       >
                         Time zone
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-53"
+                          class="no-translate MuiBox-root emotion-50"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-54"
+                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl  emotion-51"
                       >
                         <select
                           aria-describedby=" userProfile.timezone-error  "
                           aria-invalid="true"
-                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-55"
+                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-52"
                           data-se="userProfile.timezone"
                           id="userProfile.timezone"
                           name="userProfile.timezone"
@@ -1808,7 +1792,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                         </select>
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-56"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-53"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -1826,7 +1810,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-58"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-55"
                           data-se="userProfile.timezone-error"
                           id="userProfile.timezone-error"
                           role="alert"
@@ -1840,7 +1824,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-78"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-74"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1852,14 +1836,14 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-80"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-76"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-81"
+                    class="MuiBox-root emotion-77"
                   >
                     <div
-                      class="MuiBox-root emotion-82"
+                      class="MuiBox-root emotion-78"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -1874,10 +1858,10 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-82"
+                      class="MuiBox-root emotion-78"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-86"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-82"
                         data-se="back"
                         href=""
                       >
@@ -1971,142 +1955,130 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-10"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
-                        >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.lastName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-10"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-10"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-35"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-36"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
+                      >
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
+                      >
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-32"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-33"
                         data-shrink="false"
                         for="userProfile.country"
                       >
                         Country
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-37"
+                          class="no-translate MuiBox-root emotion-34"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-38"
+                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-35"
                       >
                         <select
                           aria-invalid="false"
-                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-39"
+                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-36"
                           data-se="userProfile.country"
                           id="userProfile.country"
                           name="userProfile.country"
@@ -3324,7 +3296,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                         </select>
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-40"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-37"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -3344,36 +3316,32 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.countryCode"
+                        id="userProfile.countryCode-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.countryCode"
-                          id="userProfile.countryCode-label"
-                        >
-                          <span>
-                            Country code
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.countryCode"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.countryCode-label"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.countryCode"
-                            name="userProfile.countryCode"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Country code
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.countryCode"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.countryCode-label"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.countryCode"
+                          name="userProfile.countryCode"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -3381,27 +3349,27 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-35"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-32"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-36"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-outlined emotion-33"
                         data-shrink="false"
                         for="userProfile.timezone"
                       >
                         Time zone
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-37"
+                          class="no-translate MuiBox-root emotion-34"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-38"
+                        class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-35"
                       >
                         <select
                           aria-invalid="false"
-                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-39"
+                          class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-36"
                           data-se="userProfile.timezone"
                           id="userProfile.timezone"
                           name="userProfile.timezone"
@@ -3579,7 +3547,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                         </select>
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-40"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-37"
                           fill="none"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -3599,7 +3567,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-55"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -3611,14 +3579,14 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-57"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-53"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-58"
+                    class="MuiBox-root emotion-54"
                   >
                     <div
-                      class="MuiBox-root emotion-59"
+                      class="MuiBox-root emotion-55"
                     >
                       <div
                         class="MuiBox-root emotion-11"
@@ -3633,10 +3601,10 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-59"
+                      class="MuiBox-root emotion-55"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-63"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
                         data-se="back"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -132,7 +132,6 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -142,6 +141,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -183,7 +183,6 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -193,6 +192,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -234,8 +234,6 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -245,7 +243,9 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -1557,7 +1557,6 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.countryCode"
                         required="true"
                       >
                         <input
@@ -1566,6 +1565,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                           aria-invalid="true"
                           aria-labelledby="userProfile.countryCode-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.countryCode"
                           id="userProfile.countryCode"
                           name="userProfile.countryCode"
                           required=""
@@ -1969,7 +1969,6 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -1977,6 +1976,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -2003,7 +2003,6 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -2011,6 +2010,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -2037,8 +2037,6 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -2046,7 +2044,9 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -3330,13 +3330,13 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.countryCode"
                         required="true"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.countryCode-label"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.countryCode"
                           id="userProfile.countryCode"
                           name="userProfile.countryCode"
                           required=""

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -77,31 +77,35 @@ exports[`enroll-profile-new should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -111,31 +115,35 @@ exports[`enroll-profile-new should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -145,32 +153,36 @@ exports[`enroll-profile-new should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -75,37 +75,33 @@ exports[`enroll-profile-new should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
-                        >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.lastName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -113,37 +109,33 @@ exports[`enroll-profile-new should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -151,38 +143,34 @@ exports[`enroll-profile-new should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -190,7 +178,7 @@ exports[`enroll-profile-new should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-35"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-32"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -202,14 +190,14 @@ exports[`enroll-profile-new should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-37"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-34"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-38"
+                    class="MuiBox-root emotion-35"
                   >
                     <div
-                      class="MuiBox-root emotion-39"
+                      class="MuiBox-root emotion-36"
                     >
                       <div
                         class="MuiBox-root emotion-11"
@@ -224,10 +212,10 @@ exports[`enroll-profile-new should render form 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-39"
+                      class="MuiBox-root emotion-36"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
                         data-se="back"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -89,7 +89,6 @@ exports[`enroll-profile-new should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -97,6 +96,7 @@ exports[`enroll-profile-new should render form 1`] = `
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -123,7 +123,6 @@ exports[`enroll-profile-new should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -131,6 +130,7 @@ exports[`enroll-profile-new should render form 1`] = `
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -157,8 +157,6 @@ exports[`enroll-profile-new should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -166,7 +164,9 @@ exports[`enroll-profile-new should render form 1`] = `
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -77,31 +77,35 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -111,31 +115,35 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -145,32 +153,36 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -180,30 +192,34 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.login"
-                      >
-                        Username
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.login"
+                          id="userProfile.login-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.login"
-                          id="userProfile.login"
-                          name="userProfile.login"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.login-label"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.login"
+                            name="userProfile.login"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -213,30 +229,34 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-18"
-                        data-shrink="false"
-                        for="userProfile.address"
-                      >
-                        Street Address
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-19"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-21"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
+                          data-shrink="false"
+                          for="userProfile.address"
+                          id="userProfile.address-label"
+                        >
+                          <span>
+                            Street Address
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
                           data-se="userProfile.address"
-                          id="userProfile.address"
-                          name="userProfile.address"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.address-label"
+                            class="MuiInputBase-input emotion-21"
+                            id="userProfile.address"
+                            name="userProfile.address"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -420,43 +440,51 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.lastName-error  "
-                          aria-invalid="true"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.lastName-error"
-                          id="userProfile.lastName-error"
-                          role="alert"
+                          required="true"
                         >
-                          Custom preSubmit error
+                          <input
+                            aria-describedby="userProfile.lastName-error"
+                            aria-errormessage="userProfile.lastName-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-29"
+                          id="userProfile.lastName-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            Custom preSubmit error
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -467,31 +495,35 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -501,32 +533,36 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -536,30 +572,34 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.login"
-                      >
-                        Username
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.login"
+                          id="userProfile.login-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.login"
-                          id="userProfile.login"
-                          name="userProfile.login"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.login-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.login"
+                            name="userProfile.login"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -567,7 +607,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-50"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -579,14 +619,14 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-52"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-53"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-53"
+                    class="MuiBox-root emotion-54"
                   >
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-55"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -601,10 +641,10 @@ exports[`enroll-profile-with-password should show custom error message and preve
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-55"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
                         data-se="back"
                         href=""
                       >
@@ -743,43 +783,51 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.lastName-error  "
-                          aria-invalid="true"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.lastName-error"
-                          id="userProfile.lastName-error"
-                          role="alert"
+                          required="true"
                         >
-                          Custom parseSchema error
+                          <input
+                            aria-describedby="userProfile.lastName-error"
+                            aria-errormessage="userProfile.lastName-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
+                          id="userProfile.lastName-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            Custom parseSchema error
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -790,31 +838,35 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -824,32 +876,36 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -859,30 +915,34 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.login"
-                      >
-                        Username
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.login"
+                          id="userProfile.login-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.login"
-                          id="userProfile.login"
-                          name="userProfile.login"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.login-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.login"
+                            name="userProfile.login"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -890,7 +950,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-50"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -902,14 +962,14 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-52"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-53"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-53"
+                    class="MuiBox-root emotion-54"
                   >
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-55"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -924,10 +984,10 @@ exports[`enroll-profile-with-password should show custom field level error messa
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-55"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
                         data-se="back"
                         href=""
                       >
@@ -1066,31 +1126,35 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1100,31 +1164,35 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1134,32 +1202,36 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1169,30 +1241,34 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.login"
-                      >
-                        Username
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.login"
+                          id="userProfile.login-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.login"
-                          id="userProfile.login"
-                          name="userProfile.login"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.login-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.login"
+                            name="userProfile.login"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1376,43 +1452,51 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.lastName-error  "
-                          aria-invalid="true"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="userProfile.lastName-error"
+                            aria-errormessage="userProfile.lastName-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.lastName-error"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
                           id="userProfile.lastName-error"
-                          role="alert"
                         >
-                          This field cannot be left blank
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -1423,43 +1507,51 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.firstName-error  "
-                          aria-invalid="true"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="userProfile.firstName-error"
+                            aria-errormessage="userProfile.firstName-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.firstName-error"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
                           id="userProfile.firstName-error"
-                          role="alert"
                         >
-                          This field cannot be left blank
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -1470,44 +1562,52 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.email-error  "
-                          aria-invalid="true"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="userProfile.email-error"
+                            aria-errormessage="userProfile.email-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.email-error"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
                           id="userProfile.email-error"
-                          role="alert"
                         >
-                          This field cannot be left blank
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -1518,42 +1618,50 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.login"
-                      >
-                        Username
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.login-error  "
-                          aria-invalid="true"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.login"
+                          id="userProfile.login-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.login"
-                          id="userProfile.login"
-                          name="userProfile.login"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.login-error"
-                          id="userProfile.login-error"
-                          role="alert"
+                          required="true"
                         >
-                          This field cannot be left blank
+                          <input
+                            aria-describedby="userProfile.login-error"
+                            aria-errormessage="userProfile.login-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.login-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.login"
+                            name="userProfile.login"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
+                          id="userProfile.login-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -1564,42 +1672,50 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-25"
-                        data-shrink="false"
-                        for="userProfile.address"
-                      >
-                        Street Address
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-26"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
                       >
-                        <input
-                          aria-describedby=" userProfile.address-error  "
-                          aria-invalid="true"
-                          class="MuiInputBase-input emotion-28"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
+                          data-shrink="false"
+                          for="userProfile.address"
+                          id="userProfile.address-label"
+                        >
+                          <span>
+                            Street Address
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
                           data-se="userProfile.address"
-                          id="userProfile.address"
-                          name="userProfile.address"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-30"
-                          data-se="userProfile.address-error"
-                          id="userProfile.address-error"
-                          role="alert"
+                          required="true"
                         >
-                          This field cannot be left blank
+                          <input
+                            aria-describedby="userProfile.address-error"
+                            aria-errormessage="userProfile.address-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.address-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.address"
+                            name="userProfile.address"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
+                          id="userProfile.address-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -1608,7 +1724,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-64"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-69"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1620,14 +1736,14 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-66"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-71"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-67"
+                    class="MuiBox-root emotion-72"
                   >
                     <div
-                      class="MuiBox-root emotion-68"
+                      class="MuiBox-root emotion-73"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -1642,10 +1758,10 @@ exports[`enroll-profile-with-password should show validation error messages on a
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-68"
+                      class="MuiBox-root emotion-73"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-72"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-77"
                         data-se="back"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -75,37 +75,33 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
-                        >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.lastName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -113,37 +109,33 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -151,38 +143,34 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -190,36 +178,32 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.login"
+                        id="userProfile.login-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.login"
-                          id="userProfile.login-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.login"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.login-label"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.login"
-                            name="userProfile.login"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.login"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.login-label"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.login"
+                          name="userProfile.login"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -227,36 +211,32 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-18"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.address"
+                        id="userProfile.address-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-19"
-                          data-shrink="false"
-                          for="userProfile.address"
-                          id="userProfile.address-label"
-                        >
-                          <span>
-                            Street Address
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-20"
-                          data-se="userProfile.address"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.address-label"
-                            class="MuiInputBase-input emotion-21"
-                            id="userProfile.address"
-                            name="userProfile.address"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Street Address
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        data-se="userProfile.address"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.address-label"
+                          class="MuiInputBase-input emotion-20"
+                          id="userProfile.address"
+                          name="userProfile.address"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -264,7 +244,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-47"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-42"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -276,14 +256,14 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-49"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-44"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-50"
+                    class="MuiBox-root emotion-45"
                   >
                     <div
-                      class="MuiBox-root emotion-51"
+                      class="MuiBox-root emotion-46"
                     >
                       <div
                         class="MuiBox-root emotion-11"
@@ -298,10 +278,10 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-51"
+                      class="MuiBox-root emotion-46"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-55"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-50"
                         data-se="back"
                         href=""
                       >
@@ -438,54 +418,84 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.lastName-error"
+                          aria-errormessage="userProfile.lastName-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-28"
+                        id="userProfile.lastName-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
                         >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
+                          Error:
+                        </span>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.lastName"
-                          required="true"
+                          class="MuiBox-root emotion-1"
                         >
-                          <input
-                            aria-describedby="userProfile.lastName-error"
-                            aria-errormessage="userProfile.lastName-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
+                          Custom preSubmit error
                         </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-29"
-                          id="userProfile.lastName-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            Custom preSubmit error
-                          </div>
-                        </p>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -493,37 +503,34 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -531,75 +538,32 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.login"
+                        id="userProfile.login-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
+                        <span>
+                          Username
+                        </span>
+                      </label>
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.login"
+                        required="true"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.login"
-                          id="userProfile.login-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.login"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.login-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.login"
-                            name="userProfile.login"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.login-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.login"
+                          name="userProfile.login"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -607,7 +571,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-47"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -619,14 +583,14 @@ exports[`enroll-profile-with-password should show custom error message and preve
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-53"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-49"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-54"
+                    class="MuiBox-root emotion-50"
                   >
                     <div
-                      class="MuiBox-root emotion-55"
+                      class="MuiBox-root emotion-51"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -641,10 +605,10 @@ exports[`enroll-profile-with-password should show custom error message and preve
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-55"
+                      class="MuiBox-root emotion-51"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-55"
                         data-se="back"
                         href=""
                       >
@@ -781,54 +745,84 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.lastName-error"
+                          aria-errormessage="userProfile.lastName-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-28"
+                        id="userProfile.lastName-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
                         >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
+                          Error:
+                        </span>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.lastName"
-                          required="true"
+                          class="MuiBox-root emotion-1"
                         >
-                          <input
-                            aria-describedby="userProfile.lastName-error"
-                            aria-errormessage="userProfile.lastName-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
+                          Custom parseSchema error
                         </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
-                          id="userProfile.lastName-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            Custom parseSchema error
-                          </div>
-                        </p>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -836,37 +830,34 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -874,75 +865,32 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.login"
+                        id="userProfile.login-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
+                        <span>
+                          Username
+                        </span>
+                      </label>
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.login"
+                        required="true"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.login"
-                          id="userProfile.login-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.login"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.login-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.login"
-                            name="userProfile.login"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.login-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.login"
+                          name="userProfile.login"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -950,7 +898,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-47"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -962,14 +910,14 @@ exports[`enroll-profile-with-password should show custom field level error messa
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-53"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-49"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-54"
+                    class="MuiBox-root emotion-50"
                   >
                     <div
-                      class="MuiBox-root emotion-55"
+                      class="MuiBox-root emotion-51"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -984,10 +932,10 @@ exports[`enroll-profile-with-password should show custom field level error messa
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-55"
+                      class="MuiBox-root emotion-51"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-55"
                         data-se="back"
                         href=""
                       >
@@ -1124,37 +1072,33 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
-                        >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.lastName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1162,37 +1106,33 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1200,38 +1140,34 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1239,36 +1175,32 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.login"
+                        id="userProfile.login-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.login"
-                          id="userProfile.login-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.login"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.login-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.login"
-                            name="userProfile.login"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.login"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.login-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.login"
+                          name="userProfile.login"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1276,7 +1208,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-48"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-44"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1288,14 +1220,14 @@ exports[`enroll-profile-with-password should show generic error message and prev
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-50"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-46"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-51"
+                    class="MuiBox-root emotion-47"
                   >
                     <div
-                      class="MuiBox-root emotion-52"
+                      class="MuiBox-root emotion-48"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -1310,10 +1242,10 @@ exports[`enroll-profile-with-password should show generic error message and prev
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-52"
+                      class="MuiBox-root emotion-48"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-56"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-52"
                         data-se="back"
                         href=""
                       >
@@ -1450,281 +1382,261 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
-                        >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.lastName"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.lastName-error"
-                            aria-errormessage="userProfile.lastName-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
-                          id="userProfile.lastName-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.lastName-error"
+                          aria-errormessage="userProfile.lastName-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-28"
+                        id="userProfile.lastName-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.firstName-error"
-                            aria-errormessage="userProfile.firstName-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
-                          id="userProfile.firstName-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.firstName-error"
+                          aria-errormessage="userProfile.firstName-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-28"
+                        id="userProfile.firstName-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.email-error"
-                            aria-errormessage="userProfile.email-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
-                          id="userProfile.email-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.email-error"
+                          aria-errormessage="userProfile.email-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-28"
+                        id="userProfile.email-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.login"
+                        id="userProfile.login-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.login"
-                          id="userProfile.login-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.login"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.login-error"
-                            aria-errormessage="userProfile.login-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.login-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.login"
-                            name="userProfile.login"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
-                          id="userProfile.login-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.login"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.login-error"
+                          aria-errormessage="userProfile.login-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.login-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.login"
+                          name="userProfile.login"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-28"
+                        id="userProfile.login-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-25"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.address"
+                        id="userProfile.address-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-26"
-                          data-shrink="false"
-                          for="userProfile.address"
-                          id="userProfile.address-label"
-                        >
-                          <span>
-                            Street Address
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.address"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.address-error"
-                            aria-errormessage="userProfile.address-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.address-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.address"
-                            name="userProfile.address"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-29"
-                          id="userProfile.address-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Street Address
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.address"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.address-error"
+                          aria-errormessage="userProfile.address-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.address-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.address"
+                          name="userProfile.address"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-28"
+                        id="userProfile.address-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-69"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-64"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1736,14 +1648,14 @@ exports[`enroll-profile-with-password should show validation error messages on a
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-71"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-66"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-72"
+                    class="MuiBox-root emotion-67"
                   >
                     <div
-                      class="MuiBox-root emotion-73"
+                      class="MuiBox-root emotion-68"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -1758,10 +1670,10 @@ exports[`enroll-profile-with-password should show validation error messages on a
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-73"
+                      class="MuiBox-root emotion-68"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-77"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-72"
                         data-se="back"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -89,7 +89,6 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -97,6 +96,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -123,7 +123,6 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -131,6 +130,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -157,8 +157,6 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -166,7 +164,9 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -192,13 +192,13 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.login"
                         required="true"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.login-label"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.login"
                           id="userProfile.login"
                           name="userProfile.login"
                           required=""
@@ -225,13 +225,13 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
-                        data-se="userProfile.address"
                         required="true"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.address-label"
                           class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.address"
                           id="userProfile.address"
                           name="userProfile.address"
                           required=""
@@ -432,7 +432,6 @@ exports[`enroll-profile-with-password should show custom error message and preve
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -442,6 +441,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -483,7 +483,6 @@ exports[`enroll-profile-with-password should show custom error message and preve
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -491,6 +490,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -517,8 +517,6 @@ exports[`enroll-profile-with-password should show custom error message and preve
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -526,7 +524,9 @@ exports[`enroll-profile-with-password should show custom error message and preve
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -552,13 +552,13 @@ exports[`enroll-profile-with-password should show custom error message and preve
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.login"
                         required="true"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.login-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.login"
                           id="userProfile.login"
                           name="userProfile.login"
                           required=""
@@ -759,7 +759,6 @@ exports[`enroll-profile-with-password should show custom field level error messa
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -769,6 +768,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -810,7 +810,6 @@ exports[`enroll-profile-with-password should show custom field level error messa
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -818,6 +817,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -844,8 +844,6 @@ exports[`enroll-profile-with-password should show custom field level error messa
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -853,7 +851,9 @@ exports[`enroll-profile-with-password should show custom field level error messa
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -879,13 +879,13 @@ exports[`enroll-profile-with-password should show custom field level error messa
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.login"
                         required="true"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.login-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.login"
                           id="userProfile.login"
                           name="userProfile.login"
                           required=""
@@ -1086,7 +1086,6 @@ exports[`enroll-profile-with-password should show generic error message and prev
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -1094,6 +1093,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -1120,7 +1120,6 @@ exports[`enroll-profile-with-password should show generic error message and prev
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -1128,6 +1127,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -1154,8 +1154,6 @@ exports[`enroll-profile-with-password should show generic error message and prev
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -1163,7 +1161,9 @@ exports[`enroll-profile-with-password should show generic error message and prev
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -1189,13 +1189,13 @@ exports[`enroll-profile-with-password should show generic error message and prev
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.login"
                         required="true"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.login-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.login"
                           id="userProfile.login"
                           name="userProfile.login"
                           required=""
@@ -1396,7 +1396,6 @@ exports[`enroll-profile-with-password should show validation error messages on a
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -1406,6 +1405,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -1447,7 +1447,6 @@ exports[`enroll-profile-with-password should show validation error messages on a
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -1457,6 +1456,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -1498,8 +1498,6 @@ exports[`enroll-profile-with-password should show validation error messages on a
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -1509,7 +1507,9 @@ exports[`enroll-profile-with-password should show validation error messages on a
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -1550,7 +1550,6 @@ exports[`enroll-profile-with-password should show validation error messages on a
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.login"
                         required="true"
                       >
                         <input
@@ -1559,6 +1558,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                           aria-invalid="true"
                           aria-labelledby="userProfile.login-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.login"
                           id="userProfile.login"
                           name="userProfile.login"
                           required=""
@@ -1600,7 +1600,6 @@ exports[`enroll-profile-with-password should show validation error messages on a
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.address"
                         required="true"
                       >
                         <input
@@ -1609,6 +1608,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                           aria-invalid="true"
                           aria-labelledby="userProfile.address-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.address"
                           id="userProfile.address"
                           name="userProfile.address"
                           required=""

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -120,29 +120,38 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-24"
-                        data-shrink="false"
-                        for="userProfile.newAttribute"
-                      >
-                        Some custom attribute
-                        <p
-                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
-                        >
-                          Optional
-                        </p>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                          data-shrink="false"
+                          for="userProfile.newAttribute"
+                          id="userProfile.newAttribute-label"
+                        >
+                          <span>
+                            Some custom attribute
+                          </span>
+                          <p
+                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
+                            tabindex="-1"
+                          >
+                            Optional
+                          </p>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.newAttribute"
-                          id="userProfile.newAttribute"
-                          name="userProfile.newAttribute"
-                          type="text"
-                        />
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.newAttribute-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.newAttribute"
+                            name="userProfile.newAttribute"
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -152,44 +161,52 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-24"
-                        data-shrink="false"
-                        for="userProfile.secondEmail"
-                      >
-                        Secondary email
-                        <p
-                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
-                        >
-                          Optional
-                        </p>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                       >
-                        <input
-                          aria-describedby="userProfile.secondEmail-explain"
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                          data-shrink="false"
+                          for="userProfile.secondEmail"
+                          id="userProfile.secondEmail-label"
+                        >
+                          <span>
+                            Secondary email
+                          </span>
+                          <p
+                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
+                            tabindex="-1"
+                          >
+                            Optional
+                          </p>
+                        </label>
+                        <p
+                          class="MuiFormHelperText-root MuiFormHelperText-sizeMedium emotion-34"
+                          id="userProfile.secondEmail-hint"
+                        >
+                          Use a second email to 
+                          <span
+                            class="strong"
+                          >
+                             recover your account 
+                          </span>
+                           in case you become locked out. This email must be verified after setup.
+                        </p>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.secondEmail"
-                          id="userProfile.secondEmail"
-                          name="userProfile.secondEmail"
-                          type="text"
-                        />
-                      </div>
-                      <p
-                        class="MuiFormHelperText-root o-form-explain emotion-34"
-                        data-se="userProfile.secondEmail-explain"
-                        id="userProfile.secondEmail-explain"
-                      >
-                        Use a second email to 
-                        <span
-                          class="strong"
                         >
-                           recover your account 
-                        </span>
-                         in case you become locked out. This email must be verified after setup.
-                      </p>
+                          <input
+                            aria-describedby="userProfile.secondEmail-hint"
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.secondEmail-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.secondEmail"
+                            name="userProfile.secondEmail"
+                            type="text"
+                          />
+                        </div>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -198,29 +215,38 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-24"
-                        data-shrink="false"
-                        for="userProfile.newAttribute2"
-                      >
-                        Some custom attribute 2
-                        <p
-                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
-                        >
-                          Optional
-                        </p>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                          data-shrink="false"
+                          for="userProfile.newAttribute2"
+                          id="userProfile.newAttribute2-label"
+                        >
+                          <span>
+                            Some custom attribute 2
+                          </span>
+                          <p
+                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
+                            tabindex="-1"
+                          >
+                            Optional
+                          </p>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.newAttribute2"
-                          id="userProfile.newAttribute2"
-                          name="userProfile.newAttribute2"
-                          type="text"
-                        />
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.newAttribute2-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.newAttribute2"
+                            name="userProfile.newAttribute2"
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -228,7 +254,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-42"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-45"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -240,7 +266,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                       data-se="skip"
                       href=""
                     >
@@ -251,7 +277,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -138,12 +138,12 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.newAttribute"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.newAttribute-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.newAttribute"
                           id="userProfile.newAttribute"
                           name="userProfile.newAttribute"
                           type="text"
@@ -187,13 +187,13 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                       </p>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.secondEmail"
                       >
                         <input
                           aria-describedby="userProfile.secondEmail-hint"
                           aria-invalid="false"
                           aria-labelledby="userProfile.secondEmail-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.secondEmail"
                           id="userProfile.secondEmail"
                           name="userProfile.secondEmail"
                           type="text"
@@ -225,12 +225,12 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.newAttribute2"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.newAttribute2-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.newAttribute2"
                           id="userProfile.newAttribute2"
                           name="userProfile.newAttribute2"
                           type="text"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -118,94 +118,36 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-23"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-24"
+                        data-shrink="false"
+                        for="userProfile.newAttribute"
+                        id="userProfile.newAttribute-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                          data-shrink="false"
-                          for="userProfile.newAttribute"
-                          id="userProfile.newAttribute-label"
-                        >
-                          <span>
-                            Some custom attribute
-                          </span>
-                          <p
-                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
-                            tabindex="-1"
-                          >
-                            Optional
-                          </p>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.newAttribute"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.newAttribute-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.newAttribute"
-                            name="userProfile.newAttribute"
-                            type="text"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-10"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                          data-shrink="false"
-                          for="userProfile.secondEmail"
-                          id="userProfile.secondEmail-label"
-                        >
-                          <span>
-                            Secondary email
-                          </span>
-                          <p
-                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
-                            tabindex="-1"
-                          >
-                            Optional
-                          </p>
-                        </label>
+                        <span>
+                          Some custom attribute
+                        </span>
                         <p
-                          class="MuiFormHelperText-root MuiFormHelperText-sizeMedium emotion-34"
-                          id="userProfile.secondEmail-hint"
+                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
+                          tabindex="-1"
                         >
-                          Use a second email to 
-                          <span
-                            class="strong"
-                          >
-                             recover your account 
-                          </span>
-                           in case you become locked out. This email must be verified after setup.
+                          Optional
                         </p>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.secondEmail"
-                        >
-                          <input
-                            aria-describedby="userProfile.secondEmail-hint"
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.secondEmail-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.secondEmail"
-                            name="userProfile.secondEmail"
-                            type="text"
-                          />
-                        </div>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.newAttribute"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.newAttribute-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.newAttribute"
+                          name="userProfile.newAttribute"
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -213,40 +155,86 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-23"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-24"
+                        data-shrink="false"
+                        for="userProfile.secondEmail"
+                        id="userProfile.secondEmail-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                          data-shrink="false"
-                          for="userProfile.newAttribute2"
-                          id="userProfile.newAttribute2-label"
+                        <span>
+                          Secondary email
+                        </span>
+                        <p
+                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
+                          tabindex="-1"
                         >
-                          <span>
-                            Some custom attribute 2
-                          </span>
-                          <p
-                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
-                            tabindex="-1"
-                          >
-                            Optional
-                          </p>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.newAttribute2"
+                          Optional
+                        </p>
+                      </label>
+                      <p
+                        class="MuiFormHelperText-root MuiFormHelperText-sizeMedium emotion-32"
+                        id="userProfile.secondEmail-hint"
+                      >
+                        Use a second email to 
+                        <span
+                          class="strong"
                         >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.newAttribute2-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.newAttribute2"
-                            name="userProfile.newAttribute2"
-                            type="text"
-                          />
-                        </div>
+                           recover your account 
+                        </span>
+                         in case you become locked out. This email must be verified after setup.
+                      </p>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.secondEmail"
+                      >
+                        <input
+                          aria-describedby="userProfile.secondEmail-hint"
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.secondEmail-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.secondEmail"
+                          name="userProfile.secondEmail"
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-23"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-24"
+                        data-shrink="false"
+                        for="userProfile.newAttribute2"
+                        id="userProfile.newAttribute2-label"
+                      >
+                        <span>
+                          Some custom attribute 2
+                        </span>
+                        <p
+                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
+                          tabindex="-1"
+                        >
+                          Optional
+                        </p>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.newAttribute2"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.newAttribute2-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.newAttribute2"
+                          name="userProfile.newAttribute2"
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -254,7 +242,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-45"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-42"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -266,7 +254,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
                       data-se="skip"
                       href=""
                     >
@@ -277,7 +265,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -433,94 +433,36 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-23"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-24"
+                        data-shrink="false"
+                        for="userProfile.newAttribute"
+                        id="userProfile.newAttribute-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                          data-shrink="false"
-                          for="userProfile.newAttribute"
-                          id="userProfile.newAttribute-label"
-                        >
-                          <span>
-                            Some custom attribute
-                          </span>
-                          <p
-                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
-                            tabindex="-1"
-                          >
-                            Optional
-                          </p>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.newAttribute"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.newAttribute-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.newAttribute"
-                            name="userProfile.newAttribute"
-                            type="text"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-10"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                          data-shrink="false"
-                          for="userProfile.secondEmail"
-                          id="userProfile.secondEmail-label"
-                        >
-                          <span>
-                            Secondary email
-                          </span>
-                          <p
-                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
-                            tabindex="-1"
-                          >
-                            Optional
-                          </p>
-                        </label>
+                        <span>
+                          Some custom attribute
+                        </span>
                         <p
-                          class="MuiFormHelperText-root MuiFormHelperText-sizeMedium emotion-34"
-                          id="userProfile.secondEmail-hint"
+                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
+                          tabindex="-1"
                         >
-                          Use a second email to 
-                          <span
-                            class="strong"
-                          >
-                             recover your account 
-                          </span>
-                           in case you become locked out. This email must be verified after setup.
+                          Optional
                         </p>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.secondEmail"
-                        >
-                          <input
-                            aria-describedby="userProfile.secondEmail-hint"
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.secondEmail-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.secondEmail"
-                            name="userProfile.secondEmail"
-                            type="text"
-                          />
-                        </div>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.newAttribute"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.newAttribute-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.newAttribute"
+                          name="userProfile.newAttribute"
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -528,36 +470,82 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-23"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-24"
+                        data-shrink="false"
+                        for="userProfile.secondEmail"
+                        id="userProfile.secondEmail-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                          data-shrink="false"
-                          for="userProfile.newAttribute2"
-                          id="userProfile.newAttribute2-label"
+                        <span>
+                          Secondary email
+                        </span>
+                        <p
+                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
+                          tabindex="-1"
                         >
-                          <span>
-                            Some custom attribute 2
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
-                          data-se="userProfile.newAttribute2"
-                          required="true"
+                          Optional
+                        </p>
+                      </label>
+                      <p
+                        class="MuiFormHelperText-root MuiFormHelperText-sizeMedium emotion-32"
+                        id="userProfile.secondEmail-hint"
+                      >
+                        Use a second email to 
+                        <span
+                          class="strong"
                         >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.newAttribute2-label"
-                            class="MuiInputBase-input emotion-28"
-                            id="userProfile.newAttribute2"
-                            name="userProfile.newAttribute2"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                           recover your account 
+                        </span>
+                         in case you become locked out. This email must be verified after setup.
+                      </p>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.secondEmail"
+                      >
+                        <input
+                          aria-describedby="userProfile.secondEmail-hint"
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.secondEmail-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.secondEmail"
+                          name="userProfile.secondEmail"
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-23"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-24"
+                        data-shrink="false"
+                        for="userProfile.newAttribute2"
+                        id="userProfile.newAttribute2-label"
+                      >
+                        <span>
+                          Some custom attribute 2
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        data-se="userProfile.newAttribute2"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.newAttribute2-label"
+                          class="MuiInputBase-input emotion-27"
+                          id="userProfile.newAttribute2"
+                          name="userProfile.newAttribute2"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -565,7 +553,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-44"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-41"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -577,7 +565,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -161,25 +161,30 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-30"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-31"
                         data-shrink="false"
                         for="userProfile.newAttribute"
+                        id="userProfile.newAttribute-label"
                       >
-                        Some custom attribute
+                        <span>
+                          Some custom attribute
+                        </span>
                         <p
                           class="MuiTypography-root MuiTypography-subtitle1 emotion-32"
+                          tabindex="-1"
                         >
                           Optional
                         </p>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-33"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-33"
                       >
                         <input
                           aria-invalid="false"
+                          aria-labelledby="userProfile.newAttribute-label"
                           class="MuiInputBase-input emotion-34"
                           data-se="userProfile.newAttribute"
                           id="userProfile.newAttribute"
@@ -193,37 +198,27 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-30"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-31"
                         data-shrink="false"
                         for="userProfile.secondEmail"
+                        id="userProfile.secondEmail-label"
                       >
-                        Secondary email
+                        <span>
+                          Secondary email
+                        </span>
                         <p
                           class="MuiTypography-root MuiTypography-subtitle1 emotion-32"
+                          tabindex="-1"
                         >
                           Optional
                         </p>
                       </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-33"
-                      >
-                        <input
-                          aria-describedby="userProfile.secondEmail-explain"
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-34"
-                          data-se="userProfile.secondEmail"
-                          id="userProfile.secondEmail"
-                          name="userProfile.secondEmail"
-                          type="text"
-                        />
-                      </div>
                       <p
-                        class="MuiFormHelperText-root o-form-explain emotion-41"
-                        data-se="userProfile.secondEmail-explain"
-                        id="userProfile.secondEmail-explain"
+                        class="MuiFormHelperText-root MuiFormHelperText-sizeMedium emotion-39"
+                        id="userProfile.secondEmail-hint"
                       >
                         Use a second email to 
                         <span
@@ -233,52 +228,70 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                         </span>
                          in case you become locked out. This email must be verified after setup.
                       </p>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-33"
+                      >
+                        <input
+                          aria-describedby="userProfile.secondEmail-hint"
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.secondEmail-label"
+                          class="MuiInputBase-input emotion-34"
+                          data-se="userProfile.secondEmail"
+                          id="userProfile.secondEmail"
+                          name="userProfile.secondEmail"
+                          type="text"
+                        />
+                      </div>
                     </div>
                   </div>
                   <div
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-30"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-44"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-31"
                         data-shrink="false"
                         for="userProfile.newAttribute2"
+                        id="userProfile.newAttribute2-label"
                       >
-                        Some custom attribute 2
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-45"
-                        >
-                          *
+                        <span>
+                          Some custom attribute 2
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-33"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-33"
+                        required="true"
                       >
                         <input
-                          aria-describedby=" userProfile.newAttribute2-error  "
+                          aria-describedby="userProfile.newAttribute2-error"
+                          aria-errormessage="userProfile.newAttribute2-error"
                           aria-invalid="true"
+                          aria-labelledby="userProfile.newAttribute2-label"
                           class="MuiInputBase-input emotion-34"
                           data-se="userProfile.newAttribute2"
                           id="userProfile.newAttribute2"
                           name="userProfile.newAttribute2"
+                          required=""
                           type="text"
                         />
                       </div>
-                      <div
-                        class="MuiBox-root emotion-1"
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-39"
+                        id="userProfile.newAttribute2-error"
                       >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-41"
-                          data-se="userProfile.newAttribute2-error"
-                          id="userProfile.newAttribute2-error"
-                          role="alert"
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
                         >
                           This field cannot be left blank
-                        </p>
-                      </div>
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
@@ -453,12 +466,12 @@ exports[`enroll-profile-update-required-field should render form with one requir
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.newAttribute"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.newAttribute-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.newAttribute"
                           id="userProfile.newAttribute"
                           name="userProfile.newAttribute"
                           type="text"
@@ -502,13 +515,13 @@ exports[`enroll-profile-update-required-field should render form with one requir
                       </p>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.secondEmail"
                       >
                         <input
                           aria-describedby="userProfile.secondEmail-hint"
                           aria-invalid="false"
                           aria-labelledby="userProfile.secondEmail-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.secondEmail"
                           id="userProfile.secondEmail"
                           name="userProfile.secondEmail"
                           type="text"
@@ -534,13 +547,13 @@ exports[`enroll-profile-update-required-field should render form with one requir
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        data-se="userProfile.newAttribute2"
                         required="true"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.newAttribute2-label"
                           class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.newAttribute2"
                           id="userProfile.newAttribute2"
                           name="userProfile.newAttribute2"
                           required=""

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -435,29 +435,38 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-24"
-                        data-shrink="false"
-                        for="userProfile.newAttribute"
-                      >
-                        Some custom attribute
-                        <p
-                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
-                        >
-                          Optional
-                        </p>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                          data-shrink="false"
+                          for="userProfile.newAttribute"
+                          id="userProfile.newAttribute-label"
+                        >
+                          <span>
+                            Some custom attribute
+                          </span>
+                          <p
+                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
+                            tabindex="-1"
+                          >
+                            Optional
+                          </p>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.newAttribute"
-                          id="userProfile.newAttribute"
-                          name="userProfile.newAttribute"
-                          type="text"
-                        />
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.newAttribute-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.newAttribute"
+                            name="userProfile.newAttribute"
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -467,44 +476,52 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-24"
-                        data-shrink="false"
-                        for="userProfile.secondEmail"
+                      <div
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                       >
-                        Secondary email
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                          data-shrink="false"
+                          for="userProfile.secondEmail"
+                          id="userProfile.secondEmail-label"
+                        >
+                          <span>
+                            Secondary email
+                          </span>
+                          <p
+                            class="MuiTypography-root MuiTypography-subtitle1 emotion-26"
+                            tabindex="-1"
+                          >
+                            Optional
+                          </p>
+                        </label>
                         <p
-                          class="MuiTypography-root MuiTypography-subtitle1 emotion-25"
+                          class="MuiFormHelperText-root MuiFormHelperText-sizeMedium emotion-34"
+                          id="userProfile.secondEmail-hint"
                         >
-                          Optional
+                          Use a second email to 
+                          <span
+                            class="strong"
+                          >
+                             recover your account 
+                          </span>
+                           in case you become locked out. This email must be verified after setup.
                         </p>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
-                      >
-                        <input
-                          aria-describedby="userProfile.secondEmail-explain"
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-27"
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.secondEmail"
-                          id="userProfile.secondEmail"
-                          name="userProfile.secondEmail"
-                          type="text"
-                        />
-                      </div>
-                      <p
-                        class="MuiFormHelperText-root o-form-explain emotion-34"
-                        data-se="userProfile.secondEmail-explain"
-                        id="userProfile.secondEmail-explain"
-                      >
-                        Use a second email to 
-                        <span
-                          class="strong"
                         >
-                           recover your account 
-                        </span>
-                         in case you become locked out. This email must be verified after setup.
-                      </p>
+                          <input
+                            aria-describedby="userProfile.secondEmail-hint"
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.secondEmail-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.secondEmail"
+                            name="userProfile.secondEmail"
+                            type="text"
+                          />
+                        </div>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -513,30 +530,34 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-37"
-                        data-shrink="false"
-                        for="userProfile.newAttribute2"
-                      >
-                        Some custom attribute 2
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-38"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                          data-shrink="false"
+                          for="userProfile.newAttribute2"
+                          id="userProfile.newAttribute2-label"
+                        >
+                          <span>
+                            Some custom attribute 2
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-27"
                           data-se="userProfile.newAttribute2"
-                          id="userProfile.newAttribute2"
-                          name="userProfile.newAttribute2"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.newAttribute2-label"
+                            class="MuiInputBase-input emotion-28"
+                            id="userProfile.newAttribute2"
+                            name="userProfile.newAttribute2"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -544,7 +565,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-42"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-44"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -556,7 +577,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -161,115 +161,107 @@ exports[`enroll-profile-update fails client side validation with empty required 
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-30"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-31"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-31"
+                        data-shrink="false"
+                        for="userProfile.favoriteSport"
+                        id="userProfile.favoriteSport-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-32"
-                          data-shrink="false"
-                          for="userProfile.favoriteSport"
-                          id="userProfile.favoriteSport-label"
-                        >
-                          <span>
-                            Favorite sport
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-33"
-                          data-se="userProfile.favoriteSport"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.favoriteSport-error"
-                            aria-errormessage="userProfile.favoriteSport-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.favoriteSport-label"
-                            class="MuiInputBase-input emotion-34"
-                            id="userProfile.favoriteSport"
-                            name="userProfile.favoriteSport"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-35"
-                          id="userProfile.favoriteSport-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Favorite sport
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-32"
+                        data-se="userProfile.favoriteSport"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.favoriteSport-error"
+                          aria-errormessage="userProfile.favoriteSport-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.favoriteSport-label"
+                          class="MuiInputBase-input emotion-33"
+                          id="userProfile.favoriteSport"
+                          name="userProfile.favoriteSport"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-34"
+                        id="userProfile.favoriteSport-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-30"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-31"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-31"
+                        data-shrink="false"
+                        for="userProfile.newAttribute"
+                        id="userProfile.newAttribute-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-32"
-                          data-shrink="false"
-                          for="userProfile.newAttribute"
-                          id="userProfile.newAttribute-label"
-                        >
-                          <span>
-                            Custom attribute
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-33"
-                          data-se="userProfile.newAttribute"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="userProfile.newAttribute-error"
-                            aria-errormessage="userProfile.newAttribute-error"
-                            aria-invalid="true"
-                            aria-labelledby="userProfile.newAttribute-label"
-                            class="MuiInputBase-input emotion-34"
-                            id="userProfile.newAttribute"
-                            name="userProfile.newAttribute"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-35"
-                          id="userProfile.newAttribute-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Custom attribute
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-32"
+                        data-se="userProfile.newAttribute"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="userProfile.newAttribute-error"
+                          aria-errormessage="userProfile.newAttribute-error"
+                          aria-invalid="true"
+                          aria-labelledby="userProfile.newAttribute-label"
+                          class="MuiInputBase-input emotion-33"
+                          id="userProfile.newAttribute"
+                          name="userProfile.newAttribute"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-34"
+                        id="userProfile.newAttribute-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-48"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -406,36 +398,32 @@ exports[`enroll-profile-update should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-23"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-24"
+                        data-shrink="false"
+                        for="userProfile.favoriteSport"
+                        id="userProfile.favoriteSport-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                          data-shrink="false"
-                          for="userProfile.favoriteSport"
-                          id="userProfile.favoriteSport-label"
-                        >
-                          <span>
-                            Favorite sport
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                          data-se="userProfile.favoriteSport"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.favoriteSport-label"
-                            class="MuiInputBase-input emotion-27"
-                            id="userProfile.favoriteSport"
-                            name="userProfile.favoriteSport"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Favorite sport
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-25"
+                        data-se="userProfile.favoriteSport"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.favoriteSport-label"
+                          class="MuiInputBase-input emotion-26"
+                          id="userProfile.favoriteSport"
+                          name="userProfile.favoriteSport"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -443,36 +431,32 @@ exports[`enroll-profile-update should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-23"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-24"
+                        data-shrink="false"
+                        for="userProfile.newAttribute"
+                        id="userProfile.newAttribute-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                          data-shrink="false"
-                          for="userProfile.newAttribute"
-                          id="userProfile.newAttribute-label"
-                        >
-                          <span>
-                            Custom attribute
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                          data-se="userProfile.newAttribute"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.newAttribute-label"
-                            class="MuiInputBase-input emotion-27"
-                            id="userProfile.newAttribute"
-                            name="userProfile.newAttribute"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Custom attribute
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-25"
+                        data-se="userProfile.newAttribute"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.newAttribute-label"
+                          class="MuiInputBase-input emotion-26"
+                          id="userProfile.newAttribute"
+                          name="userProfile.newAttribute"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -480,7 +464,7 @@ exports[`enroll-profile-update should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-35"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
                       data-se="save"
                       tabindex="0"
                       type="submit"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -175,7 +175,6 @@ exports[`enroll-profile-update fails client side validation with empty required 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-32"
-                        data-se="userProfile.favoriteSport"
                         required="true"
                       >
                         <input
@@ -184,6 +183,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
                           aria-invalid="true"
                           aria-labelledby="userProfile.favoriteSport-label"
                           class="MuiInputBase-input emotion-33"
+                          data-se="userProfile.favoriteSport"
                           id="userProfile.favoriteSport"
                           name="userProfile.favoriteSport"
                           required=""
@@ -225,7 +225,6 @@ exports[`enroll-profile-update fails client side validation with empty required 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-32"
-                        data-se="userProfile.newAttribute"
                         required="true"
                       >
                         <input
@@ -234,6 +233,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
                           aria-invalid="true"
                           aria-labelledby="userProfile.newAttribute-label"
                           class="MuiInputBase-input emotion-33"
+                          data-se="userProfile.newAttribute"
                           id="userProfile.newAttribute"
                           name="userProfile.newAttribute"
                           required=""
@@ -412,13 +412,13 @@ exports[`enroll-profile-update should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-25"
-                        data-se="userProfile.favoriteSport"
                         required="true"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.favoriteSport-label"
                           class="MuiInputBase-input emotion-26"
+                          data-se="userProfile.favoriteSport"
                           id="userProfile.favoriteSport"
                           name="userProfile.favoriteSport"
                           required=""
@@ -445,13 +445,13 @@ exports[`enroll-profile-update should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-25"
-                        data-se="userProfile.newAttribute"
                         required="true"
                       >
                         <input
                           aria-invalid="false"
                           aria-labelledby="userProfile.newAttribute-label"
                           class="MuiInputBase-input emotion-26"
+                          data-se="userProfile.newAttribute"
                           id="userProfile.newAttribute"
                           name="userProfile.newAttribute"
                           required=""

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -163,42 +163,50 @@ exports[`enroll-profile-update fails client side validation with empty required 
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
-                        data-shrink="false"
-                        for="userProfile.favoriteSport"
-                      >
-                        Favorite sport
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-32"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-33"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-31"
                       >
-                        <input
-                          aria-describedby=" userProfile.favoriteSport-error  "
-                          aria-invalid="true"
-                          class="MuiInputBase-input emotion-34"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-32"
+                          data-shrink="false"
+                          for="userProfile.favoriteSport"
+                          id="userProfile.favoriteSport-label"
+                        >
+                          <span>
+                            Favorite sport
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-33"
                           data-se="userProfile.favoriteSport"
-                          id="userProfile.favoriteSport"
-                          name="userProfile.favoriteSport"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-36"
-                          data-se="userProfile.favoriteSport-error"
-                          id="userProfile.favoriteSport-error"
-                          role="alert"
+                          required="true"
                         >
-                          This field cannot be left blank
+                          <input
+                            aria-describedby="userProfile.favoriteSport-error"
+                            aria-errormessage="userProfile.favoriteSport-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.favoriteSport-label"
+                            class="MuiInputBase-input emotion-34"
+                            id="userProfile.favoriteSport"
+                            name="userProfile.favoriteSport"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-35"
+                          id="userProfile.favoriteSport-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -209,42 +217,50 @@ exports[`enroll-profile-update fails client side validation with empty required 
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
-                        data-shrink="false"
-                        for="userProfile.newAttribute"
-                      >
-                        Custom attribute
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-32"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-33"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-31"
                       >
-                        <input
-                          aria-describedby=" userProfile.newAttribute-error  "
-                          aria-invalid="true"
-                          class="MuiInputBase-input emotion-34"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-32"
+                          data-shrink="false"
+                          for="userProfile.newAttribute"
+                          id="userProfile.newAttribute-label"
+                        >
+                          <span>
+                            Custom attribute
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl emotion-33"
                           data-se="userProfile.newAttribute"
-                          id="userProfile.newAttribute"
-                          name="userProfile.newAttribute"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-36"
-                          data-se="userProfile.newAttribute-error"
-                          id="userProfile.newAttribute-error"
-                          role="alert"
+                          required="true"
                         >
-                          This field cannot be left blank
+                          <input
+                            aria-describedby="userProfile.newAttribute-error"
+                            aria-errormessage="userProfile.newAttribute-error"
+                            aria-invalid="true"
+                            aria-labelledby="userProfile.newAttribute-label"
+                            class="MuiInputBase-input emotion-34"
+                            id="userProfile.newAttribute"
+                            name="userProfile.newAttribute"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-35"
+                          id="userProfile.newAttribute-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -253,7 +269,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-48"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -392,30 +408,34 @@ exports[`enroll-profile-update should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-24"
-                        data-shrink="false"
-                        for="userProfile.favoriteSport"
-                      >
-                        Favorite sport
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-25"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                          data-shrink="false"
+                          for="userProfile.favoriteSport"
+                          id="userProfile.favoriteSport-label"
+                        >
+                          <span>
+                            Favorite sport
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
                           data-se="userProfile.favoriteSport"
-                          id="userProfile.favoriteSport"
-                          name="userProfile.favoriteSport"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.favoriteSport-label"
+                            class="MuiInputBase-input emotion-27"
+                            id="userProfile.favoriteSport"
+                            name="userProfile.favoriteSport"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -425,30 +445,34 @@ exports[`enroll-profile-update should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-24"
-                        data-shrink="false"
-                        for="userProfile.newAttribute"
-                      >
-                        Custom attribute
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-25"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiInputBase-input emotion-27"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                          data-shrink="false"
+                          for="userProfile.newAttribute"
+                          id="userProfile.newAttribute-label"
+                        >
+                          <span>
+                            Custom attribute
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
                           data-se="userProfile.newAttribute"
-                          id="userProfile.newAttribute"
-                          name="userProfile.newAttribute"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.newAttribute-label"
+                            class="MuiInputBase-input emotion-27"
+                            id="userProfile.newAttribute"
+                            name="userProfile.newAttribute"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -340,32 +340,36 @@ exports[`enroll-profile-with-password should display field level error when pass
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-60"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-62"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-62"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -375,65 +379,73 @@ exports[`enroll-profile-with-password should display field level error when pass
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-60"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-62"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-60"
+                          required="true"
                         >
-                          *
-                        </span>
-                      </label>
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-62"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-1"
+                    >
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-62"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-62"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -444,20 +456,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-77"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-60"
+                          class="no-translate MuiBox-root emotion-78"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-61"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-79"
                         dir="ltr"
                       >
                         <input
@@ -936,32 +948,36 @@ exports[`enroll-profile-with-password should display field level error when pass
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-60"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-62"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-62"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -971,65 +987,73 @@ exports[`enroll-profile-with-password should display field level error when pass
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-60"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-62"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-60"
+                          required="true"
                         >
-                          *
-                        </span>
-                      </label>
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-62"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-1"
+                    >
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-61"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-62"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-62"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1040,20 +1064,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-59"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-77"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-60"
+                          class="no-translate MuiBox-root emotion-78"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-61"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-79"
                         dir="ltr"
                       >
                         <input
@@ -1467,32 +1491,36 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-52"
-                        data-shrink="false"
-                        for="userProfile.email"
-                      >
-                        Email
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-53"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-54"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-52"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-55"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-53"
+                          data-shrink="false"
+                          for="userProfile.email"
+                          id="userProfile.email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-54"
                           data-se="userProfile.email"
-                          id="userProfile.email"
                           inputmode="email"
-                          name="userProfile.email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-55"
+                            id="userProfile.email"
+                            name="userProfile.email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1502,65 +1530,73 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-52"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                      >
-                        First name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-53"
-                        >
-                          *
-                        </span>
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-54"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-52"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-55"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-53"
+                          data-shrink="false"
+                          for="userProfile.firstName"
+                          id="userProfile.firstName-label"
+                        >
+                          <span>
+                            First name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-54"
                           data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-10"
-                  >
-                    <div
-                      class="MuiBox-root emotion-1"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-52"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                      >
-                        Last name
-                        <span
-                          aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-53"
+                          required="true"
                         >
-                          *
-                        </span>
-                      </label>
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.firstName-label"
+                            autocomplete="given-name"
+                            class="MuiInputBase-input emotion-55"
+                            id="userProfile.firstName"
+                            name="userProfile.firstName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <div
+                      class="MuiBox-root emotion-1"
+                    >
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-54"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-52"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-55"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-53"
+                          data-shrink="false"
+                          for="userProfile.lastName"
+                          id="userProfile.lastName-label"
+                        >
+                          <span>
+                            Last name
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-54"
                           data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="userProfile.lastName-label"
+                            autocomplete="family-name"
+                            class="MuiInputBase-input emotion-55"
+                            id="userProfile.lastName"
+                            name="userProfile.lastName"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1571,20 +1607,20 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-52"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-70"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-53"
+                          class="no-translate MuiBox-root emotion-71"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-54"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-72"
                         dir="ltr"
                       >
                         <input

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -352,8 +352,6 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -361,7 +359,9 @@ exports[`enroll-profile-with-password should display field level error when pass
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-61"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -387,7 +387,6 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -395,6 +394,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-61"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -421,7 +421,6 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -429,6 +428,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-61"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -948,8 +948,6 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -957,7 +955,9 @@ exports[`enroll-profile-with-password should display field level error when pass
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-61"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -983,7 +983,6 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -991,6 +990,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-61"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -1017,7 +1017,6 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -1025,6 +1024,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-61"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""
@@ -1479,8 +1479,6 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-53"
-                        data-se="userProfile.email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -1488,7 +1486,9 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           aria-labelledby="userProfile.email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-54"
+                          data-se="userProfile.email"
                           id="userProfile.email"
+                          inputmode="email"
                           name="userProfile.email"
                           required=""
                           type="text"
@@ -1514,7 +1514,6 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-53"
-                        data-se="userProfile.firstName"
                         required="true"
                       >
                         <input
@@ -1522,6 +1521,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           aria-labelledby="userProfile.firstName-label"
                           autocomplete="given-name"
                           class="MuiInputBase-input emotion-54"
+                          data-se="userProfile.firstName"
                           id="userProfile.firstName"
                           name="userProfile.firstName"
                           required=""
@@ -1548,7 +1548,6 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-53"
-                        data-se="userProfile.lastName"
                         required="true"
                       >
                         <input
@@ -1556,6 +1555,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           aria-labelledby="userProfile.lastName-label"
                           autocomplete="family-name"
                           class="MuiInputBase-input emotion-54"
+                          data-se="userProfile.lastName"
                           id="userProfile.lastName"
                           name="userProfile.lastName"
                           required=""

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -338,38 +338,34 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-62"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-61"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -377,37 +373,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-62"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-61"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -415,37 +407,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
-                        >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
-                          data-se="userProfile.lastName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-62"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-61"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -456,40 +444,40 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-77"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-74"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-78"
+                          class="no-translate MuiBox-root emotion-75"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-79"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-76"
                         dir="ltr"
                       >
                         <input
                           aria-describedby=" credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_3 "
                           aria-invalid="true"
                           autocomplete="new-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-81"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-78"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-82"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-79"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
@@ -516,29 +504,29 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-85"
+                          class="MuiFormHelperText-root Mui-error emotion-82"
                           data-se="credentials.passcode-error"
                           id="credentials.passcode-error"
                           role="alert"
                         >
                           <div
-                            class="MuiBox-root emotion-86"
+                            class="MuiBox-root emotion-83"
                           >
                             <p
-                              class="MuiTypography-root MuiTypography-body1 emotion-87"
+                              class="MuiTypography-root MuiTypography-body1 emotion-84"
                             >
                               Password requirements were not met:
                             </p>
                             <ul
-                              class="MuiList-root MuiList-dense emotion-88"
+                              class="MuiList-root MuiList-dense emotion-85"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-89"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-86"
                               >
                                 At least 8 characters
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-89"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-86"
                               >
                                 An uppercase letter
                               </li>
@@ -552,7 +540,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-92"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-89"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -564,14 +552,14 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-94"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-91"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-95"
+                    class="MuiBox-root emotion-92"
                   >
                     <div
-                      class="MuiBox-root emotion-96"
+                      class="MuiBox-root emotion-93"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -586,10 +574,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-96"
+                      class="MuiBox-root emotion-93"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-100"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-97"
                         data-se="back"
                         href=""
                       >
@@ -946,38 +934,34 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-62"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-61"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -985,37 +969,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-62"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-61"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1023,37 +1003,33 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
-                        >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-61"
-                          data-se="userProfile.lastName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-62"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-61"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1064,40 +1040,40 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-77"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-74"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-78"
+                          class="no-translate MuiBox-root emotion-75"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-79"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-76"
                         dir="ltr"
                       >
                         <input
                           aria-describedby=" credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_3 "
                           aria-invalid="true"
                           autocomplete="new-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-81"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-78"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-82"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-79"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
@@ -1124,7 +1100,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-85"
+                          class="MuiFormHelperText-root Mui-error emotion-82"
                           data-se="credentials.passcode-error"
                           id="credentials.passcode-error"
                           role="alert"
@@ -1138,7 +1114,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-87"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-84"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1150,14 +1126,14 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-89"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-86"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-90"
+                    class="MuiBox-root emotion-87"
                   >
                     <div
-                      class="MuiBox-root emotion-91"
+                      class="MuiBox-root emotion-88"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -1172,10 +1148,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-91"
+                      class="MuiBox-root emotion-88"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-95"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-92"
                         data-se="back"
                         href=""
                       >
@@ -1489,38 +1465,34 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-51"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-52"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-52"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-53"
-                          data-shrink="false"
-                          for="userProfile.email"
-                          id="userProfile.email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-54"
-                          data-se="userProfile.email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-55"
-                            id="userProfile.email"
-                            name="userProfile.email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-53"
+                        data-se="userProfile.email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-54"
+                          id="userProfile.email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1528,37 +1500,33 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-51"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-52"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-52"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-53"
-                          data-shrink="false"
-                          for="userProfile.firstName"
-                          id="userProfile.firstName-label"
-                        >
-                          <span>
-                            First name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-54"
-                          data-se="userProfile.firstName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.firstName-label"
-                            autocomplete="given-name"
-                            class="MuiInputBase-input emotion-55"
-                            id="userProfile.firstName"
-                            name="userProfile.firstName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-53"
+                        data-se="userProfile.firstName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-54"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1566,37 +1534,33 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-51"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-52"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-52"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-53"
-                          data-shrink="false"
-                          for="userProfile.lastName"
-                          id="userProfile.lastName-label"
-                        >
-                          <span>
-                            Last name
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-54"
-                          data-se="userProfile.lastName"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="userProfile.lastName-label"
-                            autocomplete="family-name"
-                            class="MuiInputBase-input emotion-55"
-                            id="userProfile.lastName"
-                            name="userProfile.lastName"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-53"
+                        data-se="userProfile.lastName"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-54"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1607,47 +1571,47 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-70"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-67"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                         <span
                           aria-hidden="true"
-                          class="no-translate MuiBox-root emotion-71"
+                          class="no-translate MuiBox-root emotion-68"
                         >
                           *
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-72"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-69"
                         dir="ltr"
                       >
                         <input
                           aria-describedby="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-55"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-54"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-74"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-71"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-75"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-72"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-76"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-73"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -1669,7 +1633,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-78"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-75"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1681,14 +1645,14 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-80"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-77"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-81"
+                    class="MuiBox-root emotion-78"
                   >
                     <div
-                      class="MuiBox-root emotion-82"
+                      class="MuiBox-root emotion-79"
                     >
                       <div
                         class="MuiBox-root emotion-11"
@@ -1703,10 +1667,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-82"
+                      class="MuiBox-root emotion-79"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-86"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-83"
                         data-se="back"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -60,38 +60,33 @@ exports[`identify-recovery renders form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-14"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Email or Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-18"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email or Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-17"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -99,7 +94,7 @@ exports[`identify-recovery renders form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-20"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-19"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -111,7 +106,7 @@ exports[`identify-recovery renders form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -61,27 +61,37 @@ exports[`identify-recovery renders form 1`] = `
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Email or Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-17"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
+                        >
+                          <span>
+                            Email or Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
                           data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-18"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -89,7 +99,7 @@ exports[`identify-recovery renders form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-19"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-20"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -101,7 +111,7 @@ exports[`identify-recovery renders form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -74,7 +74,6 @@ exports[`identify-recovery renders form 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -82,6 +81,7 @@ exports[`identify-recovery renders form 1`] = `
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-17"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -117,7 +117,6 @@ exports[`identify-with-password Client-side field change validation tests fails 
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-23"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -127,6 +126,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-24"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""
@@ -450,7 +450,6 @@ exports[`identify-with-password Client-side field change validation tests should
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-23"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -460,6 +459,7 @@ exports[`identify-with-password Client-side field change validation tests should
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-24"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""
@@ -783,7 +783,6 @@ exports[`identify-with-password Client-side field change validation tests should
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-23"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -793,6 +792,7 @@ exports[`identify-with-password Client-side field change validation tests should
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-24"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""
@@ -1073,7 +1073,6 @@ exports[`identify-with-password renders form with focus 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -1081,6 +1080,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-17"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""
@@ -1333,7 +1333,6 @@ exports[`identify-with-password renders form without focus 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
-                        data-se="identifier"
                         required="true"
                       >
                         <input
@@ -1341,6 +1340,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                           aria-labelledby="identifier-label"
                           autocomplete="username"
                           class="MuiInputBase-input emotion-17"
+                          data-se="identifier"
                           id="identifier"
                           name="identifier"
                           required=""

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -104,39 +104,53 @@ exports[`identify-with-password Client-side field change validation tests fails 
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-23"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
                       >
-                        <input
-                          aria-describedby=" identifier-error  "
-                          aria-invalid="true"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-24"
-                          data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-26"
-                          data-se="identifier-error"
-                          id="identifier-error"
-                          role="alert"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
                         >
-                          This field cannot be left blank
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-24"
+                          data-se="identifier"
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="identifier-error"
+                            aria-errormessage="identifier-error"
+                            aria-invalid="true"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-25"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-26"
+                          id="identifier-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -148,34 +162,34 @@ exports[`identify-with-password Client-side field change validation tests fails 
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-23"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-32"
                         dir="ltr"
                       >
                         <input
                           aria-describedby=" credentials.passcode-error  "
                           aria-invalid="true"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-32"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-34"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-33"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-35"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
@@ -202,7 +216,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-26"
+                          class="MuiFormHelperText-root Mui-error emotion-38"
                           data-se="credentials.passcode-error"
                           id="credentials.passcode-error"
                           role="alert"
@@ -216,16 +230,16 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-38"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-40"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-39"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-41"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-40"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-42"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-41"
+                            class="PrivateSwitchBase-input emotion-43"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -235,7 +249,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-42"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-44"
                         >
                           Keep me signed in
                         </span>
@@ -246,7 +260,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-44"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -258,7 +272,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                       data-se="forgot-password"
                       href=""
                     >
@@ -269,7 +283,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -280,20 +294,20 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-50"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-52"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-51"
+                    class="MuiBox-root emotion-53"
                   >
                     <div
-                      class="MuiBox-root emotion-52"
+                      class="MuiBox-root emotion-54"
                     >
                       <div
                         class="MuiBox-root emotion-18"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-54"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-56"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -302,10 +316,10 @@ exports[`identify-with-password Client-side field change validation tests fails 
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-52"
+                      class="MuiBox-root emotion-54"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                         data-se="enroll"
                         href=""
                       >
@@ -428,39 +442,53 @@ exports[`identify-with-password Client-side field change validation tests should
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-23"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
                       >
-                        <input
-                          aria-describedby=" identifier-error  "
-                          aria-invalid="true"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-24"
-                          data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-26"
-                          data-se="identifier-error"
-                          id="identifier-error"
-                          role="alert"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
                         >
-                          This field cannot be left blank
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-24"
+                          data-se="identifier"
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="identifier-error"
+                            aria-errormessage="identifier-error"
+                            aria-invalid="true"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-25"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-26"
+                          id="identifier-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -472,34 +500,34 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-23"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-32"
                         dir="ltr"
                       >
                         <input
                           aria-describedby=" credentials.passcode-error  "
                           aria-invalid="true"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-32"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-34"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-33"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-35"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
@@ -526,7 +554,7 @@ exports[`identify-with-password Client-side field change validation tests should
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-26"
+                          class="MuiFormHelperText-root Mui-error emotion-38"
                           data-se="credentials.passcode-error"
                           id="credentials.passcode-error"
                           role="alert"
@@ -540,16 +568,16 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-38"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-40"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-39"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-41"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-40"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-42"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-41"
+                            class="PrivateSwitchBase-input emotion-43"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -559,7 +587,7 @@ exports[`identify-with-password Client-side field change validation tests should
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-42"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-44"
                         >
                           Keep me signed in
                         </span>
@@ -570,7 +598,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-44"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -582,7 +610,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                       data-se="forgot-password"
                       href=""
                     >
@@ -593,7 +621,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -604,20 +632,20 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-50"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-52"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-51"
+                    class="MuiBox-root emotion-53"
                   >
                     <div
-                      class="MuiBox-root emotion-52"
+                      class="MuiBox-root emotion-54"
                     >
                       <div
                         class="MuiBox-root emotion-18"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-54"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-56"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -626,10 +654,10 @@ exports[`identify-with-password Client-side field change validation tests should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-52"
+                      class="MuiBox-root emotion-54"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                         data-se="enroll"
                         href=""
                       >
@@ -752,39 +780,53 @@ exports[`identify-with-password Client-side field change validation tests should
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-23"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
                       >
-                        <input
-                          aria-describedby=" identifier-error  "
-                          aria-invalid="true"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-24"
-                          data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
-                      </div>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        <p
-                          class="MuiFormHelperText-root Mui-error emotion-26"
-                          data-se="identifier-error"
-                          id="identifier-error"
-                          role="alert"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
                         >
-                          This field cannot be left blank
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-24"
+                          data-se="identifier"
+                          required="true"
+                        >
+                          <input
+                            aria-describedby="identifier-error"
+                            aria-errormessage="identifier-error"
+                            aria-invalid="true"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-25"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
+                        <p
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-26"
+                          id="identifier-error"
+                        >
+                          <span
+                            class="MuiBox-root emotion-14"
+                          >
+                            Error:
+                          </span>
+                          <div
+                            class="MuiBox-root emotion-1"
+                          >
+                            This field cannot be left blank
+                          </div>
                         </p>
                       </div>
                     </div>
@@ -796,34 +838,34 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-23"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-32"
                         dir="ltr"
                       >
                         <input
                           aria-describedby=" credentials.passcode-error  "
                           aria-invalid="true"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-32"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-34"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-33"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-35"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
@@ -850,7 +892,7 @@ exports[`identify-with-password Client-side field change validation tests should
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-26"
+                          class="MuiFormHelperText-root Mui-error emotion-38"
                           data-se="credentials.passcode-error"
                           id="credentials.passcode-error"
                           role="alert"
@@ -864,16 +906,16 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-38"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-40"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-39"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-41"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-40"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-42"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-41"
+                            class="PrivateSwitchBase-input emotion-43"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -883,7 +925,7 @@ exports[`identify-with-password Client-side field change validation tests should
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-42"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-44"
                         >
                           Keep me signed in
                         </span>
@@ -894,7 +936,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-44"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -906,7 +948,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                       data-se="forgot-password"
                       href=""
                     >
@@ -917,7 +959,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -928,20 +970,20 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-50"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-52"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-51"
+                    class="MuiBox-root emotion-53"
                   >
                     <div
-                      class="MuiBox-root emotion-52"
+                      class="MuiBox-root emotion-54"
                     >
                       <div
                         class="MuiBox-root emotion-18"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-54"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-56"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -950,10 +992,10 @@ exports[`identify-with-password Client-side field change validation tests should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-52"
+                      class="MuiBox-root emotion-54"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-46"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
                         data-se="enroll"
                         href=""
                       >
@@ -1033,27 +1075,37 @@ exports[`identify-with-password renders form with focus 1`] = `
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-17"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
                           data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-18"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1064,40 +1116,40 @@ exports[`identify-with-password renders form with focus 1`] = `
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-21"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-16"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-22"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-17"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-18"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-23"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-24"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-24"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-25"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-25"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -1119,16 +1171,16 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-27"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-28"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-28"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-29"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-29"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-30"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-30"
+                            class="PrivateSwitchBase-input emotion-31"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -1138,7 +1190,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-31"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-32"
                         >
                           Keep me signed in
                         </span>
@@ -1149,7 +1201,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1161,7 +1213,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="forgot-password"
                       href=""
                     >
@@ -1172,7 +1224,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -1183,20 +1235,20 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-39"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-40"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-40"
+                    class="MuiBox-root emotion-41"
                   >
                     <div
-                      class="MuiBox-root emotion-41"
+                      class="MuiBox-root emotion-42"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-43"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-44"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -1205,10 +1257,10 @@ exports[`identify-with-password renders form with focus 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-41"
+                      class="MuiBox-root emotion-42"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                         data-se="enroll"
                         href=""
                       >
@@ -1288,27 +1340,37 @@ exports[`identify-with-password renders form without focus 1`] = `
                   >
                     <div
                       class="MuiBox-root emotion-1"
+                      dir="ltr"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
-                        data-shrink="false"
-                        for="identifier"
-                      >
-                        Username
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="username"
-                          class="MuiInputBase-input emotion-17"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
+                        >
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
                           data-se="identifier"
-                          id="identifier"
-                          name="identifier"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-18"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1319,40 +1381,40 @@ exports[`identify-with-password renders form without focus 1`] = `
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-15"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-21"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-16"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-22"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-17"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-18"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-23"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-24"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-24"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-25"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-25"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-26"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -1374,16 +1436,16 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-27"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-28"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-28"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-29"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-29"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-30"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-30"
+                            class="PrivateSwitchBase-input emotion-31"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -1393,7 +1455,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-31"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-32"
                         >
                           Keep me signed in
                         </span>
@@ -1404,7 +1466,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1416,7 +1478,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="forgot-password"
                       href=""
                     >
@@ -1427,7 +1489,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -1438,20 +1500,20 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-39"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-40"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-40"
+                    class="MuiBox-root emotion-41"
                   >
                     <div
-                      class="MuiBox-root emotion-41"
+                      class="MuiBox-root emotion-42"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-43"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-44"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -1460,10 +1522,10 @@ exports[`identify-with-password renders form without focus 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-41"
+                      class="MuiBox-root emotion-42"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                         data-se="enroll"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -103,56 +103,51 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-24"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="identifier-error"
-                            aria-errormessage="identifier-error"
-                            aria-invalid="true"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-25"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-26"
-                          id="identifier-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-23"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="identifier-error"
+                          aria-errormessage="identifier-error"
+                          aria-invalid="true"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-24"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-25"
+                        id="identifier-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
@@ -162,34 +157,34 @@ exports[`identify-with-password Client-side field change validation tests fails 
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-30"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-32"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-31"
                         dir="ltr"
                       >
                         <input
                           aria-describedby=" credentials.passcode-error  "
                           aria-invalid="true"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-34"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-33"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-35"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-34"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
@@ -216,7 +211,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-38"
+                          class="MuiFormHelperText-root Mui-error emotion-37"
                           data-se="credentials.passcode-error"
                           id="credentials.passcode-error"
                           role="alert"
@@ -230,16 +225,16 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-40"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-39"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-41"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-40"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-42"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-41"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-43"
+                            class="PrivateSwitchBase-input emotion-42"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -249,7 +244,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-44"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-43"
                         >
                           Keep me signed in
                         </span>
@@ -260,7 +255,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-45"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -272,7 +267,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                       data-se="forgot-password"
                       href=""
                     >
@@ -283,7 +278,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -294,20 +289,20 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-52"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-51"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-53"
+                    class="MuiBox-root emotion-52"
                   >
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-53"
                     >
                       <div
                         class="MuiBox-root emotion-18"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-56"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-55"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -316,10 +311,10 @@ exports[`identify-with-password Client-side field change validation tests fails 
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-53"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                         data-se="enroll"
                         href=""
                       >
@@ -441,56 +436,51 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-24"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="identifier-error"
-                            aria-errormessage="identifier-error"
-                            aria-invalid="true"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-25"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-26"
-                          id="identifier-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-23"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="identifier-error"
+                          aria-errormessage="identifier-error"
+                          aria-invalid="true"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-24"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-25"
+                        id="identifier-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
@@ -500,34 +490,34 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-30"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-32"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-31"
                         dir="ltr"
                       >
                         <input
                           aria-describedby=" credentials.passcode-error  "
                           aria-invalid="true"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-34"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-33"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-35"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-34"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
@@ -554,7 +544,7 @@ exports[`identify-with-password Client-side field change validation tests should
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-38"
+                          class="MuiFormHelperText-root Mui-error emotion-37"
                           data-se="credentials.passcode-error"
                           id="credentials.passcode-error"
                           role="alert"
@@ -568,16 +558,16 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-40"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-39"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-41"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-40"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-42"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-41"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-43"
+                            class="PrivateSwitchBase-input emotion-42"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -587,7 +577,7 @@ exports[`identify-with-password Client-side field change validation tests should
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-44"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-43"
                         >
                           Keep me signed in
                         </span>
@@ -598,7 +588,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-45"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -610,7 +600,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                       data-se="forgot-password"
                       href=""
                     >
@@ -621,7 +611,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -632,20 +622,20 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-52"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-51"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-53"
+                    class="MuiBox-root emotion-52"
                   >
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-53"
                     >
                       <div
                         class="MuiBox-root emotion-18"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-56"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-55"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -654,10 +644,10 @@ exports[`identify-with-password Client-side field change validation tests should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-53"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                         data-se="enroll"
                         href=""
                       >
@@ -779,56 +769,51 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-24"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-describedby="identifier-error"
-                            aria-errormessage="identifier-error"
-                            aria-invalid="true"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-25"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-26"
-                          id="identifier-error"
-                        >
-                          <span
-                            class="MuiBox-root emotion-14"
-                          >
-                            Error:
-                          </span>
-                          <div
-                            class="MuiBox-root emotion-1"
-                          >
-                            This field cannot be left blank
-                          </div>
-                        </p>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-23"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="identifier-error"
+                          aria-errormessage="identifier-error"
+                          aria-invalid="true"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-24"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused emotion-25"
+                        id="identifier-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          This field cannot be left blank
+                        </div>
+                      </p>
                     </div>
                   </div>
                   <div
@@ -838,34 +823,34 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-31"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-30"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-32"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-31"
                         dir="ltr"
                       >
                         <input
                           aria-describedby=" credentials.passcode-error  "
                           aria-invalid="true"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-25"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-34"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-33"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-35"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-34"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
@@ -892,7 +877,7 @@ exports[`identify-with-password Client-side field change validation tests should
                         class="MuiBox-root emotion-1"
                       >
                         <p
-                          class="MuiFormHelperText-root Mui-error emotion-38"
+                          class="MuiFormHelperText-root Mui-error emotion-37"
                           data-se="credentials.passcode-error"
                           id="credentials.passcode-error"
                           role="alert"
@@ -906,16 +891,16 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-40"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-39"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-41"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-40"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-42"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-41"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-43"
+                            class="PrivateSwitchBase-input emotion-42"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -925,7 +910,7 @@ exports[`identify-with-password Client-side field change validation tests should
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-44"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-43"
                         >
                           Keep me signed in
                         </span>
@@ -936,7 +921,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-46"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-45"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -948,7 +933,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                       data-se="forgot-password"
                       href=""
                     >
@@ -959,7 +944,7 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -970,20 +955,20 @@ exports[`identify-with-password Client-side field change validation tests should
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-52"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-51"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-53"
+                    class="MuiBox-root emotion-52"
                   >
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-53"
                     >
                       <div
                         class="MuiBox-root emotion-18"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-56"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-55"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -992,10 +977,10 @@ exports[`identify-with-password Client-side field change validation tests should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-54"
+                      class="MuiBox-root emotion-53"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-47"
                         data-se="enroll"
                         href=""
                       >
@@ -1074,38 +1059,33 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-14"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-18"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-17"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1116,40 +1096,40 @@ exports[`identify-with-password renders form with focus 1`] = `
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-21"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-22"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-21"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-18"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-17"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-24"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-23"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-25"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-24"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-26"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-25"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -1171,16 +1151,16 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-28"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-27"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-29"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-28"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-30"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-29"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-31"
+                            class="PrivateSwitchBase-input emotion-30"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -1190,7 +1170,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-32"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-31"
                         >
                           Keep me signed in
                         </span>
@@ -1201,7 +1181,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1213,7 +1193,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="forgot-password"
                       href=""
                     >
@@ -1224,7 +1204,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -1235,20 +1215,20 @@ exports[`identify-with-password renders form with focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-40"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-39"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-41"
+                    class="MuiBox-root emotion-40"
                   >
                     <div
-                      class="MuiBox-root emotion-42"
+                      class="MuiBox-root emotion-41"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-44"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-43"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -1257,10 +1237,10 @@ exports[`identify-with-password renders form with focus 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-42"
+                      class="MuiBox-root emotion-41"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                         data-se="enroll"
                         href=""
                       >
@@ -1339,38 +1319,33 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
-                      dir="ltr"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-14"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
+                        data-shrink="false"
+                        for="identifier"
+                        id="identifier-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
-                          data-shrink="false"
-                          for="identifier"
-                          id="identifier-label"
-                        >
-                          <span>
-                            Username
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                          data-se="identifier"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="identifier-label"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-18"
-                            id="identifier"
-                            name="identifier"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Username
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                        data-se="identifier"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="identifier-label"
+                          autocomplete="username"
+                          class="MuiInputBase-input emotion-17"
+                          id="identifier"
+                          name="identifier"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1381,40 +1356,40 @@ exports[`identify-with-password renders form without focus 1`] = `
                       class="MuiBox-root emotion-1"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-21"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-20"
                         data-shrink="false"
                         for="credentials.passcode"
                       >
                         Password
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-22"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-21"
                         dir="ltr"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="current-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-18"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-17"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-24"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-23"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-25"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-24"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-26"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-25"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -1436,16 +1411,16 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-28"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-27"
                     >
                       <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-29"
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-28"
                       >
                         <span
-                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-30"
+                          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-29"
                         >
                           <input
-                            class="PrivateSwitchBase-input emotion-31"
+                            class="PrivateSwitchBase-input emotion-30"
                             data-indeterminate="false"
                             data-se="rememberMe"
                             data-se-for-name="rememberMe"
@@ -1455,7 +1430,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                           />
                         </span>
                         <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-32"
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-31"
                         >
                           Keep me signed in
                         </span>
@@ -1466,7 +1441,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-33"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1478,7 +1453,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="forgot-password"
                       href=""
                     >
@@ -1489,7 +1464,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="help"
                       href="http://localhost:3000/help/login"
                     >
@@ -1500,20 +1475,20 @@ exports[`identify-with-password renders form without focus 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-40"
+                      class="MuiDivider-root MuiDivider-fullWidth separation-line emotion-39"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-41"
+                    class="MuiBox-root emotion-40"
                   >
                     <div
-                      class="MuiBox-root emotion-42"
+                      class="MuiBox-root emotion-41"
                     >
                       <div
                         class="MuiBox-root emotion-11"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-44"
+                          class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-43"
                           data-se="signup-info"
                           id="identify_Description_Dont_have_an_account_aut1egri5t7iomJ3l1d7_10"
                         >
@@ -1522,10 +1497,10 @@ exports[`identify-with-password renders form without focus 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-42"
+                      class="MuiBox-root emotion-41"
                     >
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                         data-se="enroll"
                         href=""
                       >

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -130,38 +130,34 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-1"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
                     >
-                      <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="email"
+                        id="email-label"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
-                          data-shrink="false"
-                          for="email"
-                          id="email-label"
-                        >
-                          <span>
-                            Email
-                          </span>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
-                          data-se="email"
-                          inputmode="email"
-                          required="true"
-                        >
-                          <input
-                            aria-invalid="false"
-                            aria-labelledby="email-label"
-                            autocomplete="email"
-                            class="MuiInputBase-input emotion-25"
-                            id="email"
-                            name="email"
-                            required=""
-                            type="text"
-                          />
-                        </div>
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
+                        data-se="email"
+                        inputmode="email"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-24"
+                          id="email"
+                          name="email"
+                          required=""
+                          type="text"
+                        />
                       </div>
                     </div>
                   </div>
@@ -172,7 +168,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                       class="MuiBox-root emotion-18"
                     >
                       <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-28"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-27"
                         data-se="o-form-explain"
                         id="enrollment-channel-data_Description_Make_sure_you_can_access_the_email_on_your_mobile_device_okta_verify_aut2h3fft4y9pDPCS1d7_3"
                       >
@@ -184,7 +180,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-29"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -200,7 +196,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     >
                       Or 
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways switch-channel-link emotion-33"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways switch-channel-link emotion-32"
                         href="#"
                       >
                         try a different way
@@ -212,7 +208,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -223,7 +219,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -132,26 +132,36 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     <div
                       class="MuiBox-root emotion-1"
                     >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-22"
-                        data-shrink="false"
-                        for="email"
-                      >
-                        Email
-                      </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-23"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-22"
                       >
-                        <input
-                          aria-invalid="false"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-24"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-23"
+                          data-shrink="false"
+                          for="email"
+                          id="email-label"
+                        >
+                          <span>
+                            Email
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-24"
                           data-se="email"
-                          id="email"
                           inputmode="email"
-                          name="email"
-                          type="text"
-                        />
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="email-label"
+                            autocomplete="email"
+                            class="MuiInputBase-input emotion-25"
+                            id="email"
+                            name="email"
+                            required=""
+                            type="text"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -162,7 +172,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                       class="MuiBox-root emotion-18"
                     >
                       <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-27"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-28"
                         data-se="o-form-explain"
                         id="enrollment-channel-data_Description_Make_sure_you_can_access_the_email_on_your_mobile_device_okta_verify_aut2h3fft4y9pDPCS1d7_3"
                       >
@@ -174,7 +184,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-29"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -190,7 +200,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     >
                       Or 
                       <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways switch-channel-link emotion-32"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways switch-channel-link emotion-33"
                         href="#"
                       >
                         try a different way
@@ -202,7 +212,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="switchAuthenticator"
                       href=""
                     >
@@ -213,7 +223,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -144,8 +144,6 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                       </label>
                       <div
                         class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-23"
-                        data-se="email"
-                        inputmode="email"
                         required="true"
                       >
                         <input
@@ -153,7 +151,9 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                           aria-labelledby="email-label"
                           autocomplete="email"
                           class="MuiInputBase-input emotion-24"
+                          data-se="email"
                           id="email"
+                          inputmode="email"
                           name="email"
                           required=""
                           type="text"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -64,27 +64,37 @@ exports[`user-unlock-account renders form 1`] = `
                     >
                       <div
                         class="MuiBox-root emotion-1"
+                        dir="ltr"
                       >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiFormLabel-colorPrimary MuiInputLabel-root emotion-16"
-                          data-shrink="false"
-                          for="identifier"
-                        >
-                          Username
-                        </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
-                          dir="ltr"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-16"
                         >
-                          <input
-                            aria-invalid="false"
-                            autocomplete="username"
-                            class="MuiInputBase-input emotion-18"
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-17"
+                            data-shrink="false"
+                            for="identifier"
+                            id="identifier-label"
+                          >
+                            <span>
+                              Username
+                            </span>
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-18"
                             data-se="identifier"
-                            id="identifier"
-                            name="identifier"
-                            type="text"
-                          />
+                            required="true"
+                          >
+                            <input
+                              aria-invalid="false"
+                              aria-labelledby="identifier-label"
+                              autocomplete="username"
+                              class="MuiInputBase-input emotion-19"
+                              id="identifier"
+                              name="identifier"
+                              required=""
+                              type="text"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -92,7 +102,7 @@ exports[`user-unlock-account renders form 1`] = `
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-20"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-21"
                         tabindex="0"
                         type="submit"
                       >
@@ -104,7 +114,7 @@ exports[`user-unlock-account renders form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -77,7 +77,6 @@ exports[`user-unlock-account renders form 1`] = `
                         </label>
                         <div
                           class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                          data-se="identifier"
                           required="true"
                         >
                           <input
@@ -85,6 +84,7 @@ exports[`user-unlock-account renders form 1`] = `
                             aria-labelledby="identifier-label"
                             autocomplete="username"
                             class="MuiInputBase-input emotion-18"
+                            data-se="identifier"
                             id="identifier"
                             name="identifier"
                             required=""

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -63,38 +63,33 @@ exports[`user-unlock-account renders form 1`] = `
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-1"
-                        dir="ltr"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-15"
                       >
-                        <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-16"
+                        <label
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-16"
+                          data-shrink="false"
+                          for="identifier"
+                          id="identifier-label"
                         >
-                          <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-17"
-                            data-shrink="false"
-                            for="identifier"
-                            id="identifier-label"
-                          >
-                            <span>
-                              Username
-                            </span>
-                          </label>
-                          <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-18"
-                            data-se="identifier"
-                            required="true"
-                          >
-                            <input
-                              aria-invalid="false"
-                              aria-labelledby="identifier-label"
-                              autocomplete="username"
-                              class="MuiInputBase-input emotion-19"
-                              id="identifier"
-                              name="identifier"
-                              required=""
-                              type="text"
-                            />
-                          </div>
+                          <span>
+                            Username
+                          </span>
+                        </label>
+                        <div
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
+                          data-se="identifier"
+                          required="true"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="identifier-label"
+                            autocomplete="username"
+                            class="MuiInputBase-input emotion-18"
+                            id="identifier"
+                            name="identifier"
+                            required=""
+                            type="text"
+                          />
                         </div>
                       </div>
                     </div>
@@ -102,7 +97,7 @@ exports[`user-unlock-account renders form 1`] = `
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-21"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-20"
                         tabindex="0"
                         type="submit"
                       >
@@ -114,7 +109,7 @@ exports[`user-unlock-account renders form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
                       data-se="cancel"
                       href=""
                     >

--- a/src/v3/test/integration/authenticator-enroll-email-magic-link-false.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-email-magic-link-false.test.tsx
@@ -30,7 +30,7 @@ describe('Email authenticator enroll when magic link = false Tests', () => {
       authClient,
       user,
       findByText,
-      findByTestId,
+      findByLabelText,
       findByRole,
     } = await setup({
       mockResponse,
@@ -41,7 +41,7 @@ describe('Email authenticator enroll when magic link = false Tests', () => {
     expect(headerEle.textContent).toBe('Verify with your email');
     expect(container).toMatchSnapshot();
 
-    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEle = await findByLabelText('Enter Code') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';

--- a/src/v3/test/integration/authenticator-enroll-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-google-authenticator.test.tsx
@@ -46,13 +46,13 @@ describe('authenticator-enroll-google-authenticator', () => {
 
   it('send correct payload', async () => {
     const {
-      authClient, user, findByText, findByTestId,
+      authClient, user, findByText, findByLabelText,
     } = await setup({ mockResponse });
     const nextButton = await findByText(/Next/);
     await user.click(nextButton);
     await findByText(/Enter code displayed from application/);
 
-    const codeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEl = await findByLabelText('Enter code') as HTMLInputElement;
     await user.type(codeEl, '123456');
     expect(codeEl.value).toEqual('123456');
 
@@ -68,13 +68,13 @@ describe('authenticator-enroll-google-authenticator', () => {
 
   it('should send correct payload when otp is padded with white spaces', async () => {
     const {
-      authClient, user, findByText, findByTestId,
+      authClient, user, findByText, findByLabelText,
     } = await setup({ mockResponse });
     const nextButton = await findByText(/Next/);
     await user.click(nextButton);
     await findByText(/Enter code displayed from application/);
 
-    const codeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEl = await findByLabelText('Enter code') as HTMLInputElement;
     const otp = '123456';
     const otpWithSpaces = `${otp}  `;
     await user.type(codeEl, otpWithSpaces);
@@ -92,13 +92,13 @@ describe('authenticator-enroll-google-authenticator', () => {
 
   it('should send correct payload when otp is padded with tab spaces', async () => {
     const {
-      authClient, user, findByText, findByTestId,
+      authClient, user, findByText, findByLabelText,
     } = await setup({ mockResponse });
     const nextButton = await findByText(/Next/);
     await user.click(nextButton);
     await findByText(/Enter code displayed from application/);
 
-    const codeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEl = await findByLabelText('Enter code') as HTMLInputElement;
     const otp = '123456';
     const otpWithTabSpaces = `\t${otp}\t\t`;
     await user.type(codeEl, otpWithTabSpaces);
@@ -116,13 +116,13 @@ describe('authenticator-enroll-google-authenticator', () => {
 
   it('should send correct payload when otp is padded with return characters', async () => {
     const {
-      authClient, user, findByText, findByTestId,
+      authClient, user, findByText, findByLabelText,
     } = await setup({ mockResponse });
     const nextButton = await findByText(/Next/);
     await user.click(nextButton);
     await findByText(/Enter code displayed from application/);
 
-    const codeEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEl = await findByLabelText('Enter code') as HTMLInputElement;
     const otp = '123456';
     const otpWithReturnSpaces = `\r${otp}\r`;
     await user.type(codeEl, otpWithReturnSpaces);

--- a/src/v3/test/integration/authenticator-enroll-phone-sms.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-phone-sms.test.tsx
@@ -25,7 +25,7 @@ describe('authenticator-enroll-phone-sms', () => {
   describe('Send correct payload', () => {
     it('when submit the form', async () => {
       const {
-        authClient, user, findByTestId, findByText,
+        authClient, user, findByLabelText, findByText,
       } = await setup({ mockResponse });
 
       const titleElement = await findByText(/Set up phone authentication/);
@@ -34,7 +34,7 @@ describe('authenticator-enroll-phone-sms', () => {
       await findByText(/Carrier messaging charges may apply/);
 
       const submitButton = await findByText('Verify', { selector: 'button' });
-      const otpEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+      const otpEle = await findByLabelText('Enter Code') as HTMLInputElement;
 
       const otp = '123456';
       await user.type(otpEle, otp);

--- a/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-phone-voice.test.tsx
@@ -24,7 +24,7 @@ describe('authenticator-enroll-phone-voice', () => {
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByTestId, findByText,
+      authClient, user, findByLabelText, findByText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Set up phone authentication/);
@@ -33,7 +33,7 @@ describe('authenticator-enroll-phone-voice', () => {
     await findByText(/Carrier messaging charges may apply/);
 
     const submitButton = await findByText('Verify', { selector: 'button' });
-    const otpEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const otpEle = await findByLabelText('Enter Code') as HTMLInputElement;
 
     const otp = '123456';
     await user.type(otpEle, otp);

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -128,7 +128,7 @@ describe('authenticator-enroll-security-question-error', () => {
 
     it('should send correct payload when toggling between question types and submitted form with incorrect number of characters', async () => {
       const {
-        user, authClient, container, findByText, findByTestId, findByLabelText,
+        user, authClient, container, findByText, findByTestId, findByLabelText, findByRole,
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       expect(await findByText(/Set up security question/)).toBeInTheDocument();
@@ -156,7 +156,7 @@ describe('authenticator-enroll-security-question-error', () => {
       // switch to custom question form
       await user.click(await findByLabelText(/Create my own security question/));
 
-      const customQuestionEle = await findByTestId('credentials.question') as HTMLInputElement;
+      const customQuestionEle = await findByRole('textbox', { name: 'Create my own security question' }) as HTMLInputElement;
       const customQuestionAnswerEle = await findByTestId('credentials.answer') as HTMLInputElement;
       const customQuestion = 'What is life?';
       await user.type(customQuestionEle, customQuestion);
@@ -215,7 +215,7 @@ describe('authenticator-enroll-security-question-error', () => {
   describe('custom question', () => {
     it('should show field level character count error message when invalid number of characters are sent and field should retain characters', async () => {
       const {
-        user, authClient, container, findByText, findByTestId, findByLabelText,
+        user, authClient, container, findByText, findByTestId, findByLabelText, findByRole,
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       expect(await findByText(/Set up security question/)).toBeInTheDocument();
@@ -225,7 +225,7 @@ describe('authenticator-enroll-security-question-error', () => {
 
       const submitButton = await findByText('Verify', { selector: 'button' });
       const answerEle = await findByTestId('credentials.answer') as HTMLInputElement;
-      const customQuestionEle = await findByTestId('credentials.question') as HTMLInputElement;
+      const customQuestionEle = await findByRole('textbox', { name: 'Create my own security question' }) as HTMLInputElement;
 
       const question = 'What is the meaning of life?';
       await user.type(customQuestionEle, question);

--- a/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
@@ -184,7 +184,7 @@ describe('authenticator-enroll-security-question', () => {
       const [globalError] = await findAllByRole('alert');
       expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
-      expect(questionEle).toHaveErrorMessage(/This field cannot be left blank$/);
+      expect(questionEle).toHaveErrorMessage(/This field cannot be left blank/);
       const answerFieldError = queryByTestId('credentials.answer-error');
       expect(answerFieldError).toBeNull();
       expect(container).toMatchSnapshot();
@@ -242,7 +242,7 @@ describe('authenticator-enroll-security-question', () => {
       expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
       const customQuestionEle = await findByRole('textbox', { name: 'Create my own security question' }) as HTMLInputElement;
-      expect(customQuestionEle).toHaveErrorMessage(/This field cannot be left blank$/);
+      expect(customQuestionEle).toHaveErrorMessage(/This field cannot be left blank/);
       const answerFieldError = await findByTestId('credentials.answer-error');
       expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
     });

--- a/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
@@ -124,13 +124,13 @@ describe('authenticator-enroll-security-question', () => {
 
     it('should send correct payload', async () => {
       const {
-        authClient, user, findByTestId, findByText, findByLabelText,
+        authClient, user, findByTestId, findByText, findByLabelText, findByRole,
       } = await setup({ mockResponse });
 
       // switch to custom question form
       user.click(await findByLabelText(/Create my own security question/));
 
-      const customQuestionEle = await findByTestId('credentials.question') as HTMLInputElement;
+      const customQuestionEle = await findByRole('textbox', { name: 'Create my own security question' }) as HTMLInputElement;
       const answerEle = await findByTestId('credentials.answer') as HTMLInputElement;
       const submitButton = await findByText('Verify', { selector: 'button' });
 
@@ -161,6 +161,7 @@ describe('authenticator-enroll-security-question', () => {
         container,
         findByTestId,
         findByText,
+        findByRole,
         findByLabelText,
         findAllByRole,
         queryByTestId,
@@ -169,7 +170,7 @@ describe('authenticator-enroll-security-question', () => {
       // switch to custom question form
       user.click(await findByLabelText(/Create my own security question/));
 
-      const questionEle = await findByTestId('credentials.question') as HTMLInputElement;
+      const questionEle = await findByRole('textbox', { name: 'Create my own security question' }) as HTMLInputElement;
       const answerEle = await findByTestId('credentials.answer') as HTMLInputElement;
       const answer = '42';
       await user.type(answerEle, answer);
@@ -183,8 +184,7 @@ describe('authenticator-enroll-security-question', () => {
       const [globalError] = await findAllByRole('alert');
       expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
-      const questionFieldError = await findByTestId('credentials.question-error');
-      expect(questionFieldError.innerHTML).toEqual('This field cannot be left blank');
+      expect(questionEle).toHaveErrorMessage(/This field cannot be left blank$/);
       const answerFieldError = queryByTestId('credentials.answer-error');
       expect(answerFieldError).toBeNull();
       expect(container).toMatchSnapshot();
@@ -196,15 +196,15 @@ describe('authenticator-enroll-security-question', () => {
         user,
         findByTestId,
         findByText,
+        findByRole,
         findByLabelText,
         findAllByRole,
-        queryByTestId,
       } = await setup({ mockResponse });
 
       // switch to custom question form
       user.click(await findByLabelText(/Create my own security question/));
 
-      const customQuestionEle = await findByTestId('credentials.question') as HTMLInputElement;
+      const customQuestionEle = await findByRole('textbox', { name: 'Create my own security question' }) as HTMLInputElement;
       const question = 'What is the meaning of life?';
       await user.type(customQuestionEle, question);
       expect(customQuestionEle.value).toEqual(question);
@@ -218,8 +218,7 @@ describe('authenticator-enroll-security-question', () => {
       // assert field level error
       const answerFieldError = await findByTestId('credentials.answer-error');
       expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
-      const questionFieldError = queryByTestId('credentials.question-error');
-      expect(questionFieldError).toBeNull();
+      expect(customQuestionEle).not.toHaveErrorMessage();
     });
 
     it('fails client side validation when both custom question and answer are missing', async () => {
@@ -230,6 +229,7 @@ describe('authenticator-enroll-security-question', () => {
         findByText,
         findByLabelText,
         findAllByRole,
+        findByRole,
       } = await setup({ mockResponse });
 
       // switch to custom question form
@@ -241,8 +241,8 @@ describe('authenticator-enroll-security-question', () => {
       const [globalError] = await findAllByRole('alert');
       expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
-      const questionFieldError = await findByTestId('credentials.question-error');
-      expect(questionFieldError.innerHTML).toEqual('This field cannot be left blank');
+      const customQuestionEle = await findByRole('textbox', { name: 'Create my own security question' }) as HTMLInputElement;
+      expect(customQuestionEle).toHaveErrorMessage(/This field cannot be left blank$/);
       const answerFieldError = await findByTestId('credentials.answer-error');
       expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
     });

--- a/src/v3/test/integration/authenticator-verification-custom-otp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-custom-otp.test.tsx
@@ -26,7 +26,7 @@ describe('authenticator-verification-custom-otp', () => {
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByTestId, findByRole, findByText,
+      authClient, user, findByLabelText, findByRole, findByText,
     } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
     const heading = await findByRole('heading', { level: 2 });
@@ -34,7 +34,7 @@ describe('authenticator-verification-custom-otp', () => {
     expect(heading.textContent).toBe('Verify with Atko Custom OTP Authenticator');
 
     const submitButton = await findByText('Verify', { selector: 'button' });
-    const otpCodeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const otpCodeEle = await findByLabelText('Enter code') as HTMLInputElement;
     await waitFor(() => expect(otpCodeEle).toHaveFocus());
 
     const code = '123456';

--- a/src/v3/test/integration/authenticator-verification-email-magic-link-false.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email-magic-link-false.test.tsx
@@ -21,7 +21,7 @@ describe('Email authenticator verification when email magic link = false Tests',
       authClient,
       user,
       findByText,
-      findByTestId,
+      findByLabelText,
       findByRole,
     } = await setup({
       mockResponse,
@@ -32,7 +32,7 @@ describe('Email authenticator verification when email magic link = false Tests',
     expect(headerEle.textContent).toBe('Verify with your email');
     expect(container).toMatchSnapshot();
 
-    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEle = await findByLabelText('Enter Code') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -95,7 +95,7 @@ describe('Email authenticator verification when email magic link = undefined', (
         container,
         user,
         findByText,
-        findByTestId,
+        findByLabelText,
         queryByText,
       } = await setup({
         mockResponses: {
@@ -123,7 +123,7 @@ describe('Email authenticator verification when email magic link = undefined', (
       jest.advanceTimersByTime(500);
       await findByText(/Haven't received an email?/);
 
-      const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+      const codeEle = await findByLabelText('Enter Code') as HTMLInputElement;
       const submitButton = await findByText('Verify', { selector: 'button' });
       const verificationCode = '123456';
       await user.type(codeEle, verificationCode);
@@ -148,7 +148,7 @@ describe('Email authenticator verification when email magic link = undefined', (
         container,
         user,
         findByText,
-        findByTestId,
+        findByLabelText,
         queryByText,
       } = await setup({
         mockResponses: {
@@ -187,14 +187,14 @@ describe('Email authenticator verification when email magic link = undefined', (
       jest.advanceTimersByTime(500);
       await findByText(/Haven't received an email?/);
       // render invalid otp message
-      const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+      const codeEle = await findByLabelText('Enter Code') as HTMLInputElement;
       const submitButton = await findByText('Verify', { selector: 'button' });
       const verificationCode = '123456';
       await user.type(codeEle, verificationCode);
       await user.click(submitButton);
       await findByText('Invalid code. Try again.');
       await waitFor( async () => {
-        const codeEntryEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+        const codeEntryEle = await findByLabelText('Enter Code') as HTMLInputElement;
         expect((codeEntryEle)).toHaveFocus();
       });
       // After an error, verify that the Reminder prompt is removed in lieu of the global error
@@ -244,7 +244,7 @@ describe('Email authenticator verification when email magic link = undefined', (
       authClient,
       user,
       findByText,
-      findByTestId,
+      findByLabelText,
     } = await setup({
       mockResponse: authenticatorVerificationEmail,
     });
@@ -257,7 +257,7 @@ describe('Email authenticator verification when email magic link = undefined', (
     await user.click(nextPageBtn);
     await findByText(/Enter Code/);
 
-    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEle = await findByLabelText('Enter Code') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
@@ -277,7 +277,7 @@ describe('Email authenticator verification when email magic link = undefined', (
       authClient,
       user,
       findByText,
-      findByTestId,
+      findByLabelText,
     } = await setup({
       mockResponse: authenticatorVerificationEmail,
     });
@@ -290,7 +290,7 @@ describe('Email authenticator verification when email magic link = undefined', (
     await user.click(nextPageBtn);
     await findByText(/Enter Code/);
 
-    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEle = await findByLabelText('Enter Code') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const otp = '123456';
@@ -315,7 +315,7 @@ describe('Email authenticator verification when email magic link = undefined', (
       container,
       user,
       findByText,
-      findByTestId,
+      findByLabelText,
     } = await setup({
       mockResponse: authenticatorVerificationEmail,
       widgetOptions: { features: { autoFocus: true } },
@@ -329,7 +329,7 @@ describe('Email authenticator verification when email magic link = undefined', (
     await user.click(nextPageBtn);
     await findByText(/Enter Code/);
 
-    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEle = await findByLabelText('Enter Code') as HTMLInputElement;
 
     expect(codeEle.getAttribute('autocomplete')).toBe('one-time-code');
     expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-google-authenticator.test.tsx
@@ -26,14 +26,14 @@ describe('authenticator-verification-google-authenticator', () => {
       authClient,
       user,
       findByText,
-      findByTestId,
+      findByLabelText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Verify with Google Authenticator/);
     await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Enter the temporary code generated in your Google Authenticator app/);
 
-    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEle = await findByLabelText('Enter code') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';
@@ -52,14 +52,14 @@ describe('authenticator-verification-google-authenticator', () => {
       authClient,
       user,
       findByText,
-      findByTestId,
+      findByLabelText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Verify with Google Authenticator/);
     await waitFor(() => expect(titleElement).toHaveFocus());
     await findByText(/Enter the temporary code generated in your Google Authenticator app/);
 
-    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEle = await findByLabelText('Enter code') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const otp = '123456';

--- a/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-okta-verify-totp.test.tsx
@@ -24,14 +24,14 @@ describe('authenticator-verification-okta-verify-totp', () => {
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByTestId, findByText,
+      authClient, user, findByLabelText, findByText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Enter a code/);
     await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Verify', { selector: 'button' });
-    const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;
+    const otpEle = await findByLabelText('Enter code from Okta Verify app') as HTMLInputElement;
 
     const totp = '123456';
     await user.type(otpEle, totp);
@@ -48,14 +48,14 @@ describe('authenticator-verification-okta-verify-totp', () => {
 
   it('should send correct payload when totp is padded with non-breaking spaces', async () => {
     const {
-      authClient, user, findByTestId, findByText,
+      authClient, user, findByLabelText, findByText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Enter a code/);
     await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Verify', { selector: 'button' });
-    const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;
+    const otpEle = await findByLabelText('Enter code from Okta Verify app') as HTMLInputElement;
 
     const totp = '123456';
     const totpWithNonBreakingSpaces = `\u00A0${totp}\u00A0`;
@@ -77,12 +77,12 @@ describe('authenticator-verification-okta-verify-totp', () => {
       { userAgent: 'iPhone' } as unknown as Navigator,
     );
     const {
-      container, findByTestId, findByText,
+      container, findByLabelText, findByText,
     } = await setup({ mockResponse });
 
     await findByText(/Enter a code/);
 
-    const otpEle = await findByTestId('credentials.totp') as HTMLInputElement;
+    const otpEle = await findByLabelText('Enter code from Okta Verify app') as HTMLInputElement;
 
     expect(otpEle.getAttribute('autocomplete')).toBe('one-time-code');
     expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/authenticator-verification-phone-sms.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-phone-sms.test.tsx
@@ -27,7 +27,7 @@ describe('authenticator-verification-phone-sms', () => {
       authClient,
       user,
       findByText,
-      findByTestId,
+      findByLabelText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Verify with your phone/);
@@ -35,7 +35,7 @@ describe('authenticator-verification-phone-sms', () => {
     await findByText(/A code was sent to/);
     await findByText(/Carrier messaging charges may apply/);
 
-    const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const codeEle = await findByLabelText('Enter Code') as HTMLInputElement;
     const submitButton = await findByText('Verify', { selector: 'button' });
 
     const verificationCode = '123456';

--- a/src/v3/test/integration/device-code-activate.test.tsx
+++ b/src/v3/test/integration/device-code-activate.test.tsx
@@ -26,7 +26,7 @@ describe('device-code-activate', () => {
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByTestId, findByRole, findByText,
+      authClient, user, findByLabelText, findByRole, findByText,
     } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
     const heading = await findByRole('heading', { level: 2 });
@@ -34,7 +34,7 @@ describe('device-code-activate', () => {
     expect(heading.textContent).toBe('Activate your device');
 
     const submitButton = await findByText('Next', { selector: 'button' });
-    const userCodeEle = await findByTestId('userCode') as HTMLInputElement;
+    const userCodeEle = await findByLabelText(/^Activation Code/) as HTMLInputElement;
     await waitFor(() => expect(userCodeEle).toHaveFocus());
 
     const code = '12345678';

--- a/src/v3/test/integration/enroll-profile-new-additional-fields.test.tsx
+++ b/src/v3/test/integration/enroll-profile-new-additional-fields.test.tsx
@@ -16,28 +16,28 @@ import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('enroll-profile-new-additional-fields', () => {
   it('should render form', async () => {
-    const { container, findByRole, findByTestId } = await setup({ mockResponse });
+    const { container, findByRole, findByLabelText } = await setup({ mockResponse });
     const heading = await findByRole('heading', { level: 2 });
     expect(heading.textContent).toBe('Sign up');
     expect(container).toMatchSnapshot();
-    const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
     expect(firstNameEle).not.toHaveFocus();
   });
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByTestId, findByRole,
+      authClient, user, findByLabelText, findByRole, findByTestId,
     } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
     const heading = await findByRole('heading', { level: 2 });
     expect(heading.textContent).toBe('Sign up');
 
     const submitButton = await findByRole('button', { name: 'Sign Up' });
-    const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
-    const lastNameEle = await findByTestId('userProfile.lastName') as HTMLInputElement;
-    const emailEle = await findByTestId('userProfile.email') as HTMLInputElement;
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
+    const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
+    const emailEle = await findByLabelText('Email') as HTMLInputElement;
     const countryEle = await findByTestId('userProfile.country') as HTMLSelectElement;
-    const countryCodeEle = await findByTestId('userProfile.countryCode') as HTMLInputElement;
+    const countryCodeEle = await findByLabelText('Country code') as HTMLInputElement;
     const timezoneEle = await findByTestId('userProfile.timezone') as HTMLSelectElement;
 
     const firstName = 'tester';
@@ -79,18 +79,18 @@ describe('enroll-profile-new-additional-fields', () => {
 
   it('fails client side validation with empty required fields', async () => {
     const {
-      authClient, container, user, findByRole, findByTestId,
+      authClient, container, user, findByLabelText, findByRole,
     } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
     const submitButton = await findByRole('button', { name: 'Sign Up' });
 
     await user.click(submitButton);
-    const firstNameError = await findByTestId('userProfile.firstName-error');
-    expect(firstNameError.textContent).toEqual('This field cannot be left blank');
-    const lastNameError = await findByTestId('userProfile.lastName-error');
-    expect(lastNameError.textContent).toEqual('This field cannot be left blank');
-    const emailError = await findByTestId('userProfile.email-error');
-    expect(emailError.textContent).toEqual('This field cannot be left blank');
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
+    const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
+    const emailEle = await findByLabelText('Email') as HTMLInputElement;
+    expect(firstNameEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(lastNameEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(emailEle).toHaveErrorMessage(/This field cannot be left blank$/);
 
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
     expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/enroll-profile-new-additional-fields.test.tsx
+++ b/src/v3/test/integration/enroll-profile-new-additional-fields.test.tsx
@@ -88,9 +88,9 @@ describe('enroll-profile-new-additional-fields', () => {
     const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
     const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
     const emailEle = await findByLabelText('Email') as HTMLInputElement;
-    expect(firstNameEle).toHaveErrorMessage(/This field cannot be left blank$/);
-    expect(lastNameEle).toHaveErrorMessage(/This field cannot be left blank$/);
-    expect(emailEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(firstNameEle).toHaveErrorMessage(/This field cannot be left blank/);
+    expect(lastNameEle).toHaveErrorMessage(/This field cannot be left blank/);
+    expect(emailEle).toHaveErrorMessage(/This field cannot be left blank/);
 
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
     expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/enroll-profile-new.test.tsx
+++ b/src/v3/test/integration/enroll-profile-new.test.tsx
@@ -72,9 +72,9 @@ describe('enroll-profile-new', () => {
     const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
     const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
     const emailEle = await findByLabelText('Email') as HTMLInputElement;
-    expect(firstNameEle).toHaveErrorMessage(/This field cannot be left blank$/);
-    expect(lastNameEle).toHaveErrorMessage(/This field cannot be left blank$/);
-    expect(emailEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(firstNameEle).toHaveErrorMessage(/This field cannot be left blank/);
+    expect(lastNameEle).toHaveErrorMessage(/This field cannot be left blank/);
+    expect(emailEle).toHaveErrorMessage(/This field cannot be left blank/);
 
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
   });

--- a/src/v3/test/integration/enroll-profile-new.test.tsx
+++ b/src/v3/test/integration/enroll-profile-new.test.tsx
@@ -17,24 +17,24 @@ import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('enroll-profile-new', () => {
   it('should render form', async () => {
-    const { container, findByText, findByTestId } = await setup({ mockResponse });
+    const { container, findByText, findByLabelText } = await setup({ mockResponse });
     await findByText(/Sign up/);
     expect(container).toMatchSnapshot();
-    const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
     expect(firstNameEle).not.toHaveFocus();
   });
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByTestId, findByText,
+      authClient, user, findByLabelText, findByText,
     } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
     await findByText(/Sign up/);
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
-    const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
-    const lastNameEle = await findByTestId('userProfile.lastName') as HTMLInputElement;
-    const emailEle = await findByTestId('userProfile.email') as HTMLInputElement;
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
+    const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
+    const emailEle = await findByLabelText('Email') as HTMLInputElement;
 
     const firstName = 'tester';
     const lastName = 'McTesterson';
@@ -63,18 +63,18 @@ describe('enroll-profile-new', () => {
 
   it('fails client side validation with empty fields', async () => {
     const {
-      authClient, user, findByText, findByTestId,
+      authClient, user, findByLabelText, findByText,
     } = await setup({ mockResponse });
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
 
     await user.click(submitButton);
-    const firstNameError = await findByTestId('userProfile.firstName-error');
-    expect(firstNameError.textContent).toEqual('This field cannot be left blank');
-    const lastNameError = await findByTestId('userProfile.lastName-error');
-    expect(lastNameError.textContent).toEqual('This field cannot be left blank');
-    const emailError = await findByTestId('userProfile.email-error');
-    expect(emailError.textContent).toEqual('This field cannot be left blank');
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
+    const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
+    const emailEle = await findByLabelText('Email') as HTMLInputElement;
+    expect(firstNameEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(lastNameEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(emailEle).toHaveErrorMessage(/This field cannot be left blank$/);
 
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
   });

--- a/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
+++ b/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
@@ -161,7 +161,7 @@ describe('enroll-profile-with-password', () => {
     const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
 
     expect(heading.textContent).toBe('Sign up');
-    expect(lastNameEle).toHaveErrorMessage(/Custom parseSchema error$/);
+    expect(lastNameEle).toHaveErrorMessage(/Custom parseSchema error/);
     expect(container).toMatchSnapshot();
   });
 
@@ -224,7 +224,7 @@ describe('enroll-profile-with-password', () => {
 
     await user.click(submitButton);
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
-    await waitFor(() => expect(lastNameEle).toHaveErrorMessage(/Custom preSubmit error$/));
+    await waitFor(() => expect(lastNameEle).toHaveErrorMessage(/Custom preSubmit error/));
     expect(container).toMatchSnapshot();
   });
 
@@ -340,7 +340,7 @@ describe('enroll-profile-with-password', () => {
 
     await user.click(submitButton);
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalledWith('POST', 'idp/idx/enroll');
-    expect(addressEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(addressEle).toHaveErrorMessage(/This field cannot be left blank/);
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
+++ b/src/v3/test/integration/enroll-profile-registration-callbacks.test.tsx
@@ -126,7 +126,7 @@ describe('enroll-profile-with-password', () => {
 
   it('should show custom field level error message and custom global message on page load', async () => {
     const {
-      container, findByRole, findByTestId,
+      container, findByLabelText, findByRole,
     } = await setup({
       mockResponses: {
         '/introspect': {
@@ -158,16 +158,16 @@ describe('enroll-profile-with-password', () => {
       },
     });
     const heading = await findByRole('heading', { level: 2 });
-    const lastNameFieldError = await findByTestId('userProfile.lastName-error');
+    const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
 
     expect(heading.textContent).toBe('Sign up');
-    expect(lastNameFieldError.textContent).toContain('Custom parseSchema error');
+    expect(lastNameEle).toHaveErrorMessage(/Custom parseSchema error$/);
     expect(container).toMatchSnapshot();
   });
 
   it('should show custom error message and prevent submission when failure is triggered in preSubmit callback', async () => {
     const {
-      authClient, container, user, findByRole, findByLabelText, findByText, findByTestId,
+      authClient, container, user, findByRole, findByLabelText, findByText,
     } = await setup({
       mockResponses: {
         '/introspect': {
@@ -224,8 +224,7 @@ describe('enroll-profile-with-password', () => {
 
     await user.click(submitButton);
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
-    const lastNameFieldError = await findByTestId('userProfile.lastName-error');
-    expect(lastNameFieldError.textContent).toContain('Custom preSubmit error');
+    await waitFor(() => expect(lastNameEle).toHaveErrorMessage(/Custom preSubmit error$/));
     expect(container).toMatchSnapshot();
   });
 
@@ -299,7 +298,7 @@ describe('enroll-profile-with-password', () => {
 
   it('should show validation error messages on all fields when submitted without completing required fields', async () => {
     const {
-      authClient, container, user, findByRole, findByText, findByTestId,
+      authClient, container, user, findByLabelText, findByRole, findByText,
     } = await setup({
       mockResponses: {
         '/introspect': {
@@ -335,13 +334,13 @@ describe('enroll-profile-with-password', () => {
     });
     const heading = await findByRole('heading', { level: 2 });
     const submitButton = await findByText('Sign Up', { selector: 'button' });
+    const addressEle = await findByLabelText(/Street Address/) as HTMLInputElement;
 
     expect(heading.textContent).toBe('Sign up');
 
     await user.click(submitButton);
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalledWith('POST', 'idp/idx/enroll');
-    const addressError = await findByTestId('userProfile.address-error');
-    expect(addressError.textContent).toContain('This field cannot be left blank');
+    expect(addressEle).toHaveErrorMessage(/This field cannot be left blank$/);
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/v3/test/integration/enroll-profile-update-required-field.test.tsx
+++ b/src/v3/test/integration/enroll-profile-update-required-field.test.tsx
@@ -44,7 +44,7 @@ describe('enroll-profile-update-required-field', () => {
 
     await user.click(submitButton);
     const customAttr2Ele = await findByLabelText('Some custom attribute 2') as HTMLInputElement;
-    expect(customAttr2Ele).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(customAttr2Ele).toHaveErrorMessage(/This field cannot be left blank/);
 
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
     expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/enroll-profile-update-required-field.test.tsx
+++ b/src/v3/test/integration/enroll-profile-update-required-field.test.tsx
@@ -16,19 +16,19 @@ import { setup } from './util';
 
 describe('enroll-profile-update-required-field', () => {
   it('should render form with one required field', async () => {
-    const { container, findByRole, findByTestId } = await setup(
+    const { container, findByTestId, findByRole } = await setup(
       { mockResponse: enrollProfileUpdatMockResponse },
     );
     const heading = await findByRole('heading', { level: 2 });
     expect(heading.textContent).toBe('Additional Profile information');
     expect(container).toMatchSnapshot();
     const customAttrEle = await findByTestId('userProfile.newAttribute') as HTMLInputElement;
-    await expect(customAttrEle).not.toHaveFocus();
+    expect(customAttrEle).not.toHaveFocus();
   });
 
   it('fails client side validation with empty required fields', async () => {
     const {
-      authClient, container, user, findByRole, findByTestId,
+      authClient, container, user, findByLabelText, findByRole, findByTestId,
     } = await setup({
       mockResponse: enrollProfileUpdatMockResponse,
       widgetOptions: { features: { autoFocus: true } },
@@ -43,8 +43,8 @@ describe('enroll-profile-update-required-field', () => {
     await waitFor(() => expect(customAttrEle).toHaveFocus());
 
     await user.click(submitButton);
-    const customAttrError = await findByTestId('userProfile.newAttribute2-error');
-    expect(customAttrError.textContent).toEqual('This field cannot be left blank');
+    const customAttr2Ele = await findByLabelText('Some custom attribute 2') as HTMLInputElement;
+    expect(customAttr2Ele).toHaveErrorMessage(/This field cannot be left blank$/);
 
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
     expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/enroll-profile-update.test.tsx
+++ b/src/v3/test/integration/enroll-profile-update.test.tsx
@@ -65,9 +65,9 @@ describe('enroll-profile-update', () => {
 
     await user.click(submitButton);
     const favoriteSportEle = await findByLabelText('Favorite sport') as HTMLInputElement;
-    expect(favoriteSportEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(favoriteSportEle).toHaveErrorMessage(/This field cannot be left blank/);
     const newAttributeEle = await findByLabelText('Custom attribute') as HTMLInputElement;
-    expect(newAttributeEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(newAttributeEle).toHaveErrorMessage(/This field cannot be left blank/);
 
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
     expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/enroll-profile-update.test.tsx
+++ b/src/v3/test/integration/enroll-profile-update.test.tsx
@@ -16,25 +16,25 @@ import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('enroll-profile-update', () => {
   it('should render form', async () => {
-    const { container, findByRole, findByTestId } = await setup({ mockResponse });
+    const { container, findByLabelText, findByRole } = await setup({ mockResponse });
     const heading = await findByRole('heading', { level: 2 });
     expect(heading.textContent).toBe('Sign in');
     expect(container).toMatchSnapshot();
-    const favoriteSportEle = await findByTestId('userProfile.favoriteSport') as HTMLInputElement;
+    const favoriteSportEle = await findByLabelText('Favorite sport') as HTMLInputElement;
     expect(favoriteSportEle).not.toHaveFocus();
   });
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByTestId, findByRole,
+      authClient, user, findByLabelText, findByRole,
     } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
     const heading = await findByRole('heading', { level: 2 });
     expect(heading.textContent).toBe('Sign in');
 
     const submitButton = await findByRole('button', { name: 'Submit' });
-    const favoriteSportEle = await findByTestId('userProfile.favoriteSport') as HTMLInputElement;
-    const newAttributeEle = await findByTestId('userProfile.newAttribute') as HTMLInputElement;
+    const favoriteSportEle = await findByLabelText('Favorite sport') as HTMLInputElement;
+    const newAttributeEle = await findByLabelText('Custom attribute') as HTMLInputElement;
 
     const favoriteSport = 'Football';
     const newAttribute = 'New Attr';
@@ -58,16 +58,16 @@ describe('enroll-profile-update', () => {
 
   it('fails client side validation with empty required fields', async () => {
     const {
-      authClient, container, user, findByRole, findByTestId,
+      authClient, container, user, findByLabelText, findByRole,
     } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
     const submitButton = await findByRole('button', { name: 'Submit' });
 
     await user.click(submitButton);
-    const favoriteSportError = await findByTestId('userProfile.favoriteSport-error');
-    expect(favoriteSportError.textContent).toEqual('This field cannot be left blank');
-    const newAttributeError = await findByTestId('userProfile.newAttribute-error');
-    expect(newAttributeError.textContent).toEqual('This field cannot be left blank');
+    const favoriteSportEle = await findByLabelText('Favorite sport') as HTMLInputElement;
+    expect(favoriteSportEle).toHaveErrorMessage(/This field cannot be left blank$/);
+    const newAttributeEle = await findByLabelText('Custom attribute') as HTMLInputElement;
+    expect(newAttributeEle).toHaveErrorMessage(/This field cannot be left blank$/);
 
     expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
     expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/enroll-profile-with-password.test.tsx
+++ b/src/v3/test/integration/enroll-profile-with-password.test.tsx
@@ -17,25 +17,25 @@ import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('enroll-profile-with-password', () => {
   it('should render form', async () => {
-    const { container, findByText, findByTestId } = await setup({ mockResponse });
+    const { container, findByText, findByLabelText } = await setup({ mockResponse });
     await findByText(/Sign up/);
     expect(container).toMatchSnapshot();
-    const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
     expect(firstNameEle).not.toHaveFocus();
   });
 
   it('should display field level error when password field is required but is not filled', async () => {
     const {
-      authClient, container, user, findByTestId, findByText,
+      authClient, container, user, findByTestId, findByText, findByLabelText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Sign up/);
     await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
-    const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
-    const lastNameEle = await findByTestId('userProfile.lastName') as HTMLInputElement;
-    const emailEle = await findByTestId('userProfile.email') as HTMLInputElement;
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
+    const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
+    const emailEle = await findByLabelText('Email') as HTMLInputElement;
 
     const firstName = 'tester';
     const lastName = 'McTesterson';
@@ -57,16 +57,16 @@ describe('enroll-profile-with-password', () => {
 
   it('should display field level error when password does not fulfill requirements', async () => {
     const {
-      authClient, container, user, findByTestId, findByText,
+      authClient, container, user, findByTestId, findByText, findByLabelText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Sign up/);
     await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
-    const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
-    const lastNameEle = await findByTestId('userProfile.lastName') as HTMLInputElement;
-    const emailEle = await findByTestId('userProfile.email') as HTMLInputElement;
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
+    const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
+    const emailEle = await findByLabelText('Email') as HTMLInputElement;
     const passwordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
 
     const firstName = 'tester';
@@ -92,16 +92,16 @@ describe('enroll-profile-with-password', () => {
 
   it('should send correct payload', async () => {
     const {
-      authClient, user, findByText, findByTestId,
+      authClient, user, findByText, findByTestId, findByLabelText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Sign up/);
     await waitFor(() => expect(titleElement).toHaveFocus());
 
     const submitButton = await findByText('Sign Up', { selector: 'button' });
-    const firstNameEle = await findByTestId('userProfile.firstName') as HTMLInputElement;
-    const lastNameEle = await findByTestId('userProfile.lastName') as HTMLInputElement;
-    const emailEle = await findByTestId('userProfile.email') as HTMLInputElement;
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
+    const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
+    const emailEle = await findByLabelText('Email') as HTMLInputElement;
     const passwordEle = await findByTestId('credentials.passcode') as HTMLInputElement;
 
     const firstName = 'tester';

--- a/src/v3/test/integration/flow-transition.test.tsx
+++ b/src/v3/test/integration/flow-transition.test.tsx
@@ -41,6 +41,7 @@ describe('Flow transitions', () => {
   it('clears field data when transition from identify-with-password to authentication-verification-ga', async () => {
     const {
       user,
+      findByLabelText,
       findByTestId,
       findByText,
     } = await setup({
@@ -59,7 +60,7 @@ describe('Flow transitions', () => {
     // form: identify-with-password
     const titleElement = await findByText('Sign In', { selector: 'h2' });
     await waitFor(() => expect(titleElement).toHaveFocus());
-    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const usernameEl = await findByLabelText('Username') as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Sign in', { selector: 'button' });
 
@@ -71,7 +72,7 @@ describe('Flow transitions', () => {
 
     // form: authentication-verification-ga
     await findByText(/Verify with Google Authenticator/);
-    const newFormPasswordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const newFormPasswordEl = await findByLabelText('Enter code') as HTMLInputElement;
     expect(newFormPasswordEl.value).toEqual('');
   });
 });

--- a/src/v3/test/integration/identify-recovery.test.tsx
+++ b/src/v3/test/integration/identify-recovery.test.tsx
@@ -34,7 +34,7 @@ describe('identify-recovery', () => {
     const [globalError] = await findAllByRole('alert');
     expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
     const identifierEl = await findByLabelText('Email or Username') as HTMLInputElement;
-    expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank$/);
+    expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank/);
   });
 
   it('sends correct payload', async () => {

--- a/src/v3/test/integration/identify-recovery.test.tsx
+++ b/src/v3/test/integration/identify-recovery.test.tsx
@@ -25,7 +25,7 @@ describe('identify-recovery', () => {
   it('fails client validation when missing identifier', async () => {
     const {
       user,
-      findByTestId,
+      findByLabelText,
       findByText,
       findAllByRole,
     } = await setup({ mockResponse });
@@ -33,21 +33,21 @@ describe('identify-recovery', () => {
     await user.click(await findByText('Next', { selector: 'button' }));
     const [globalError] = await findAllByRole('alert');
     expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
-    const identifierError = await findByTestId('identifier-error');
-    expect(identifierError.textContent).toEqual('This field cannot be left blank');
+    const identifierEl = await findByLabelText('Email or Username') as HTMLInputElement;
+    expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank$/);
   });
 
   it('sends correct payload', async () => {
     const {
       authClient,
       user,
-      findByTestId,
+      findByLabelText,
       findByText,
     } = await setup({ mockResponse });
 
     const titleElement = await findByText('Reset your password');
     await waitFor(() => expect(titleElement).toHaveFocus());
-    const usernameEl = await findByTestId('identifier');
+    const usernameEl = await findByLabelText('Email or Username') as HTMLInputElement;
     await user.type(usernameEl, 'testuser@okta.com');
     await user.click(await findByText('Next', { selector: 'button' }));
 

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -25,6 +25,7 @@ describe('identify-with-password-error-flow', () => {
     jest.spyOn(cookieUtils, 'getUsernameCookie').mockReturnValue(mockUsername);
     const {
       user,
+      findByLabelText,
       findByTestId,
       findByText,
     } = await setup({
@@ -42,7 +43,7 @@ describe('identify-with-password-error-flow', () => {
     });
 
     const submitButton = await findByText('Sign in', { selector: 'button' });
-    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const usernameEl = await findByLabelText('Username') as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
 
     await user.clear(usernameEl);
@@ -51,7 +52,7 @@ describe('identify-with-password-error-flow', () => {
     await user.click(submitButton);
 
     await findByText('Unable to sign in');
-    expect((await findByTestId('identifier') as HTMLInputElement).value).toBe(badUsername);
+    expect(usernameEl.value).toBe(badUsername);
   });
 
   it('should display warning message when invalid identifier is entered and should allow user to resubmit same information without showing client-side errors', async () => {
@@ -59,6 +60,7 @@ describe('identify-with-password-error-flow', () => {
     const {
       authClient,
       user,
+      findByLabelText,
       findByTestId,
       findByText,
     } = await setup({
@@ -78,7 +80,7 @@ describe('identify-with-password-error-flow', () => {
     const titleElement = await findByText('Sign In', { selector: 'h2' });
     await waitFor(() => expect(titleElement).toHaveFocus());
     const submitButton = await findByText('Sign in', { selector: 'button' });
-    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const usernameEl = await findByLabelText('Username') as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
 
     const username = 'testeruser@okta1.com';
@@ -89,7 +91,7 @@ describe('identify-with-password-error-flow', () => {
 
     await findByText(/There is no account with the Username/);
 
-    expect((await findByTestId('identifier') as HTMLInputElement).value).toBe(username);
+    expect(usernameEl.value).toBe(username);
     expect((await findByTestId('credentials.passcode') as HTMLInputElement).value).toBe(password);
 
     await user.click(await findByText('Sign in', { selector: 'button' }));

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -114,7 +114,7 @@ describe('identify-with-password', () => {
       await findByText(/We found some errors./);
       const passwordError = await findByTestId('credentials.passcode-error');
 
-      expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank$/);
+      expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank/);
       expect(container).toMatchSnapshot();
       expect(passwordError.textContent).toEqual('This field cannot be left blank');
       expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
@@ -138,7 +138,7 @@ describe('identify-with-password', () => {
       await findByText(/We found some errors./);
       const passwordError = await findByTestId('credentials.passcode-error');
 
-      expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank$/);
+      expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank/);
       expect(container).toMatchSnapshot();
       expect(passwordError.textContent).toEqual('This field cannot be left blank');
       expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
@@ -168,7 +168,7 @@ describe('identify-with-password', () => {
       await user.clear(identifierEl);
       await user.tab();
 
-      expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank$/);
+      expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank/);
       expect(queryByTestId('credentials.passcode-error')).toBeNull();
     });
 
@@ -191,7 +191,7 @@ describe('identify-with-password', () => {
       // empty username & empty password
       await user.click(submitButton);
       await findByText(/We found some errors./);
-      expect(usernameEl).toHaveErrorMessage(/This field cannot be left blank$/);
+      expect(usernameEl).toHaveErrorMessage(/This field cannot be left blank/);
       expect(container).toMatchSnapshot();
 
       passwordError = await findByTestId('credentials.passcode-error');

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -440,7 +440,7 @@ describe('identify-with-password', () => {
     const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
 
-    expect(usernameEl.parentElement?.parentElement?.parentElement?.getAttribute('dir')).toBe('ltr');
+    expect(usernameEl.parentElement).toHaveStyle('direction: ltr');
     expect(passwordEl.parentElement?.getAttribute('dir')).toBe('ltr');
   });
 });

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -28,7 +28,7 @@ describe('identify-with-password', () => {
       },
     };
     const {
-      findByTestId, findByText,
+      findByLabelText, findByTestId, findByText,
     } = await setup({
       mockResponse,
       widgetOptions: {
@@ -37,10 +37,10 @@ describe('identify-with-password', () => {
     });
 
     await findByText('Sign in', { selector: 'button' });
-    const usernameEl = await findByTestId('identifier-hint') as HTMLLabelElement;
+    const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode-hint') as HTMLLabelElement;
 
-    expect(usernameEl.textContent).toEqual(usernameHint);
+    expect(usernameEl).toHaveAccessibleDescription(usernameHint);
     expect(passwordEl.textContent).toEqual(passwordHint);
   });
 
@@ -69,13 +69,13 @@ describe('identify-with-password', () => {
   it('should pre-populate username into identifier field when set in widget config props', async () => {
     const mockUsername = 'testuser@okta1.com';
     const {
-      findByTestId,
+      findByLabelText,
     } = await setup({
       mockResponse,
       widgetOptions: { username: mockUsername },
     });
 
-    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
 
     expect(usernameEl.value).toBe(mockUsername);
   });
@@ -84,13 +84,13 @@ describe('identify-with-password', () => {
     const mockUsername = 'testuser@okta1.com';
     jest.spyOn(cookieUtils, 'getUsernameCookie').mockReturnValue(mockUsername);
     const {
-      findByTestId,
+      findByLabelText,
     } = await setup({
       mockResponse,
       widgetOptions: { features: { rememberMe: true } },
     });
 
-    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
 
     expect(usernameEl.value).toBe(mockUsername);
   });
@@ -101,20 +101,20 @@ describe('identify-with-password', () => {
         authClient,
         user,
         container,
+        findByLabelText,
         findByTestId,
         findByText,
       } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
-      await findByTestId('identifier') as HTMLInputElement;
+      const identifierEl = await findByLabelText(/Username/) as HTMLInputElement;
       await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
 
       await user.click(submitButton);
       await findByText(/We found some errors./);
-      const identifierError = await findByTestId('identifier-error');
       const passwordError = await findByTestId('credentials.passcode-error');
 
-      expect(identifierError.textContent).toEqual('This field cannot be left blank');
+      expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank$/);
       expect(container).toMatchSnapshot();
       expect(passwordError.textContent).toEqual('This field cannot be left blank');
       expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
@@ -125,52 +125,50 @@ describe('identify-with-password', () => {
         authClient,
         user,
         container,
+        findByLabelText,
         findByTestId,
-        queryByTestId,
         findByText,
       } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
-      await findByTestId('identifier') as HTMLInputElement;
+      const identifierEl = await findByLabelText(/Username/) as HTMLInputElement;
       await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
 
       await user.click(submitButton);
       await findByText(/We found some errors./);
-      const identifierError = await findByTestId('identifier-error');
       const passwordError = await findByTestId('credentials.passcode-error');
 
-      expect(identifierError.textContent).toEqual('This field cannot be left blank');
+      expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank$/);
       expect(container).toMatchSnapshot();
       expect(passwordError.textContent).toEqual('This field cannot be left blank');
       expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
 
-      const identifierField = await findByTestId('identifier') as HTMLInputElement;
-      await user.type(identifierField, 'someuser@okta1.com');
+      await user.type(identifierEl, 'someuser@okta1.com');
 
-      expect(queryByTestId('identifier-error')).toBeNull();
+      expect(identifierEl).not.toHaveErrorMessage();
       expect((await findByTestId('credentials.passcode-error')).textContent).toBe('This field cannot be left blank');
     });
 
     it('should type in field, then clear field to view field level error', async () => {
       const {
         user,
+        findByLabelText,
         findByTestId,
         queryByTestId,
         findByText,
       } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
 
-      const identifierEle = await findByTestId('identifier') as HTMLInputElement;
+      const identifierEl = await findByLabelText(/Username/) as HTMLInputElement;
       await findByTestId('credentials.passcode') as HTMLInputElement;
       await findByText('Sign in', { selector: 'button' });
-      expect(queryByTestId('identifier-error')).toBeNull();
+      expect(identifierEl).not.toHaveErrorMessage();
       expect(queryByTestId('credentials.passcode-error')).toBeNull();
 
-      await user.type(identifierEle, 'aaa');
-      await user.clear(identifierEle);
+      await user.type(identifierEl, 'aaa');
+      await user.clear(identifierEl);
       await user.tab();
 
-      const identifierError = await findByTestId('identifier-error');
-      expect(identifierError.textContent).toEqual('This field cannot be left blank');
+      expect(identifierEl).toHaveErrorMessage(/This field cannot be left blank$/);
       expect(queryByTestId('credentials.passcode-error')).toBeNull();
     });
 
@@ -179,22 +177,21 @@ describe('identify-with-password', () => {
         authClient,
         user,
         container,
+        findByLabelText,
         findByTestId,
         findByText,
         queryByTestId,
       } = await setup({ mockResponse, widgetOptions: { features: { autoFocus: true } } });
-      let identifierError;
       let passwordError;
 
-      const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+      const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
 
       // empty username & empty password
       await user.click(submitButton);
       await findByText(/We found some errors./);
-      identifierError = await findByTestId('identifier-error');
-      expect(identifierError.textContent).toEqual('This field cannot be left blank');
+      expect(usernameEl).toHaveErrorMessage(/This field cannot be left blank$/);
       expect(container).toMatchSnapshot();
 
       passwordError = await findByTestId('credentials.passcode-error');
@@ -207,8 +204,7 @@ describe('identify-with-password', () => {
       await waitFor(async () => {
         passwordError = await findByTestId('credentials.passcode-error');
         expect(passwordError.textContent).toEqual('This field cannot be left blank');
-        identifierError = queryByTestId('identifier-error');
-        expect(identifierError).toBeNull();
+        expect(usernameEl).not.toHaveErrorMessage();
         expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
       });
 
@@ -224,8 +220,7 @@ describe('identify-with-password', () => {
             },
           }),
         );
-        identifierError = queryByTestId('identifier-error');
-        expect(identifierError).toBeNull();
+        expect(usernameEl).not.toHaveErrorMessage();
         passwordError = queryByTestId('credentials.passcode-error');
         expect(passwordError).toBeNull();
       });
@@ -235,11 +230,15 @@ describe('identify-with-password', () => {
   describe('sends correct payload', () => {
     it('with all required fields', async () => {
       const {
-        authClient, user, findByTestId, findByText,
+        authClient,
+        user,
+        findByLabelText,
+        findByTestId,
+        findByText,
       } = await setup({ mockResponse });
 
       await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
-      const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+      const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
 
@@ -261,7 +260,11 @@ describe('identify-with-password', () => {
 
     it('should modify username for PRIMARY_AUTH operation when transformUsername function is defined', async () => {
       const {
-        authClient, user, findByTestId, findByText,
+        authClient,
+        user,
+        findByLabelText,
+        findByTestId,
+        findByText,
       } = await setup({
         mockResponse,
         widgetOptions: {
@@ -272,7 +275,7 @@ describe('identify-with-password', () => {
       });
 
       await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
-      const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+      const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
       const mockUsername = 'testuser@okta1.com';
@@ -293,7 +296,11 @@ describe('identify-with-password', () => {
 
     it('should not modify username for when operation is PRIMARY_AUTH as defined in transformUsername function', async () => {
       const {
-        authClient, user, findByTestId, findByText,
+        authClient,
+        user,
+        findByLabelText,
+        findByTestId,
+        findByText,
       } = await setup({
         mockResponse,
         widgetOptions: {
@@ -304,7 +311,7 @@ describe('identify-with-password', () => {
       });
 
       await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
-      const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+      const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
       const mockUsername = 'testuser@okta1.com';
@@ -325,11 +332,15 @@ describe('identify-with-password', () => {
 
     it('should not remove padded spaces from password', async () => {
       const {
-        authClient, user, findByTestId, findByText,
+        authClient,
+        user,
+        findByLabelText,
+        findByTestId,
+        findByText,
       } = await setup({ mockResponse });
 
       await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
-      const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+      const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Sign in', { selector: 'button' });
 
@@ -352,11 +363,15 @@ describe('identify-with-password', () => {
 
     it('with required fields + optional fields', async () => {
       const {
-        authClient, user, findByTestId, findByText,
+        authClient,
+        user,
+        findByLabelText,
+        findByTestId,
+        findByText,
       } = await setup({ mockResponse });
 
       await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
-      const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+      const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
       const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
       const rememberMeEl = await findByTestId('rememberMe');
       const submitButton = await findByText('Sign in', { selector: 'button' });
@@ -382,11 +397,15 @@ describe('identify-with-password', () => {
 
   it('should only send one api request when submit button is double clicked', async () => {
     const {
-      authClient, user, findByTestId, findByText,
+      authClient,
+      user,
+      findByLabelText,
+      findByTestId,
+      findByText,
     } = await setup({ mockResponse });
 
     await waitFor(async () => expect(await findByText('Sign In', { selector: 'h2' })).toHaveFocus());
-    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
     const submitButton = await findByText('Sign in', { selector: 'button' });
 
@@ -414,13 +433,14 @@ describe('identify-with-password', () => {
 
   it('identifier and password fields should be ltr even when a rtl language is set', async () => {
     const {
+      findByLabelText,
       findByTestId,
     } = await setup({ mockResponse, widgetOptions: { language: 'ar' } });
 
-    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const usernameEl = await findByLabelText(/Username/) as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
 
-    expect(usernameEl.parentElement?.getAttribute('dir')).toBe('ltr');
+    expect(usernameEl.parentElement?.parentElement?.parentElement?.getAttribute('dir')).toBe('ltr');
     expect(passwordEl.parentElement?.getAttribute('dir')).toBe('ltr');
   });
 });

--- a/src/v3/test/integration/okta-verify-email-channel-enrollment.test.tsx
+++ b/src/v3/test/integration/okta-verify-email-channel-enrollment.test.tsx
@@ -17,13 +17,13 @@ import mockResponse from '../../src/mocks/response/idp/idx/credential/enroll/enr
 describe('okta-verify-email-channel-enrollment', () => {
   it('should render email channel form and send correct payload', async () => {
     const {
-      container, findByText, findByTestId, user, authClient,
+      container, findByText, findByLabelText, user, authClient,
     } = await setup({ mockResponse });
 
     const headerEle = await findByText(/Set up Okta Verify via email link/);
     await waitFor(() => expect(headerEle).toHaveFocus());
     await findByText(/Make sure you can access the email on your mobile device./);
-    const emailEl = await findByTestId(/email/) as HTMLInputElement;
+    const emailEl = await findByLabelText('Email') as HTMLInputElement;
     const submitBtn = await findByText(/Send me the setup link/);
 
     expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/user-unlock-account.test.tsx
+++ b/src/v3/test/integration/user-unlock-account.test.tsx
@@ -39,11 +39,11 @@ describe('user-unlock-account', () => {
   describe('send correct payload', () => {
     it('when select email authenticator', async () => {
       const {
-        authClient, user, findByTestId, findByText,
+        authClient, user, findByTestId, findByText, findByLabelText,
       } = await setup({ mockResponse });
       const titleElement = await findByText(/Unlock account\?/);
       await waitFor(() => expect(titleElement).toHaveFocus());
-      const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+      const usernameEl = await findByLabelText('Username') as HTMLInputElement;
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
 
@@ -64,12 +64,12 @@ describe('user-unlock-account', () => {
 
     it('when select phone authenticator', async () => {
       const {
-        authClient, user, findByTestId, findByText,
+        authClient, user, findByTestId, findByText, findByLabelText,
       } = await setup({ mockResponse });
 
       const titleElement = await findByText(/Unlock account\?/);
       await waitFor(() => expect(titleElement).toHaveFocus());
-      const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+      const usernameEl = await findByLabelText('Username') as HTMLInputElement;
       await user.type(usernameEl, 'testuser@okta.com');
       expect(usernameEl.value).toEqual('testuser@okta.com');
 

--- a/src/v3/webpack.common.config.ts
+++ b/src/v3/webpack.common.config.ts
@@ -136,8 +136,8 @@ const baseConfig: Partial<Configuration> = {
                   './node_modules',
                   '../../node_modules',
                 ],
-              }
-            }
+              },
+            },
           },
           {
             loader: 'postcss-loader',

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -272,10 +272,17 @@ export default class IdentityPageObject extends BasePageObject {
   }
 
   getIdentifierSubLabelValue() {
+    if (userVariables.gen3) {
+      return Selector('#identifier-hint').textContent;
+    }
     return Selector(SUB_LABEL_SELECTOR).nth(0).textContent;
   }
 
   getPasswordSubLabelValue() {
+    // OKTA-678800: Change after InputPassword migration
+    if (userVariables.gen3) {
+      return Selector('.o-form-explain').nth(0).textContent;
+    }
     return Selector(SUB_LABEL_SELECTOR).nth(1).textContent;
   }
 

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -77,7 +77,7 @@ export default class IdentityPageObject extends BasePageObject {
   }
 
   getIdentifierValue() {
-    return this.form.getTextBoxValue('Username', true);
+    return this.form.getTextBoxValue(/Username/, true);
   }
 
   fillPasswordField(value) {

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -279,10 +279,6 @@ export default class IdentityPageObject extends BasePageObject {
   }
 
   getPasswordSubLabelValue() {
-    // OKTA-678800: Change after InputPassword migration
-    if (userVariables.gen3) {
-      return Selector('.o-form-explain').nth(0).textContent;
-    }
     return Selector(SUB_LABEL_SELECTOR).nth(1).textContent;
   }
 

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -337,7 +337,7 @@ export default class BaseFormObject {
 
   getNthErrorMessage(fieldName, value) {
     if (userVariables.gen3) {
-      return this.el.find(`#${fieldName}-error-${value}`).innerText;
+      return this.el.find(`#${fieldName}-error`).child('div').child('ul').child('li').nth(value).innerText;
     }
     const selectContainer = this.findFormFieldInput(fieldName).sibling('.o-form-input-error').nth(value);
     return selectContainer.innerText;

--- a/test/testcafe/spec/AuthenticatorSymantecView_spec.js
+++ b/test/testcafe/spec/AuthenticatorSymantecView_spec.js
@@ -140,7 +140,7 @@ test
     await pageObject.submit('Verify');
 
     await t.expect(pageObject.form.getTextBoxErrorMessage(fieldName))
-      .match(/Your code doesn't match our records. Please try again.$/);
+      .match(/Your code doesn't match our records. Please try again./);
   });
 
 test.requestHooks(verifyMock)('should show custom factor page link', async t => {

--- a/test/testcafe/spec/AuthenticatorSymantecView_spec.js
+++ b/test/testcafe/spec/AuthenticatorSymantecView_spec.js
@@ -140,7 +140,7 @@ test
     await pageObject.submit('Verify');
 
     await t.expect(pageObject.form.getTextBoxErrorMessage(fieldName))
-      .eql('Your code doesn\'t match our records. Please try again.');
+      .match(/Your code doesn't match our records. Please try again.$/);
   });
 
 test.requestHooks(verifyMock)('should show custom factor page link', async t => {

--- a/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
@@ -75,7 +75,7 @@ test.requestHooks(mockChallengeAuthenticatorOnPrem)('passcode is required', asyn
   await challengeOnPremPage.clickNextButton('Verify');
 
   await challengeOnPremPage.waitForErrorBox();
-  await t.expect(challengeOnPremPage.getPasscodeError()).match(/This field cannot be left blank$/);
+  await t.expect(challengeOnPremPage.getPasscodeError()).match(/This field cannot be left blank/);
 });
 
 test.requestHooks(mockInvalidPasscode)('challenge on prem authenticator with invalid passcode', async t => {

--- a/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
@@ -75,7 +75,7 @@ test.requestHooks(mockChallengeAuthenticatorOnPrem)('passcode is required', asyn
   await challengeOnPremPage.clickNextButton('Verify');
 
   await challengeOnPremPage.waitForErrorBox();
-  await t.expect(challengeOnPremPage.getPasscodeError()).eql('This field cannot be left blank');
+  await t.expect(challengeOnPremPage.getPasscodeError()).match(/This field cannot be left blank$/);
 });
 
 test.requestHooks(mockInvalidPasscode)('challenge on prem authenticator with invalid passcode', async t => {

--- a/test/testcafe/spec/ChallengeAuthenticatorRsa_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorRsa_spec.js
@@ -82,7 +82,7 @@ test.requestHooks(mockChallengeAuthenticatorRsa)('passcode is required', async t
   await challengeRsaPage.clickNextButton('Verify');
 
   await challengeRsaPage.form.waitForErrorBox();
-  await t.expect(challengeRsaPage.getPasscodeError()).eql('This field cannot be left blank');
+  await t.expect(challengeRsaPage.getPasscodeError()).match(/This field cannot be left blank$/);
 });
 
 test.requestHooks(mockInvalidPasscode)('challege RSA authenticator with invalid passcode', async t => {

--- a/test/testcafe/spec/ChallengeAuthenticatorRsa_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorRsa_spec.js
@@ -82,7 +82,7 @@ test.requestHooks(mockChallengeAuthenticatorRsa)('passcode is required', async t
   await challengeRsaPage.clickNextButton('Verify');
 
   await challengeRsaPage.form.waitForErrorBox();
-  await t.expect(challengeRsaPage.getPasscodeError()).match(/This field cannot be left blank$/);
+  await t.expect(challengeRsaPage.getPasscodeError()).match(/This field cannot be left blank/);
 });
 
 test.requestHooks(mockInvalidPasscode)('challege RSA authenticator with invalid passcode', async t => {

--- a/test/testcafe/spec/ChallengeCustomOTPAuthenticatorView_spec.js
+++ b/test/testcafe/spec/ChallengeCustomOTPAuthenticatorView_spec.js
@@ -66,7 +66,7 @@ test.requestHooks(mockChallengeAuthenticatorCustomOTP)('OTP is required', async 
   await challengeOnPremPage.clickNextButton('Verify');
 
   await challengeOnPremPage.waitForErrorBox();
-  await t.expect(challengeOnPremPage.getPasscodeError()).match(/This field cannot be left blank$/);
+  await t.expect(challengeOnPremPage.getPasscodeError()).match(/This field cannot be left blank/);
 });
 
 test.requestHooks(mockInvalidPasscode)('challege custom otp authenticator with invalid passcode', async t => {

--- a/test/testcafe/spec/ChallengeCustomOTPAuthenticatorView_spec.js
+++ b/test/testcafe/spec/ChallengeCustomOTPAuthenticatorView_spec.js
@@ -66,7 +66,7 @@ test.requestHooks(mockChallengeAuthenticatorCustomOTP)('OTP is required', async 
   await challengeOnPremPage.clickNextButton('Verify');
 
   await challengeOnPremPage.waitForErrorBox();
-  await t.expect(challengeOnPremPage.getPasscodeError()).eql('This field cannot be left blank');
+  await t.expect(challengeOnPremPage.getPasscodeError()).match(/This field cannot be left blank$/);
 });
 
 test.requestHooks(mockInvalidPasscode)('challege custom otp authenticator with invalid passcode', async t => {

--- a/test/testcafe/spec/ChallengeGoogleAuthenticatorOtp_spec.js
+++ b/test/testcafe/spec/ChallengeGoogleAuthenticatorOtp_spec.js
@@ -105,7 +105,7 @@ test
     await checkA11y(t);
     await challengeGoogleAuthenticatorPageObject.verifyFactor('credentials.passcode', '123');
     await challengeGoogleAuthenticatorPageObject.clickVerifyButton();
-    await t.expect(challengeGoogleAuthenticatorPageObject.getAnswerInlineError()).match(/Your code doesn't match our records. Please try again.$/);
+    await t.expect(challengeGoogleAuthenticatorPageObject.getAnswerInlineError()).match(/Your code doesn't match our records. Please try again./);
   });
 
 test
@@ -114,7 +114,7 @@ test
     await checkA11y(t);
     await challengeGoogleAuthenticatorPageObject.verifyFactor('credentials.passcode', '123');
     await challengeGoogleAuthenticatorPageObject.clickVerifyButton();
-    await t.expect(challengeGoogleAuthenticatorPageObject.getAnswerInlineError()).match(/Each code can only be used once. Please wait for a new code and try again.$/);
+    await t.expect(challengeGoogleAuthenticatorPageObject.getAnswerInlineError()).match(/Each code can only be used once. Please wait for a new code and try again./);
   });
 
 test.requestHooks(validOTPmock)('should show custom factor page link', async t => {

--- a/test/testcafe/spec/ChallengeGoogleAuthenticatorOtp_spec.js
+++ b/test/testcafe/spec/ChallengeGoogleAuthenticatorOtp_spec.js
@@ -105,7 +105,7 @@ test
     await checkA11y(t);
     await challengeGoogleAuthenticatorPageObject.verifyFactor('credentials.passcode', '123');
     await challengeGoogleAuthenticatorPageObject.clickVerifyButton();
-    await t.expect(challengeGoogleAuthenticatorPageObject.getAnswerInlineError()).eql('Your code doesn\'t match our records. Please try again.');
+    await t.expect(challengeGoogleAuthenticatorPageObject.getAnswerInlineError()).match(/Your code doesn't match our records. Please try again.$/);
   });
 
 test
@@ -114,7 +114,7 @@ test
     await checkA11y(t);
     await challengeGoogleAuthenticatorPageObject.verifyFactor('credentials.passcode', '123');
     await challengeGoogleAuthenticatorPageObject.clickVerifyButton();
-    await t.expect(challengeGoogleAuthenticatorPageObject.getAnswerInlineError()).eql('Each code can only be used once. Please wait for a new code and try again.');
+    await t.expect(challengeGoogleAuthenticatorPageObject.getAnswerInlineError()).match(/Each code can only be used once. Please wait for a new code and try again.$/);
   });
 
 test.requestHooks(validOTPmock)('should show custom factor page link', async t => {

--- a/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
@@ -59,8 +59,8 @@ test
     }
     await enrollOnPremPage.clickNextButton('Verify');
     await enrollOnPremPage.waitForGeneralErrorBox();
-    await t.expect(enrollOnPremPage.getPasscodeError()).match(/This field cannot be left blank$/);
-    await t.expect(enrollOnPremPage.getUserNameError()).match(/This field cannot be left blank$/);
+    await t.expect(enrollOnPremPage.getPasscodeError()).match(/This field cannot be left blank/);
+    await t.expect(enrollOnPremPage.getUserNameError()).match(/This field cannot be left blank/);
 
     await t.expect(await enrollOnPremPage.signoutLinkExists()).ok();
   });

--- a/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
@@ -59,8 +59,8 @@ test
     }
     await enrollOnPremPage.clickNextButton('Verify');
     await enrollOnPremPage.waitForGeneralErrorBox();
-    await t.expect(enrollOnPremPage.getPasscodeError()).eql('This field cannot be left blank');
-    await t.expect(enrollOnPremPage.getUserNameError()).eql('This field cannot be left blank');
+    await t.expect(enrollOnPremPage.getPasscodeError()).match(/This field cannot be left blank$/);
+    await t.expect(enrollOnPremPage.getUserNameError()).match(/This field cannot be left blank$/);
 
     await t.expect(await enrollOnPremPage.signoutLinkExists()).ok();
   });

--- a/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
@@ -167,9 +167,9 @@ test
     const enrollPhonePageObject = await setup(t);
     await checkA11y(t);
     await enrollPhonePageObject.clickNextButton();
-    await t.expect(await enrollPhonePageObject.resendCodeExists(2)).eql(false);
+    await t.expect(await enrollPhonePageObject.resendCodeExists(1)).eql(false);
     await t.wait(30500);
-    await t.expect(await enrollPhonePageObject.resendCodeExists(2)).eql(true);
+    await t.expect(await enrollPhonePageObject.resendCodeExists(1)).eql(true);
     const resendCodeText = await enrollPhonePageObject.resendCodeText(1);
     await t.expect(resendCodeText).contains('Haven\'t received an SMS?');
     await t.expect(resendCodeText).contains('Send again');
@@ -180,9 +180,9 @@ test
     const enrollPhonePageObject = await setup(t);
     await checkA11y(t);
     await enrollPhonePageObject.clickNextButton();
-    await t.expect(await enrollPhonePageObject.resendCodeExists(2)).eql(false);
+    await t.expect(await enrollPhonePageObject.resendCodeExists(1)).eql(false);
     await t.wait(30500);
-    await t.expect(await enrollPhonePageObject.resendCodeExists(2)).eql(true);
+    await t.expect(await enrollPhonePageObject.resendCodeExists(1)).eql(true);
     const resendCodeText = await enrollPhonePageObject.resendCodeText(1);
     await t.expect(resendCodeText).contains('Haven\'t received a call?');
     await t.expect(resendCodeText).contains('Call again');
@@ -193,12 +193,12 @@ test
     const enrollPhonePageObject = await setup(t);
     await checkA11y(t);
     await enrollPhonePageObject.clickNextButton();
-    await t.expect(await enrollPhonePageObject.resendCodeExists(2)).eql(false);
+    await t.expect(await enrollPhonePageObject.resendCodeExists(1)).eql(false);
     await t.wait(15000);
     enrollPhonePageObject.navigateToPage();
     await enrollPhonePageObject.clickNextButton();
     await t.wait(15500);
-    await t.expect(await enrollPhonePageObject.resendCodeExists(2)).eql(true);
+    await t.expect(await enrollPhonePageObject.resendCodeExists(1)).eql(true);
     const resendCodeText = await enrollPhonePageObject.resendCodeText(1);
     await t.expect(resendCodeText).contains('Haven\'t received an SMS?');
     await t.expect(resendCodeText).contains('Send again');

--- a/test/testcafe/spec/EnrollAuthenticatorRsaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorRsaView_spec.js
@@ -58,8 +58,8 @@ test
     await t.pressKey('tab');
     await enrollRsaPage.clickNextButton('Verify');
     await enrollRsaPage.waitForGeneralErrorBox();
-    await t.expect(enrollRsaPage.getPasscodeError()).eql('This field cannot be left blank');
-    await t.expect(enrollRsaPage.getUserNameError()).eql('This field cannot be left blank');
+    await t.expect(enrollRsaPage.getPasscodeError()).match(/This field cannot be left blank$/);
+    await t.expect(enrollRsaPage.getUserNameError()).match(/This field cannot be left blank$/);
 
     // Verify links (switch authenticator link is present even if there is just one authenticator available)
     await t.expect(await enrollRsaPage.returnToAuthenticatorListLinkExists()).eql(true);

--- a/test/testcafe/spec/EnrollAuthenticatorRsaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorRsaView_spec.js
@@ -58,8 +58,8 @@ test
     await t.pressKey('tab');
     await enrollRsaPage.clickNextButton('Verify');
     await enrollRsaPage.waitForGeneralErrorBox();
-    await t.expect(enrollRsaPage.getPasscodeError()).match(/This field cannot be left blank$/);
-    await t.expect(enrollRsaPage.getUserNameError()).match(/This field cannot be left blank$/);
+    await t.expect(enrollRsaPage.getPasscodeError()).match(/This field cannot be left blank/);
+    await t.expect(enrollRsaPage.getUserNameError()).match(/This field cannot be left blank/);
 
     // Verify links (switch authenticator link is present even if there is just one authenticator available)
     await t.expect(await enrollRsaPage.returnToAuthenticatorListLinkExists()).eql(true);

--- a/test/testcafe/spec/EnrollProfileUpdateView_spec.js
+++ b/test/testcafe/spec/EnrollProfileUpdateView_spec.js
@@ -59,7 +59,7 @@ test.requestHooks(xhrEnrollProfileUpdateMock)('should have correct form title, f
 
   // show error when field is required
   await enrollProfileUpdatePage.clickFinishButton();
-  await t.expect(await enrollProfileUpdatePage.getTextBoxErrorMessage('userProfile.newAttribute2')).match(/This field cannot be left blank$/);
+  await t.expect(await enrollProfileUpdatePage.getTextBoxErrorMessage('userProfile.newAttribute2')).match(/This field cannot be left blank/);
 });
 
 test.requestHooks(requestLogger, xhrEnrollProfileUpdateAllOptionalMock)('should have skip link when all fields are optional', async t => {

--- a/test/testcafe/spec/EnrollProfileUpdateView_spec.js
+++ b/test/testcafe/spec/EnrollProfileUpdateView_spec.js
@@ -59,7 +59,7 @@ test.requestHooks(xhrEnrollProfileUpdateMock)('should have correct form title, f
 
   // show error when field is required
   await enrollProfileUpdatePage.clickFinishButton();
-  await t.expect(await enrollProfileUpdatePage.getTextBoxErrorMessage('userProfile.newAttribute2')).eql('This field cannot be left blank');
+  await t.expect(await enrollProfileUpdatePage.getTextBoxErrorMessage('userProfile.newAttribute2')).match(/This field cannot be left blank$/);
 });
 
 test.requestHooks(requestLogger, xhrEnrollProfileUpdateAllOptionalMock)('should have skip link when all fields are optional', async t => {

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -313,7 +313,7 @@ test.requestHooks(requestLogger, EnrollProfileSignUpWithPasswordMultipleErrorsMo
     await enrollProfilePage.form.clickSaveButton('Sign Up');
   }
 
-  await t.expect(await enrollProfilePage.form.hasTextBoxErrorMessage('userProfile.email', 0)).eql(true);
+  await t.expect(await enrollProfilePage.form.hasTextBoxErrorMessage('userProfile.email')).eql(true);
 });
 
 test.requestHooks(requestLogger, EnrollProfileSignUpWIthIdpsMock)('Should render social IDP buttons when returned via remediation', async t => {

--- a/test/testcafe/spec/IdentifyRegistrationHooks_spec.js
+++ b/test/testcafe/spec/IdentifyRegistrationHooks_spec.js
@@ -141,7 +141,7 @@ test.requestHooks(logger, mock)('settings.registration.preSubmit hook can call o
   await registrationPage.clickRegisterButton();
 
   await t.expect(registrationPage.getErrorBoxText()).contains('We found some errors. Please review the form and make corrections.');
-  await t.expect(registrationPage.form.getTextBoxErrorMessage('userProfile.lastName')).eql('my preSubmit error summary');
+  await t.expect(registrationPage.form.getTextBoxErrorMessage('userProfile.lastName')).match(/my preSubmit error summary$/);
 
   // no request because the form fails to submit
   await t.expect(logger.requests.length).eql(0);

--- a/test/testcafe/spec/IdentifyRegistrationHooks_spec.js
+++ b/test/testcafe/spec/IdentifyRegistrationHooks_spec.js
@@ -141,7 +141,7 @@ test.requestHooks(logger, mock)('settings.registration.preSubmit hook can call o
   await registrationPage.clickRegisterButton();
 
   await t.expect(registrationPage.getErrorBoxText()).contains('We found some errors. Please review the form and make corrections.');
-  await t.expect(registrationPage.form.getTextBoxErrorMessage('userProfile.lastName')).match(/my preSubmit error summary$/);
+  await t.expect(registrationPage.form.getTextBoxErrorMessage('userProfile.lastName')).match(/my preSubmit error summary/);
 
   // no request because the form fails to submit
   await t.expect(logger.requests.length).eql(0);

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -364,7 +364,7 @@ test.requestHooks(logger, enrollProfileNewMock)('should be able to create a new 
 
   //click register
   await registrationPage.clickRegisterButton();
-  await t.expect(registrationPage.getEmailErrorMessage()).match(/A user with this Email already exists$/);
+  await t.expect(registrationPage.getEmailErrorMessage()).match(/A user with this Email already exists/);
   let req = logger.requests[0].request;
   let reqBody = JSON.parse(req.body);
   await t.expect(reqBody).eql({

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -225,9 +225,9 @@ test.requestHooks(enrollProfileErrorMock)('should show email field validation er
 
   await registrationPage.waitForEmailError();
 
-  await t.expect(registrationPage.hasEmailError(0)).eql(true);
-  await t.expect(registrationPage.hasEmailErrorMessage(0)).eql(true);
-  await t.expect(registrationPage.getEmailErrorMessage(0)).contains('\'Email\' must be in the form of an email address');
+  await t.expect(registrationPage.hasEmailError()).eql(true);
+  await t.expect(registrationPage.hasEmailErrorMessage()).eql(true);
+  await t.expect(registrationPage.getEmailErrorMessage()).contains('\'Email\' must be in the form of an email address');
 
   await checkConsoleMessages([
     'ready',
@@ -364,7 +364,7 @@ test.requestHooks(logger, enrollProfileNewMock)('should be able to create a new 
 
   //click register
   await registrationPage.clickRegisterButton();
-  await t.expect(registrationPage.getEmailErrorMessage()).eql('A user with this Email already exists');
+  await t.expect(registrationPage.getEmailErrorMessage()).match(/A user with this Email already exists$/);
   let req = logger.requests[0].request;
   let reqBody = JSON.parse(req.body);
   await t.expect(reqBody).eql({

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -58,14 +58,14 @@ test.requestHooks(identifyWithPasswordMock)('should show errors if required fiel
   await identityPage.waitForErrorBox();
 
   await t.expect(identityPage.hasIdentifierErrorMessage()).eql(true);
-  await t.expect(identityPage.getIdentifierErrorMessage()).match(/This field cannot be left blank$/);
+  await t.expect(identityPage.getIdentifierErrorMessage()).match(/This field cannot be left blank/);
 
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.clickSignInButton();
   await identityPage.waitForErrorBox();
 
   await t.expect(identityPage.hasPasswordErrorMessage()).eql(true);
-  await t.expect(identityPage.getPasswordErrorMessage()).match(/This field cannot be left blank$/);
+  await t.expect(identityPage.getPasswordErrorMessage()).match(/This field cannot be left blank/);
 });
 
 test.requestHooks(identifyWithPasswordMock)('should show customized error if required field password is empty', async t => {
@@ -83,7 +83,7 @@ test.requestHooks(identifyWithPasswordMock)('should show customized error if req
   await identityPage.waitForErrorBox();
 
   await t.expect(identityPage.hasIdentifierErrorMessage()).eql(true);
-  await t.expect(identityPage.getIdentifierErrorMessage()).match(/Username is required!$/);
+  await t.expect(identityPage.getIdentifierErrorMessage()).match(/Username is required!/);
 
 
   await identityPage.fillIdentifierField('Test Identifier');

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -58,14 +58,14 @@ test.requestHooks(identifyWithPasswordMock)('should show errors if required fiel
   await identityPage.waitForErrorBox();
 
   await t.expect(identityPage.hasIdentifierErrorMessage()).eql(true);
-  await t.expect(identityPage.getIdentifierErrorMessage()).eql('This field cannot be left blank');
+  await t.expect(identityPage.getIdentifierErrorMessage()).match(/This field cannot be left blank$/);
 
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.clickSignInButton();
   await identityPage.waitForErrorBox();
 
   await t.expect(identityPage.hasPasswordErrorMessage()).eql(true);
-  await t.expect(identityPage.getPasswordErrorMessage()).eql('This field cannot be left blank');
+  await t.expect(identityPage.getPasswordErrorMessage()).match(/This field cannot be left blank$/);
 });
 
 test.requestHooks(identifyWithPasswordMock)('should show customized error if required field password is empty', async t => {
@@ -83,7 +83,7 @@ test.requestHooks(identifyWithPasswordMock)('should show customized error if req
   await identityPage.waitForErrorBox();
 
   await t.expect(identityPage.hasIdentifierErrorMessage()).eql(true);
-  await t.expect(identityPage.getIdentifierErrorMessage()).eql('Username is required!');
+  await t.expect(identityPage.getIdentifierErrorMessage()).match(/Username is required!$/);
 
 
   await identityPage.fillIdentifierField('Test Identifier');

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -173,7 +173,7 @@ test.requestHooks(identifyMock)('should show errors if required fields are empty
   await identityPage.clickNextButton();
   await identityPage.waitForErrorBox();
 
-  await t.expect(identityPage.getIdentifierErrorMessage()).eql('This field cannot be left blank');
+  await t.expect(identityPage.getIdentifierErrorMessage()).match(/This field cannot be left blank$/);
 });
 
 test.requestHooks(identifyMockWithUnsupportedResponseError)('should show error if server response is unsupported', async t => {
@@ -198,7 +198,7 @@ test.requestHooks(identifyMock)('should show customized error if required field 
   await identityPage.clickNextButton();
   await identityPage.waitForErrorBox();
 
-  await t.expect(identityPage.getIdentifierErrorMessage()).eql('Username is required!');
+  await t.expect(identityPage.getIdentifierErrorMessage()).match(/Username is required!$/);
 });
 
 test.requestHooks(identifyRequestLogger, identifyMock)('should not show custom error if password doesn\'t exist in remediation', async t => {

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -173,7 +173,7 @@ test.requestHooks(identifyMock)('should show errors if required fields are empty
   await identityPage.clickNextButton();
   await identityPage.waitForErrorBox();
 
-  await t.expect(identityPage.getIdentifierErrorMessage()).match(/This field cannot be left blank$/);
+  await t.expect(identityPage.getIdentifierErrorMessage()).match(/This field cannot be left blank/);
 });
 
 test.requestHooks(identifyMockWithUnsupportedResponseError)('should show error if server response is unsupported', async t => {
@@ -198,7 +198,7 @@ test.requestHooks(identifyMock)('should show customized error if required field 
   await identityPage.clickNextButton();
   await identityPage.waitForErrorBox();
 
-  await t.expect(identityPage.getIdentifierErrorMessage()).match(/Username is required!$/);
+  await t.expect(identityPage.getIdentifierErrorMessage()).match(/Username is required!/);
 });
 
 test.requestHooks(identifyRequestLogger, identifyMock)('should not show custom error if password doesn\'t exist in remediation', async t => {


### PR DESCRIPTION
## Description:
- Migrate `InputText` to use Odyssey `TextField`
- Updates React Testing Library integration tests to use better selectors where possible (prioritized `findByLabelText`)

NOTES: 
- All migration PRs have the same changes to update `buttonFocusRef` and `linkFocusRef`, which I was asked to change upstream in Odyssey. Once one of these PRs gets merged in those changes will no longer be marked as file changes
- All migration PRs switch to use a `buildFieldLevelErrorMessages.ts` utility that combines logic that was present in the `FieldLevelMessageContainer` and `WidgetMessageContainer` components. This utility takes in the list of error messages and returns an object containing the appropriate values to pass to `errorMessage` and `errorMessageList` for Odyssey `Field` components.
- Tested each component migration manually in IE11 and fixed any bugs I saw
- Ran english leak detection suite locally for all migrations since english leak script is not on gen 3 in Bacon


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-678814](https://oktainc.atlassian.net/browse/OKTA-678814)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



