### PR TITLE
Display masked primary email during email enrollment

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-false.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-false.json
@@ -246,7 +246,10 @@
     "type": "object",
     "value": {
       "id": "00u2m55pu8UZyeMMl0g4",
-      "identifier": "testUser@okta.com"
+      "identifier": "testUser@okta.com",
+      "profile": {
+        "email": "t*****@okta.com"
+      }
     }
   },
   "cancel": {

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -10,7 +10,8 @@ const Body = BaseAuthenticatorEmailForm.extend(
     initialize() {
       BaseAuthenticatorEmailForm.prototype.initialize.apply(this, arguments);
 
-      const email = this.options.appState.get('user')?.identifier || {};
+      const email = this.options.appState.get('user')?.profile?.email || (this.options.appState.get('user')?.identifier || {});
+      console.log(this.options.appState.get('user')?.profile?.email);
 
       const useEmailMagicLinkValue = this.isUseEmailMagicLink();
 

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -10,8 +10,8 @@ const Body = BaseAuthenticatorEmailForm.extend(
     initialize() {
       BaseAuthenticatorEmailForm.prototype.initialize.apply(this, arguments);
 
-      const email = this.options.appState.get('user')?.profile?.email || (this.options.appState.get('user')?.identifier
-       || {});
+      const email = this.options.appState.get('user')?.profile?.email || this.options.appState.get('user')?.identifier
+       || {};
 
       const useEmailMagicLinkValue = this.isUseEmailMagicLink();
 

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -10,8 +10,8 @@ const Body = BaseAuthenticatorEmailForm.extend(
     initialize() {
       BaseAuthenticatorEmailForm.prototype.initialize.apply(this, arguments);
 
-      const email = this.options.appState.get('user')?.profile?.email || (this.options.appState.get('user')?.identifier || {});
-      console.log(this.options.appState.get('user')?.profile?.email);
+      const email = this.options.appState.get('user')?.profile?.email || (this.options.appState.get('user')?.identifier
+       || {});
 
       const useEmailMagicLinkValue = this.isUseEmailMagicLink();
 

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
@@ -68,8 +68,8 @@ export const transformEmailAuthenticatorEnroll: IdxStepTransformer = ({ transact
   if (typeof useEmailMagicLink === 'undefined') {
     subTitleElement.options.content = loc('oie.email.enroll.subtitle', 'login');
   } else {
-    const emailAddress = getUserInfo(transaction)?.profile?.email
-    || getUserInfo(transaction).identifier;
+    const userInfo = getUserInfo(transaction);
+    const emailAddress = userInfo?.profile?.email || userInfo.identifier;
     const tokenReplacement: TokenReplacement | undefined = typeof emailAddress !== 'undefined'
       ? { $1: { element: 'span', attributes: { class: 'strong no-translate' } } }
       : undefined;

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
@@ -68,8 +68,8 @@ export const transformEmailAuthenticatorEnroll: IdxStepTransformer = ({ transact
   if (typeof useEmailMagicLink === 'undefined') {
     subTitleElement.options.content = loc('oie.email.enroll.subtitle', 'login');
   } else {
-    const emailAddress = getUserInfo(transaction)?.profile?.email ||
-    getUserInfo(transaction).identifier;
+    const emailAddress = getUserInfo(transaction)?.profile?.email
+    || getUserInfo(transaction).identifier;
     const tokenReplacement: TokenReplacement | undefined = typeof emailAddress !== 'undefined'
       ? { $1: { element: 'span', attributes: { class: 'strong no-translate' } } }
       : undefined;

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
@@ -68,7 +68,8 @@ export const transformEmailAuthenticatorEnroll: IdxStepTransformer = ({ transact
   if (typeof useEmailMagicLink === 'undefined') {
     subTitleElement.options.content = loc('oie.email.enroll.subtitle', 'login');
   } else {
-    const emailAddress = getUserInfo(transaction)?.profile?.email || getUserInfo(transaction).identifier;
+    const emailAddress = getUserInfo(transaction)?.profile?.email || 
+    getUserInfo(transaction).identifier;
     const tokenReplacement: TokenReplacement | undefined = typeof emailAddress !== 'undefined'
       ? { $1: { element: 'span', attributes: { class: 'strong no-translate' } } }
       : undefined;

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
@@ -68,7 +68,7 @@ export const transformEmailAuthenticatorEnroll: IdxStepTransformer = ({ transact
   if (typeof useEmailMagicLink === 'undefined') {
     subTitleElement.options.content = loc('oie.email.enroll.subtitle', 'login');
   } else {
-    const emailAddress = getUserInfo(transaction)?.profile?.email || 
+    const emailAddress = getUserInfo(transaction)?.profile?.email ||
     getUserInfo(transaction).identifier;
     const tokenReplacement: TokenReplacement | undefined = typeof emailAddress !== 'undefined'
       ? { $1: { element: 'span', attributes: { class: 'strong no-translate' } } }

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
@@ -68,7 +68,7 @@ export const transformEmailAuthenticatorEnroll: IdxStepTransformer = ({ transact
   if (typeof useEmailMagicLink === 'undefined') {
     subTitleElement.options.content = loc('oie.email.enroll.subtitle', 'login');
   } else {
-    const emailAddress = getUserInfo(transaction).identifier;
+    const emailAddress = getUserInfo(transaction)?.profile?.email || getUserInfo(transaction).identifier;
     const tokenReplacement: TokenReplacement | undefined = typeof emailAddress !== 'undefined'
       ? { $1: { element: 'span', attributes: { class: 'strong no-translate' } } }
       : undefined;

--- a/src/v3/src/types/userInfo.ts
+++ b/src/v3/src/types/userInfo.ts
@@ -15,6 +15,7 @@ export type UserInfo = {
   profile?: {
     firstName?: string;
     lastName?: string;
+    email?: string;
   };
   [key: string]: unknown;
 };

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                         <span
                           class="strong no-translate"
                         >
-                          testUser@okta.com
+                          t*****@okta.com
                         </span>
                         . Enter the verification code in the text box.
                       </p>

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -162,7 +162,7 @@ test
 
     await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
 
-    const emailAddress = xhrEnrollEmailWithoutEmailMagicLink.user.value.identifier;
+    const emailAddress = xhrEnrollEmailWithoutEmailMagicLink.user.value.profile.email;
     await t.expect(await enrollEmailPageObject.verificationLinkTextExists(emailAddress)).ok();
 
     await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).notOk();


### PR DESCRIPTION
## Description:
* Display masked email during email enrollment
* Currently we are showing identifier/username as sent to email which may not be same for all users.
* We are sending masked email now from backend which will be used with this change.

## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-625907](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:
@glenfannin-okta @lesterchoi-okta 

### Screenshot/Video:
Without backend change:
<img width="1296" alt="Screenshot 2024-03-26 at 8 10 51 PM" src="https://github.com/okta/okta-signin-widget/assets/100623681/7f466a8d-60dc-4972-a9eb-297f259e3883">

With backend change:
<img width="1296" alt="Screenshot 2024-03-26 at 5 45 11 PM" src="https://github.com/okta/okta-signin-widget/assets/100623681/4ff6e023-8b8a-4b6e-98f3-46855d769894">


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=1176af112d7796136171dcfc4b7881a325ea170e&tab=main



