### PR TITLE
chore: generate sris for generated assets

### DIFF
--- a/scripts/buildtools/commands/prepack.js
+++ b/scripts/buildtools/commands/prepack.js
@@ -8,26 +8,26 @@ const BUILD_DIR = path.resolve(__dirname, '..', '..', '..', 'dist');
 const JS_DIR = path.join(BUILD_DIR, 'dist/js');
 const CSS_DIR = path.join(BUILD_DIR, 'dist/css');
 
-function generateSris () {
+function generateSris() {
   const jsFiles = fs.readdirSync(JS_DIR);
   const cssFiles = fs.readdirSync(CSS_DIR);
   return [
-    ...jsFiles.map(file => path.join(JS_DIR, file)), 
+    ...jsFiles.map(file => path.join(JS_DIR, file)),
     ...cssFiles.map(file => path.join(CSS_DIR, file))
   ]
-  .filter(path => !path.endsWith('.map'))
-  .reduce((acc, path) => {
-    // get filename (key)
-    const parts = path.split('/');
-    const filename = parts[parts.length - 1];
-    const content = fs.readFileSync(path, { encoding: 'utf8' });
-    // generate sri (value)
-    const hash = crypto.createHash('sha384').update(content, 'utf8');
-    const hashBase64 = hash.digest('base64');
-    const sri = 'sha384-' + hashBase64;
-    // add sri in map
-    return { ...acc, [filename]: sri }
-  }, {});
+    .filter(path => !path.endsWith('.map'))
+    .reduce((acc, path) => {
+      // get filename (key)
+      const parts = path.split('/');
+      const filename = parts[parts.length - 1];
+      const content = fs.readFileSync(path, { encoding: 'utf8' });
+      // generate sri (value)
+      const hash = crypto.createHash('sha384').update(content, 'utf8');
+      const hashBase64 = hash.digest('base64');
+      const sri = 'sha384-' + hashBase64;
+      // add sri in map
+      return { ...acc, [filename]: sri };
+    }, {});
 }
 
 exports.command = 'build:prepack';

--- a/scripts/buildtools/commands/prepack.js
+++ b/scripts/buildtools/commands/prepack.js
@@ -22,9 +22,9 @@ function generateSris () {
     const filename = parts[parts.length - 1];
     const content = fs.readFileSync(path, { encoding: 'utf8' });
     // generate sri (value)
-    const hash = crypto.createHash('sha256').update(content, 'utf8');
+    const hash = crypto.createHash('sha384').update(content, 'utf8');
     const hashBase64 = hash.digest('base64');
-    const sri = 'sha256-' + hashBase64;
+    const sri = 'sha384-' + hashBase64;
     // add sri in map
     return { ...acc, [filename]: sri }
   }, {});


### PR DESCRIPTION
## Description:

**NOTE**: as codebase has been changed since last release (7.15.1), we will need to update readme with proper `integrity` for cdn usage examples after the next release.

In this PR:

* adds `sri` field to package.json
```
"sri": {
      "okta-plugin-a11y.js": "sha256-MU4UlTmVhfSvl80azTGEFOWJdXyOD8IgXEWs9/C9KPE=",
      "okta-sign-in.classic.js": "sha256-SWu3q9xeevuiMEdHC9wlb/7YExUhDw7y3KYJGZpMKI8=",
      "okta-sign-in.classic.min.js": "sha256-wfxW5HBoOy9qvRZ9Ed4f/GQsiOUY/ITTRQugKBPNWpA=",
      "okta-sign-in.js": "sha256-xXVOZBkO2srB3c50hw5ciXgG2ZPmYGCtLK1esA3sj2E=",
      "okta-sign-in.min.js": "sha256-xVeaYWjvwag0GjwomrpHsibzBJ6AZ6WSKzqx+8UPLPo=",
      "okta-sign-in.next.js": "sha256-JYpjmGH/H/zHBrDo1PVKWP6dyeNLFJFvA+7Jm96dt2Q=",
      "okta-sign-in.next.no-polyfill.js": "sha256-+9Kj5polj+RgMEwZLaGP0rHcKnqiK6LTfznv3LsNzYw=",
      "okta-sign-in.no-polyfill.min.js": "sha256-IB06oL+shAVl8A3x3QbaM+qb4iy9VIVTntJuTDMNEcA=",
      "okta-sign-in.oie.js": "sha256-8Fj733+umVQK6b8+IKKxwlENOG02BpoYe6DyVGsHRHI=",
      "okta-sign-in.oie.min.js": "sha256-dK1Dj42FiB9tpPkVoVcjOEADkN7pGcTcSxkdrn7Rl5E=",
      "okta-sign-in.polyfill.js": "sha256-ZnMSExrtGWvhI6I/KWhpSh+1m/TAT8w8JTC85RKUpjw=",
      "okta-sign-in.polyfill.min.js": "sha256-VSTdU3V0+PjQR+PTW7umLzBxxe5ZxDw0XsAnSP+PT48=",
      "okta-plugin-a11y.css": "sha256-ocjO8Irc3fy0igKNto0cAI1iWmHBxmTgqjmxg4hST94=",
      "okta-sign-in.min.css": "sha256-GXFOrwy/ben5CXlL3cokcL9JjcU7AvUJR6XolHYlH94=",
      "okta-sign-in.next.css": "sha256-q31Ec+/S1m1cqkMyN0mncdHaryiGOOIg0yImTncCBZs="
  }
```

How it's tested:

Checked with integrity generated from okta-core against branch 7.15, result matches.
 


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-700807](https://oktainc.atlassian.net/browse/OKTA-700807)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



