### PR TITLE
OKTA-704879 : OV enrollment on Android for Gen 3

### DIFF
--- a/playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json
+++ b/playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0",
-    "stateHandle": "02.id.E5Z9_9ITDXufLZm6JUSRLAP_PUJWhdg4E6lMUGwo~c.sndpnpK2e0kAkId_qkfWzNjvzFq0uTj2SdIg8E1aC9KT5WGJiyh1tmNxWA38LvNcYBAVXs9dOc40edP6-fuw6EAtlep-WiYpfcW8XD7ZWQLQSKQABOz-W6Mp_7zxyLQscWP16FaQX6TbV4n_JCbp05Vgh4DrmebSdAm10qYaRiRsKJA_XahCriE20csknCQjBGKqRPzf42KIGtHpoiRJMfBaxMAuS00sSrgE4oaMNXAcKM9p0kkzhU4TKscvtkHuyc8BLpMZjXdXyBLQtDHB40O0GVSIZpb4wvQ2ai_96Xpz4YDpuXe2zoBsloH5A4DGh7A79WWyGIUF5sBlY2oD4OeKycWcgdlg4XclhqIYjDUU961AJ8EJTzObWItRh7JV6s0pbbKU5UKsdllNBWSMVKjsz6mfjMOc0Cr6-EnnKmYzPJAfHAxlukWjmZV3kAvgbfp8QSG43Kyh4e7X_FN6IFW04j7_NOm4dYIfDhEH_uAEWUSEjX1cdM4P9IXbwVZbqGpWAZc0POxhrSgBdMhGOb2zJ4ippW1oYC6OsI3Z0y0ZhEfbFPM4VElE_yVNtkX120cz-UJGyWFMCQBK66BJtzghJ9wHQ-_uHMjm5nD1eN5Pz8BEIb2GoVshBvgx3V1zPv5TeO5iWoL-fRToJZnwNYIhbZnMjScp_x3C5RTRYW3501fSU3RSUuE6rFlRqROr_2iIDmdAPiUYzP7WEqXGx2BLJhEc17HlsTNbOErb4Rf5LVtxd9euDYAeDTZOoqbZhHF_HNXzL2a9UMz_iG-cTSQ-lJU_omZwuiMLjIt3DQOwyOIX5Pw9fpd7FKOnnOHydL6KLeAm4y6Ni0g3Z3BuTzDjf1DP7dsVzVCU0rjIHe9hrEU-UkkX8-gpv2n7qVPjda3YNghSgf6sdCPT3fTHlteFhQVA0wbOVklYpT5hFSKCA0KvPj0NYmuJ3Up6JBRD3OPXPr5mPi4IMyOjgvpgsA2pX0z3FpzYp97a2TN9r8-xRUoNGqtsLuRNKNPdUHA_Lwix_B4C1qZUaKuS9bIkzA_cxDrH2-ePpgsHlKEdMEERDisq3YDQaC6Q5jD9fd2qds5eVx8zFjoDoXE4R3f6x814oRryIvYIDDFPNIlQdGUbnjFjMAPb4nMvhSPp2sY9O0c5V0gUTx8Q8IdUphZL37GAMwFQqpshf0E1vo_s18k",
+    "stateHandle": "abcd.1234.defagh",
     "expiresAt": "2024-02-16T15:27:57.000Z",
     "intent": "CREDENTIAL_ENROLLMENT",
     "user": {
@@ -32,7 +32,7 @@
             {
                 "name": "stateHandle",
                 "required": true,
-                "value": "02.id.E5Z9_9ITDXufLZm6JUSRLAP_PUJWhdg4E6lMUGwo~c.sndpnpK2e0kAkId_qkfWzNjvzFq0uTj2SdIg8E1aC9KT5WGJiyh1tmNxWA38LvNcYBAVXs9dOc40edP6-fuw6EAtlep-WiYpfcW8XD7ZWQLQSKQABOz-W6Mp_7zxyLQscWP16FaQX6TbV4n_JCbp05Vgh4DrmebSdAm10qYaRiRsKJA_XahCriE20csknCQjBGKqRPzf42KIGtHpoiRJMfBaxMAuS00sSrgE4oaMNXAcKM9p0kkzhU4TKscvtkHuyc8BLpMZjXdXyBLQtDHB40O0GVSIZpb4wvQ2ai_96Xpz4YDpuXe2zoBsloH5A4DGh7A79WWyGIUF5sBlY2oD4OeKycWcgdlg4XclhqIYjDUU961AJ8EJTzObWItRh7JV6s0pbbKU5UKsdllNBWSMVKjsz6mfjMOc0Cr6-EnnKmYzPJAfHAxlukWjmZV3kAvgbfp8QSG43Kyh4e7X_FN6IFW04j7_NOm4dYIfDhEH_uAEWUSEjX1cdM4P9IXbwVZbqGpWAZc0POxhrSgBdMhGOb2zJ4ippW1oYC6OsI3Z0y0ZhEfbFPM4VElE_yVNtkX120cz-UJGyWFMCQBK66BJtzghJ9wHQ-_uHMjm5nD1eN5Pz8BEIb2GoVshBvgx3V1zPv5TeO5iWoL-fRToJZnwNYIhbZnMjScp_x3C5RTRYW3501fSU3RSUuE6rFlRqROr_2iIDmdAPiUYzP7WEqXGx2BLJhEc17HlsTNbOErb4Rf5LVtxd9euDYAeDTZOoqbZhHF_HNXzL2a9UMz_iG-cTSQ-lJU_omZwuiMLjIt3DQOwyOIX5Pw9fpd7FKOnnOHydL6KLeAm4y6Ni0g3Z3BuTzDjf1DP7dsVzVCU0rjIHe9hrEU-UkkX8-gpv2n7qVPjda3YNghSgf6sdCPT3fTHlteFhQVA0wbOVklYpT5hFSKCA0KvPj0NYmuJ3Up6JBRD3OPXPr5mPi4IMyOjgvpgsA2pX0z3FpzYp97a2TN9r8-xRUoNGqtsLuRNKNPdUHA_Lwix_B4C1qZUaKuS9bIkzA_cxDrH2-ePpgsHlKEdMEERDisq3YDQaC6Q5jD9fd2qds5eVx8zFjoDoXE4R3f6x814oRryIvYIDDFPNIlQdGUbnjFjMAPb4nMvhSPp2sY9O0c5V0gUTx8Q8IdUphZL37GAMwFQqpshf0E1vo_s18k",
+                "value": "abcd.1234.defagh",
                 "visible": false,
                 "mutable": false
             }
@@ -44,7 +44,7 @@
         "value": {
             "name": "Okta_Authenticator",
             "label": "Okta Authenticator",
-            "id": "0oa187fpq61oHIerJ0h8"
+            "id": "BDSC3453323dsdfS"
         }
     },
     "authentication": {
@@ -63,8 +63,8 @@
                 "redirect_uri": "https://login.okta.com/oauth/callback",
                 "state": "i41VVuProw96htTUmvRP9A",
                 "code_challenge_method": "S256",
-                "nonce": "HF0lENQII5XZt-GhS8SQCw",
-                "code_challenge": "vpGSw_6gRkOhMwn9iR6mLv_-_4ItM04Enrtnufpp-dg",
+                "nonce": "ASDF4343SDFS3-GhS8SQCw",
+                "code_challenge": "abcd_8asd8asdf8as98fasdf_-_9sadif9rasd9fasdf-cc",
                 "response_mode": "query"
             }
         }

