### PR TITLE
OKTA-703334 : fix : include user info for password validation during profile enrollment

### DIFF
--- a/src/v3/src/mocks/response/idp/idx/enroll/enroll-profile-with-password-full-requirements.json
+++ b/src/v3/src/mocks/response/idp/idx/enroll/enroll-profile-with-password-full-requirements.json
@@ -1,0 +1,143 @@
+{
+  "stateHandle": "NON_NULL_VALUE",
+  "version": "1.0.0",
+  "expiresAt": "DATE",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-profile",
+        "href": "http://localhost:3000/idp/idx/enroll/new",
+        "method": "POST",
+        "accepts": "application\\/json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "produces": "application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "value": [
+          {
+            "name": "userProfile",
+            "form": {
+              "value": [
+                {
+                  "name": "email",
+                  "label": "Email",
+                  "required": true
+                },
+                {
+                  "name": "firstName",
+                  "label": "First name",
+                  "required": true,
+                  "minLength": 1,
+                  "maxLength": 50
+                },
+                {
+                  "name": "lastName",
+                  "label": "Last name",
+                  "required": true,
+                  "minLength": 1,
+                  "maxLength": 50
+                }
+              ]
+            }
+          },
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter Password",
+                  "required": true,
+                  "secret": true
+                }
+              ]
+            },
+            "required": true,
+            "relatesTo": "$.currentAuthenticator"
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "NON_NULL_VALUE",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-identify",
+        "href": "http://localhost:3000/idp/idx/identify/select",
+        "method": "POST",
+        "accepts": "application\\/json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "produces": "application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "NON_NULL_VALUE",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "password",
+      "key": "okta_password",
+      "id": "NON_NULL_VALUE",
+      "displayName": "NON_NULL_VALUE",
+      "methods": [
+        {
+          "type": "password"
+        }
+      ],
+      "settings": {
+        "complexity": {
+          "minLength": 8,
+          "minLowerCase": 1,
+          "minUpperCase": 1,
+          "minNumber": 1,
+          "minSymbol": 1,
+          "excludeUsername": true,
+          "excludeAttributes": ["firstName", "lastName"]
+        },
+        "age": {
+          "minAgeMinutes": 0,
+          "historyCount": 4
+        }
+      }
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application\\/json; okta-version=\\d+\\.\\d+\\.\\d+",
+    "produces": "application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "NON_NULL_VALUE",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+    "type": "object",
+    "value": "OBJECT"
+  }
+}

--- a/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
+++ b/src/v3/src/transformer/profile/__snapshots__/transformEnrollProfile.test.ts.snap
@@ -123,37 +123,6 @@ Object {
       },
       Object {
         "options": Object {
-          "header": "password.complexity.requirements.header",
-          "id": "password-authenticator--list",
-          "requirements": Array [
-            Object {
-              "label": "password.complexity.number.description",
-              "ruleKey": "minNumber",
-            },
-            Object {
-              "label": "password.complexity.symbol.description",
-              "ruleKey": "minSymbol",
-            },
-          ],
-          "settings": Object {
-            "complexity": Object {
-              "minNumber": 1,
-              "minSymbol": 1,
-            },
-          },
-          "userInfo": Object {
-            "identifier": "testuser@okta.com",
-            "profile": Object {
-              "firstName": "test",
-              "lastName": "user",
-            },
-          },
-          "validationDelayMs": 50,
-        },
-        "type": "PasswordRequirements",
-      },
-      Object {
-        "options": Object {
           "inputMeta": Object {
             "name": "userProfile.firstName",
           },
@@ -175,6 +144,32 @@ Object {
           },
         },
         "type": "Field",
+      },
+      Object {
+        "noMargin": true,
+        "options": Object {
+          "header": "password.complexity.requirements.header",
+          "id": "password-authenticator--list",
+          "requirements": Array [
+            Object {
+              "label": "password.complexity.number.description",
+              "ruleKey": "minNumber",
+            },
+            Object {
+              "label": "password.complexity.symbol.description",
+              "ruleKey": "minSymbol",
+            },
+          ],
+          "settings": Object {
+            "complexity": Object {
+              "minNumber": 1,
+              "minSymbol": 1,
+            },
+          },
+          "userInfo": Object {},
+          "validationDelayMs": 50,
+        },
+        "type": "PasswordRequirements",
       },
       Object {
         "label": "Password",

--- a/src/v3/src/transformer/profile/transformEnrollProfile.test.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfile.test.ts
@@ -40,7 +40,7 @@ describe('Enroll Profile Transformer Tests', () => {
     transaction.nextStep = {
       name: '',
     };
-    widgetProps = {};
+    widgetProps = {} as unknown as WidgetProps;
   });
 
   it('should only add title and submit button when select-identify doesnt exist in available steps '
@@ -75,14 +75,6 @@ describe('Enroll Profile Transformer Tests', () => {
         inputMeta: { name: 'credentials.passcode', secret: true },
       },
     } as FieldElement);
-    const mockUserInfo = {
-      identifier: 'testuser@okta.com',
-      profile: { firstName: 'test', lastName: 'user' },
-    };
-    transaction.context.user = {
-      type: 'object',
-      value: mockUserInfo,
-    };
 
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
@@ -134,14 +126,6 @@ describe('Enroll Profile Transformer Tests', () => {
         },
       ],
     };
-    const mockUserInfo = {
-      identifier: 'testuser@okta.com',
-      profile: { firstName: 'test', lastName: 'user' },
-    };
-    transaction.context.user = {
-      type: 'object',
-      value: mockUserInfo,
-    };
 
     const updatedFormBag = transformEnrollProfile({ transaction, formBag, widgetProps });
 
@@ -152,23 +136,23 @@ describe('Enroll Profile Transformer Tests', () => {
       .toBe('oie.registration.form.title');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
       .toBe('oie.form.field.optional.description');
-    expect(updatedFormBag.uischema.elements[2].type).toBe('PasswordRequirements');
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.id)
-      .toBe('password-authenticator--list');
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.header)
-      .toBe('password.complexity.requirements.header');
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.userInfo)
-      .toEqual(mockUserInfo);
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement).options?.settings)
-      .toEqual({ complexity: { minNumber: 1, minSymbol: 1 } });
-    expect((updatedFormBag.uischema.elements[2] as PasswordRequirementsElement)
-      .options?.validationDelayMs).toBe(PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS);
-    expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
+    expect((updatedFormBag.uischema.elements[2] as FieldElement).options?.inputMeta.name)
       .toBe('userProfile.firstName');
-    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
+    expect((updatedFormBag.uischema.elements[3] as FieldElement).options?.inputMeta.name)
       .toBe('userProfile.lastName');
-    expect((updatedFormBag.uischema.elements[5] as FieldElement).options?.inputMeta.name)
+    expect((updatedFormBag.uischema.elements[4] as FieldElement).options?.inputMeta.name)
       .toBe('userProfile.email');
+    expect(updatedFormBag.uischema.elements[5].type).toBe('PasswordRequirements');
+    expect((updatedFormBag.uischema.elements[5] as PasswordRequirementsElement).options?.id)
+      .toBe('password-authenticator--list');
+    expect((updatedFormBag.uischema.elements[5] as PasswordRequirementsElement).options?.header)
+      .toBe('password.complexity.requirements.header');
+    expect((updatedFormBag.uischema.elements[5] as PasswordRequirementsElement).options?.userInfo)
+      .toEqual({});
+    expect((updatedFormBag.uischema.elements[5] as PasswordRequirementsElement).options?.settings)
+      .toEqual({ complexity: { minNumber: 1, minSymbol: 1 } });
+    expect((updatedFormBag.uischema.elements[5] as PasswordRequirementsElement)
+      .options?.validationDelayMs).toBe(PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS);
     expect((updatedFormBag.uischema.elements[6] as FieldElement).options?.inputMeta.name)
       .toBe('credentials.passcode');
     expect((updatedFormBag.uischema.elements[6] as FieldElement).options?.attributes?.autocomplete)

--- a/src/v3/src/transformer/utils.ts
+++ b/src/v3/src/transformer/utils.ts
@@ -34,7 +34,7 @@ export const removeUIElementWithName = (
   elements: UISchemaElement[],
 ): UISchemaElement[] => (
   elements.filter((element) => (
-    name !== (element as FieldElement).options.inputMeta.name
+    name !== (element as FieldElement).options?.inputMeta?.name
   ))
 );
 
@@ -43,6 +43,6 @@ export const getUIElementWithName = (
   elements: UISchemaElement[],
 ): UISchemaElement | undefined => (
   elements.find((element) => (
-    name === (element as FieldElement).options.inputMeta.name
+    name === (element as FieldElement).options?.inputMeta?.name
   ))
 );

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -37,6 +37,7 @@ import {
 import {
   AppInfo,
   AuthCoinProps,
+  FormBag,
   IWidgetContext,
   PhoneVerificationMethodType,
   RegistrationElementSchema,
@@ -60,6 +61,26 @@ export const getUserInfo = (transaction: IdxTransaction): UserInfo => {
     return {};
   }
   return user.value as UserInfo;
+};
+
+export const getUserProvidedUserInfo = (data: FormBag['data']): UserInfo => {
+  const identifier = ('userProfile.login' in data
+    ? data['userProfile.login']
+    : data['userProfile.email']) as string;
+  const firstName = 'userProfile.firstName' in data
+    ? data['userProfile.firstName'] as string
+    : undefined;
+  const lastName = 'userProfile.lastName' in data
+    ? data['userProfile.lastName'] as string
+    : undefined;
+
+  return {
+    identifier,
+    profile: {
+      firstName,
+      lastName,
+    },
+  };
 };
 
 export const getAppInfo = (transaction: IdxTransaction): AppInfo => {

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`enroll-profile-with-password should display field level error when password does not fulfill requirements 1`] = `
+exports[`enroll-profile-with-password should display field level error when password does not fulfill first and last name exclusion requirement 1`] = `
 <div>
   <div
     class="MuiScopedCssBaseline-root emotion-0"
@@ -428,6 +428,45 @@ exports[`enroll-profile-with-password should display field level error when pass
                                 class="MuiTypography-root MuiTypography-body1 emotion-22"
                                 tabindex="-1"
                               >
+                                A symbol
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
                                 No parts of your username
                               </p>
                             </div>
@@ -531,7 +570,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-87"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-93"
                         required="true"
                       >
                         <input
@@ -549,13 +588,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-89"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-95"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-90"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-96"
                             tabindex="0"
                             type="button"
                           >
@@ -578,7 +617,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <p
-                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-92"
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-98"
                         id="credentials.passcode-error"
                       >
                         <span
@@ -591,17 +630,17 @@ exports[`enroll-profile-with-password should display field level error when pass
                         >
                           Password requirements were not met:
                           <ul
-                            class="MuiList-root MuiList-dense emotion-95"
+                            class="MuiList-root MuiList-dense emotion-101"
                           >
                             <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-102"
                             >
-                              At least 8 characters
+                              Does not include your first name
                             </li>
                             <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-102"
                             >
-                              An uppercase letter
+                              Does not include your last name
                             </li>
                           </ul>
                         </div>
@@ -612,7 +651,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-99"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-105"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -624,15 +663,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth emotion-101"
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-107"
                       data-se="separation-line"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-102"
+                    class="MuiBox-root emotion-108"
                   >
                     <div
-                      class="MuiBox-root emotion-103"
+                      class="MuiBox-root emotion-109"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -647,10 +686,1426 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-103"
+                      class="MuiBox-root emotion-109"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-113"
+                        data-se="back"
+                        role="link"
+                      >
+                        Sign In
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
+exports[`enroll-profile-with-password should display field level error when password does not fulfill minLength requirement 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-se="auth-container main-container"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="MuiScopedCssBaseline-root emotion-2"
+      >
+        <div
+          class="MuiBox-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="MuiBox-root emotion-5"
+              data-se="okta-sign-in-header auth-header "
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 emotion-6"
+                tabindex="-1"
+              />
+            </div>
+            <div
+              class="MuiBox-root emotion-7"
+            >
+              <form
+                aria-live="polite"
+                class="o-form MuiBox-root emotion-8"
+                data-se="o-form"
+                novalidate=""
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutError MuiAlert-callout emotion-10"
+                    role="alert"
+                  >
+                    <div
+                      class="MuiAlert-icon emotion-11"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
+                        fill="none"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="MuiAlert-message emotion-13"
+                    >
+                      <span
+                        class="MuiBox-root emotion-14"
+                        translate="no"
+                      >
+                        error
+                      </span>
+                      <div
+                        class="MuiBox-root emotion-1"
+                      >
+                        We found some errors. Please review the form and make corrections.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-16"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
+                        data-se="o-form-head"
+                        tabindex="-1"
+                      >
+                        Sign up
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 emotion-22"
+                        data-se="o-form-explain"
+                        tabindex="-1"
+                      >
+                        Fields are required unless marked optional.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
+                      >
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
+                          id="userProfile.email"
+                          inputmode="email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
+                      >
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-1"
+                  >
+                    <figure
+                      class="MuiBox-root emotion-39"
+                      data-se="password-authenticator--rules"
+                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
+                    >
+                      <figcaption
+                        class="MuiBox-root emotion-1"
+                        data-se="password-authenticator--heading"
+                      >
+                        Password requirements:
+                      </figcaption>
+                      <ul
+                        class="MuiBox-root emotion-41"
+                        id="password-authenticator--list"
+                      >
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                At least 8 characters
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A lowercase letter
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                An uppercase letter
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A number
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A symbol
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                No parts of your username
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your first name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your last name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </figure>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
+                      >
+                        <span>
+                          Password
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-93"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
+                          aria-errormessage="credentials.passcode-error"
+                          aria-invalid="true"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="new-password"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          role="textbox"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-95"
+                        >
+                          <button
+                            aria-controls="credentials.passcode"
+                            aria-label="Show password"
+                            aria-pressed="false"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-96"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
+                              fill="none"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M3.43 12.813A12.814 12.814 0 0 1 3.069 12a14.153 14.153 0 0 1 1.966-3.38C6.506 6.762 8.746 5 12 5s5.494 1.761 6.966 3.62A14.152 14.152 0 0 1 20.932 12a14.151 14.151 0 0 1-1.966 3.38C17.494 17.238 15.254 19 12 19s-5.494-1.761-6.966-3.62a14.152 14.152 0 0 1-1.603-2.567Zm19.518-1.13L22 12c.949.316.949.317.948.317v.004l-.003.007-.008.024a7.012 7.012 0 0 1-.137.362 16.147 16.147 0 0 1-2.266 3.906C18.84 18.762 16.08 21 12 21c-4.08 0-6.84-2.239-8.534-4.38A16.15 16.15 0 0 1 1.2 12.715a10.039 10.039 0 0 1-.137-.362l-.008-.024-.002-.007-.001-.003c0-.001 0-.002.948-.318a91.698 91.698 0 0 1-.948-.317v-.004l.003-.007.008-.024.029-.08c.025-.067.06-.163.108-.282A16.15 16.15 0 0 1 3.466 7.38C5.16 5.24 7.92 3 12 3c4.08 0 6.84 2.239 8.534 4.38a16.147 16.147 0 0 1 2.266 3.906 10.026 10.026 0 0 1 .137.362l.008.024.002.007.001.003ZM2 12l-.949.316L.946 12l.105-.316L2 12Zm20 0 .949-.316.105.316-.105.316L22 12ZM9 12a3 3 0 1 1 6 0 3 3 0 0 1-6 0Zm3-5a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-98"
+                        id="credentials.passcode-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          Password requirements were not met:
+                          <ul
+                            class="MuiList-root MuiList-dense emotion-101"
+                          >
+                            <li
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-102"
+                            >
+                              At least 8 characters
+                            </li>
+                            <li
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-102"
+                            >
+                              An uppercase letter
+                            </li>
+                            <li
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-102"
+                            >
+                              A symbol
+                            </li>
+                          </ul>
+                        </div>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-106"
+                      data-se="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Sign Up
+                    </button>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <hr
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-108"
+                      data-se="separation-line"
+                    />
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-109"
+                  >
+                    <div
+                      class="MuiBox-root emotion-110"
+                    >
+                      <div
+                        class="MuiBox-root emotion-18"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-22"
+                          data-se="haveaccount"
+                          tabindex="-1"
+                        >
+                          Already have an account?
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-110"
+                    >
+                      <button
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-114"
+                        data-se="back"
+                        role="link"
+                      >
+                        Sign In
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
+exports[`enroll-profile-with-password should display field level error when password does not fulfill username requirement 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-se="auth-container main-container"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="MuiScopedCssBaseline-root emotion-2"
+      >
+        <div
+          class="MuiBox-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="MuiBox-root emotion-5"
+              data-se="okta-sign-in-header auth-header "
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 emotion-6"
+                tabindex="-1"
+              />
+            </div>
+            <div
+              class="MuiBox-root emotion-7"
+            >
+              <form
+                aria-live="polite"
+                class="o-form MuiBox-root emotion-8"
+                data-se="o-form"
+                novalidate=""
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutError MuiAlert-callout emotion-10"
+                    role="alert"
+                  >
+                    <div
+                      class="MuiAlert-icon emotion-11"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
+                        fill="none"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="MuiAlert-message emotion-13"
+                    >
+                      <span
+                        class="MuiBox-root emotion-14"
+                        translate="no"
+                      >
+                        error
+                      </span>
+                      <div
+                        class="MuiBox-root emotion-1"
+                      >
+                        We found some errors. Please review the form and make corrections.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-16"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
+                        data-se="o-form-head"
+                        tabindex="-1"
+                      >
+                        Sign up
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 emotion-22"
+                        data-se="o-form-explain"
+                        tabindex="-1"
+                      >
+                        Fields are required unless marked optional.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
+                      >
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
+                          id="userProfile.email"
+                          inputmode="email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
+                      >
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-1"
+                  >
+                    <figure
+                      class="MuiBox-root emotion-39"
+                      data-se="password-authenticator--rules"
+                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
+                    >
+                      <figcaption
+                        class="MuiBox-root emotion-1"
+                        data-se="password-authenticator--heading"
+                      >
+                        Password requirements:
+                      </figcaption>
+                      <ul
+                        class="MuiBox-root emotion-41"
+                        id="password-authenticator--list"
+                      >
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                At least 8 characters
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A lowercase letter
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                An uppercase letter
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A number
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A symbol
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                No parts of your username
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your first name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your last name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </figure>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
+                      >
+                        <span>
+                          Password
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-93"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
+                          aria-errormessage="credentials.passcode-error"
+                          aria-invalid="true"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="new-password"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          role="textbox"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-95"
+                        >
+                          <button
+                            aria-controls="credentials.passcode"
+                            aria-label="Show password"
+                            aria-pressed="false"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-96"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
+                              fill="none"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M3.43 12.813A12.814 12.814 0 0 1 3.069 12a14.153 14.153 0 0 1 1.966-3.38C6.506 6.762 8.746 5 12 5s5.494 1.761 6.966 3.62A14.152 14.152 0 0 1 20.932 12a14.151 14.151 0 0 1-1.966 3.38C17.494 17.238 15.254 19 12 19s-5.494-1.761-6.966-3.62a14.152 14.152 0 0 1-1.603-2.567Zm19.518-1.13L22 12c.949.316.949.317.948.317v.004l-.003.007-.008.024a7.012 7.012 0 0 1-.137.362 16.147 16.147 0 0 1-2.266 3.906C18.84 18.762 16.08 21 12 21c-4.08 0-6.84-2.239-8.534-4.38A16.15 16.15 0 0 1 1.2 12.715a10.039 10.039 0 0 1-.137-.362l-.008-.024-.002-.007-.001-.003c0-.001 0-.002.948-.318a91.698 91.698 0 0 1-.948-.317v-.004l.003-.007.008-.024.029-.08c.025-.067.06-.163.108-.282A16.15 16.15 0 0 1 3.466 7.38C5.16 5.24 7.92 3 12 3c4.08 0 6.84 2.239 8.534 4.38a16.147 16.147 0 0 1 2.266 3.906 10.026 10.026 0 0 1 .137.362l.008.024.002.007.001.003ZM2 12l-.949.316L.946 12l.105-.316L2 12Zm20 0 .949-.316.105.316-.105.316L22 12ZM9 12a3 3 0 1 1 6 0 3 3 0 0 1-6 0Zm3-5a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-98"
+                        id="credentials.passcode-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          Password requirements were not met:
+                          <ul
+                            class="MuiList-root MuiList-dense emotion-101"
+                          >
+                            <li
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-102"
+                            >
+                              No parts of your username
+                            </li>
+                          </ul>
+                        </div>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-104"
+                      data-se="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Sign Up
+                    </button>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <hr
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-106"
+                      data-se="separation-line"
+                    />
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-107"
+                  >
+                    <div
+                      class="MuiBox-root emotion-108"
+                    >
+                      <div
+                        class="MuiBox-root emotion-18"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-22"
+                          data-se="haveaccount"
+                          tabindex="-1"
+                        >
+                          Already have an account?
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-108"
+                    >
+                      <button
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-112"
                         data-se="back"
                         role="link"
                       >
@@ -1097,6 +2552,45 @@ exports[`enroll-profile-with-password should display field level error when pass
                                 class="MuiTypography-root MuiTypography-body1 emotion-22"
                                 tabindex="-1"
                               >
+                                A symbol
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
                                 No parts of your username
                               </p>
                             </div>
@@ -1200,7 +2694,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-87"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-93"
                         required="true"
                       >
                         <input
@@ -1218,13 +2712,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-89"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-95"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-90"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-96"
                             tabindex="0"
                             type="button"
                           >
@@ -1247,7 +2741,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <p
-                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-92"
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-98"
                         id="credentials.passcode-error"
                       >
                         <span
@@ -1267,7 +2761,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-96"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-102"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1279,15 +2773,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth emotion-98"
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-104"
                       data-se="separation-line"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-99"
+                    class="MuiBox-root emotion-105"
                   >
                     <div
-                      class="MuiBox-root emotion-100"
+                      class="MuiBox-root emotion-106"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -1302,1353 +2796,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-100"
+                      class="MuiBox-root emotion-106"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-104"
-                        data-se="back"
-                        role="link"
-                      >
-                        Sign In
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-          </div>
-        </div>
-      </div>
-    </main>
-  </div>
-</div>
-`;
-
-exports[`enroll-profile-with-password should display field level error when password includes first and last name 1`] = `
-<div>
-  <div
-    class="MuiScopedCssBaseline-root emotion-0"
-  >
-    <main
-      class="MuiBox-root emotion-1"
-      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
-      data-se="auth-container main-container"
-      data-version="0.0.0"
-      dir="ltr"
-      id="okta-sign-in"
-      lang="en"
-    >
-      <div
-        class="MuiScopedCssBaseline-root emotion-2"
-      >
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <div
-            class="MuiBox-root emotion-4"
-          >
-            <div
-              class="MuiBox-root emotion-5"
-              data-se="okta-sign-in-header auth-header "
-            >
-              <h1
-                class="MuiTypography-root MuiTypography-h1 emotion-6"
-                tabindex="-1"
-              />
-            </div>
-            <div
-              class="MuiBox-root emotion-7"
-            >
-              <form
-                aria-live="polite"
-                class="o-form MuiBox-root emotion-8"
-                data-se="o-form"
-                novalidate=""
-              >
-                <div
-                  class="MuiBox-root emotion-9"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutError MuiAlert-callout emotion-10"
-                    role="alert"
-                  >
-                    <div
-                      class="MuiAlert-icon emotion-11"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
-                        fill="none"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          clip-rule="evenodd"
-                          d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
-                          fill="currentColor"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="MuiAlert-message emotion-13"
-                    >
-                      <span
-                        class="MuiBox-root emotion-14"
-                        translate="no"
-                      >
-                        error
-                      </span>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        We found some errors. Please review the form and make corrections.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-18"
-                    >
-                      <h2
-                        class="MuiTypography-root MuiTypography-h4 emotion-19"
-                        data-se="o-form-head"
-                        tabindex="-1"
-                      >
-                        Sign up
-                      </h2>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-18"
-                    >
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 emotion-22"
-                        data-se="o-form-explain"
-                        tabindex="-1"
-                      >
-                        Fields are required unless marked optional.
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                        data-shrink="false"
-                        for="userProfile.email"
-                        id="userProfile.email-label"
-                      >
-                        <span>
-                          Email
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.email-label"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-27"
-                          data-se="userProfile.email"
-                          id="userProfile.email"
-                          inputmode="email"
-                          name="userProfile.email"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                        id="userProfile.firstName-label"
-                      >
-                        <span>
-                          First name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.firstName-label"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-27"
-                          data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                        id="userProfile.lastName-label"
-                      >
-                        <span>
-                          Last name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.lastName-label"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-27"
-                          data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-1"
-                  >
-                    <figure
-                      class="MuiBox-root emotion-39"
-                      data-se="password-authenticator--rules"
-                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
-                    >
-                      <figcaption
-                        class="MuiBox-root emotion-1"
-                        data-se="password-authenticator--heading"
-                      >
-                        Password requirements:
-                      </figcaption>
-                      <ul
-                        class="MuiBox-root emotion-41"
-                        id="password-authenticator--list"
-                      >
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                At least 8 characters
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                A lowercase letter
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                An uppercase letter
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                A number
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                No parts of your username
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                Does not include your first name
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                Does not include your last name
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                      </ul>
-                    </figure>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                        data-shrink="false"
-                        for="credentials.passcode"
-                        id="credentials.passcode-label"
-                      >
-                        <span>
-                          Password
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-87"
-                        required="true"
-                      >
-                        <input
-                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
-                          aria-errormessage="credentials.passcode-error"
-                          aria-invalid="true"
-                          aria-labelledby="credentials.passcode-label"
-                          autocomplete="new-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
-                          data-se="credentials.passcode"
-                          id="credentials.passcode"
-                          name="credentials.passcode"
-                          required=""
-                          role="textbox"
-                          type="password"
-                        />
-                        <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-89"
-                        >
-                          <button
-                            aria-controls="credentials.passcode"
-                            aria-label="Show password"
-                            aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-90"
-                            tabindex="0"
-                            type="button"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
-                              fill="none"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M3.43 12.813A12.814 12.814 0 0 1 3.069 12a14.153 14.153 0 0 1 1.966-3.38C6.506 6.762 8.746 5 12 5s5.494 1.761 6.966 3.62A14.152 14.152 0 0 1 20.932 12a14.151 14.151 0 0 1-1.966 3.38C17.494 17.238 15.254 19 12 19s-5.494-1.761-6.966-3.62a14.152 14.152 0 0 1-1.603-2.567Zm19.518-1.13L22 12c.949.316.949.317.948.317v.004l-.003.007-.008.024a7.012 7.012 0 0 1-.137.362 16.147 16.147 0 0 1-2.266 3.906C18.84 18.762 16.08 21 12 21c-4.08 0-6.84-2.239-8.534-4.38A16.15 16.15 0 0 1 1.2 12.715a10.039 10.039 0 0 1-.137-.362l-.008-.024-.002-.007-.001-.003c0-.001 0-.002.948-.318a91.698 91.698 0 0 1-.948-.317v-.004l.003-.007.008-.024.029-.08c.025-.067.06-.163.108-.282A16.15 16.15 0 0 1 3.466 7.38C5.16 5.24 7.92 3 12 3c4.08 0 6.84 2.239 8.534 4.38a16.147 16.147 0 0 1 2.266 3.906 10.026 10.026 0 0 1 .137.362l.008.024.002.007.001.003ZM2 12l-.949.316L.946 12l.105-.316L2 12Zm20 0 .949-.316.105.316-.105.316L22 12ZM9 12a3 3 0 1 1 6 0 3 3 0 0 1-6 0Zm3-5a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                      <p
-                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-92"
-                        id="credentials.passcode-error"
-                      >
-                        <span
-                          class="MuiBox-root emotion-14"
-                        >
-                          Error:
-                        </span>
-                        <div
-                          class="MuiBox-root emotion-1"
-                        >
-                          Password requirements were not met:
-                          <ul
-                            class="MuiList-root MuiList-dense emotion-95"
-                          >
-                            <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
-                            >
-                              Does not include your first name
-                            </li>
-                            <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
-                            >
-                              Does not include your last name
-                            </li>
-                          </ul>
-                        </div>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-99"
-                      data-se="save"
-                      tabindex="0"
-                      type="submit"
-                    >
-                      Sign Up
-                    </button>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <hr
-                      class="MuiDivider-root MuiDivider-fullWidth emotion-101"
-                      data-se="separation-line"
-                    />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-102"
-                  >
-                    <div
-                      class="MuiBox-root emotion-103"
-                    >
-                      <div
-                        class="MuiBox-root emotion-18"
-                      >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-22"
-                          data-se="haveaccount"
-                          tabindex="-1"
-                        >
-                          Already have an account?
-                        </p>
-                      </div>
-                    </div>
-                    <div
-                      class="MuiBox-root emotion-103"
-                    >
-                      <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
-                        data-se="back"
-                        role="link"
-                      >
-                        Sign In
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-          </div>
-        </div>
-      </div>
-    </main>
-  </div>
-</div>
-`;
-
-exports[`enroll-profile-with-password should display field level error when password includes username 1`] = `
-<div>
-  <div
-    class="MuiScopedCssBaseline-root emotion-0"
-  >
-    <main
-      class="MuiBox-root emotion-1"
-      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
-      data-se="auth-container main-container"
-      data-version="0.0.0"
-      dir="ltr"
-      id="okta-sign-in"
-      lang="en"
-    >
-      <div
-        class="MuiScopedCssBaseline-root emotion-2"
-      >
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <div
-            class="MuiBox-root emotion-4"
-          >
-            <div
-              class="MuiBox-root emotion-5"
-              data-se="okta-sign-in-header auth-header "
-            >
-              <h1
-                class="MuiTypography-root MuiTypography-h1 emotion-6"
-                tabindex="-1"
-              />
-            </div>
-            <div
-              class="MuiBox-root emotion-7"
-            >
-              <form
-                aria-live="polite"
-                class="o-form MuiBox-root emotion-8"
-                data-se="o-form"
-                novalidate=""
-              >
-                <div
-                  class="MuiBox-root emotion-9"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutError MuiAlert-callout emotion-10"
-                    role="alert"
-                  >
-                    <div
-                      class="MuiAlert-icon emotion-11"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
-                        fill="none"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          clip-rule="evenodd"
-                          d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
-                          fill="currentColor"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="MuiAlert-message emotion-13"
-                    >
-                      <span
-                        class="MuiBox-root emotion-14"
-                        translate="no"
-                      >
-                        error
-                      </span>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        We found some errors. Please review the form and make corrections.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-18"
-                    >
-                      <h2
-                        class="MuiTypography-root MuiTypography-h4 emotion-19"
-                        data-se="o-form-head"
-                        tabindex="-1"
-                      >
-                        Sign up
-                      </h2>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiBox-root emotion-18"
-                    >
-                      <p
-                        class="MuiTypography-root MuiTypography-body1 emotion-22"
-                        data-se="o-form-explain"
-                        tabindex="-1"
-                      >
-                        Fields are required unless marked optional.
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                        data-shrink="false"
-                        for="userProfile.email"
-                        id="userProfile.email-label"
-                      >
-                        <span>
-                          Email
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.email-label"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-27"
-                          data-se="userProfile.email"
-                          id="userProfile.email"
-                          inputmode="email"
-                          name="userProfile.email"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                        id="userProfile.firstName-label"
-                      >
-                        <span>
-                          First name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.firstName-label"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-27"
-                          data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                        id="userProfile.lastName-label"
-                      >
-                        <span>
-                          Last name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.lastName-label"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-27"
-                          data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-1"
-                  >
-                    <figure
-                      class="MuiBox-root emotion-39"
-                      data-se="password-authenticator--rules"
-                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
-                    >
-                      <figcaption
-                        class="MuiBox-root emotion-1"
-                        data-se="password-authenticator--heading"
-                      >
-                        Password requirements:
-                      </figcaption>
-                      <ul
-                        class="MuiBox-root emotion-41"
-                        id="password-authenticator--list"
-                      >
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                At least 8 characters
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                A lowercase letter
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                An uppercase letter
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                A number
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                No parts of your username
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                Does not include your first name
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                        <li
-                          class="MuiBox-root emotion-42"
-                        >
-                          <div
-                            class="MuiBox-root emotion-43"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="MuiBox-root emotion-44"
-                              data-se="passwordRequirementIcon-info"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiBox-root emotion-1"
-                            >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 emotion-22"
-                                tabindex="-1"
-                              >
-                                Does not include your last name
-                              </p>
-                            </div>
-                          </div>
-                        </li>
-                      </ul>
-                    </figure>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
-                        data-shrink="false"
-                        for="credentials.passcode"
-                        id="credentials.passcode-label"
-                      >
-                        <span>
-                          Password
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-87"
-                        required="true"
-                      >
-                        <input
-                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
-                          aria-errormessage="credentials.passcode-error"
-                          aria-invalid="true"
-                          aria-labelledby="credentials.passcode-label"
-                          autocomplete="new-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
-                          data-se="credentials.passcode"
-                          id="credentials.passcode"
-                          name="credentials.passcode"
-                          required=""
-                          role="textbox"
-                          type="password"
-                        />
-                        <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-89"
-                        >
-                          <button
-                            aria-controls="credentials.passcode"
-                            aria-label="Show password"
-                            aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-90"
-                            tabindex="0"
-                            type="button"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
-                              fill="none"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M3.43 12.813A12.814 12.814 0 0 1 3.069 12a14.153 14.153 0 0 1 1.966-3.38C6.506 6.762 8.746 5 12 5s5.494 1.761 6.966 3.62A14.152 14.152 0 0 1 20.932 12a14.151 14.151 0 0 1-1.966 3.38C17.494 17.238 15.254 19 12 19s-5.494-1.761-6.966-3.62a14.152 14.152 0 0 1-1.603-2.567Zm19.518-1.13L22 12c.949.316.949.317.948.317v.004l-.003.007-.008.024a7.012 7.012 0 0 1-.137.362 16.147 16.147 0 0 1-2.266 3.906C18.84 18.762 16.08 21 12 21c-4.08 0-6.84-2.239-8.534-4.38A16.15 16.15 0 0 1 1.2 12.715a10.039 10.039 0 0 1-.137-.362l-.008-.024-.002-.007-.001-.003c0-.001 0-.002.948-.318a91.698 91.698 0 0 1-.948-.317v-.004l.003-.007.008-.024.029-.08c.025-.067.06-.163.108-.282A16.15 16.15 0 0 1 3.466 7.38C5.16 5.24 7.92 3 12 3c4.08 0 6.84 2.239 8.534 4.38a16.147 16.147 0 0 1 2.266 3.906 10.026 10.026 0 0 1 .137.362l.008.024.002.007.001.003ZM2 12l-.949.316L.946 12l.105-.316L2 12Zm20 0 .949-.316.105.316-.105.316L22 12ZM9 12a3 3 0 1 1 6 0 3 3 0 0 1-6 0Zm3-5a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                      <p
-                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-92"
-                        id="credentials.passcode-error"
-                      >
-                        <span
-                          class="MuiBox-root emotion-14"
-                        >
-                          Error:
-                        </span>
-                        <div
-                          class="MuiBox-root emotion-1"
-                        >
-                          Password requirements were not met:
-                          <ul
-                            class="MuiList-root MuiList-dense emotion-95"
-                          >
-                            <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
-                            >
-                              An uppercase letter
-                            </li>
-                            <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
-                            >
-                              No parts of your username
-                            </li>
-                            <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
-                            >
-                              Does not include your first name
-                            </li>
-                          </ul>
-                        </div>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-100"
-                      data-se="save"
-                      tabindex="0"
-                      type="submit"
-                    >
-                      Sign Up
-                    </button>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <hr
-                      class="MuiDivider-root MuiDivider-fullWidth emotion-102"
-                      data-se="separation-line"
-                    />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-103"
-                  >
-                    <div
-                      class="MuiBox-root emotion-104"
-                    >
-                      <div
-                        class="MuiBox-root emotion-18"
-                      >
-                        <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-22"
-                          data-se="haveaccount"
-                          tabindex="-1"
-                        >
-                          Already have an account?
-                        </p>
-                      </div>
-                    </div>
-                    <div
-                      class="MuiBox-root emotion-104"
-                    >
-                      <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-108"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-110"
                         data-se="back"
                         role="link"
                       >
@@ -3052,6 +3203,45 @@ exports[`enroll-profile-with-password should render form 1`] = `
                                 class="MuiTypography-root MuiTypography-body1 emotion-15"
                                 tabindex="-1"
                               >
+                                A symbol
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-35"
+                        >
+                          <div
+                            class="MuiBox-root emotion-36"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-37"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-38"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-15"
+                                tabindex="-1"
+                              >
                                 No parts of your username
                               </p>
                             </div>
@@ -3155,7 +3345,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-80"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-86"
                         required="true"
                       >
                         <input
@@ -3172,19 +3362,19 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-82"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-88"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-83"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-89"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-84"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-90"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -3206,7 +3396,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-86"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-92"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -3218,15 +3408,15 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth emotion-88"
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-94"
                       data-se="separation-line"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-89"
+                    class="MuiBox-root emotion-95"
                   >
                     <div
-                      class="MuiBox-root emotion-90"
+                      class="MuiBox-root emotion-96"
                     >
                       <div
                         class="MuiBox-root emotion-11"
@@ -3241,10 +3431,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-90"
+                      class="MuiBox-root emotion-96"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-94"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
                         data-se="back"
                         role="link"
                       >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -433,6 +433,84 @@ exports[`enroll-profile-with-password should display field level error when pass
                             </div>
                           </div>
                         </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your first name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your last name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
                       </ul>
                     </figure>
                   </div>
@@ -453,7 +531,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-75"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-87"
                         required="true"
                       >
                         <input
@@ -471,13 +549,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-77"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-89"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-78"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-90"
                             tabindex="0"
                             type="button"
                           >
@@ -500,7 +578,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <p
-                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-80"
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-92"
                         id="credentials.passcode-error"
                       >
                         <span
@@ -513,15 +591,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                         >
                           Password requirements were not met:
                           <ul
-                            class="MuiList-root MuiList-dense emotion-83"
+                            class="MuiList-root MuiList-dense emotion-95"
                           >
                             <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-84"
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
                             >
                               At least 8 characters
                             </li>
                             <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-84"
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
                             >
                               An uppercase letter
                             </li>
@@ -534,7 +612,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-87"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-99"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -546,15 +624,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth emotion-89"
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-101"
                       data-se="separation-line"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-90"
+                    class="MuiBox-root emotion-102"
                   >
                     <div
-                      class="MuiBox-root emotion-91"
+                      class="MuiBox-root emotion-103"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -569,10 +647,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-91"
+                      class="MuiBox-root emotion-103"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-95"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
                         data-se="back"
                         role="link"
                       >
@@ -1024,6 +1102,84 @@ exports[`enroll-profile-with-password should display field level error when pass
                             </div>
                           </div>
                         </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your first name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your last name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
                       </ul>
                     </figure>
                   </div>
@@ -1044,7 +1200,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-75"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-87"
                         required="true"
                       >
                         <input
@@ -1062,13 +1218,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-77"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-89"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-78"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-90"
                             tabindex="0"
                             type="button"
                           >
@@ -1091,7 +1247,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <p
-                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-80"
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-92"
                         id="credentials.passcode-error"
                       >
                         <span
@@ -1111,7 +1267,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-84"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-96"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1123,15 +1279,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth emotion-86"
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-98"
                       data-se="separation-line"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-87"
+                    class="MuiBox-root emotion-99"
                   >
                     <div
-                      class="MuiBox-root emotion-88"
+                      class="MuiBox-root emotion-100"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -1146,10 +1302,679 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-88"
+                      class="MuiBox-root emotion-100"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-92"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-104"
+                        data-se="back"
+                        role="link"
+                      >
+                        Sign In
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
+exports[`enroll-profile-with-password should display field level error when password includes first and last name 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-se="auth-container main-container"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="MuiScopedCssBaseline-root emotion-2"
+      >
+        <div
+          class="MuiBox-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="MuiBox-root emotion-5"
+              data-se="okta-sign-in-header auth-header "
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 emotion-6"
+                tabindex="-1"
+              />
+            </div>
+            <div
+              class="MuiBox-root emotion-7"
+            >
+              <form
+                aria-live="polite"
+                class="o-form MuiBox-root emotion-8"
+                data-se="o-form"
+                novalidate=""
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutError MuiAlert-callout emotion-10"
+                    role="alert"
+                  >
+                    <div
+                      class="MuiAlert-icon emotion-11"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
+                        fill="none"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="MuiAlert-message emotion-13"
+                    >
+                      <span
+                        class="MuiBox-root emotion-14"
+                        translate="no"
+                      >
+                        error
+                      </span>
+                      <div
+                        class="MuiBox-root emotion-1"
+                      >
+                        We found some errors. Please review the form and make corrections.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-16"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
+                        data-se="o-form-head"
+                        tabindex="-1"
+                      >
+                        Sign up
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 emotion-22"
+                        data-se="o-form-explain"
+                        tabindex="-1"
+                      >
+                        Fields are required unless marked optional.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
+                      >
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
+                          id="userProfile.email"
+                          inputmode="email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
+                      >
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-1"
+                  >
+                    <figure
+                      class="MuiBox-root emotion-39"
+                      data-se="password-authenticator--rules"
+                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
+                    >
+                      <figcaption
+                        class="MuiBox-root emotion-1"
+                        data-se="password-authenticator--heading"
+                      >
+                        Password requirements:
+                      </figcaption>
+                      <ul
+                        class="MuiBox-root emotion-41"
+                        id="password-authenticator--list"
+                      >
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                At least 8 characters
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A lowercase letter
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                An uppercase letter
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A number
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                No parts of your username
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your first name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your last name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </figure>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
+                      >
+                        <span>
+                          Password
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-87"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
+                          aria-errormessage="credentials.passcode-error"
+                          aria-invalid="true"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="new-password"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          role="textbox"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-89"
+                        >
+                          <button
+                            aria-controls="credentials.passcode"
+                            aria-label="Show password"
+                            aria-pressed="false"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-90"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
+                              fill="none"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M3.43 12.813A12.814 12.814 0 0 1 3.069 12a14.153 14.153 0 0 1 1.966-3.38C6.506 6.762 8.746 5 12 5s5.494 1.761 6.966 3.62A14.152 14.152 0 0 1 20.932 12a14.151 14.151 0 0 1-1.966 3.38C17.494 17.238 15.254 19 12 19s-5.494-1.761-6.966-3.62a14.152 14.152 0 0 1-1.603-2.567Zm19.518-1.13L22 12c.949.316.949.317.948.317v.004l-.003.007-.008.024a7.012 7.012 0 0 1-.137.362 16.147 16.147 0 0 1-2.266 3.906C18.84 18.762 16.08 21 12 21c-4.08 0-6.84-2.239-8.534-4.38A16.15 16.15 0 0 1 1.2 12.715a10.039 10.039 0 0 1-.137-.362l-.008-.024-.002-.007-.001-.003c0-.001 0-.002.948-.318a91.698 91.698 0 0 1-.948-.317v-.004l.003-.007.008-.024.029-.08c.025-.067.06-.163.108-.282A16.15 16.15 0 0 1 3.466 7.38C5.16 5.24 7.92 3 12 3c4.08 0 6.84 2.239 8.534 4.38a16.147 16.147 0 0 1 2.266 3.906 10.026 10.026 0 0 1 .137.362l.008.024.002.007.001.003ZM2 12l-.949.316L.946 12l.105-.316L2 12Zm20 0 .949-.316.105.316-.105.316L22 12ZM9 12a3 3 0 1 1 6 0 3 3 0 0 1-6 0Zm3-5a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-92"
+                        id="credentials.passcode-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          Password requirements were not met:
+                          <ul
+                            class="MuiList-root MuiList-dense emotion-95"
+                          >
+                            <li
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
+                            >
+                              Does not include your first name
+                            </li>
+                            <li
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
+                            >
+                              Does not include your last name
+                            </li>
+                          </ul>
+                        </div>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-99"
+                      data-se="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Sign Up
+                    </button>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <hr
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-101"
+                      data-se="separation-line"
+                    />
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-102"
+                  >
+                    <div
+                      class="MuiBox-root emotion-103"
+                    >
+                      <div
+                        class="MuiBox-root emotion-18"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-22"
+                          data-se="haveaccount"
+                          tabindex="-1"
+                        >
+                          Already have an account?
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-103"
+                    >
+                      <button
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
                         data-se="back"
                         role="link"
                       >
@@ -1601,6 +2426,84 @@ exports[`enroll-profile-with-password should display field level error when pass
                             </div>
                           </div>
                         </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your first name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                Does not include your last name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
                       </ul>
                     </figure>
                   </div>
@@ -1621,7 +2524,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-75"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-87"
                         required="true"
                       >
                         <input
@@ -1639,13 +2542,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-77"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-89"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-78"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-90"
                             tabindex="0"
                             type="button"
                           >
@@ -1668,7 +2571,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <p
-                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-80"
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-92"
                         id="credentials.passcode-error"
                       >
                         <span
@@ -1681,17 +2584,22 @@ exports[`enroll-profile-with-password should display field level error when pass
                         >
                           Password requirements were not met:
                           <ul
-                            class="MuiList-root MuiList-dense emotion-83"
+                            class="MuiList-root MuiList-dense emotion-95"
                           >
                             <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-84"
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
                             >
                               An uppercase letter
                             </li>
                             <li
-                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-84"
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
                             >
                               No parts of your username
+                            </li>
+                            <li
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-96"
+                            >
+                              Does not include your first name
                             </li>
                           </ul>
                         </div>
@@ -1702,7 +2610,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-87"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-100"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -1714,15 +2622,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth emotion-89"
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-102"
                       data-se="separation-line"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-90"
+                    class="MuiBox-root emotion-103"
                   >
                     <div
-                      class="MuiBox-root emotion-91"
+                      class="MuiBox-root emotion-104"
                     >
                       <div
                         class="MuiBox-root emotion-18"
@@ -1737,10 +2645,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-91"
+                      class="MuiBox-root emotion-104"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-95"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-108"
                         data-se="back"
                         role="link"
                       >
@@ -2149,6 +3057,84 @@ exports[`enroll-profile-with-password should render form 1`] = `
                             </div>
                           </div>
                         </li>
+                        <li
+                          class="MuiBox-root emotion-35"
+                        >
+                          <div
+                            class="MuiBox-root emotion-36"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-37"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-38"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-15"
+                                tabindex="-1"
+                              >
+                                Does not include your first name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-35"
+                        >
+                          <div
+                            class="MuiBox-root emotion-36"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-37"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-38"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-15"
+                                tabindex="-1"
+                              >
+                                Does not include your last name
+                              </p>
+                            </div>
+                          </div>
+                        </li>
                       </ul>
                     </figure>
                   </div>
@@ -2169,7 +3155,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         </span>
                       </label>
                       <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-68"
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-80"
                         required="true"
                       >
                         <input
@@ -2186,19 +3172,19 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-70"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-82"
                         >
                           <button
                             aria-controls="credentials.passcode"
                             aria-label="Show password"
                             aria-pressed="false"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-71"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-83"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-72"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-84"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -2220,7 +3206,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-74"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-86"
                       data-se="save"
                       tabindex="0"
                       type="submit"
@@ -2232,15 +3218,15 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <hr
-                      class="MuiDivider-root MuiDivider-fullWidth emotion-76"
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-88"
                       data-se="separation-line"
                     />
                   </div>
                   <div
-                    class="MuiBox-root emotion-77"
+                    class="MuiBox-root emotion-89"
                   >
                     <div
-                      class="MuiBox-root emotion-78"
+                      class="MuiBox-root emotion-90"
                     >
                       <div
                         class="MuiBox-root emotion-11"
@@ -2255,10 +3241,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-78"
+                      class="MuiBox-root emotion-90"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-82"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-94"
                         data-se="back"
                         role="link"
                       >

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -120,10 +120,113 @@ exports[`enroll-profile-with-password should display field level error when pass
                   <div
                     class="MuiBox-root emotion-17"
                   >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
+                      >
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
+                          id="userProfile.email"
+                          inputmode="email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
+                      >
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-1"
+                  >
                     <figure
-                      class="MuiBox-root emotion-24"
+                      class="MuiBox-root emotion-39"
                       data-se="password-authenticator--rules"
-                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
+                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
                     >
                       <figcaption
                         class="MuiBox-root emotion-1"
@@ -132,23 +235,23 @@ exports[`enroll-profile-with-password should display field level error when pass
                         Password requirements:
                       </figcaption>
                       <ul
-                        class="MuiBox-root emotion-26"
+                        class="MuiBox-root emotion-41"
                         id="password-authenticator--list"
                       >
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -175,19 +278,19 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -214,19 +317,19 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -253,19 +356,19 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -292,19 +395,19 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -337,113 +440,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
-                        data-shrink="false"
-                        for="userProfile.email"
-                        id="userProfile.email-label"
-                      >
-                        <span>
-                          Email
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.email-label"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-61"
-                          data-se="userProfile.email"
-                          id="userProfile.email"
-                          inputmode="email"
-                          name="userProfile.email"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                        id="userProfile.firstName-label"
-                      >
-                        <span>
-                          First name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.firstName-label"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-61"
-                          data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                        id="userProfile.lastName-label"
-                      >
-                        <span>
-                          Last name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.lastName-label"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-61"
-                          data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
                         data-shrink="false"
                         for="credentials.passcode"
                         id="credentials.passcode-label"
@@ -457,12 +457,12 @@ exports[`enroll-profile-with-password should display field level error when pass
                         required="true"
                       >
                         <input
-                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
+                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
                           aria-errormessage="credentials.passcode-error"
                           aria-invalid="true"
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="new-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
@@ -711,10 +711,113 @@ exports[`enroll-profile-with-password should display field level error when pass
                   <div
                     class="MuiBox-root emotion-17"
                   >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
+                      >
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
+                          id="userProfile.email"
+                          inputmode="email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
+                      >
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-1"
+                  >
                     <figure
-                      class="MuiBox-root emotion-24"
+                      class="MuiBox-root emotion-39"
                       data-se="password-authenticator--rules"
-                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
+                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
                     >
                       <figcaption
                         class="MuiBox-root emotion-1"
@@ -723,23 +826,23 @@ exports[`enroll-profile-with-password should display field level error when pass
                         Password requirements:
                       </figcaption>
                       <ul
-                        class="MuiBox-root emotion-26"
+                        class="MuiBox-root emotion-41"
                         id="password-authenticator--list"
                       >
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -766,19 +869,19 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -805,19 +908,19 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -844,19 +947,19 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -883,19 +986,19 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-27"
+                          class="MuiBox-root emotion-42"
                         >
                           <div
-                            class="MuiBox-root emotion-28"
+                            class="MuiBox-root emotion-43"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-29"
+                              class="MuiBox-root emotion-44"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-30"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -928,113 +1031,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                     class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
-                        data-shrink="false"
-                        for="userProfile.email"
-                        id="userProfile.email-label"
-                      >
-                        <span>
-                          Email
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.email-label"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-61"
-                          data-se="userProfile.email"
-                          id="userProfile.email"
-                          inputmode="email"
-                          name="userProfile.email"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                        id="userProfile.firstName-label"
-                      >
-                        <span>
-                          First name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.firstName-label"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-61"
-                          data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                        id="userProfile.lastName-label"
-                      >
-                        <span>
-                          Last name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-60"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.lastName-label"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-61"
-                          data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-17"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
                         data-shrink="false"
                         for="credentials.passcode"
                         id="credentials.passcode-label"
@@ -1048,12 +1048,12 @@ exports[`enroll-profile-with-password should display field level error when pass
                         required="true"
                       >
                         <input
-                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
+                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
                           aria-errormessage="credentials.passcode-error"
                           aria-invalid="true"
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="new-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
@@ -1168,6 +1168,597 @@ exports[`enroll-profile-with-password should display field level error when pass
 </div>
 `;
 
+exports[`enroll-profile-with-password should display field level error when password includes username 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-se="auth-container main-container"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="MuiScopedCssBaseline-root emotion-2"
+      >
+        <div
+          class="MuiBox-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="MuiBox-root emotion-5"
+              data-se="okta-sign-in-header auth-header "
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 emotion-6"
+                tabindex="-1"
+              />
+            </div>
+            <div
+              class="MuiBox-root emotion-7"
+            >
+              <form
+                aria-live="polite"
+                class="o-form MuiBox-root emotion-8"
+                data-se="o-form"
+                novalidate=""
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <div
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutError MuiAlert-callout emotion-10"
+                    role="alert"
+                  >
+                    <div
+                      class="MuiAlert-icon emotion-11"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
+                        fill="none"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="MuiAlert-message emotion-13"
+                    >
+                      <span
+                        class="MuiBox-root emotion-14"
+                        translate="no"
+                      >
+                        error
+                      </span>
+                      <div
+                        class="MuiBox-root emotion-1"
+                      >
+                        We found some errors. Please review the form and make corrections.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-16"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
+                        data-se="o-form-head"
+                        tabindex="-1"
+                      >
+                        Sign up
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 emotion-22"
+                        data-se="o-form-explain"
+                        tabindex="-1"
+                      >
+                        Fields are required unless marked optional.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
+                      >
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.email"
+                          id="userProfile.email"
+                          inputmode="email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.firstName"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
+                      >
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-26"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-27"
+                          data-se="userProfile.lastName"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-1"
+                  >
+                    <figure
+                      class="MuiBox-root emotion-39"
+                      data-se="password-authenticator--rules"
+                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
+                    >
+                      <figcaption
+                        class="MuiBox-root emotion-1"
+                        data-se="password-authenticator--heading"
+                      >
+                        Password requirements:
+                      </figcaption>
+                      <ul
+                        class="MuiBox-root emotion-41"
+                        id="password-authenticator--list"
+                      >
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                At least 8 characters
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A lowercase letter
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                An uppercase letter
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                A number
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          class="MuiBox-root emotion-42"
+                        >
+                          <div
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              aria-hidden="true"
+                              class="MuiBox-root emotion-44"
+                              data-se="passwordRequirementIcon-info"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-45"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiBox-root emotion-1"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 emotion-22"
+                                tabindex="-1"
+                              >
+                                No parts of your username
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </figure>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-24"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-25"
+                        data-shrink="false"
+                        for="credentials.passcode"
+                        id="credentials.passcode-label"
+                      >
+                        <span>
+                          Password
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-75"
+                        required="true"
+                      >
+                        <input
+                          aria-describedby="credentials.passcode-error enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
+                          aria-errormessage="credentials.passcode-error"
+                          aria-invalid="true"
+                          aria-labelledby="credentials.passcode-label"
+                          autocomplete="new-password"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          required=""
+                          role="textbox"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-77"
+                        >
+                          <button
+                            aria-controls="credentials.passcode"
+                            aria-label="Show password"
+                            aria-pressed="false"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-78"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-12"
+                              fill="none"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M3.43 12.813A12.814 12.814 0 0 1 3.069 12a14.153 14.153 0 0 1 1.966-3.38C6.506 6.762 8.746 5 12 5s5.494 1.761 6.966 3.62A14.152 14.152 0 0 1 20.932 12a14.151 14.151 0 0 1-1.966 3.38C17.494 17.238 15.254 19 12 19s-5.494-1.761-6.966-3.62a14.152 14.152 0 0 1-1.603-2.567Zm19.518-1.13L22 12c.949.316.949.317.948.317v.004l-.003.007-.008.024a7.012 7.012 0 0 1-.137.362 16.147 16.147 0 0 1-2.266 3.906C18.84 18.762 16.08 21 12 21c-4.08 0-6.84-2.239-8.534-4.38A16.15 16.15 0 0 1 1.2 12.715a10.039 10.039 0 0 1-.137-.362l-.008-.024-.002-.007-.001-.003c0-.001 0-.002.948-.318a91.698 91.698 0 0 1-.948-.317v-.004l.003-.007.008-.024.029-.08c.025-.067.06-.163.108-.282A16.15 16.15 0 0 1 3.466 7.38C5.16 5.24 7.92 3 12 3c4.08 0 6.84 2.239 8.534 4.38a16.147 16.147 0 0 1 2.266 3.906 10.026 10.026 0 0 1 .137.362l.008.024.002.007.001.003ZM2 12l-.949.316L.946 12l.105-.316L2 12Zm20 0 .949-.316.105.316-.105.316L22 12ZM9 12a3 3 0 1 1 6 0 3 3 0 0 1-6 0Zm3-5a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-80"
+                        id="credentials.passcode-error"
+                      >
+                        <span
+                          class="MuiBox-root emotion-14"
+                        >
+                          Error:
+                        </span>
+                        <div
+                          class="MuiBox-root emotion-1"
+                        >
+                          Password requirements were not met:
+                          <ul
+                            class="MuiList-root MuiList-dense emotion-83"
+                          >
+                            <li
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-84"
+                            >
+                              An uppercase letter
+                            </li>
+                            <li
+                              class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-84"
+                            >
+                              No parts of your username
+                            </li>
+                          </ul>
+                        </div>
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-87"
+                      data-se="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Sign Up
+                    </button>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <hr
+                      class="MuiDivider-root MuiDivider-fullWidth emotion-89"
+                      data-se="separation-line"
+                    />
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-90"
+                  >
+                    <div
+                      class="MuiBox-root emotion-91"
+                    >
+                      <div
+                        class="MuiBox-root emotion-18"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 emotion-22"
+                          data-se="haveaccount"
+                          tabindex="-1"
+                        >
+                          Already have an account?
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-91"
+                    >
+                      <button
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-95"
+                        data-se="back"
+                        role="link"
+                      >
+                        Sign In
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
 exports[`enroll-profile-with-password should render form 1`] = `
 <div>
   <div
@@ -1245,10 +1836,113 @@ exports[`enroll-profile-with-password should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-10"
                   >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.email"
+                        id="userProfile.email-label"
+                      >
+                        <span>
+                          Email
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.email-label"
+                          autocomplete="email"
+                          class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.email"
+                          id="userProfile.email"
+                          inputmode="email"
+                          name="userProfile.email"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.firstName"
+                        id="userProfile.firstName-label"
+                      >
+                        <span>
+                          First name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.firstName-label"
+                          autocomplete="given-name"
+                          class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.firstName"
+                          id="userProfile.firstName"
+                          name="userProfile.firstName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
+                        data-shrink="false"
+                        for="userProfile.lastName"
+                        id="userProfile.lastName-label"
+                      >
+                        <span>
+                          Last name
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
+                        required="true"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="userProfile.lastName-label"
+                          autocomplete="family-name"
+                          class="MuiInputBase-input emotion-20"
+                          data-se="userProfile.lastName"
+                          id="userProfile.lastName"
+                          name="userProfile.lastName"
+                          required=""
+                          type="text"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-1"
+                  >
                     <figure
-                      class="MuiBox-root emotion-17"
+                      class="MuiBox-root emotion-32"
                       data-se="password-authenticator--rules"
-                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
+                      id="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
                     >
                       <figcaption
                         class="MuiBox-root emotion-1"
@@ -1257,23 +1951,23 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         Password requirements:
                       </figcaption>
                       <ul
-                        class="MuiBox-root emotion-19"
+                        class="MuiBox-root emotion-34"
                         id="password-authenticator--list"
                       >
                         <li
-                          class="MuiBox-root emotion-20"
+                          class="MuiBox-root emotion-35"
                         >
                           <div
-                            class="MuiBox-root emotion-21"
+                            class="MuiBox-root emotion-36"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-22"
+                              class="MuiBox-root emotion-37"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-23"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-38"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1300,19 +1994,19 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-20"
+                          class="MuiBox-root emotion-35"
                         >
                           <div
-                            class="MuiBox-root emotion-21"
+                            class="MuiBox-root emotion-36"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-22"
+                              class="MuiBox-root emotion-37"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-23"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-38"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1339,19 +2033,19 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-20"
+                          class="MuiBox-root emotion-35"
                         >
                           <div
-                            class="MuiBox-root emotion-21"
+                            class="MuiBox-root emotion-36"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-22"
+                              class="MuiBox-root emotion-37"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-23"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-38"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1378,19 +2072,19 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-20"
+                          class="MuiBox-root emotion-35"
                         >
                           <div
-                            class="MuiBox-root emotion-21"
+                            class="MuiBox-root emotion-36"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-22"
+                              class="MuiBox-root emotion-37"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-23"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-38"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1417,19 +2111,19 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </div>
                         </li>
                         <li
-                          class="MuiBox-root emotion-20"
+                          class="MuiBox-root emotion-35"
                         >
                           <div
-                            class="MuiBox-root emotion-21"
+                            class="MuiBox-root emotion-36"
                           >
                             <div
                               aria-hidden="true"
-                              class="MuiBox-root emotion-22"
+                              class="MuiBox-root emotion-37"
                               data-se="passwordRequirementIcon-info"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-23"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-38"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1462,113 +2156,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-51"
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-17"
                     >
                       <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-52"
-                        data-shrink="false"
-                        for="userProfile.email"
-                        id="userProfile.email-label"
-                      >
-                        <span>
-                          Email
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-53"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.email-label"
-                          autocomplete="email"
-                          class="MuiInputBase-input emotion-54"
-                          data-se="userProfile.email"
-                          id="userProfile.email"
-                          inputmode="email"
-                          name="userProfile.email"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-10"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-51"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-52"
-                        data-shrink="false"
-                        for="userProfile.firstName"
-                        id="userProfile.firstName-label"
-                      >
-                        <span>
-                          First name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-53"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.firstName-label"
-                          autocomplete="given-name"
-                          class="MuiInputBase-input emotion-54"
-                          data-se="userProfile.firstName"
-                          id="userProfile.firstName"
-                          name="userProfile.firstName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-10"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-51"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-52"
-                        data-shrink="false"
-                        for="userProfile.lastName"
-                        id="userProfile.lastName-label"
-                      >
-                        <span>
-                          Last name
-                        </span>
-                      </label>
-                      <div
-                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-53"
-                        required="true"
-                      >
-                        <input
-                          aria-invalid="false"
-                          aria-labelledby="userProfile.lastName-label"
-                          autocomplete="family-name"
-                          class="MuiInputBase-input emotion-54"
-                          data-se="userProfile.lastName"
-                          id="userProfile.lastName"
-                          name="userProfile.lastName"
-                          required=""
-                          type="text"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-10"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-51"
-                    >
-                      <label
-                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-52"
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-18"
                         data-shrink="false"
                         for="credentials.passcode"
                         id="credentials.passcode-label"
@@ -1582,11 +2173,11 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         required="true"
                       >
                         <input
-                          aria-describedby="enroll-profile_PasswordRequirements_NON_NULL_VALUE_3"
+                          aria-describedby="enroll-profile_PasswordRequirements_NON_NULL_VALUE_6"
                           aria-invalid="false"
                           aria-labelledby="credentials.passcode-label"
                           autocomplete="new-password"
-                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-54"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-20"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"

--- a/src/v3/test/integration/enroll-profile-with-password.test.tsx
+++ b/src/v3/test/integration/enroll-profile-with-password.test.tsx
@@ -89,6 +89,40 @@ describe('enroll-profile-with-password', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should display field level error when password includes username', async () => {
+    const {
+      authClient, container, user, findByText, findByLabelText,
+    } = await setup({ mockResponse });
+
+    const titleElement = await findByText(/Sign up/);
+    await waitFor(() => expect(titleElement).toHaveFocus());
+
+    const submitButton = await findByText('Sign Up', { selector: 'button' });
+    const firstNameEle = await findByLabelText('First name') as HTMLInputElement;
+    const lastNameEle = await findByLabelText('Last name') as HTMLInputElement;
+    const emailEle = await findByLabelText('Email') as HTMLInputElement;
+    const passwordEle = await findByLabelText('Password') as HTMLInputElement;
+
+    const firstName = 'tester';
+    const lastName = 'McTesterson';
+    const email = 'tester@okta1.com';
+    const password = 'abc123testerabcd243';
+    await user.type(firstNameEle, firstName);
+    await user.type(lastNameEle, lastName);
+    await user.type(emailEle, email);
+    await user.type(passwordEle, password);
+
+    expect(firstNameEle.value).toEqual(firstName);
+    expect(lastNameEle.value).toEqual(lastName);
+    expect(emailEle.value).toEqual(email);
+    expect(passwordEle.value).toEqual(password);
+
+    await user.click(submitButton);
+    expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
+    expect(passwordEle).toHaveErrorMessage(/No parts of your username/);
+    expect(container).toMatchSnapshot();
+  });
+
   it('should send correct payload', async () => {
     const {
       authClient, user, findByText, findByLabelText,

--- a/src/v3/test/integration/enroll-profile-with-password.test.tsx
+++ b/src/v3/test/integration/enroll-profile-with-password.test.tsx
@@ -12,7 +12,8 @@
 
 import { waitFor } from '@testing-library/preact';
 
-import mockResponse from '../../../../playground/mocks/data/idp/idx/enroll-profile-with-password.json';
+import mockResponse from '../../src/mocks/response/idp/idx/enroll/enroll-profile-with-password-full-requirements.json';
+// import mockResponseWithFullRequirements from '../../src/mocks/response/idp/idx/enroll/enroll-profile-with-password-full-requirements.json';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 describe('enroll-profile-with-password', () => {
@@ -55,7 +56,7 @@ describe('enroll-profile-with-password', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should display field level error when password does not fulfill requirements', async () => {
+  it('should display field level error when password does not fulfill minLength requirement', async () => {
     const {
       authClient, container, user, findByText, findByLabelText,
     } = await setup({ mockResponse });
@@ -89,7 +90,7 @@ describe('enroll-profile-with-password', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should display field level error when password includes username', async () => {
+  it('should display field level error when password does not fulfill username requirement', async () => {
     const {
       authClient, container, user, findByText, findByLabelText,
     } = await setup({ mockResponse });
@@ -103,10 +104,10 @@ describe('enroll-profile-with-password', () => {
     const emailEle = await findByLabelText('Email') as HTMLInputElement;
     const passwordEle = await findByLabelText('Password') as HTMLInputElement;
 
-    const firstName = 'tester';
+    const firstName = 'Johnny';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
-    const password = 'abc123testerabcd243';
+    const password = 'abc123testerabcd243T$';
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -123,26 +124,10 @@ describe('enroll-profile-with-password', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should display field level error when password includes first and last name', async () => {
-    const mockResponseWithRequirements = {
-      ...mockResponse,
-      currentAuthenticator: {
-        ...mockResponse.currentAuthenticator,
-        value: {
-          ...mockResponse.currentAuthenticator.value,
-          settings: {
-            ...mockResponse.currentAuthenticator.value.settings,
-            complexity: {
-              ...mockResponse.currentAuthenticator.value.settings.complexity,
-              excludeAttributes: ['firstName', 'lastName'],
-            },
-          },
-        }
-      },
-    };
+  it('should display field level error when password does not fulfill first and last name exclusion requirement', async () => {
     const {
       authClient, container, user, findByText, findByLabelText,
-    } = await setup({ mockResponse: mockResponseWithRequirements });
+    } = await setup({ mockResponse });
 
     const titleElement = await findByText(/Sign up/);
     await waitFor(() => expect(titleElement).toHaveFocus());
@@ -153,10 +138,10 @@ describe('enroll-profile-with-password', () => {
     const emailEle = await findByLabelText('Email') as HTMLInputElement;
     const passwordEle = await findByLabelText('Password') as HTMLInputElement;
 
-    const firstName = 'tester';
+    const firstName = 'Johnny';
     const lastName = 'McTesterson';
     const email = 'oktauser@okta1.com';
-    const password = 'Abc123testerabcd243mctesterson$534534sdfa';
+    const password = 'Abc123johnnyabcd243mctesterson$534534sdfa';
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);
@@ -191,7 +176,7 @@ describe('enroll-profile-with-password', () => {
     const firstName = 'tester';
     const lastName = 'McTesterson';
     const email = 'tester@okta1.com';
-    const password = 'abc123DE';
+    const password = 'Abcd1234@hasdfaerterww';
     await user.type(firstNameEle, firstName);
     await user.type(lastNameEle, lastName);
     await user.type(emailEle, email);


### PR DESCRIPTION
## Description:

The purpose of this PR is to include user information (identifier, first name, last name) in password validation client-side function when enrolling in a new profile. During profile enrollment, this user info data is provided at the time of enrollment instead of provided by the server, so conditions was added to ensure we check the appropriate data before validation.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-703334](https://oktainc.atlassian.net/browse/OKTA-703334)

### Reviewers:

### Screenshot/Video:


https://github.com/okta/okta-signin-widget/assets/97472729/c4e10894-7ca1-4d7e-b544-68e3926f86b9

Parts of username, firstname and lastname:
<img width="617" alt="image" src="https://github.com/okta/okta-signin-widget/assets/97472729/ebc85f78-750a-4d93-8d5d-97474033e69c">


### Downstream Monolith Build:



