### PR TITLE
Gen3: Support skipIdpFactorVerificationBtn feature

### DIFF
--- a/src/v3/src/transformer/layout/idp/__snapshots__/transformIdpAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/layout/idp/__snapshots__/transformIdpAuthenticator.test.ts.snap
@@ -43,7 +43,7 @@ Object {
 }
 `;
 
-exports[`IDP Authenticator transformer Tests IDP Authenticator Enroll tests should add title, description, spinner and redirect when skipIdpFactorVerificationBtn feature is true 1`] = `
+exports[`IDP Authenticator transformer Tests IDP Authenticator Enroll tests should add title, description, spinner and auto-redirect when skipIdpFactorVerificationBtn feature is true 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -171,7 +171,7 @@ Object {
 }
 `;
 
-exports[`IDP Authenticator transformer Tests IDP Authenticator verify tests should add title, description, spinner and redirect when skipIdpFactorVerificationBtn feature is true 1`] = `
+exports[`IDP Authenticator transformer Tests IDP Authenticator verify tests should add title, description, spinner and auto-redirect when skipIdpFactorVerificationBtn feature is true 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {

--- a/src/v3/src/transformer/layout/idp/__snapshots__/transformIdpAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/layout/idp/__snapshots__/transformIdpAuthenticator.test.ts.snap
@@ -43,7 +43,177 @@ Object {
 }
 `;
 
+exports[`IDP Authenticator transformer Tests IDP Authenticator Enroll tests should add title, description, spinner and redirect when skipIdpFactorVerificationBtn feature is true 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.idp.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.idp.enroll.description",
+        },
+        "type": "Description",
+      },
+      Object {
+        "type": "Spinner",
+      },
+      Object {
+        "options": Object {
+          "url": "http://localhost:3000/sso/idps/mockedIdp123?stateToken=mockedStateToken124",
+        },
+        "type": "Redirect",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`IDP Authenticator transformer Tests IDP Authenticator Enroll tests should not auto-redirect when skipIdpFactorVerificationBtn feature is true but there is an error in transaction 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.idp.enroll.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.idp.enroll.description",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "mfa.enroll",
+        "options": Object {
+          "isActionStep": false,
+          "onClick": [Function],
+          "step": "enroll-authenticator",
+          "type": "button",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
 exports[`IDP Authenticator transformer Tests IDP Authenticator verify tests should add correct title, description, and button 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.idp.challenge.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.idp.challenge.description",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "mfa.challenge.verify",
+        "options": Object {
+          "isActionStep": false,
+          "onClick": [Function],
+          "step": "challenge-authenticator",
+          "type": "button",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`IDP Authenticator transformer Tests IDP Authenticator verify tests should add title, description, spinner and redirect when skipIdpFactorVerificationBtn feature is true 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.idp.challenge.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.idp.challenge.description",
+        },
+        "type": "Description",
+      },
+      Object {
+        "type": "Spinner",
+      },
+      Object {
+        "options": Object {
+          "url": "http://localhost:3000/sso/idps/mockedIdp123?stateToken=mockedStateToken124",
+        },
+        "type": "Redirect",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`IDP Authenticator transformer Tests IDP Authenticator verify tests should not auto-redirect when skipIdpFactorVerificationBtn feature is true but there is an error in transaction 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {

--- a/src/v3/src/transformer/layout/idp/transformIdpAuthenticator.test.ts
+++ b/src/v3/src/transformer/layout/idp/transformIdpAuthenticator.test.ts
@@ -16,6 +16,8 @@ import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/
 import {
   ButtonElement,
   DescriptionElement,
+  RedirectElement,
+  SpinnerElement,
   TitleElement,
   WidgetProps,
 } from '../../../types';
@@ -30,11 +32,66 @@ describe('IDP Authenticator transformer Tests', () => {
     beforeEach(() => {
       transaction.nextStep = {
         name: IDX_STEP.ENROLL_AUTHENTICATOR,
+        href: 'http://localhost:3000/sso/idps/mockedIdp123?stateToken=mockedStateToken124',
       };
+      transaction.messages = [];
       widgetProps = {};
     });
 
     it('should add correct title, description, and button', () => {
+      const updatedFormBag = transformIdpAuthenticator({
+        transaction,
+        formBag,
+        widgetProps,
+      });
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(3);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+        .toBe('oie.idp.enroll.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.idp.enroll.description');
+      expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+        .toBe('mfa.enroll');
+    });
+
+    it('should add title, description, spinner and auto-redirect '
+      + 'when skipIdpFactorVerificationBtn feature is true', () => {
+      widgetProps = {
+        features: {
+          skipIdpFactorVerificationBtn: true,
+        },
+      };
+      const updatedFormBag = transformIdpAuthenticator({
+        transaction,
+        formBag,
+        widgetProps,
+      });
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+        .toBe('oie.idp.enroll.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.idp.enroll.description');
+      expect((updatedFormBag.uischema.elements[2] as SpinnerElement).type)
+        .toBe('Spinner');
+      expect((updatedFormBag.uischema.elements[3] as RedirectElement).options.url)
+        .toBe('http://localhost:3000/sso/idps/mockedIdp123?stateToken=mockedStateToken124');
+    });
+
+    it('should not auto-redirect when skipIdpFactorVerificationBtn feature is true '
+      + 'but there is an error in transaction', () => {
+      widgetProps = {
+        features: {
+          skipIdpFactorVerificationBtn: true,
+        },
+      };
+      transaction.messages = [
+        {
+          message: 'This is a standard message',
+          class: 'ERROR',
+          i18n: { key: 'some.standard.key' },
+        },
+      ];
       const updatedFormBag = transformIdpAuthenticator({
         transaction,
         formBag,
@@ -55,11 +112,66 @@ describe('IDP Authenticator transformer Tests', () => {
     beforeEach(() => {
       transaction.nextStep = {
         name: IDX_STEP.CHALLENGE_AUTHENTICATOR,
+        href: 'http://localhost:3000/sso/idps/mockedIdp123?stateToken=mockedStateToken124',
       };
+      transaction.messages = [];
       widgetProps = {};
     });
 
     it('should add correct title, description, and button', () => {
+      const updatedFormBag = transformIdpAuthenticator({
+        transaction,
+        formBag,
+        widgetProps,
+      });
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(3);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+        .toBe('oie.idp.challenge.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.idp.challenge.description');
+      expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
+        .toBe('mfa.challenge.verify');
+    });
+
+    it('should add title, description, spinner and auto-redirect '
+      + 'when skipIdpFactorVerificationBtn feature is true', () => {
+      widgetProps = {
+        features: {
+          skipIdpFactorVerificationBtn: true,
+        },
+      };
+      const updatedFormBag = transformIdpAuthenticator({
+        transaction,
+        formBag,
+        widgetProps,
+      });
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(4);
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
+        .toBe('oie.idp.challenge.title');
+      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+        .toBe('oie.idp.challenge.description');
+      expect((updatedFormBag.uischema.elements[2] as SpinnerElement).type)
+        .toBe('Spinner');
+      expect((updatedFormBag.uischema.elements[3] as RedirectElement).options.url)
+        .toBe('http://localhost:3000/sso/idps/mockedIdp123?stateToken=mockedStateToken124');
+    });
+
+    it('should not auto-redirect when skipIdpFactorVerificationBtn feature is true '
+      + 'but there is an error in transaction', () => {
+      widgetProps = {
+        features: {
+          skipIdpFactorVerificationBtn: true,
+        },
+      };
+      transaction.messages = [
+        {
+          message: 'This is a standard message',
+          class: 'ERROR',
+          i18n: { key: 'some.standard.key' },
+        },
+      ];
       const updatedFormBag = transformIdpAuthenticator({
         transaction,
         formBag,

--- a/test/testcafe/spec/AuthenticatorIdPView_spec.js
+++ b/test/testcafe/spec/AuthenticatorIdPView_spec.js
@@ -82,7 +82,9 @@ async function setup(t, {isVerify, expectAutoRedirect} = {}, widgetOptions = und
   if (widgetOptions) {
     await renderWidget(widgetOptions);
   }
-  if (!expectAutoRedirect) {
+  if (expectAutoRedirect) {
+    await t.expect(pageObject.formExists()).eql(false);
+  } else {
     await t.expect(pageObject.formExists()).eql(true);
     await checkConsoleMessages({
       controller: null,


### PR DESCRIPTION
## Description:

Adds support of `skipIdpFactorVerificationBtn` feature for Gen3.

[Doc](https://github.com/okta/okta-signin-widget/blob/master/docs/classic.md#feature-flags):
> **features.skipIdpFactorVerificationBtn** - Automatically redirects to the selected Identity Provider when selected from the list of factors. Defaults to `false`.

(Same feature in Gen2: https://github.com/okta/okta-signin-widget/pull/2793)

Note: can be tested locally in playground with [`mocks: idpAuthenticator`](https://github.com/okta/okta-signin-widget/blob/master/playground/mocks/config/responseConfig.js#L910) and `features: { skipIdpFactorVerificationBtn: true }` in `.widgetrc.js`

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-697391](https://oktainc.atlassian.net/browse/OKTA-697391)

### Reviewers:

### Screenshot/Video:

*Verify with IDP:*
With `skipIdpFactorVerificationBtn: true`:
<img width="451" alt="Screenshot 2024-02-27 at 12 14 19" src="https://github.com/okta/okta-signin-widget/assets/72614880/c278623a-daed-4b9b-845c-e0aab604d6b2">
With `skipIdpFactorVerificationBtn: false`:
<img width="452" alt="Screenshot 2024-02-27 at 12 18 58" src="https://github.com/okta/okta-signin-widget/assets/72614880/478e308c-578c-47f0-a4ee-09d12992a737">
With `skipIdpFactorVerificationBtn: true` and error:
<img width="477" alt="Screenshot 2024-02-27 at 12 24 00" src="https://github.com/okta/okta-signin-widget/assets/72614880/e6e81b1b-9a2d-4e23-af7f-6e53ea5b2aa3">

*Enroll IDP:*
With `skipIdpFactorVerificationBtn: true`:
<img width="441" alt="Screenshot 2024-02-27 at 12 22 45" src="https://github.com/okta/okta-signin-widget/assets/72614880/877dc9dd-1cf3-4166-a6f8-bbde5028678a">
With `skipIdpFactorVerificationBtn: false`:
<img width="458" alt="Screenshot 2024-02-27 at 12 25 39" src="https://github.com/okta/okta-signin-widget/assets/72614880/7962795c-0578-43c5-9c9c-bb048b0a93e3">
VerificationBtn: true` and error:
<img width="450" alt="Screenshot 2024-02-27 at 12 25 09" src="https://github.com/okta/okta-signin-widget/assets/72614880/867e5a15-052a-4714-817b-cdedfeb7dac8">


### Downstream Monolith Build:



