### PR TITLE
OKTA-704879 : Gen 3 : fix : OV enrollment on android device

### DIFF
--- a/playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json
+++ b/playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json
@@ -1,0 +1,72 @@
+{
+    "version": "1.0.0",
+    "stateHandle": "abcd.1234.defagh",
+    "expiresAt": "2024-02-16T15:27:57.000Z",
+    "intent": "CREDENTIAL_ENROLLMENT",
+    "user": {
+        "type": "object",
+        "value": {
+            "id": "00u12fnxjbjtgwaUP0h8",
+            "identifier": "tester@okta1.com",
+            "profile": {
+                "firstName": "Tester",
+                "lastName": "McTesterson",
+                "timeZone": "America/Los_Angeles",
+                "locale": "en_US"
+            }
+        }
+    },
+    "success": {
+        "name": "success-redirect",
+        "href": "http://localhost:3000/login/token/redirect?stateToken=02.id.E5Z9_9ITDXufLZm6JUSRLAP_PUJWhdg4E6lMUGwo"
+    },
+    "cancel": {
+        "rel": [
+            "create-form"
+        ],
+        "name": "cancel",
+        "href": "http://localhost:3000/idp/idx/cancel",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+            {
+                "name": "stateHandle",
+                "required": true,
+                "value": "abcd.1234.defagh",
+                "visible": false,
+                "mutable": false
+            }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+    },
+    "app": {
+        "type": "object",
+        "value": {
+            "name": "Okta_Authenticator",
+            "label": "Okta Authenticator",
+            "id": "BDSC3453323dsdfS"
+        }
+    },
+    "authentication": {
+        "type": "object",
+        "value": {
+            "protocol": "OAUTH2.0",
+            "issuer": {
+                "name": "Test App",
+                "uri": "http://localhost:3000"
+            },
+            "request": {
+                "max_age": -1,
+                "scope": "openid profile email okta.authenticators.read okta.authenticators.manage.self",
+                "display": "page",
+                "response_type": "code",
+                "redirect_uri": "https://login.okta.com/oauth/callback",
+                "state": "i41VVuProw96htTUmvRP9A",
+                "code_challenge_method": "S256",
+                "nonce": "ASDF4343SDFS3-GhS8SQCw",
+                "code_challenge": "abcd_8asd8asdf8as98fasdf_-_9sadif9rasd9fasdf-cc",
+                "response_mode": "query"
+            }
+        }
+    }
+}

--- a/src/v3/src/transformer/redirect/redirectTransformer.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.ts
@@ -12,8 +12,11 @@
 
 import { IdxTransaction } from '@okta/okta-auth-js';
 
