### PR TITLE
Gen2/3: Allow configuration of hCaptcha and reCAPTCHA script src

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,6 +1105,35 @@ Custom link href for the "Unlock Account" link. For this link to display, `featu
 
 Array of custom link objects `{text, href, target}` that will be added after the "Help" link. The `target` of the link is optional.
 
+#### hCaptcha options
+
+Set the following config options to customize `hCaptcha` script URI:
+
+```javascript
+// An example that uses cn1 host
+hcaptcha: {
+  scriptSource: 'https://cn1.hcaptcha.com/1/api.js',
+  scriptParams: {
+    apihost: 'https://cn1.hcaptcha.com',
+    endpoint: 'https://cn1.hcaptcha.com',
+    assethost: 'https://assets-cn1.hcaptcha.com',
+    imghost: 'https://imgs-cn1.hcaptcha.com',
+    reportapi: 'https://reportapi-cn1.hcaptcha.com',
+  }
+},
+```
+
+#### reCAPTCHA options
+
+Set the following config options to customize `reCAPTCHA` script URI:
+
+```javascript
+// An example that uses recaptcha.net
+recaptcha: {
+  scriptSource: 'https://recaptcha.net/recaptcha/api.js'
+},
+```
+
 ### Hooks
 
 Asynchronous callbacks can be invoked before or after a specific view is rendered. Hooks can be used to add custom logic such as instrumentation, logging, or additional user input. Normal execution is blocked while the hook function is executing and will resume after the Promise returned from the hook function resolves. Hooks can be added via config, as shown below, or at runtime using the [before](#before) or [after](#after) methods. The full list of views can be found in [RemediationConstants.js](https://github.com/okta/okta-signin-widget/blob/master/src/v2/ion/RemediationConstants.js#L19).

--- a/docs/classic.md
+++ b/docs/classic.md
@@ -1043,34 +1043,6 @@ helpLinks: {
 
 - **helpLinks.custom** - Array of custom link objects `{text, href, target}` that will be added to the *"Need help signing in?"* section. The `target` of the link is optional.
 
-#### hCaptcha options
-
-Set the following config options to customize `hCaptcha` script URI:
-
-```javascript
-// An example that uses cn1 host
-hcaptcha: {
-  scriptSource: 'https://cn1.hcaptcha.com/1/api.js',
-  scriptParams: {
-    endpoint: 'https://cn1.hcaptcha.com',
-    assethost: 'https://assets-cn1.hcaptcha.com',
-    imghost: 'https://imgs-cn1.hcaptcha.com',
-    reportapi: 'https://reportapi-cn1.hcaptcha.com',
-  }
-},
-```
-
-#### reCAPTCHA options
-
-Set the following config options to customize `reCAPTCHA` script URI:
-
-```javascript
-// An example that uses recaptcha.net
-recaptcha: {
-  scriptSource: 'https://recaptcha.net/recaptcha/api.js'
-},
-```
-
 #### Sign Out Link
 
 Set the following config option to override the sign out link URL. If not provided, the widget will navigate to Primary Auth.

--- a/docs/classic.md
+++ b/docs/classic.md
@@ -1043,6 +1043,34 @@ helpLinks: {
 
 - **helpLinks.custom** - Array of custom link objects `{text, href, target}` that will be added to the *"Need help signing in?"* section. The `target` of the link is optional.
 
+#### hCaptcha options
+
+Set the following config options to customize `hCaptcha` script URI:
+
+```javascript
+// An example that uses cn1 host
+hcaptcha: {
+  scriptSource: 'https://cn1.hcaptcha.com/1/api.js',
+  scriptParams: {
+    endpoint: 'https://cn1.hcaptcha.com',
+    assethost: 'https://assets-cn1.hcaptcha.com',
+    imghost: 'https://imgs-cn1.hcaptcha.com',
+    reportapi: 'https://reportapi-cn1.hcaptcha.com',
+  }
+},
+```
+
+#### reCAPTCHA options
+
+Set the following config options to customize `reCAPTCHA` script URI:
+
+```javascript
+// An example that uses recaptcha.net
+recaptcha: {
+  scriptSource: 'https://recaptcha.net/recaptcha/api.js'
+},
+```
+
 #### Sign Out Link
 
 Set the following config option to override the sign out link URL. If not provided, the widget will navigate to Primary Auth.

--- a/scripts/buildtools/commands/verify-package.js
+++ b/scripts/buildtools/commands/verify-package.js
@@ -3,7 +3,7 @@ const { readFileSync } = require('fs');
 
 const KB = 1024;
 const MB = 1024 * 1024;
-const EXPECTED_PACKAGE_SIZE = 17.6 * MB;
+const EXPECTED_PACKAGE_SIZE = 17.7 * MB;
 const EXPECTED_PACKAGE_FILES = 3560;
 
 const EXPECTED_BUNDLE_SIZES = {

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -187,10 +187,13 @@ const local: Record<string, ModelProperty> = {
   //Support classic engine
   useClassicEngine: ['boolean', false, false],
 
-  //hCaptcha options
+  //hCaptcha script source URI
   'hcaptcha.scriptSource': ['string', false],
-  //https://github.com/hCaptcha/hcaptcha-loader/blob/main/lib/src/loader.ts#L52
+  //query params for hCaptcha script source URI
   'hcaptcha.scriptParams': ['object', false, {}],
+
+  //reCAPTCHA script source URI
+  'recaptcha.scriptSource': ['string', false],
 };
 
 const derived: Record<string, ModelProperty>  = {

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -185,7 +185,12 @@ const local: Record<string, ModelProperty> = {
   otp: 'string',
 
   //Support classic engine
-  useClassicEngine: ['boolean', false, false]
+  useClassicEngine: ['boolean', false, false],
+
+  //hCaptcha options
+  'hcaptcha.scriptSource': ['string', false],
+  //https://github.com/hCaptcha/hcaptcha-loader/blob/main/lib/src/loader.ts#L52
+  'hcaptcha.scriptParams': ['object', false, {}],
 };
 
 const derived: Record<string, ModelProperty>  = {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -106,9 +106,14 @@ export interface WidgetOptions
   proxyIdxResponse?: any;
   // hCaptcha options
   hcaptcha?: {
+    // script source URI
     scriptSource?: string;
-    // https://github.com/hCaptcha/hcaptcha-loader/blob/main/lib/src/loader.ts#L52
+    // query params for script source URI
     scriptParams?: Record<string, string>;
+  };
+  // reCAPTCHA options
+  recaptcha?: {
+    scriptSource?: string;
   };
 
   /**

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -104,6 +104,12 @@ export interface WidgetOptions
   useClassicEngine?: boolean;
   hooks?: HooksOptions;
   proxyIdxResponse?: any;
+  // hCaptcha options
+  hcaptcha?: {
+    scriptSource?: string;
+    // https://github.com/hCaptcha/hcaptcha-loader/blob/main/lib/src/loader.ts#L52
+    scriptParams?: Record<string, string>;
+  };
 
   /**
    * @deprecated since version 7.0

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -260,19 +260,20 @@ Util.getAutocompleteValue = function(settings, defaultValue) {
   return defaultValue;
 };
 
+/**
+ * Equivalent of `new URLSearchParams(params).toString()` with broadest browser support.
+ * Does not include params with nullish values.
+ */
 Util.searchParamsToString = function(params) {
-  const parts = [];
-  for (const key in params) {
-    const val = params[key];
-    const canUseParam = Object.prototype.hasOwnProperty.call(params, key)
-      && val !== undefined
-      && val !== null
-      && val !== '';
-    if (canUseParam) {
-      parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(val));
-    }
-  }
-  return parts.join('&');
-}
+  return Object.keys(params)
+    .filter((key) => {
+      const val = params[key];
+      return val !== undefined && val !== null;
+    })
+    .map((key) => {
+      return encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
+    })
+    .join('&');
+};
 
 export default Util;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -260,4 +260,19 @@ Util.getAutocompleteValue = function(settings, defaultValue) {
   return defaultValue;
 };
 
+Util.searchParamsToString = function(params) {
+  const parts = [];
+  for (const key in params) {
+    const val = params[key];
+    const canUseParam = Object.prototype.hasOwnProperty.call(params, key)
+      && val !== undefined
+      && val !== null
+      && val !== '';
+    if (canUseParam) {
+      parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(val));
+    }
+  }
+  return parts.join('&');
+}
+
 export default Util;

--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -19,10 +19,8 @@ import { WIDGET_FOOTER_CLASS } from '../../utils/Constants';
 const OktaSignInWidgetOnCaptchaLoadedCallback = 'OktaSignInWidgetOnCaptchaLoaded';
 const OktaSignInWidgetOnCaptchaSolvedCallback = 'OktaSignInWidgetOnCaptchaSolved';
 
-const HCAPTCHA_BASE_URL =
-  'https://hcaptcha.com/1/api.js';
-const RECAPTCHAV2_URL = 
-  `https://www.google.com/recaptcha/api.js?onload=${OktaSignInWidgetOnCaptchaLoadedCallback}&render=explicit`;
+const HCAPTCHA_URL = 'https://hcaptcha.com/1/api.js';
+const RECAPTCHAV2_URL = 'https://www.google.com/recaptcha/api.js';
 
 export default View.extend({
   className: 'captcha-view',
@@ -134,9 +132,9 @@ export default View.extend({
 
     
     if (this.captchaConfig.type === 'HCAPTCHA') {
-      this._loadCaptchaLib(this._getHCaptchaUrl(HCAPTCHA_BASE_URL));
+      this._loadCaptchaLib(this._getCaptchaUrl(HCAPTCHA_URL, 'hcaptcha'));
     } else if (this.captchaConfig.type === 'RECAPTCHA_V2') {
-      this._loadCaptchaLib(this._getCaptchaUrl(RECAPTCHAV2_URL));
+      this._loadCaptchaLib(this._getCaptchaUrl(RECAPTCHAV2_URL, 'recaptcha'));
     }
   },
   
@@ -177,14 +175,16 @@ export default View.extend({
   },
 
   /**
-   *  Options for `@hcaptcha/loader`:
-   *   https://github.com/hCaptcha/hcaptcha-loader/blob/main/lib/src/loader.ts#L52
-   *   https://www.npmjs.com/package/@hcaptcha/loader#props
+   *  Supported params for hCaptcha script:
+   *   https://github.com/hCaptcha/hcaptcha-loader#props
+   *   (starting from 'apihost')
+   *  Supported params for reCAPTCHA script:
+   *   https://developers.google.com/recaptcha/docs/display#javascript_resource_apijs_parameters
   * */
-  _getHCaptchaUrl(defaultBaseUrl) {
+  _getCaptchaUrl(defaultBaseUrl, settingsKey) {
     const locale = this.options.settings.get('language');
-    const scriptSource = this.options.settings.get('hcaptcha.scriptSource');
-    const scriptParams = this.options.settings.get('hcaptcha.scriptParams');
+    const scriptSource = this.options.settings.get(`${settingsKey}.scriptSource`);
+    const scriptParams = this.options.settings.get(`${settingsKey}.scriptParams`);
 
     const baseUrl = scriptSource || defaultBaseUrl;
     const params = {
@@ -194,12 +194,7 @@ export default View.extend({
       hl: locale || navigator.language,
     };
     const query = Util.searchParamsToString(params);
-
     return baseUrl + '?' + query;
   },
 
-  _getCaptchaUrl(baseURL) {
-    const locale = this.options.settings.get('language');
-    return `${baseURL}&hl=${locale || navigator.language}`;
-  }
 });

--- a/src/v3/jest.config.js
+++ b/src/v3/jest.config.js
@@ -68,6 +68,7 @@ module.exports = {
     '^create-react-class$': 'preact/compat/lib/create-react-class',
     '^react-addons-css-transition-group$': 'preact-css-transition-group',
     '^@okta/odyssey-react-mui/icons$': '<rootDir>/../../node_modules/@okta/odyssey-react-mui/dist/icons.generated/index.js',
+    '^@hcaptcha/loader$': '<rootDir>/../../node_modules/@hcaptcha/loader/dist/index.cjs',
   },
 
   modulePaths: [

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -44,7 +44,7 @@
     "@emotion/cache": "^11.9.3",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
-    "@hcaptcha/react-hcaptcha": "^1.8.1",
+    "@hcaptcha/react-hcaptcha": "^1.10.1",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.5",
     "@okta/odyssey-design-tokens": "1.13.0",

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -142,12 +142,15 @@ const CaptchaContainer: UISchemaElementComponent<{
       //  (starting from 'apihost')
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...(scriptParams || {})}
+      scriptSource={scriptSource}
       id="captcha-container"
       sitekey={siteKey}
       ref={captchaRef}
       onVerify={onVerifyCaptcha}
       size="invisible"
-      scriptSource={scriptSource}
+      // Fixes issue with IE11:
+      // If hCaptcha loader removes <script>, `onload` callback won't be executed
+      cleanup={false}
     />
   );
 };

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -114,6 +114,9 @@ const CaptchaContainer: UISchemaElementComponent<{
   };
 
   if (captchaType === 'RECAPTCHA_V2') {
+    // Note: Unlike HCaptcha, we can't customize script URI with props.
+    // This can be done with global `recaptchaOptions` object:
+    // https://github.com/dozoisch/react-google-recaptcha#advanced-usage
     return (
       // set z-index to 1 for ReCaptcha so the badge does not get covered by the footer
       <Box
@@ -133,15 +136,17 @@ const CaptchaContainer: UISchemaElementComponent<{
   }
   return (
     <HCaptcha
+      // Params like `apihost` will be passed to hCaptcha loader.
+      // Supported params for hCaptcha script:
+      //  https://github.com/hCaptcha/hcaptcha-loader#props
+      //  (starting from 'apihost')
+      {...(scriptParams || {})}
       id="captcha-container"
       sitekey={siteKey}
       ref={captchaRef}
       onVerify={onVerifyCaptcha}
       size="invisible"
       scriptSource={scriptSource}
-      // params like `assethost` will be passed to hcaptcha loader
-      // https://github.com/hCaptcha/hcaptcha-loader/blob/main/lib/src/loader.ts#L52
-      {...(scriptParams || {})}
     />
   );
 };

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -34,7 +34,8 @@ const CaptchaContainer: UISchemaElementComponent<{
     },
   } = uischema;
 
-  const { dataSchemaRef } = useWidgetContext();
+  const { dataSchemaRef, widgetProps } = useWidgetContext();
+  const { hcaptcha: { scriptSource, scriptParams } = {} } = widgetProps;
   const onSubmitHandler = useOnSubmit();
   const dataSchema = dataSchemaRef.current!;
   const captchaRef = useRef<ReCAPTCHA | HCaptcha>(null);
@@ -137,6 +138,10 @@ const CaptchaContainer: UISchemaElementComponent<{
       ref={captchaRef}
       onVerify={onVerifyCaptcha}
       size="invisible"
+      scriptSource={scriptSource}
+      // params like `assethost` will be passed to hcaptcha loader
+      // https://github.com/hCaptcha/hcaptcha-loader/blob/main/lib/src/loader.ts#L52
+      {...(scriptParams || {})}
     />
   );
 };

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -140,6 +140,7 @@ const CaptchaContainer: UISchemaElementComponent<{
       // Supported params for hCaptcha script:
       //  https://github.com/hCaptcha/hcaptcha-loader#props
       //  (starting from 'apihost')
+      // eslint-disable-next-line react/jsx-props-no-spreading
       {...(scriptParams || {})}
       id="captcha-container"
       sitekey={siteKey}

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -219,6 +219,10 @@ export type WidgetOptions = {
     // query params for script source URI
     scriptParams?: Record<string, string>;
   };
+  // reCAPTCHA options
+  recaptcha?: {
+    scriptSource?: string;
+  };
 };
 
 export type IdxMethod =

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -212,6 +212,12 @@ export type WidgetOptions = {
   transformUsername?: (username: string, operation: UserOperation) => string;
   globalSuccessFn?: (res: RenderResult) => void;
   globalErrorFn?: (res: RenderError) => void;
+  // hCaptcha options
+  hcaptcha?: {
+    scriptSource?: string;
+    // https://github.com/hCaptcha/hcaptcha-loader/blob/main/lib/src/loader.ts#L52
+    scriptParams?: Record<string, string>;
+  };
 };
 
 export type IdxMethod =

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -214,8 +214,9 @@ export type WidgetOptions = {
   globalErrorFn?: (res: RenderError) => void;
   // hCaptcha options
   hcaptcha?: {
+    // script source URI
     scriptSource?: string;
-    // https://github.com/hCaptcha/hcaptcha-loader/blob/main/lib/src/loader.ts#L52
+    // query params for script source URI
     scriptParams?: Record<string, string>;
   };
 };

--- a/src/v3/webpack.common.config.ts
+++ b/src/v3/webpack.common.config.ts
@@ -83,7 +83,7 @@ const baseConfig: Partial<Configuration> = {
   module: {
     rules: [
       {
-        test: /\.[jt]sx?$/,
+        test: /\.m?[jt]sx?$/,
         exclude(filePath) {
           const filePathContains = (f) => filePath.indexOf(f) >= 0;
           const npmRequiresTransform = [
@@ -95,6 +95,8 @@ const baseConfig: Partial<Configuration> = {
             '/node_modules/p-cancelable',
             '/node_modules/i18next',
             '/node_modules/@adobe/leonardo-contrast-colors',
+            '/node_modules/@hcaptcha/loader',
+            '/node_modules/@hcaptcha/react-hcaptcha'
           ].some(filePathContains);
           const shallBeExcluded = [
             // /src/ will be handled in next rule

--- a/src/v3/webpack.common.config.ts
+++ b/src/v3/webpack.common.config.ts
@@ -96,7 +96,7 @@ const baseConfig: Partial<Configuration> = {
             '/node_modules/i18next',
             '/node_modules/@adobe/leonardo-contrast-colors',
             '/node_modules/@hcaptcha/loader',
-            '/node_modules/@hcaptcha/react-hcaptcha'
+            '/node_modules/@hcaptcha/react-hcaptcha',
           ].some(filePathContains);
           const shallBeExcluded = [
             // /src/ will be handled in next rule

--- a/src/v3/webpack.dev.config.ts
+++ b/src/v3/webpack.dev.config.ts
@@ -164,7 +164,7 @@ const devConfig: Configuration = mergeWithRules({
     },
     optimization: {
       ...(process.env.IE11_COMPAT_MODE !== 'true' && {
-        runtimeChunk: 'single'
+        runtimeChunk: 'single',
       }),
     },
   },

--- a/test/testcafe/spec/IdentifyWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyWithCaptcha_spec.js
@@ -86,7 +86,6 @@ test.requestHooks(identifyRequestLogger, identifyMockwithHCaptcha, hcaptchaReque
 
   // Wait for the hCaptcha container to appear in the DOM and become visible.
   await t.expect(Selector('#captcha-container').find('iframe').exists).ok();
-  
   await identityPage.clickSignInButton();
   await t.expect(identifyRequestLogger.count(() => true)).eql(1);
 

--- a/test/testcafe/spec/IdentifyWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyWithCaptcha_spec.js
@@ -42,18 +42,11 @@ const hcaptchaRequestLogger = RequestLogger(
   }
 );
 
-const setGlobalRecaptchaOptions = ClientFunction((recaptchaOptions) => {
-  window.recaptchaOptions = recaptchaOptions;
-});
-
 fixture('Identify + Password With Captcha');
 
-async function setup(t, widgetOptions, recaptchaOptions) {
+async function setup(t, widgetOptions) {
   const identityPage = new IdentityPageObject(t);
   await identityPage.navigateToPage({ render: false });
-  if (recaptchaOptions) {
-    await setGlobalRecaptchaOptions(recaptchaOptions);
-  }
   await renderWidget(widgetOptions || {});
   await t.expect(identityPage.formExists()).eql(true);
   await checkConsoleMessages({
@@ -148,24 +141,12 @@ test.requestHooks(identifyRequestLogger, reCaptchaRequestLogger, identifyMockWit
 });
 
 test.requestHooks(identifyRequestLogger, identifyMockWithReCaptcha)('can load reCAPTCHA script with custom URI', async t => {
-  if (userVariables.gen3) {
-    // For Gen3 `recaptcha` options in SIW settings will have no effect
-    // Need to use global `recaptchaOptions` object
-    // https://github.com/dozoisch/react-google-recaptcha#advanced-usage
-    await setup(t, {
-      language: 'en',
-    }, {
-      // recaptchaOptions
-      useRecaptchaNet: true,
-    });
-  } else {
-    await setup(t, {
-      recaptcha: {
-        scriptSource: 'https://recaptcha.net/recaptcha/api.js',
-      },
-      language: 'en',
-    });
-  }
+  await setup(t, {
+    recaptcha: {
+      scriptSource: 'https://recaptcha.net/recaptcha/api.js',
+    },
+    language: 'en',
+  });
 
   await checkA11y(t);
 

--- a/test/testcafe/spec/IdentifyWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyWithCaptcha_spec.js
@@ -1,4 +1,4 @@
-import { ClientFunction, RequestMock, RequestLogger, Selector, userVariables } from 'testcafe';
+import { RequestMock, RequestLogger, Selector, userVariables } from 'testcafe';
 import { checkA11y } from '../framework/a11y';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import { checkConsoleMessages, renderWidget } from '../framework/shared';

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -358,4 +358,29 @@ describe('util/Util', () => {
       expect(Util.isAndroidOVEnrollment()).toBe(false);
     });
   });
+
+  describe('searchParamsToString', () => {
+    it('encodes keys and values', () => {
+      const params = {
+        a: 1,
+        'key 2': 'value/2'
+      };
+      const expected = 'a=1&key%202=value%2F2';
+      expect(Util.searchParamsToString(params)).toEqual(expected);
+    });
+
+    it('skips parameters with nullish values', () => {
+      const params = {
+        a: 1,
+        b: undefined,
+        c: null,
+        d: '',
+        e: ' ',
+        f: 0,
+        g: '0'
+      };
+      const expected = 'a=1&d=&e=%20&f=0&g=0';
+      expect(Util.searchParamsToString(params)).toEqual(expected);
+    });
+  });
 });

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -9,13 +9,18 @@ import { WIDGET_FOOTER_CLASS } from 'v2/view-builder/utils/Constants';
 describe('v2/view-builder/views/CaptchaView', function() {
   let testContext;
   let language = undefined;
+  let hcaptchaOptions = undefined;
   beforeEach(function() { 
     testContext = {};
     testContext.init = (captcha = enrollProfileWithReCaptcha.captcha.value) => {
       const appState = new AppState({
         captcha
       }, {});
-      const settings = new Settings({ baseUrl: 'http://localhost:3000', language });
+      const settings = new Settings({
+        baseUrl: 'http://localhost:3000',
+        language,
+        hcaptcha: hcaptchaOptions
+      });
       testContext.view = new CaptchaView({
         appState,
         settings,
@@ -80,6 +85,19 @@ describe('v2/view-builder/views/CaptchaView', function() {
     
     testContext.init(enrollProfileWithHCaptcha.captcha.value);
     expect(spy).toHaveBeenCalledWith('https://hcaptcha.com/1/api.js?onload=OktaSignInWidgetOnCaptchaLoaded&render=explicit&hl=fr');
+
+    // Set hCaptcha options for SIW and ensure hCaptcha gets loaded with correct custom URL
+    hcaptchaOptions = {
+      scriptSource: 'https://cn1.hcaptcha.com/1/api.js',
+      scriptParams: {
+        endpoint: 'https://cn1.hcaptcha.com',
+        assethost: 'https://assets-cn1.hcaptcha.com',
+        imghost: 'https://imgs-cn1.hcaptcha.com',
+        reportapi: 'https://reportapi-cn1.hcaptcha.com',
+      }
+    };
+    testContext.init(enrollProfileWithHCaptcha.captcha.value);
+    expect(spy).toHaveBeenCalledWith('https://cn1.hcaptcha.com/1/api.js?endpoint=https%3A%2F%2Fcn1.hcaptcha.com&assethost=https%3A%2F%2Fassets-cn1.hcaptcha.com&imghost=https%3A%2F%2Fimgs-cn1.hcaptcha.com&reportapi=https%3A%2F%2Freportapi-cn1.hcaptcha.com&onload=OktaSignInWidgetOnCaptchaLoaded&render=explicit&hl=fr');
   });
 
   it('Captcha gets removed properly', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3129,12 +3129,18 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hcaptcha/react-hcaptcha@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-1.8.1.tgz#3e6e0423100158bae089e4ef6507db0d4c62ec3f"
-  integrity sha512-33tIl77HgeahiQ6R0+JPDA8cGBBv95cIVcdOcFVwiGCJhrOxyiOQetCdEUNTDS13xrkvIP29K/PrqLXXSbKl6Q==
+"@hcaptcha/loader@^1.2.1":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@hcaptcha/loader/-/loader-1.2.3.tgz#d2a7d0925d13009dc18b13dd4e46c399aa24e253"
+  integrity sha512-tJVkPpvWZ9kIXMAFeH/7B8iIDNN+kpFLBVgtJQgtWa1cAN0bUve2VPuc/UTVa0NUh7tsmd6oAg/C0VUplMt2UQ==
+
+"@hcaptcha/react-hcaptcha@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@hcaptcha/react-hcaptcha/-/react-hcaptcha-1.10.1.tgz#c9c4a913cde4fd6e9c09180f1aa6f65d9f136263"
+  integrity sha512-P0en4gEZAecah7Pt3WIaJO2gFlaLZKkI0+Tfdg8fNqsDxqT9VytZWSkH4WAkiPRULK1QcGgUZK+J56MXYmPifw==
   dependencies:
     "@babel/runtime" "^7.17.9"
+    "@hcaptcha/loader" "^1.2.1"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## Description:

Added possibility to customize hCaptcha/reCAPTCHA script source URI.

Added SIW config options:
```javascript
// An example that uses cn1 host
hcaptcha: {
  scriptSource: 'https://cn1.hcaptcha.com/1/api.js',
  scriptParams: {
    endpoint: 'https://cn1.hcaptcha.com',
    assethost: 'https://assets-cn1.hcaptcha.com',
    imghost: 'https://imgs-cn1.hcaptcha.com',
    reportapi: 'https://reportapi-cn1.hcaptcha.com',
  }
},
// An example that uses recaptcha.net
recaptcha: {
  scriptSource: 'https://recaptcha.net/recaptcha/api.js'
},
```

**Note:** `recaptcha` config has no effect in Gen3.
Because `react-google-recaptcha` has no props to customize host for  recaptcha, but supports global options object:
https://github.com/dozoisch/react-google-recaptcha?tab=readme-ov-file#global-properties-used-by-recaptcha


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-701285](https://oktainc.atlassian.net/browse/OKTA-701285)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



