### PR TITLE
Gen1: Fix appStoreLinkText in EnrollTotpController

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -292,6 +292,12 @@ const enrollQROktaVerify  = {
   ]
 };
 
+const enrollTotp = {
+  '/api/v1/authn': [
+    'mfa-enroll-totp'
+  ],
+};
+
 const enrollOVManually  = {
   '/api/v1/authn': [
     'mfa-enroll-ov-manual'

--- a/playground/mocks/data/api/v1/authn/mfa-enroll-totp.json
+++ b/playground/mocks/data/api/v1/authn/mfa-enroll-totp.json
@@ -1,0 +1,57 @@
+{
+  "stateToken": "00vr2lZLK8ciKcTVYS91pPFJ3RFS2BsgxtoNP5jWPS",
+  "expiresAt": "2022-10-03T17:31:38.000Z",
+  "status": "MFA_ENROLL",
+  "_embedded": {
+    "user": {
+      "id": "00u3sxoelNuhUf5sO9c5",
+      "passwordChanged": "2022-10-02T05:17:40.000Z",
+      "profile": {
+        "login": "test.user@test.com",
+        "firstName": "Test",
+        "lastName": "User",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    },
+    "factors": [{
+      "id": "osthw62MEvG6YFuHe0g3",
+      "factorType": "token:software:totp",
+      "provider": "OKTA",
+      "vendorName": "OKTA",
+      "_links": {
+        "enroll": {
+          "href": "https://foo.com/api/v1/authn/factors/osthw62MEvG6YFuHe0g3/verify",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      },
+      "status": "NOT_SETUP",
+      "enrollment": "NOT_REQUIRED"
+    }, {
+      "id": "ufthp18Zup4EGLtrd0g3",
+      "factorType": "token:software:totp",
+      "provider": "GOOGLE",
+      "vendorName": "GOOGLE",
+      "_links": {
+        "enroll": {
+          "href": "https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g3/verify",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      },
+      "status": "NOT_SETUP",
+      "enrollment": "NOT_REQUIRED"
+    }]
+  },
+  "_links": {
+    "cancel": {
+      "href": "http://localhost:3000/api/v1/authn/cancel",
+      "hints": {
+        "allow": ["POST"]
+      }
+    }
+  }
+}

--- a/src/v1/controllers/EnrollTotpController.js
+++ b/src/v1/controllers/EnrollTotpController.js
@@ -55,8 +55,11 @@ const EnrollTotpControllerAppDownloadInstructionsView = View.extend({
       appStoreLink = StoreLinks.OKTA[this.model.get('__deviceType__')];
       appIcon = 'okta-verify-download-icon';
     }
+    const appStoreLinkText = appStoreName
+      ? loc('enroll.totp.downloadApp', 'login', [appStoreLink, factorName, appStoreName])
+      : null;
     return {
-      appStoreLinkText: loc('enroll.totp.downloadApp', 'login', [appStoreLink, factorName, appStoreName]),
+      appStoreLinkText: appStoreLinkText,
       appIcon: appIcon,
     };
   },

--- a/test/unit/spec/v1/EnrollTotpController_spec.js
+++ b/test/unit/spec/v1/EnrollTotpController_spec.js
@@ -150,10 +150,14 @@ Expect.describe('EnrollTotp', function() {
     expectedStateToken
   ) {
     itp('has correct device type options for Okta Verify', function() {
+      // Spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
       return setupOktaTotpFn().then(function(test) {
         expect(test.form.deviceTypeOptions().length).toBe(2);
         expect(test.form.deviceTypeOptionLabel('APPLE').length).toBe(1);
         expect(test.form.deviceTypeOptionLabel('ANDROID').length).toBe(1);
+        // Until provider is selected, `appStoreLinkText` should not be created and localised
+        expect(dispatchEventSpy).not.toHaveBeenCalled();
       });
     });
     itp('has correct device type options for Google Authenticator', function() {

--- a/test/unit/spec/v1/EnrollTotpController_spec.js
+++ b/test/unit/spec/v1/EnrollTotpController_spec.js
@@ -156,7 +156,7 @@ Expect.describe('EnrollTotp', function() {
         expect(test.form.deviceTypeOptions().length).toBe(2);
         expect(test.form.deviceTypeOptionLabel('APPLE').length).toBe(1);
         expect(test.form.deviceTypeOptionLabel('ANDROID').length).toBe(1);
-        // Until provider is selected, `appStoreLinkText` should not be created and localised
+        // Until device type is selected, `appStoreLinkText` should not be created and localised
         expect(dispatchEventSpy).not.toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
## Description:

https://github.com/okta/okta-signin-widget/blob/master/src/v1/controllers/EnrollTotpController.js#L59

Before device type is selected, `getTemplateData()` is called for `EnrollTotpController` and `loc()` call triggers 'okta-i18n-error'  event because of incomplete arguments for i18n key `enroll.totp.downloadApp`

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-700845](https://oktainc.atlassian.net/browse/OKTA-700845)

### Reviewers:

### Screenshot/Video:


https://github.com/okta/okta-signin-widget/assets/72614880/6cb6f697-0324-4fdb-875b-dbb364ca90b7



### Downstream Monolith Build:



