### PR TITLE
Gen1: Clear warning timer on ChallengePushView destroy

### DIFF
--- a/src/v2/view-builder/views/shared/ChallengePushView.js
+++ b/src/v2/view-builder/views/shared/ChallengePushView.js
@@ -101,7 +101,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
 
     remove() {
       BaseFormWithPolling.prototype.remove.apply(this, arguments);
-      this.stopPolling();
+      this.stopPoll();
     },
 
     isOV() {

--- a/test/testcafe/spec/ChallengeCustomAppPush_spec.js
+++ b/test/testcafe/spec/ChallengeCustomAppPush_spec.js
@@ -506,7 +506,7 @@ test
       .contains('Haven\'t received a push notification yet? Try opening Custom Push on your phone.');
   });
 
-test.skip
+test
   .requestHooks(pushWaitMock)('Warning timer should be stopped on view destroy', async t => {
     const challengeCustomAppPushPageObject = await setup(t);
     await checkA11y(t);

--- a/test/testcafe/spec/ChallengeCustomAppPush_spec.js
+++ b/test/testcafe/spec/ChallengeCustomAppPush_spec.js
@@ -2,7 +2,13 @@ import { RequestMock, RequestLogger, userVariables } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import ChallengeCustomAppPushPageObject from '../framework/page-objects/ChallengeCustomAppPushPageObject';
-import { checkConsoleMessages, renderWidget, oktaDashboardContent } from '../framework/shared';
+import {
+  checkConsoleMessages,
+  renderWidget,
+  oktaDashboardContent,
+  logI18nErrorsToConsole,
+  checkI18nErrors,
+} from '../framework/shared';
 
 import pushPoll from '../../../playground/mocks/data/idp/idx/authenticator-verification-custom-app-push';
 import pushPollReject from '../../../playground/mocks/data/idp/idx/authenticator-verification-custom-app-push-reject';
@@ -498,6 +504,16 @@ test
     const warningBox = challengeCustomAppPushPageObject.getWarningBox();
     await t.expect(warningBox.innerText)
       .contains('Haven\'t received a push notification yet? Try opening Custom Push on your phone.');
+  });
+
+test.skip
+  .requestHooks(pushWaitMock)('Warning timer should be stopped on view destroy', async t => {
+    const challengeCustomAppPushPageObject = await setup(t);
+    await checkA11y(t);
+    await logI18nErrorsToConsole();
+    await challengeCustomAppPushPageObject.clickGoBackLink();
+    await t.wait(30100);
+    await checkI18nErrors([]);
   });
 
 test.requestHooks(pushSuccessMock1)('should show custom factor page link', async t => {


### PR DESCRIPTION
## Description:

`ChallengePushView` doesn't clear timer on destroy: 
https://github.com/okta/okta-signin-widget/blob/806abe6a4a31a2fe79eb9a5e89756dd40388e21b/src/v2/view-builder/views/shared/ChallengePushView.js#L78
On 30s timer it tries to localise `oie.custom_app.push.warning` but argument at that time could be null (calculated with [appState.getAuthenticatorDisplayName()](https://github.com/okta/okta-signin-widget/blob/e63951ffcff0fd6843199d546c52ee332db93c0a/src/v2/models/AppState.ts#L182)), so `loc()` can trigger 'okta-i18n-error'.

Note: I added a test and disabled it since it should take 30s to complete

Test locally: 
- add manually 
```js
  document.addEventListener('okta-i18n-error', (ev) => {
    console.warn(JSON.stringify(ev.detail))
  });
```
- use `authenticator-verification-custom-app-push` mock
- click "Back to sign-in"
- wait 30s

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-700845](https://oktainc.atlassian.net/browse/OKTA-700845)

### Reviewers:

### Screenshot/Video:

Changed timer to 3s:

https://github.com/okta/okta-signin-widget/assets/72614880/2093591e-7848-4bdb-ba7f-d28b57f63458



### Downstream Monolith Build:



