### PR TITLE
Pd okta 671029 ov mobile flow fix

### DIFF
--- a/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
@@ -13,8 +13,14 @@ const Body = BaseForm.extend({
     const schemas = BaseForm.prototype.getUISchema.apply(this, arguments);
     // filter selected channel
     const channelField = _.find(schemas, (schema) => schema.name === 'authenticator.channel');
-    channelField.options = _.filter(channelField?.options, (option) =>
-      option.value !== this.options.appState.get('currentAuthenticator')?.contextualData?.selectedChannel);
+    if (BrowserFeatures.isAndroid() || BrowserFeatures.isIOS()) {
+      // Special case: always filter qr code on mobile
+      channelField.options = _.filter(channelField?.options, (option) =>
+        option.value !== 'qrcode');
+    } else {
+      channelField.options = _.filter(channelField?.options, (option) =>
+        option.value !== this.options.appState.get('currentAuthenticator')?.contextualData?.selectedChannel);
+    }
     channelField.value = channelField.options[0]?.value;
     channelField.sublabel = null;
     this.model.set('authenticator.channel', channelField.value);

--- a/test/unit/spec/v2/view-builder/views/SelectEnrollmentChannelOktaVerifyView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/SelectEnrollmentChannelOktaVerifyView_spec.js
@@ -76,8 +76,16 @@ describe('v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView', funct
     expect(testContext.view.model.get('authenticator.channel')).toEqual(QRCODE);
   });
 
-  it('Always have selected channel as email on mobile', function() {
+  it('Always have selected channel as email on mobile - android', function() {
     jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
+    jest.spyOn(BaseForm.prototype.getUISchema, 'apply').mockReturnValue(schema);
+    testContext.init(TEXT);
+
+    expect(testContext.view.model.get('authenticator.channel')).toEqual(EMAIL);
+  });
+
+  it('Always have selected channel as email on mobile - ios', function() {
+    jest.spyOn(BrowserFeatures, 'isIOS').mockReturnValue(true);
     jest.spyOn(BaseForm.prototype.getUISchema, 'apply').mockReturnValue(schema);
     testContext.init(TEXT);
 

--- a/test/unit/spec/v2/view-builder/views/SelectEnrollmentChannelOktaVerifyView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/SelectEnrollmentChannelOktaVerifyView_spec.js
@@ -3,6 +3,7 @@ import { Model } from '@okta/courage';
 import { BaseForm } from 'v2/view-builder/internals';
 import AppState from 'v2/models/AppState';
 import Settings from 'models/Settings';
+import BrowserFeatures from '../../../../../../src/util/BrowserFeatures';
 
 describe('v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView', function() {
   const QRCODE = 'qrcode';
@@ -73,6 +74,14 @@ describe('v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView', funct
     testContext.init(TEXT);
 
     expect(testContext.view.model.get('authenticator.channel')).toEqual(QRCODE);
+  });
+
+  it('Always have selected channel as email on mobile', function() {
+    jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
+    jest.spyOn(BaseForm.prototype.getUISchema, 'apply').mockReturnValue(schema);
+    testContext.init(TEXT);
+
+    expect(testContext.view.model.get('authenticator.channel')).toEqual(EMAIL);
   });
 
 });


### PR DESCRIPTION
## Description:

Bug: OV enrollment flow in mobile - https://docs.google.com/document/d/1IptezX1HjzPwq9zAFfk4MO_cELX8nF20-VSCYcZtro0/edit?pli=1

Fix: Filter QR Code enrollment channel for mobile.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-671029](https://oktainc.atlassian.net/browse/OKTA-671029)

### Reviewers:

### Screenshot/Video:

#### Before Fix
https://docs.google.com/document/d/1IptezX1HjzPwq9zAFfk4MO_cELX8nF20-VSCYcZtro0/edit?pli=1

#### After FIx
https://github.com/okta/okta-signin-widget/assets/94395085/e8915f0b-5e8a-4cbf-bbc5-085655f2f734




### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=86fb279bbd2ca0944f6e9f405ff007489b10b4bb&tab=main

