### PR TITLE
Adds unit test for fix of localize call in ErrorParser (Gen1)

### DIFF
--- a/test/unit/spec/v1/Registration_spec.js
+++ b/test/unit/spec/v1/Registration_spec.js
@@ -963,11 +963,11 @@ Expect.describe('Registration', function() {
             preSubmitSpy(postData, onSuccess, onFailure);
             if (postData.firstName.length < 5) {
               const error = {
-                "errorSummary": "Custom Validation Error",
-                "errorCauses": [
+                errorSummary: 'Custom Validation Error',
+                errorCauses: [
                   {
-                    "errorSummary": "First name should have at least 5 characters",
-                    "property": "firstName",
+                    errorSummary: 'First name should have at least 5 characters',
+                    property: 'firstName',
                   }
                 ]
               };

--- a/test/unit/spec/v1/Registration_spec.js
+++ b/test/unit/spec/v1/Registration_spec.js
@@ -952,7 +952,7 @@ Expect.describe('Registration', function() {
         expectRegCallbackError(test, 'preSubmit', DEFAULT_CALLBACK_ERROR);
       });
     });
-    itp('shows form errors if an error object passed to onFailure contains errorCauses', function() {
+    itp('shows form field errors if an error object passed to onFailure contains errorCauses', function() {
       // Spy on emitting of CustomEvent with type 'okta-i18n-error' in `StringUtil.localize()`
       const dispatchEventSpy = spyOn(document, 'dispatchEvent');
       const preSubmitSpy = jasmine.createSpy('preSubmitSpy');


### PR DESCRIPTION
## Description:

This PR just adds test for the `okta-courage` fix from https://github.com/okta/okta-signin-widget/pull/3578



_Issue description:_
(For Gen1)
When error response (that may come from API or from `onFailure` callback used in registration hooks) contains form field level errors, `@okta/courage` tries to localize them.
Example of field level error: https://github.com/okta/okta-signin-widget/blob/master/docs/classic.md#use-field-level-error
If `property` and `errorSummary` are defined but `reason` is not, `parseErrorCauseObject()` calls `StringUtil.localize(undefined)` which will trigger a CustomEvent with type 'okta-i18n-error':
https://github.com/okta/okta-signin-widget/blob/e63951ffcff0fd6843199d546c52ee332db93c0a/packages/%40okta/courage-dist/esm/src/courage/views/forms/helpers/ErrorParser.js#L76-L77
https://github.com/okta/okta-signin-widget/blob/e63951ffcff0fd6843199d546c52ee332db93c0a/packages/%40okta/courage-dist/esm/src/courage/views/forms/helpers/ErrorParser.js#L38-L40

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-700850](https://oktainc.atlassian.net/browse/OKTA-700850)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



