### PR TITLE
OKTA-706541 Stop polling when SIW makes /poll/cancel call

### DIFF
--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -170,6 +170,10 @@ const Body = BaseFormWithPolling.extend({
           Logger.error(`Authenticator is not listening on port ${currentPort}.`);
           if (countFailedPorts === ports.length) {
             Logger.error('No available ports. Loopback server failed and polling is cancelled.');
+            // When no port is found, cancel the polling as well
+            // This is to avoid concurrency issue where /poll/cancel takes long time to complete
+            // and SIW will receive 400 error if the polling continues
+            this.stopPolling();
             cancelPollingWithParams(
               this.options.appState,
               this.pollingCancelAction,

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -385,25 +385,25 @@ test
     await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
   });
 
-  test
-    .meta('gen3', false) // Gen3 does not have the same redundant polling issue as Gen2 and does not need to implement enhancedPollingEnabled, so skip this test
-    .requestHooks(loopbackRedundantPollingForPollCancelMock)('in loopback server, no more polling when cancel polling has been called', async t => {
-      const deviceChallengePollPageObject = await setup(t);
-      await checkA11y(t);
-      await t.expect(deviceChallengePollPageObject.getBeaconSelector()).contains(BEACON_CLASS);
-      await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
-      await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
-      await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().innerText).eql('Verify with something else');
-      await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
+test
+  .meta('gen3', false) // Gen3 does not have the same redundant polling issue as Gen2 and does not need to implement enhancedPollingEnabled, so skip this test
+  .requestHooks(loopbackRedundantPollingForPollCancelMock)('in loopback server, no more polling when cancel polling has been called', async t => {
+    const deviceChallengePollPageObject = await setup(t);
+    await checkA11y(t);
+    await t.expect(deviceChallengePollPageObject.getBeaconSelector()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
+    await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
+    await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().innerText).eql('Verify with something else');
+    await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
 
-      // this wait time makes sure we don't assert too early if /poll call happens
-      await t.wait(2000);
-      await t.expect(deviceChallengePollPageObject.hasErrorBox()).eql(false);
-  
-      const identityPage = new IdentityPageObject(t);
-      await identityPage.fillIdentifierField('Test Identifier');
-      await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
-    });
+    // this wait time makes sure we don't assert too early if /poll call happens
+    await t.wait(2000);
+    await t.expect(deviceChallengePollPageObject.hasErrorBox()).eql(false);
+
+    const identityPage = new IdentityPageObject(t);
+    await identityPage.fillIdentifierField('Test Identifier');
+    await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+  });
 
 test
   .requestHooks(loopbackEnhancedPollingLogger, loopbackEnhancedPollingMock)('in loopback server, no redundant polling if server returns enhancedPollingEnabled as true', async t => {

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -189,13 +189,22 @@ const loopbackBiometricsErrorMobileAfterProbePollMock = RequestMock()
 const loopbackBiometricsErrorMobileMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/introspect/)
   .respond(identifyWithUserVerificationLoopback)
-  .onRequestTo(/2000|6511|6512|6513\/probe/)
+  .onRequestTo(/2000|6511\/probe/)
   .respond(null, 500, {
     'access-control-allow-origin': '*',
     'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
   })
-  .onRequestTo(/\/idp\/idx\/authenticators\/poll\/cancel/)
-  .respond(identifyWithUserVerificationLoopback);
+  .onRequestTo(/6512\/probe/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6512\/challenge/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
+    'access-control-allow-methods': 'POST, OPTIONS'
+  });
 
 const loopbackBiometricsErrorDesktopAfterProbePollMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
@@ -206,13 +215,22 @@ const loopbackBiometricsErrorDesktopAfterProbePollMock = RequestMock()
 const loopbackBiometricsErrorDesktopMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/introspect/)
   .respond(identifyWithUserVerificationLoopback)
-  .onRequestTo(/2000|6511|6512|6513\/probe/)
+  .onRequestTo(/2000|6511\/probe/)
   .respond(null, 500, {
     'access-control-allow-origin': '*',
     'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
   })
-  .onRequestTo(/\/idp\/idx\/authenticators\/poll\/cancel/)
-  .respond(identifyWithUserVerificationLoopback);
+  .onRequestTo(/6512\/probe/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6512\/challenge/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
+    'access-control-allow-methods': 'POST, OPTIONS'
+  });
 
 const loopbackBiometricsNoResponseErrorLogger = RequestLogger(
   /introspect|probe|cancel|challenge|poll/,
@@ -499,7 +517,7 @@ test
   });
 
 test
-  .requestHooks(loopbackBiometricsErrorMobileMock, loopbackBiometricsErrorInitialPollMock)('show biometrics error for mobile platform in loopback', async t => {
+  .requestHooks(loopbackBiometricsErrorMobileMock, loopbackBiometricsErrorInitialPollMock)('abc', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await checkA11y(t);
     await t.expect(deviceChallengePollPageObject.getBeaconSelector()).contains(BEACON_CLASS);
@@ -525,7 +543,7 @@ test
   });
 
 test
-  .requestHooks(loopbackBiometricsErrorDesktopMock, loopbackBiometricsErrorInitialPollMock)('show biometrics error for desktop platform in loopback', async t => {
+  .requestHooks(loopbackBiometricsErrorDesktopMock, loopbackBiometricsErrorInitialPollMock)('bcd', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await checkA11y(t);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -517,7 +517,7 @@ test
   });
 
 test
-  .requestHooks(loopbackBiometricsErrorMobileMock, loopbackBiometricsErrorInitialPollMock)('abc', async t => {
+  .requestHooks(loopbackBiometricsErrorMobileMock, loopbackBiometricsErrorInitialPollMock)('show biometrics error for mobile platform in loopback', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await checkA11y(t);
     await t.expect(deviceChallengePollPageObject.getBeaconSelector()).contains(BEACON_CLASS);
@@ -543,7 +543,7 @@ test
   });
 
 test
-  .requestHooks(loopbackBiometricsErrorDesktopMock, loopbackBiometricsErrorInitialPollMock)('bcd', async t => {
+  .requestHooks(loopbackBiometricsErrorDesktopMock, loopbackBiometricsErrorInitialPollMock)('show biometrics error for desktop platform in loopback', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await checkA11y(t);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');


### PR DESCRIPTION
## Description:
- When we make /poll/cancel from SIW, there is a corner case that when it takes long time to complete (5-10 seconds), there will be proceeding polling call happen before /poll/cancel completes
- Even the /poll/cancel is not completed yet, the FastPass transaction is completed in the backend and hence the poll call will not be able to find it, hence the 400
- The fix is to stop polling when we decide to call the /poll/cancel call
- Ideally we should put this under the cancel polling method, but to make it less risky and quicker to unblock the customers, we only added it for use cases where OV is not reachable from SIW
- Created https://oktainc.atlassian.net/browse/OKTA-712835 as a fast follow


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-706541](https://oktainc.atlassian.net/browse/OKTA-706541)

### Reviewers:
@lesterchoi-okta @shuowu 

### Screenshot/Video:
Before and after fix testcafe video https://drive.google.com/drive/u/0/folders/110QsoolJrkBR6flnXavUqL64RlN6ONpb



