### PR TITLE
Gen 2/3: Perform redirect only on visible page

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -1117,6 +1117,28 @@ const smartCardEnrollOrVerify = {
   ],
 };
 
+const redirectOnPoll = {  
+  '/idp/idx/introspect': [
+    'authenticator-verification-email',
+    // 'authenticator-verification-data-okta-verify-push-autoChallenge-off',
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-verification-okta-verify-push-autoChallenge-on',
+  ],
+  '/idp/idx/challenge/poll': [
+    'success-redirect-remediation',
+    // 'error-with-failure-redirect',
+    // 'failure-redirect-remediation',
+    // 'success',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'success-redirect-remediation',
+    // 'error-with-failure-redirect',
+    // 'failure-redirect-remediation',
+    // 'success',
+  ],
+};
+
 module.exports = {
   mocks: idx
 };

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -199,7 +199,7 @@ Util.redirect = function(url, win = window, isAppLink = false) {
   }
 };
 
-Util.executeOnVisible = function(cb) {
+Util.executeOnVisiblePage = function(cb) {
   if (document.visibilityState === 'hidden') {
     const visibilityChangeHandler = () => {
       if (document.visibilityState === 'visible') {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -199,6 +199,20 @@ Util.redirect = function(url, win = window, isAppLink = false) {
   }
 };
 
+Util.executeOnVisible = function(cb) {
+  if (document.visibilityState === 'hidden') {
+    const visibilityChangeHandler = () => {
+      if (document.visibilityState === 'visible') {
+        document.removeEventListener('visibilitychange', visibilityChangeHandler);
+        cb();
+      }
+    };
+    document.addEventListener('visibilitychange', visibilityChangeHandler);
+  } else {
+    cb();
+  }
+};
+
 Util.isAndroidOVEnrollment = function() {
   const ovEnrollment = decodeURIComponent(window.location.href).includes(ovDeepLink);
   return BrowserFeatures.isAndroid() && ovEnrollment;

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -247,7 +247,10 @@ export default Controller.extend({
       // if Util.isAndroidOVEnrollment() returns true we use a user gesture to complete the redirect in AutoRedirectView
       if (!Util.isAndroidOVEnrollment()) {
         const currentViewState = this.options.appState.getCurrentViewState();
-        Util.redirectWithFormGet(currentViewState.href);
+        // OKTA-702402: redirect only if/when the page is visible
+        Util.executeOnVisible(() => {
+          Util.redirectWithFormGet(currentViewState.href);
+        });
       }
 
       return;

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -248,7 +248,7 @@ export default Controller.extend({
       if (!Util.isAndroidOVEnrollment()) {
         const currentViewState = this.options.appState.getCurrentViewState();
         // OKTA-702402: redirect only if/when the page is visible
-        Util.executeOnVisible(() => {
+        Util.executeOnVisiblePage(() => {
           Util.redirectWithFormGet(currentViewState.href);
         });
       }

--- a/src/v3/src/components/Redirect/Redirect.tsx
+++ b/src/v3/src/components/Redirect/Redirect.tsx
@@ -12,8 +12,8 @@
 
 import { useEffect } from 'preact/hooks';
 
-import { RedirectElement, UISchemaElementComponent } from '../../types';
 import Util from '../../../../util/Util';
+import { RedirectElement, UISchemaElementComponent } from '../../types';
 
 const Redirect: UISchemaElementComponent<{ uischema: RedirectElement }> = ({
   uischema: { options },
@@ -22,7 +22,7 @@ const Redirect: UISchemaElementComponent<{ uischema: RedirectElement }> = ({
     // we only want this to ever happen once (on initial component mount)
     // and when document is visible
     if (options?.url) {
-      Util.executeOnVisible(() => {
+      Util.executeOnVisiblePage(() => {
         window.location.assign(options.url);
       });
     }

--- a/src/v3/src/components/Redirect/Redirect.tsx
+++ b/src/v3/src/components/Redirect/Redirect.tsx
@@ -13,14 +13,18 @@
 import { useEffect } from 'preact/hooks';
 
 import { RedirectElement, UISchemaElementComponent } from '../../types';
+import Util from '../../../../util/Util';
 
 const Redirect: UISchemaElementComponent<{ uischema: RedirectElement }> = ({
   uischema: { options },
 }) => {
   useEffect(() => {
     // we only want this to ever happen once (on initial component mount)
+    // and when document is visible
     if (options?.url) {
-      window.location.assign(options.url);
+      Util.executeOnVisible(() => {
+        window.location.assign(options.url);
+      });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -155,7 +155,8 @@ export const transformTerminalTransaction = (
   if (transaction.context?.failure?.href) {
     // Direct auth clients display the error instead of redirecting
     // when redirect option is set to 'always' it will override the default behavior
-    const shouldRedirect = isOauth2Enabled(widgetProps) === false || widgetProps.redirect === 'always';
+    const shouldRedirect = (isOauth2Enabled(widgetProps) === false || widgetProps.redirect === 'always')
+      && !transaction.messages?.length;
     if (shouldRedirect) {
       SessionStorage.removeStateHandle();
       return redirectTransformer(

--- a/src/v3/webpack.dev.config.ts
+++ b/src/v3/webpack.dev.config.ts
@@ -164,7 +164,7 @@ const devConfig: Configuration = mergeWithRules({
     },
     optimization: {
       ...(process.env.IE11_COMPAT_MODE !== 'true' && {
-        runtimeChunk: 'single'
+        runtimeChunk: 'single',
       }),
     },
   },


### PR DESCRIPTION
## Description:

This PR fixes the issue with a redirect to app on mobile devices (Chrome for Android) when page is hidden (in background).
PR adds general rule for redirects - if page is hidden, wait for [visibility change](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event) to `visible` before changing URL.



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-702402](https://oktainc.atlassian.net/browse/OKTA-702402)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



