### PR TITLE
Gen1: Don't translate API error E0000068 message

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -99,11 +99,16 @@ Util.transformErrorXHR = function(xhr) {
   }
   // Replace error messages
   if (!_.isEmpty(xhr.responseJSON)) {
-    const errorMsg = xhr.responseJSON.errorCode
+    const { errorCode } = xhr.responseJSON;
+    const untranslatedErrorCodes = [
+      // API already provides localized and factor specific error message in errorCauses
+      'E0000068',
+    ];
+    const errorMsg = errorCode && !untranslatedErrorCodes.includes(errorCode)
       // We don't pass parameters to the `loc()` util
       // However some i18n keys like `errors.E0000001` require one parameter
       // Don't dispatch custom 'okta-i18n-error' event in this case
-      ? loc('errors.' + xhr.responseJSON.errorCode, 'login', [], true)
+      ? loc('errors.' + errorCode, 'login', [], true)
       : undefined;
 
     if (errorMsg?.indexOf('L10N_ERROR[') === -1) {

--- a/test/unit/spec/v1/EnrollCall_spec.js
+++ b/test/unit/spec/v1/EnrollCall_spec.js
@@ -506,6 +506,8 @@ Expect.describe('EnrollCall', function() {
         });
     });
     itp('shows error if error response on verification', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
       return setupAndSendCodeFn()
         .then(function(test) {
           Q.stopUnhandledRejectionTracking();
@@ -545,6 +547,7 @@ Expect.describe('EnrollCall', function() {
               },
             },
           ]);
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
     });
   }

--- a/test/unit/spec/v1/EnrollSms_spec.js
+++ b/test/unit/spec/v1/EnrollSms_spec.js
@@ -724,6 +724,8 @@ Expect.describe('EnrollSms', function() {
         });
     });
     itp('shows error if error response on verification', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
       return sendValidCodeFn()
         .then(function(test) {
           test.setNextResponse(resEnrollActivateError);
@@ -762,6 +764,7 @@ Expect.describe('EnrollSms', function() {
               },
             },
           ]);
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
     });
   }

--- a/test/unit/spec/v1/MfaVerify_spec.js
+++ b/test/unit/spec/v1/MfaVerify_spec.js
@@ -1117,6 +1117,8 @@ Expect.describe('MFA Verify', function() {
         });
     });
     itp('shows an error if error response from authClient', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
       return setupFn()
         .then(function(test) {
           test.setNextResponse(resInvalid);
@@ -1127,6 +1129,7 @@ Expect.describe('MFA Verify', function() {
         .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Your answer doesn\'t match our records. Please try again.');
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
     });
     itp('shows errors if verify button is clicked and answer is empty', function() {
@@ -2065,6 +2068,8 @@ Expect.describe('MFA Verify', function() {
         });
     });
     itp('shows an error if error response from authClient', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
       return setupFn()
         .then(function(test) {
           test.setNextResponse(resInvalidTotp);
@@ -2086,6 +2091,7 @@ Expect.describe('MFA Verify', function() {
               errorCauses: [],
             },
           });
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
     });
     itp('shows errors if verify button is clicked and answer is empty', function() {
@@ -2223,6 +2229,8 @@ Expect.describe('MFA Verify', function() {
         });
     });
     itp('shows an error if error response from authClient', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
       return setupFn()
         .then(function(test) {
           test.setNextResponse(resInvalidPassword);
@@ -2250,6 +2258,7 @@ Expect.describe('MFA Verify', function() {
               ],
             },
           });
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
     });
     itp('shows errors if verify button is clicked and password is empty', function() {
@@ -3627,6 +3636,8 @@ Expect.describe('MFA Verify', function() {
             });
         });
         itp('shows an error if error response from authClient', function() {
+          // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+          const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
           return setupOktaPushWithTOTP()
             .then(function(test) {
               const form = test.form[1];
@@ -3643,6 +3654,7 @@ Expect.describe('MFA Verify', function() {
             .then(function(form) {
               expect(form.hasErrors()).toBe(true);
               expect(form.errorMessage()).toBe('Invalid Passcode/Answer');
+              expect(dispatchEventSpy).not.toHaveBeenCalled();
             });
         });
         itp('shows errors if verify button is clicked and answer is empty', function() {


### PR DESCRIPTION
## Description:

This PR replaces https://github.com/okta/okta-signin-widget/pull/3561

Error [E0000068](https://developer.okta.com/docs/reference/error-codes/#E0000068) should not be translated on client-side.
Because it can appear in different contexts:  https://github.com/okta/okta-signin-widget/pull/3561#discussion_r1520488474
So a translation would be too generic like "Invalid Passcode/Answer".
Instead we can just use error message from API as before. It's factor specific and translated.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-700843](https://oktainc.atlassian.net/browse/OKTA-700843)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