--- a/playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json
+++ b/playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json
@@ -1,0 +1,72 @@
+{
+    "version": "1.0.0",
+    "stateHandle": "02.id.E5Z9_9ITDXufLZm6JUSRLAP_PUJWhdg4E6lMUGwo~c.sndpnpK2e0kAkId_qkfWzNjvzFq0uTj2SdIg8E1aC9KT5WGJiyh1tmNxWA38LvNcYBAVXs9dOc40edP6-fuw6EAtlep-WiYpfcW8XD7ZWQLQSKQABOz-W6Mp_7zxyLQscWP16FaQX6TbV4n_JCbp05Vgh4DrmebSdAm10qYaRiRsKJA_XahCriE20csknCQjBGKqRPzf42KIGtHpoiRJMfBaxMAuS00sSrgE4oaMNXAcKM9p0kkzhU4TKscvtkHuyc8BLpMZjXdXyBLQtDHB40O0GVSIZpb4wvQ2ai_96Xpz4YDpuXe2zoBsloH5A4DGh7A79WWyGIUF5sBlY2oD4OeKycWcgdlg4XclhqIYjDUU961AJ8EJTzObWItRh7JV6s0pbbKU5UKsdllNBWSMVKjsz6mfjMOc0Cr6-EnnKmYzPJAfHAxlukWjmZV3kAvgbfp8QSG43Kyh4e7X_FN6IFW04j7_NOm4dYIfDhEH_uAEWUSEjX1cdM4P9IXbwVZbqGpWAZc0POxhrSgBdMhGOb2zJ4ippW1oYC6OsI3Z0y0ZhEfbFPM4VElE_yVNtkX120cz-UJGyWFMCQBK66BJtzghJ9wHQ-_uHMjm5nD1eN5Pz8BEIb2GoVshBvgx3V1zPv5TeO5iWoL-fRToJZnwNYIhbZnMjScp_x3C5RTRYW3501fSU3RSUuE6rFlRqROr_2iIDmdAPiUYzP7WEqXGx2BLJhEc17HlsTNbOErb4Rf5LVtxd9euDYAeDTZOoqbZhHF_HNXzL2a9UMz_iG-cTSQ-lJU_omZwuiMLjIt3DQOwyOIX5Pw9fpd7FKOnnOHydL6KLeAm4y6Ni0g3Z3BuTzDjf1DP7dsVzVCU0rjIHe9hrEU-UkkX8-gpv2n7qVPjda3YNghSgf6sdCPT3fTHlteFhQVA0wbOVklYpT5hFSKCA0KvPj0NYmuJ3Up6JBRD3OPXPr5mPi4IMyOjgvpgsA2pX0z3FpzYp97a2TN9r8-xRUoNGqtsLuRNKNPdUHA_Lwix_B4C1qZUaKuS9bIkzA_cxDrH2-ePpgsHlKEdMEERDisq3YDQaC6Q5jD9fd2qds5eVx8zFjoDoXE4R3f6x814oRryIvYIDDFPNIlQdGUbnjFjMAPb4nMvhSPp2sY9O0c5V0gUTx8Q8IdUphZL37GAMwFQqpshf0E1vo_s18k",
+    "expiresAt": "2024-02-16T15:27:57.000Z",
+    "intent": "CREDENTIAL_ENROLLMENT",
+    "user": {
+        "type": "object",
+        "value": {
+            "id": "00u12fnxjbjtgwaUP0h8",
+            "identifier": "tester@okta1.com",
+            "profile": {
+                "firstName": "Tester",
+                "lastName": "McTesterson",
+                "timeZone": "America/Los_Angeles",
+                "locale": "en_US"
+            }
+        }
+    },
+    "success": {
+        "name": "success-redirect",
+        "href": "http://localhost:3000/login/token/redirect?stateToken=02.id.E5Z9_9ITDXufLZm6JUSRLAP_PUJWhdg4E6lMUGwo"
+    },
+    "cancel": {
+        "rel": [
+            "create-form"
+        ],
+        "name": "cancel",
+        "href": "http://localhost:3000/idp/idx/cancel",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+            {
+                "name": "stateHandle",
+                "required": true,
+                "value": "02.id.E5Z9_9ITDXufLZm6JUSRLAP_PUJWhdg4E6lMUGwo~c.sndpnpK2e0kAkId_qkfWzNjvzFq0uTj2SdIg8E1aC9KT5WGJiyh1tmNxWA38LvNcYBAVXs9dOc40edP6-fuw6EAtlep-WiYpfcW8XD7ZWQLQSKQABOz-W6Mp_7zxyLQscWP16FaQX6TbV4n_JCbp05Vgh4DrmebSdAm10qYaRiRsKJA_XahCriE20csknCQjBGKqRPzf42KIGtHpoiRJMfBaxMAuS00sSrgE4oaMNXAcKM9p0kkzhU4TKscvtkHuyc8BLpMZjXdXyBLQtDHB40O0GVSIZpb4wvQ2ai_96Xpz4YDpuXe2zoBsloH5A4DGh7A79WWyGIUF5sBlY2oD4OeKycWcgdlg4XclhqIYjDUU961AJ8EJTzObWItRh7JV6s0pbbKU5UKsdllNBWSMVKjsz6mfjMOc0Cr6-EnnKmYzPJAfHAxlukWjmZV3kAvgbfp8QSG43Kyh4e7X_FN6IFW04j7_NOm4dYIfDhEH_uAEWUSEjX1cdM4P9IXbwVZbqGpWAZc0POxhrSgBdMhGOb2zJ4ippW1oYC6OsI3Z0y0ZhEfbFPM4VElE_yVNtkX120cz-UJGyWFMCQBK66BJtzghJ9wHQ-_uHMjm5nD1eN5Pz8BEIb2GoVshBvgx3V1zPv5TeO5iWoL-fRToJZnwNYIhbZnMjScp_x3C5RTRYW3501fSU3RSUuE6rFlRqROr_2iIDmdAPiUYzP7WEqXGx2BLJhEc17HlsTNbOErb4Rf5LVtxd9euDYAeDTZOoqbZhHF_HNXzL2a9UMz_iG-cTSQ-lJU_omZwuiMLjIt3DQOwyOIX5Pw9fpd7FKOnnOHydL6KLeAm4y6Ni0g3Z3BuTzDjf1DP7dsVzVCU0rjIHe9hrEU-UkkX8-gpv2n7qVPjda3YNghSgf6sdCPT3fTHlteFhQVA0wbOVklYpT5hFSKCA0KvPj0NYmuJ3Up6JBRD3OPXPr5mPi4IMyOjgvpgsA2pX0z3FpzYp97a2TN9r8-xRUoNGqtsLuRNKNPdUHA_Lwix_B4C1qZUaKuS9bIkzA_cxDrH2-ePpgsHlKEdMEERDisq3YDQaC6Q5jD9fd2qds5eVx8zFjoDoXE4R3f6x814oRryIvYIDDFPNIlQdGUbnjFjMAPb4nMvhSPp2sY9O0c5V0gUTx8Q8IdUphZL37GAMwFQqpshf0E1vo_s18k",
+                "visible": false,
+                "mutable": false
+            }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+    },
+    "app": {
+        "type": "object",
+        "value": {
+            "name": "Okta_Authenticator",
+            "label": "Okta Authenticator",
+            "id": "0oa187fpq61oHIerJ0h8"
+        }
+    },
+    "authentication": {
+        "type": "object",
+        "value": {
+            "protocol": "OAUTH2.0",
+            "issuer": {
+                "name": "Test App",
+                "uri": "http://localhost:3000"
+            },
+            "request": {
+                "max_age": -1,
+                "scope": "openid profile email okta.authenticators.read okta.authenticators.manage.self",
+                "display": "page",
+                "response_type": "code",
+                "redirect_uri": "https://login.okta.com/oauth/callback",
+                "state": "i41VVuProw96htTUmvRP9A",
+                "code_challenge_method": "S256",
+                "nonce": "HF0lENQII5XZt-GhS8SQCw",
+                "code_challenge": "vpGSw_6gRkOhMwn9iR6mLv_-_4ItM04Enrtnufpp-dg",
+                "response_mode": "query"
+            }
+        }
+    }
+}

--- a/src/v3/src/transformer/redirect/redirectTransformer.test.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.test.ts
@@ -12,10 +12,17 @@
 
 import { IdxTransaction } from '@okta/okta-auth-js';
 
-import { InterstitialRedirectView } from '../../constants';
+import { IDX_STEP, InterstitialRedirectView } from '../../constants';
 import { getStubTransaction } from '../../mocks/utils/utils';
-import { DescriptionElement, RedirectElement, WidgetProps } from '../../types';
+import {
+  ButtonElement, DescriptionElement, RedirectElement, WidgetProps,
+} from '../../types';
 import { redirectTransformer } from '.';
+
+const mockIsAndroidOVEnrollment = jest.fn();
+jest.mock('../../../../util/Util', () => ({
+  isAndroidOVEnrollment: jest.fn().mockImplementation(() => mockIsAndroidOVEnrollment()),
+}));
 
 describe('Success Redirect Transform Tests', () => {
   const REDIRECT_URL = 'https://acme.okta1.com';
@@ -24,7 +31,7 @@ describe('Success Redirect Transform Tests', () => {
 
   beforeEach(() => {
     transaction = getStubTransaction();
-    widgetProps = {};
+    widgetProps = {} as unknown as WidgetProps;
   });
 
   it('should add description & redirect elements only when interstitialRedirect option is not set', () => {
@@ -39,7 +46,9 @@ describe('Success Redirect Transform Tests', () => {
   });
 
   it('should add description & redirect elements only when interstitialRedirect option is set to NONE', () => {
-    widgetProps = { interstitialBeforeLoginRedirect: InterstitialRedirectView.NONE };
+    widgetProps = {
+      interstitialBeforeLoginRedirect: InterstitialRedirectView.NONE,
+    } as unknown as WidgetProps;
     const formBag = redirectTransformer(transaction, REDIRECT_URL, widgetProps);
 
     expect(formBag.uischema.elements.length).toBe(2);
@@ -64,7 +73,7 @@ describe('Success Redirect Transform Tests', () => {
     widgetProps = {
       interstitialBeforeLoginRedirect: InterstitialRedirectView.DEFAULT,
       features: { showIdentifier: false },
-    };
+    } as unknown as WidgetProps;
     const formBag = redirectTransformer(
       transaction,
       REDIRECT_URL,
@@ -87,7 +96,7 @@ describe('Success Redirect Transform Tests', () => {
     widgetProps = {
       interstitialBeforeLoginRedirect: InterstitialRedirectView.DEFAULT,
       features: { showIdentifier: true },
-    };
+    } as unknown as WidgetProps;
     const formBag = redirectTransformer(
       transaction,
       REDIRECT_URL,
@@ -112,7 +121,9 @@ describe('Success Redirect Transform Tests', () => {
       type: 'object',
       value: appInfo,
     };
-    widgetProps = { interstitialBeforeLoginRedirect: InterstitialRedirectView.DEFAULT };
+    widgetProps = {
+      interstitialBeforeLoginRedirect: InterstitialRedirectView.DEFAULT,
+    } as unknown as WidgetProps;
     const formBag = redirectTransformer(
       transaction,
       REDIRECT_URL,
@@ -126,5 +137,35 @@ describe('Success Redirect Transform Tests', () => {
     expect(formBag.uischema.elements[1].type).toBe('Redirect');
     expect((formBag.uischema.elements[1] as RedirectElement).options?.url).toBe(REDIRECT_URL);
     expect(formBag.uischema.elements[2].type).toBe('Spinner');
+  });
+
+  it.each(['DEFAULT', 'NONE', undefined])('should add OV subtitle and button when interstitialBeforeLoginRedirect value is: %s and isAndroidOVEnrollment: true', (interstitialBeforeLoginRedirect) => {
+    transaction = {
+      ...transaction,
+      context: {
+        ...transaction.context,
+        success: {
+          name: IDX_STEP.SUCCESS_REDIRECT,
+          href: 'http://localhost:3000/success_redirect',
+        },
+      },
+    };
+    widgetProps = {
+      interstitialBeforeLoginRedirect,
+    } as unknown as WidgetProps;
+    mockIsAndroidOVEnrollment.mockReturnValue(true);
+    const formBag = redirectTransformer(
+      transaction,
+      REDIRECT_URL,
+      widgetProps,
+    );
+
+    expect(formBag.uischema.elements.length).toBe(2);
+    expect(formBag.uischema.elements[0].type).toBe('Description');
+    expect((formBag.uischema.elements[0] as DescriptionElement).options?.content)
+      .toBe('oie.success.text.signingIn.with.appName.android.ov.enrollment');
+    expect(formBag.uischema.elements[1].type).toBe('Button');
+    expect((formBag.uischema.elements[1] as ButtonElement).options?.step)
+      .toBe(IDX_STEP.SUCCESS_REDIRECT);
   });
 });

--- a/src/v3/src/transformer/redirect/redirectTransformer.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.ts
@@ -12,8 +12,11 @@
 
 import { IdxTransaction } from '@okta/okta-auth-js';
 
+import Util from '../../../../util/Util';
 import { InterstitialRedirectView } from '../../constants';
 import {
+  ButtonElement,
+  ButtonType,
   DescriptionElement,
   FormBag,
   RedirectElement,
@@ -21,6 +24,8 @@ import {
   WidgetProps,
 } from '../../types';
 import { getAppInfo, getUserInfo, loc } from '../../util';
+import { createIdentifierContainer } from '../uischema/createIdentifierContainer';
+import { setFocusOnFirstElement } from '../uischema/setFocusOnFirstElement';
 import { createForm } from '../utils';
 
 export const redirectTransformer = (
@@ -32,6 +37,38 @@ export const redirectTransformer = (
   const formBag = createForm();
 
   const { uischema } = formBag;
+  const { context } = transaction;
+
+  // OKTA-635926: add user gesture for ov enrollment on android
+  if (Util.isAndroidOVEnrollment()) {
+    createIdentifierContainer({
+      transaction,
+      widgetProps,
+      step: '',
+      setMessage: () => {},
+      isClientTransaction: false,
+    })(formBag);
+
+    const subtitleElement: DescriptionElement = {
+      type: 'Description',
+      contentType: 'subtitle',
+      options: { content: loc('oie.success.text.signingIn.with.appName.android.ov.enrollment', 'login') },
+    };
+
+    const redirectBtn: ButtonElement = {
+      type: 'Button',
+      label: loc('oktaVerify.open.button', 'login'),
+      options: {
+        type: ButtonType.BUTTON,
+        step: context.success?.name || '',
+        onClick: () => Util.redirectWithFormGet(context.success?.href),
+      },
+    };
+    uischema.elements = uischema.elements.concat([subtitleElement, redirectBtn]);
+    setFocusOnFirstElement(formBag);
+    return formBag;
+  }
+
   uischema.elements.push({
     type: 'Redirect',
     options: { url },

--- a/src/v3/src/util/idxUtils.test.ts
+++ b/src/v3/src/util/idxUtils.test.ts
@@ -24,6 +24,11 @@ import {
   triggerRegistrationErrorMessages,
 } from '.';
 
+const mockIsAndroidOVEnrollment = jest.fn();
+jest.mock('../../../util/Util', () => ({
+  isAndroidOVEnrollment: jest.fn().mockImplementation(() => mockIsAndroidOVEnrollment()),
+}));
+
 describe('IdxUtils Tests', () => {
   const TEST_USERNAME = 'tester@test.com';
   const TEST_FIRSTNAME = 'Tester';
@@ -137,6 +142,21 @@ describe('IdxUtils Tests', () => {
       ],
     };
     expect(buildAuthCoinProps(transaction)?.authenticatorKey).toBe(AUTHENTICATOR_KEY.EMAIL);
+  });
+
+  it('should build AuthCoin data when isAndroidOVEnrollment is true and is success redirect transaction', () => {
+    transaction = {
+      ...transaction,
+      context: {
+        ...transaction.context,
+        success: {
+          name: 'success-redirect',
+          href: 'http://localhost:3000/success_redirect',
+        },
+      },
+    };
+    mockIsAndroidOVEnrollment.mockReturnValue(true);
+    expect(buildAuthCoinProps(transaction)?.authenticatorKey).toBe(AUTHENTICATOR_KEY.OV);
   });
 
   it('should not perform conversion of Idx Inputs into Registration schema elements when input array is empty', () => {
@@ -364,7 +384,7 @@ describe('IdxUtils Tests', () => {
       widgetProps = {
         authClient: mockAuthClient,
         otp,
-      };
+      } as unknown as WidgetProps;
     });
 
     describe('if there is an interactionHandle in storage', () => {

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -25,6 +25,7 @@ import {
 import { IdxForm } from '@okta/okta-auth-js/types/lib/idx/types/idx-js';
 import { StateUpdater } from 'preact/hooks';
 
+import Util from '../../../util/Util';
 import { getMessage } from '../../../v2/ion/i18nUtils';
 import {
   AUTHENTICATOR_KEY,
@@ -109,6 +110,11 @@ export const buildAuthCoinProps = (
 ): AuthCoinProps | undefined => {
   if (!transaction) {
     return undefined;
+  }
+
+  if (Util.isAndroidOVEnrollment()
+    && transaction.context.success?.name === IDX_STEP.SUCCESS_REDIRECT) {
+    return { authenticatorKey: AUTHENTICATOR_KEY.OV };
   }
 
   const { nextStep, messages } = transaction;

--- a/src/v3/test/integration/__snapshots__/terminal-okta-verify-enrollment-android-device.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-okta-verify-enrollment-android-device.test.tsx.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`terminal-okta-verify-enrollment-android-device should render form 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-se="auth-container main-container"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="MuiScopedCssBaseline-root emotion-2"
+      >
+        <div
+          class="MuiBox-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="MuiBox-root emotion-5"
+              data-se="okta-sign-in-header auth-header authCoinSpacing"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 emotion-6"
+                tabindex="-1"
+              />
+              <div
+                aria-hidden="true"
+                class="MuiBox-root emotion-7"
+                data-se="factor-beacon mfa-okta-verify "
+              >
+                <svg
+                  aria-labelledby="mfa-okta-verify"
+                  fill="none"
+                  height="2.85714286rem"
+                  role="img"
+                  viewBox="0 0 48 48"
+                  width="2.85714286rem"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <title
+                    id="mfa-okta-verify"
+                  >
+                    Okta Verify
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M32.872 22.853a8.947 8.947 0 1 1-2.288-4.91L24 24.498l-3.205-3.19c-.482-.48-1.322-.48-1.804 0a1.26 1.26 0 0 0-.374.898c0 .34.133.659.374.898l4.107 4.09c.24.239.561.371.902.371.336 0 .664-.136.902-.372L38.636 13.52a18.089 18.089 0 0 0-1.634-1.967A17.947 17.947 0 0 0 24 6C14.059 6 6 14.059 6 24s8.059 18 18 18 18-8.059 18-18c0-2.972-.722-5.775-1.998-8.245l-7.13 7.098Z"
+                    fill="#00297A"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-8"
+            >
+              <form
+                aria-live="polite"
+                class="o-form MuiBox-root emotion-9"
+                data-se="o-form"
+                novalidate=""
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-12"
+                      data-se="identifier-container"
+                      title="tester@okta1.com"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-13"
+                        data-se="identifier"
+                        translate="no"
+                      >
+                        <div
+                          class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-14"
+                        >
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M15.5 6.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Zm2 0a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0ZM5 23c0-2.357.694-4.363 1.886-5.762C8.064 15.856 9.782 15 12 15c2.215 0 3.934.862 5.113 2.25C18.307 18.652 19 20.66 19 23h2c0-2.722-.807-5.216-2.363-7.046C17.067 14.107 14.785 13 12 13c-2.782 0-5.064 1.097-6.636 2.941C3.806 17.77 3 20.263 3 23h2Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              User
+                            </title>
+                          </svg>
+                        </div>
+                        <span
+                          class="MuiChip-label MuiChip-labelMedium emotion-16"
+                        >
+                          tester@okta1.com
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 emotion-19"
+                        data-se="o-form-explain"
+                        tabindex="-1"
+                      >
+                        To continue, tap "Open Okta Verify"
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-21"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Open Okta Verify
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;

--- a/src/v3/test/integration/terminal-okta-verify-enrollment-android-device.test.tsx
+++ b/src/v3/test/integration/terminal-okta-verify-enrollment-android-device.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { setup } from './util';
+
+import mockResponse from '../../../../playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json';
+
+jest.mock('../../../util/Util', () => {
+  const original = jest.requireActual('../../../util/Util');
+  return {
+    __esModule: true,
+    default: original.default,
+    isAndroidOVEnrollment: jest.fn().mockReturnValue(true),
+  };
+});
+
+describe('terminal-okta-verify-enrollment-android-device', () => {
+  it('should render form', async () => {
+    const { container, findByText } = await setup({ mockResponse });
+    await findByText(/To continue, tap "Open Okta Verify"/);
+    await findByText('Open Okta Verify', { selector: 'button' });
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/v3/test/integration/terminal-okta-verify-enrollment-android-device.test.tsx
+++ b/src/v3/test/integration/terminal-okta-verify-enrollment-android-device.test.tsx
@@ -13,18 +13,11 @@
 import { setup } from './util';
 
 import mockResponse from '../../../../playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json';
-
-jest.mock('../../../util/Util', () => {
-  const original = jest.requireActual('../../../util/Util');
-  return {
-    __esModule: true,
-    default: original.default,
-    isAndroidOVEnrollment: jest.fn().mockReturnValue(true),
-  };
-});
+import Util from '../../../util/Util';
 
 describe('terminal-okta-verify-enrollment-android-device', () => {
   it('should render form', async () => {
+    jest.spyOn(Util, 'isAndroidOVEnrollment').mockReturnValue(true);
     const { container, findByText } = await setup({ mockResponse });
     await findByText(/To continue, tap "Open Okta Verify"/);
     await findByText('Open Okta Verify', { selector: 'button' });


### PR DESCRIPTION
## Description:

The purpose of this PR is to meet parity for the OV enrollment flow on an Android device in SIW Gen 3. Original implementation can be found here: https://github.com/okta/okta-signin-widget/pull/3372

Since the original PR, a fix was made to ensure this flow ignores the interstitialBeforeLoginRedirect config option, which has been implemented for Gen 3. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-704879](https://oktainc.atlassian.net/browse/OKTA-704879)

### Reviewers:

### Screenshot/Video:
OV Enrollment view on Android device: 
<img width="571" alt="image" src="https://github.com/okta/okta-signin-widget/assets/97472729/67aec43d-bdac-48de-9e16-b69d1fe98302">



### Downstream Monolith Build:



