### PR TITLE
OKTA-698916 : fix : Fixing OV enrollment view on Android devices when…

### DIFF
--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -15,6 +15,12 @@ const Body = BaseForm.extend({
     const app = this.options.appState.get('app');
     const user = this.options.appState.get('user');
 
+    // OKTA-635926: add user gesture for ov enrollment on android
+    if (Util.isAndroidOVEnrollment()) {
+      titleString = loc('oie.success.text.signingIn.with.appName.android.ov.enrollment', 'login');
+      return titleString;
+    }
+
     // If the option is not set, we treat that as being the case where we don't render the spinner.
     // This is to account for the customer hosted scenario, because by default okta-core will pass in
     // the correct value as set by the option in the Admin UI (which by default is "DEFAULT").
@@ -32,10 +38,7 @@ const Body = BaseForm.extend({
 
     const appName = appInstanceName ? appInstanceName : appDisplayName;
 
-    // OKTA-635926: add user gesture for ov enrollment on android
-    if (Util.isAndroidOVEnrollment()) {
-      titleString = loc('oie.success.text.signingIn.with.appName.android.ov.enrollment', 'login');
-    } else if (appName && userEmail && !this.settings.get('features.showIdentifier')) {
+    if (appName && userEmail && !this.settings.get('features.showIdentifier')) {
       titleString = loc('oie.success.text.signingIn.with.appName.and.identifier', 'login', [appName, userEmail]);
     } else if (appName) {
       titleString = loc('oie.success.text.signingIn.with.appName', 'login', [appName]);
@@ -73,22 +76,18 @@ const Body = BaseForm.extend({
 
   render() {
     BaseForm.prototype.render.apply(this, arguments);
-    if (this.redirectView === INTERSTITIAL_REDIRECT_VIEW.DEFAULT) {
-
-      // OKTA-635926: add user gesture for ov enrollment on android
-      if (Util.isAndroidOVEnrollment()) {
-        const currentViewState = this.options.appState.getCurrentViewState();
-        this.add(createButton({
-          className: 'ul-button button button-wide button-primary hide-underline',
-          title: loc('oktaVerify.open.button', 'login'),
-          id: 'launch-enrollment-ov',
-          click: () => {
-            Util.redirectWithFormGet(currentViewState.href);
-          }
-        }));
-      } else {
-        this.add('<div class="okta-waiting-spinner"></div>');
-      }
+    if (Util.isAndroidOVEnrollment()) {
+      const currentViewState = this.options.appState.getCurrentViewState();
+      this.add(createButton({
+        className: 'ul-button button button-wide button-primary hide-underline',
+        title: loc('oktaVerify.open.button', 'login'),
+        id: 'launch-enrollment-ov',
+        click: () => {
+          Util.redirectWithFormGet(currentViewState.href);
+        }
+      }));
+    } else if (this.redirectView === INTERSTITIAL_REDIRECT_VIEW.DEFAULT) {
+      this.add('<div class="okta-waiting-spinner"></div>');
     }
   }
 });

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -123,7 +123,15 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
       });
     });
 
-    it('Add User Gesture if OV enrollment on Android', () => {
+    it.each([
+      'NONE',
+      'DEFAULT',
+      null,
+    ])('should add user gesture if OV enrollment on Android with interstitialBeforeLoginRedirect = "%s"', function(interstitialBeforeLoginRedirect) {
+      settings = new Settings({
+        baseUrl: 'http://localhost:3000',
+        'interstitialBeforeLoginRedirect': interstitialBeforeLoginRedirect,
+      });
       jest.spyOn(utilSpy, 'isAndroidOVEnrollment').mockReturnValue(true);
       testContext.init();
       expect(testContext.view.el).toMatchSnapshot('should show user gesture');

--- a/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
+++ b/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Add User Gesture if OV enrollment on Android: should show user gesture 1`] = `
+exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add User Gesture if not OV enrollment on Android: should not show user gesture 1`] = `
 <div
   class="siw-main-view "
 >
@@ -16,7 +16,77 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Add User G
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form90"
+      id="form150"
+      method="POST"
+      slot="content"
+    >
+      <div
+        class="o-form-content o-form-theme clearfix"
+        data-se="o-form-content"
+      >
+        <h2
+          class="okta-form-title o-form-head"
+          data-se="o-form-head"
+        >
+          Signing in to Okta Administration
+        </h2>
+        <div
+          class="identifier-container"
+        >
+          <span
+            class="identifier no-translate"
+            data-se="identifier"
+            title="testUser@okta.com"
+          >
+            testUser@okta.com
+          </span>
+        </div>
+        <div
+          class="o-form-info-container"
+        />
+        <div
+          class="o-form-error-container"
+          data-se="o-form-error-container"
+          role="alert"
+        />
+        <div
+          class="o-form-fieldset-container"
+          data-se="o-form-fieldset-container"
+        >
+          <div
+            class="okta-waiting-spinner"
+          />
+        </div>
+      </div>
+    </form>
+  </div>
+  <div
+    class="siw-main-footer"
+  >
+    <div
+      class="auth-footer"
+    />
+  </div>
+</div>
+`;
+
+exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add user gesture if OV enrollment on Android with interstitialBeforeLoginRedirect = "DEFAULT": should show user gesture 1`] = `
+<div
+  class="siw-main-view "
+>
+  <div
+    class="siw-main-header"
+  >
+    <div />
+  </div>
+  <div
+    class="siw-main-body"
+  >
+    <form
+      action="/"
+      class="ion-form o-form o-form-edit-mode"
+      data-se="o-form"
+      id="form111"
       method="POST"
       slot="content"
     >
@@ -75,7 +145,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Add User G
 </div>
 `;
 
-exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add User Gesture if not OV enrollment on Android: should not show user gesture 1`] = `
+exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add user gesture if OV enrollment on Android with interstitialBeforeLoginRedirect = "NONE": should show user gesture 1`] = `
 <div
   class="siw-main-view "
 >
@@ -91,7 +161,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form109"
+      id="form91"
       method="POST"
       slot="content"
     >
@@ -103,7 +173,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add
           class="okta-form-title o-form-head"
           data-se="o-form-head"
         >
-          Signing in to Okta Administration
+          To continue, tap "Open Okta Verify"
         </h2>
         <div
           class="identifier-container"
@@ -128,9 +198,89 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add
           class="o-form-fieldset-container"
           data-se="o-form-fieldset-container"
         >
-          <div
-            class="okta-waiting-spinner"
-          />
+          <a
+            class="ul-button button button-wide button-primary hide-underline link-button"
+            data-se="button"
+            href="#"
+            id="launch-enrollment-ov"
+          >
+            Open Okta Verify
+          </a>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div
+    class="siw-main-footer"
+  >
+    <div
+      class="auth-footer"
+    />
+  </div>
+</div>
+`;
+
+exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add user gesture if OV enrollment on Android with interstitialBeforeLoginRedirect = "null": should show user gesture 1`] = `
+<div
+  class="siw-main-view "
+>
+  <div
+    class="siw-main-header"
+  >
+    <div />
+  </div>
+  <div
+    class="siw-main-body"
+  >
+    <form
+      action="/"
+      class="ion-form o-form o-form-edit-mode"
+      data-se="o-form"
+      id="form131"
+      method="POST"
+      slot="content"
+    >
+      <div
+        class="o-form-content o-form-theme clearfix"
+        data-se="o-form-content"
+      >
+        <h2
+          class="okta-form-title o-form-head"
+          data-se="o-form-head"
+        >
+          To continue, tap "Open Okta Verify"
+        </h2>
+        <div
+          class="identifier-container"
+        >
+          <span
+            class="identifier no-translate"
+            data-se="identifier"
+            title="testUser@okta.com"
+          >
+            testUser@okta.com
+          </span>
+        </div>
+        <div
+          class="o-form-info-container"
+        />
+        <div
+          class="o-form-error-container"
+          data-se="o-form-error-container"
+          role="alert"
+        />
+        <div
+          class="o-form-fieldset-container"
+          data-se="o-form-fieldset-container"
+        >
+          <a
+            class="ul-button button button-wide button-primary hide-underline link-button"
+            data-se="button"
+            href="#"
+            id="launch-enrollment-ov"
+          >
+            Open Okta Verify
+          </a>
         </div>
       </div>
     </form>


### PR DESCRIPTION
## Description:
We received reports that orgs utilizing a custom domain (with no template customizations) we unable to enroll into OV from android devices. After researching this with the device platform team, we found that when the interstitial value is set to anything other than `DEFAULT` it would not render the OV launch button as expected and would not advance the user as expected. 

This value within the AutoRedirect view is only used to control whether or not the spinner displays and the sub title text that is displayed. In the case of OV enrollment on Android, this value does not matter, so we re-arranged the condition under which we display the button. More information can be found in the ticket comments. 

For additional reference, see original implementation: https://github.com/okta/okta-signin-widget/pull/3372

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-698916](https://oktainc.atlassian.net/browse/OKTA-698916)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