+import Util from '../../../../util/Util';
 import { InterstitialRedirectView } from '../../constants';
 import {
+  ButtonElement,
+  ButtonType,
   DescriptionElement,
   FormBag,
   RedirectElement,
@@ -21,6 +24,8 @@ import {
   WidgetProps,
 } from '../../types';
 import { getAppInfo, getUserInfo, loc } from '../../util';
+import { createIdentifierContainer } from '../uischema/createIdentifierContainer';
+import { setFocusOnFirstElement } from '../uischema/setFocusOnFirstElement';
 import { createForm } from '../utils';
 
 export const redirectTransformer = (
@@ -32,6 +37,38 @@ export const redirectTransformer = (
   const formBag = createForm();
 
   const { uischema } = formBag;
+  const { context } = transaction;
+
+  // OKTA-635926: add user gesture for ov enrollment on android
+  if (Util.isAndroidOVEnrollment()) {
+    createIdentifierContainer({
+      transaction,
+      widgetProps,
+      step: '',
+      setMessage: () => {},
+      isClientTransaction: false,
+    })(formBag);
+
+    const subtitleElement: DescriptionElement = {
+      type: 'Description',
+      contentType: 'subtitle',
+      options: { content: loc('oie.success.text.signingIn.with.appName.android.ov.enrollment', 'login') },
+    };
+
+    const redirectBtn: ButtonElement = {
+      type: 'Button',
+      label: loc('oktaVerify.open.button', 'login'),
+      options: {
+        type: ButtonType.BUTTON,
+        step: context.success?.name || '',
+        onClick: () => Util.redirectWithFormGet(context.success?.href),
+      },
+    };
+    uischema.elements = uischema.elements.concat([subtitleElement, redirectBtn]);
+    setFocusOnFirstElement(formBag);
+    return formBag;
+  }
+  
   uischema.elements.push({
     type: 'Redirect',
     options: { url },

--- a/src/v3/src/transformer/redirect/redirectTransformer.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.ts
@@ -68,7 +68,7 @@ export const redirectTransformer = (
     setFocusOnFirstElement(formBag);
     return formBag;
   }
-  
+
   uischema.elements.push({
     type: 'Redirect',
     options: { url },

--- a/src/v3/src/util/idxUtils.test.ts
+++ b/src/v3/src/util/idxUtils.test.ts
@@ -24,6 +24,11 @@ import {
   triggerRegistrationErrorMessages,
 } from '.';
 
+const mockIsAndroidOVEnrollment = jest.fn();
+jest.mock('../../../util/Util', () => ({
+  isAndroidOVEnrollment: jest.fn().mockImplementation(() => mockIsAndroidOVEnrollment()),
+}));
+
 describe('IdxUtils Tests', () => {
   const TEST_USERNAME = 'tester@test.com';
   const TEST_FIRSTNAME = 'Tester';
@@ -137,6 +142,21 @@ describe('IdxUtils Tests', () => {
       ],
     };
     expect(buildAuthCoinProps(transaction)?.authenticatorKey).toBe(AUTHENTICATOR_KEY.EMAIL);
+  });
+
+  it('should build AuthCoin data when isAndroidOVEnrollment is true and is success redirect transaction', () => {
+    transaction = {
+      ...transaction,
+      context: {
+        ...transaction.context,
+        success: {
+          name: 'success-redirect',
+          href: 'http://localhost:3000/success_redirect',
+        },
+      },
+    };
+    mockIsAndroidOVEnrollment.mockReturnValue(true);
+    expect(buildAuthCoinProps(transaction)?.authenticatorKey).toBe(AUTHENTICATOR_KEY.OV);
   });
 
   it('should not perform conversion of Idx Inputs into Registration schema elements when input array is empty', () => {
@@ -364,7 +384,7 @@ describe('IdxUtils Tests', () => {
       widgetProps = {
         authClient: mockAuthClient,
         otp,
-      };
+      } as unknown as WidgetProps;
     });
 
     describe('if there is an interactionHandle in storage', () => {

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -25,6 +25,7 @@ import {
 import { IdxForm } from '@okta/okta-auth-js/types/lib/idx/types/idx-js';
 import { StateUpdater } from 'preact/hooks';
 
+import Util from '../../../util/Util';
 import { getMessage } from '../../../v2/ion/i18nUtils';
 import {
   AUTHENTICATOR_KEY,
@@ -112,6 +113,11 @@ export const buildAuthCoinProps = (
   }
 
   const { nextStep, messages } = transaction;
+  if (Util.isAndroidOVEnrollment()
+    && transaction.context.success?.name === IDX_STEP.SUCCESS_REDIRECT) {
+    return { authenticatorKey: AUTHENTICATOR_KEY.OV };
+  }
+
   if (containsOneOfMessageKeys(EMAIL_AUTHENTICATOR_TERMINAL_KEYS, messages)
     || nextStep?.name === IDX_STEP.CONSENT_EMAIL_CHALLENGE) {
     return { authenticatorKey: AUTHENTICATOR_KEY.EMAIL };

--- a/src/v3/test/integration/__snapshots__/terminal-okta-verify-enrollment-android-device.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-okta-verify-enrollment-android-device.test.tsx.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`terminal-okta-verify-enrollment-android-device should render form 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-se="auth-container main-container"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="MuiScopedCssBaseline-root emotion-2"
+      >
+        <div
+          class="MuiBox-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="MuiBox-root emotion-5"
+              data-se="okta-sign-in-header auth-header authCoinSpacing"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 emotion-6"
+                tabindex="-1"
+              />
+              <div
+                aria-hidden="true"
+                class="MuiBox-root emotion-7"
+                data-se="factor-beacon mfa-okta-verify "
+              >
+                <svg
+                  aria-labelledby="mfa-okta-verify"
+                  fill="none"
+                  height="2.85714286rem"
+                  role="img"
+                  viewBox="0 0 48 48"
+                  width="2.85714286rem"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <title
+                    id="mfa-okta-verify"
+                  >
+                    Okta Verify
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M32.872 22.853a8.947 8.947 0 1 1-2.288-4.91L24 24.498l-3.205-3.19c-.482-.48-1.322-.48-1.804 0a1.26 1.26 0 0 0-.374.898c0 .34.133.659.374.898l4.107 4.09c.24.239.561.371.902.371.336 0 .664-.136.902-.372L38.636 13.52a18.089 18.089 0 0 0-1.634-1.967A17.947 17.947 0 0 0 24 6C14.059 6 6 14.059 6 24s8.059 18 18 18 18-8.059 18-18c0-2.972-.722-5.775-1.998-8.245l-7.13 7.098Z"
+                    fill="#00297A"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-8"
+            >
+              <form
+                aria-live="polite"
+                class="o-form MuiBox-root emotion-9"
+                data-se="o-form"
+                novalidate=""
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-12"
+                      data-se="identifier-container"
+                      title="tester@okta1.com"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-13"
+                        data-se="identifier"
+                        translate="no"
+                      >
+                        <div
+                          class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-14"
+                        >
+                          <svg
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M15.5 6.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Zm2 0a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0ZM5 23c0-2.357.694-4.363 1.886-5.762C8.064 15.856 9.782 15 12 15c2.215 0 3.934.862 5.113 2.25C18.307 18.652 19 20.66 19 23h2c0-2.722-.807-5.216-2.363-7.046C17.067 14.107 14.785 13 12 13c-2.782 0-5.064 1.097-6.636 2.941C3.806 17.77 3 20.263 3 23h2Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              User
+                            </title>
+                          </svg>
+                        </div>
+                        <span
+                          class="MuiChip-label MuiChip-labelMedium emotion-16"
+                        >
+                          tester@okta1.com
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 emotion-19"
+                        data-se="o-form-explain"
+                        tabindex="-1"
+                      >
+                        To continue, tap "Open Okta Verify"
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-21"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Open Okta Verify
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;

--- a/src/v3/test/integration/terminal-okta-verify-enrollment-android-device.test.tsx
+++ b/src/v3/test/integration/terminal-okta-verify-enrollment-android-device.test.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { setup } from './util';
+
+import mockResponse from '../../../../playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json';
+import Util from '../../../util/Util';
+
+describe('terminal-okta-verify-enrollment-android-device', () => {
+  it('should render form', async () => {
+    jest.spyOn(Util, 'isAndroidOVEnrollment').mockReturnValue(true);
+    const { container, findByText } = await setup({ mockResponse });
+    await findByText(/To continue, tap "Open Okta Verify"/);
+    await findByText('Open Okta Verify', { selector: 'button' });
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -30,6 +30,7 @@ const ignoredMocks = [
   'enroll-profile-new-boolean-fields.json', // custom registration fields
   'authenticator-expired-custom-password.json', // seems to be flaky
   'enroll-profile-new-custom-labels.json', // custom message/label
+  'terminal-okta-verify-enrollment-android-device.json', // Automatic redirect, in app logic handles this view, no english leak.
 ];
 
 const optionsForInteractionCodeFlow = {


### PR DESCRIPTION
## Description:
The purpose of this PR is to meet parity for the OV enrollment flow on an Android device in SIW Gen 3. Original implementation can be found here: https://github.com/okta/okta-signin-widget/pull/3372

Since the original PR, a fix was made to ensure this flow ignores the interstitialBeforeLoginRedirect config option, which has been implemented for Gen 3.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-704879](https://oktainc.atlassian.net/browse/OKTA-704879)

### Reviewers:

### Screenshot/Video:
![image](https://github.com/okta/okta-signin-widget/assets/97472729/565fc9dc-8eae-41f8-aafe-97c1e66fb921)


### Downstream Monolith Build:



