### PR TITLE
Gen1/2: 

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -99,9 +99,11 @@ Util.transformErrorXHR = function(xhr) {
   }
   // Replace error messages
   if (!_.isEmpty(xhr.responseJSON)) {
-    const errorMsg = loc('errors.' + xhr.responseJSON.errorCode, 'login');
+    const errorMsg = xhr.responseJSON.errorCode
+      ? loc('errors.' + xhr.responseJSON.errorCode, 'login')
+      : undefined;
 
-    if (errorMsg.indexOf('L10N_ERROR[') === -1) {
+    if (errorMsg?.indexOf('L10N_ERROR[') === -1) {
       xhr.responseJSON.errorSummary = errorMsg;
       if (xhr.responseJSON && xhr.responseJSON.errorCauses && xhr.responseJSON.errorCauses.length) {
         // BaseForm will consume errorCauses before errorSummary if it is an array,

--- a/test/testcafe/framework/shared/index.js
+++ b/test/testcafe/framework/shared/index.js
@@ -31,6 +31,27 @@ export const renderWidget = ClientFunction((settings) => {
   window.renderPlaygroundWidget(settings);
 });
 
+export const logI18nErrorsToConsole = ClientFunction(() => {
+  document.addEventListener('okta-i18n-error', (ev) => {
+    console.warn(JSON.stringify(ev.detail));
+  });
+});
+
+export async function checkI18nErrors(expectedErrors = []) {
+  const { warn } = await t.getBrowserConsoleMessages();
+  const i18nErrors = warn
+    .filter((msg) => msg.includes('l10n-error'))
+    .map((msg) => JSON.parse(msg));
+  console.assert(
+    i18nErrors.length === expectedErrors.length,
+    JSON.stringify({ i18nErrors, expectedErrors }, null, 2)
+  );
+  await t.expect(i18nErrors.length).eql(expectedErrors.length);
+  for (let i = 0; i < expectedErrors.length; i++) {
+    await t.expect(i18nErrors[i]).eql(expectedErrors[i]);
+  }
+}
+
 // Centralized console log assertion for verifying:
 // 1. Widget is ready to accept user input for the first time (ready)
 // 2. Widget transitions to a new page and animations have finished (afterRender)

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -2,7 +2,7 @@ import { ClientFunction, RequestMock, RequestLogger, userVariables } from 'testc
 import { checkA11y } from '../framework/a11y';
 import BasePageObject from '../framework/page-objects/BasePageObject';
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, logI18nErrorsToConsole, checkI18nErrors } from '../framework/shared';
 import xhrErrorFeatureNotEnabled from '../../../playground/mocks/data/oauth2/error-feature-not-enabled';
 import xhrErrorInvalidRecoveryToken from '../../../playground/mocks/data/oauth2/error-recovery-token-invalid';
 import xhrErrorInvalidActivationToken from '../../../playground/mocks/data/oauth2/error-activation-token-invalid';
@@ -115,6 +115,10 @@ async function setup(t, options = {}) {
     await saveTransactionMeta(options.transactionMeta);
   }
 
+  if (options.logI18nErrorsToConsole) {
+    await logI18nErrorsToConsole();
+  }
+
   // Render the widget for interaction code flow
   await pageObject.mockCrypto();
   await renderWidget({
@@ -133,7 +137,7 @@ async function setup(t, options = {}) {
 }
 
 test.requestHooks(requestLogger, errorOIENotEnabledMock)('shows an error when feature is not enabled', async t => {
-  await setup(t);
+  await setup(t, { logI18nErrorsToConsole: true });
   await checkA11y(t);
 
   const terminalPageObject = new TerminalPageObject(t);
@@ -146,6 +150,7 @@ test.requestHooks(requestLogger, errorOIENotEnabledMock)('shows an error when fe
     'afterRender',
     expectTerminalView
   ]);
+  await checkI18nErrors([]);
 });
 
 test.requestHooks(requestLogger, interactMock)('receives interaction_handle from interact endpoint', async t => {
@@ -266,7 +271,7 @@ test.requestHooks(requestLogger, cancelResetPasswordMock)('clears recovery_token
 });
 
 test.requestHooks(requestLogger, errorInvalidRecoveryTokenMock)('shows an error when recovery token is invalid', async t => {
-  await setup(t);
+  await setup(t, { logI18nErrorsToConsole: true });
   await checkA11y(t);
 
   const terminalPageObject = new TerminalPageObject(t);
@@ -279,10 +284,11 @@ test.requestHooks(requestLogger, errorInvalidRecoveryTokenMock)('shows an error 
     'afterRender',
     expectTerminalView
   ]);
+  await checkI18nErrors([]);
 });
 
 test.requestHooks(requestLogger, errorInvalidActivationTokenMock)('shows an error when activation token is invalid', async t => {
-  await setup(t);
+  await setup(t, { logI18nErrorsToConsole: true });
   await checkA11y(t);
 
   const terminalPageObject = new TerminalPageObject(t);
@@ -299,4 +305,5 @@ test.requestHooks(requestLogger, errorInvalidActivationTokenMock)('shows an erro
     'afterRender',
     expectTerminalView
   ]);
+  await checkI18nErrors([]);
 });

--- a/test/unit/spec/OktaSignInV2Bootstrap_spec.js
+++ b/test/unit/spec/OktaSignInV2Bootstrap_spec.js
@@ -174,6 +174,8 @@ describe('OktaSignIn v2 bootstrap', function() {
 
     describe('shows error when IDENTITY_ENGINE feature is not enabled', () => {
       itp('shows translated error when i18n is available', async () => {
+        // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+        const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
         const view = new TerminalView($sandbox);
         const testStr = 'This is a test string';
         setupLoginFlow({
@@ -200,10 +202,13 @@ describe('OktaSignIn v2 bootstrap', function() {
           });
         }
         expect(didThrow).toBe(true);
+        expect(dispatchEventSpy).not.toHaveBeenCalled();
         expect($('.siw-main-view.terminal').length).toBe(1);
         expect(view.getErrorMessages()).toBe(testStr);
       });
       itp('shows untranslated error when i18n is not available', async () => {
+        // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+        const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
         const view = new TerminalView($sandbox);
         const testStr = 'The requested feature is not enabled in this environment.';
         setupLoginFlow({
@@ -223,6 +228,7 @@ describe('OktaSignIn v2 bootstrap', function() {
           });
         }
         expect(didThrow).toBe(true);
+        expect(dispatchEventSpy).not.toHaveBeenCalled();
         expect($('.siw-main-view.terminal').length).toBe(1);
         expect(view.getErrorMessages()).toBe(testStr);
       });

--- a/test/unit/spec/v2/WidgetRouter_spec.js
+++ b/test/unit/spec/v2/WidgetRouter_spec.js
@@ -90,6 +90,8 @@ describe('v2/WidgetRouter', function() {
   });
   
   it('should be visible and render initial error', async function() {
+    // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+    const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
     const { authClient } = setup({
       clientId: 'abc', // use interaction code flow
       codeChallenge: 'someChallenge'
@@ -108,5 +110,6 @@ describe('v2/WidgetRouter', function() {
     expect(router.controller.$el.find('.o-form-error-container').text()).toBe(
       'The requested feature is not enabled in this environment.'
     );
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description:

Don't try to localize oauth2 error messages with `loc()` using by `errorCode` which is undefined.
Example of oauth2 error:
https://github.com/okta/okta-signin-widget/blob/master/playground/mocks/data/oauth2/error-feature-not-enabled.json

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-700849](https://oktainc.atlassian.net/browse/OKTA-700849)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



