### PR TITLE
Gen1: Don't dispatch custom 'okta-i18n-error' event for server errors with required argument (like E0000001)

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -100,7 +100,10 @@ Util.transformErrorXHR = function(xhr) {
   // Replace error messages
   if (!_.isEmpty(xhr.responseJSON)) {
     const errorMsg = xhr.responseJSON.errorCode
-      ? loc('errors.' + xhr.responseJSON.errorCode, 'login')
+      // We don't pass parameters to the `loc()` util
+      // However some i18n keys like `errors.E0000001` require one parameter
+      // Don't dispatch custom 'okta-i18n-error' event in this case
+      ? loc('errors.' + xhr.responseJSON.errorCode, 'login', [], true)
       : undefined;
 
     if (errorMsg?.indexOf('L10N_ERROR[') === -1) {

--- a/src/util/loc.ts
+++ b/src/util/loc.ts
@@ -45,15 +45,17 @@ declare global {
  * @param  {String} key The key
  * @param  {String} [bundle="login"] The name of the i18n bundle. Defaults to "login".
  * @param  {Array} [params] A list of parameters to apply as tokens to the i18n value
+ * @param  {Boolean} [ignoreIncorrectParams] If true, a custom 'okta-i18n-error' event would not be dispatched
  * @return {String} The localized value
  */
 export const loc = function (
   key: string,
   bundleName: BundleName = 'login',
-  params: Array<string | number | boolean | unknown> = []
+  params: Array<string | number | boolean | unknown> = [],
+  ignoreIncorrectParams = false
 ) {
   const bundle = getBundle(bundleName);
-  /* eslint complexity: [2, 6] */
+  /* eslint complexity: [2, 7] */
 
   if (!bundle) {
     emitL10nError(key, bundleName, 'bundle');
@@ -73,7 +75,9 @@ export const loc = function (
       return 'L10N_ERROR[' + key + ']';
     }
   } catch (e) {
-    emitL10nError(key, bundleName, 'parameters');
+    if (!ignoreIncorrectParams) {
+      emitL10nError(key, bundleName, 'parameters');
+    }
     return 'L10N_ERROR[' + key + ']';
   }
 };

--- a/test/unit/spec/v1/EnrollOnPrem_spec.js
+++ b/test/unit/spec/v1/EnrollOnPrem_spec.js
@@ -161,6 +161,8 @@ Expect.describe('EnrollOnPrem', function() {
         });
       });
       itp('shows error in case of an error response', function() {
+        // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+        const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
         return setup()
           .then(function(test) {
             test.setNextResponse(resEnrollError);
@@ -174,6 +176,7 @@ Expect.describe('EnrollOnPrem', function() {
             // Note: This will change when we get field specific error messages
             expect(test.form.errorMessage()).toBe('Api validation failed: factorEnrollRequest');
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+            expect(dispatchEventSpy).not.toHaveBeenCalled();
             expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
               {
                 controller: 'enroll-rsa',


### PR DESCRIPTION
## Description:

For i18n keys `errors.E*` with a required argument (like [`errors.E0000001`](https://github.com/okta/okta-signin-widget/blob/master/packages/%40okta/i18n/src/properties/login.properties#L85) which should be translated to `Api validation failed: {0}`, or E0000007 etc.) the localisation in this line:
https://github.com/okta/okta-signin-widget/blob/e63951ffcff0fd6843199d546c52ee332db93c0a/src/util/Util.js#L102
would fail because we don't pass parameters to the `loc()` util. And a custom 'okta-i18n-error' event will be triggered.

(Gen1/2 are affected. But API errors like `E*` are typically produced by authn API used in Gen1)

Error message will be constructed from `errorSummary` in server response as a fallback:
https://github.com/okta/okta-signin-widget/blob/e63951ffcff0fd6843199d546c52ee332db93c0a/src/util/Util.js#L98
See example: 
https://github.com/okta/okta-signin-widget/blob/9f4ff4a605057639aebe5445d69e0d9dfae195fe/test/unit/spec/v1/EnrollSms_spec.js#L402

This PR changes `transformErrorXHR` util to not dispatch 'okta-i18n-error' event in cases when translation for `errors.E*` requires an argument.

Another approach would be to modify `errors.E*` translations with removing `{0}`

Error description in Okta API: https://developer.okta.com/docs/reference/error-codes/#E0000001

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-700848](https://oktainc.atlassian.net/browse/OKTA-700848)

### Reviewers:

### Screenshot/Video:

For https://github.com/okta/okta-signin-widget/blob/master/test/unit/helpers/xhr/MFA_ENROLL_ACTIVATE_error.js

<img width="419" alt="Screenshot 2024-03-06 at 14 49 11" src="https://github.com/okta/okta-signin-widget/assets/72614880/36ed4fbf-20b7-4b88-8acb-36cc53ac6a21">


### Downstream Monolith Build:



