### PR TITLE
OKTA-664298 : Migrating jest test to testcafe

### DIFF
--- a/test/testcafe/spec/v1/PrimaryAuthForm_spec.js
+++ b/test/testcafe/spec/v1/PrimaryAuthForm_spec.js
@@ -20,7 +20,7 @@ const authNSuccessMock = RequestMock()
 fixture('Primary Auth Form');
 
 const logger = RequestLogger(
-  /api\/v1/,
+  [/api\/v1/, /auth\/services\/devicefingerprint/],
   {
     logRequestBody: true,
     stringifyRequestBody: true,
@@ -227,7 +227,7 @@ test.requestHooks(logger)('removes anti-phishing message if help link is clicked
   await t.expect(unlockAccountForm.isSecurityImageTooltipVisible()).eql(false);
 });
 
-test.requestHooks(logger)('shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)', async (t) => {
+test.only.requestHooks(logger)('shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)', async (t) => {
   const toggleBeacon = ClientFunction((show = true) => {
     document.querySelector('.beacon-container').style.display = show ? 'block' : 'none';
   });
@@ -261,12 +261,21 @@ test.requestHooks(logger)('shows beacon-loading animation when primaryAuth is su
   await t.expect(primaryAuthForm.getSecurityImageTooltip().visible).eql(true);
 
   await primaryAuthForm.clickNextButton('Sign In');
+  const [deviceFingerPrintReq, authNReq] = logger.requests;
   const {
     request: {
-      method: reqMethod,
-      url: reqUrl,
+      method: deviceFingerprintMethod,
+      url: deviceFingerprintReqUrl,
     }
-  } = logger.requests[0];
-  await t.expect(reqMethod).eql('get');
-  await t.expect(reqUrl).contains('devicefingerprint');
+  } = deviceFingerPrintReq;
+  const {
+    request: {
+      method: authNReqMethod,
+      url: authNReqUrl,
+    }
+  } = authNReq;
+  await t.expect(deviceFingerprintMethod).eql('get');
+  await t.expect(deviceFingerprintReqUrl).contains('devicefingerprint');
+  await t.expect(authNReqMethod).eql('post');
+  await t.expect(authNReqUrl).contains('api/v1/authn');
 });

--- a/test/testcafe/spec/v1/PrimaryAuthForm_spec.js
+++ b/test/testcafe/spec/v1/PrimaryAuthForm_spec.js
@@ -227,7 +227,7 @@ test.requestHooks(logger)('removes anti-phishing message if help link is clicked
   await t.expect(unlockAccountForm.isSecurityImageTooltipVisible()).eql(false);
 });
 
-test.only.requestHooks(logger)('shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)', async (t) => {
+test.requestHooks(logger)('shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)', async (t) => {
   const toggleBeacon = ClientFunction((show = true) => {
     document.querySelector('.beacon-container').style.display = show ? 'block' : 'none';
   });

--- a/test/unit/spec/v1/PrimaryAuth_spec.js
+++ b/test/unit/spec/v1/PrimaryAuth_spec.js
@@ -1494,40 +1494,6 @@ Expect.describe('PrimaryAuth', function() {
             );
           });
       });
-      itp('shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)', function() {
-        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
-          const deferred = Q.defer();
-  
-          deferred.resolve('thisIsTheDeviceFingerprint');
-          return deferred.promise;
-        });
-        return setup({
-          features: { securityImage: true, deviceFingerprinting: true, useDeviceFingerprintForSecurityImage: false },
-        })
-          .then(function(test) {
-            test.securityBeacon = test.router.header.currentBeacon.$el;
-            test.setNextResponse(resSecurityImage);
-            return setUsernameAndWaitForBeaconChange(test, 'testuser');
-          })
-          .then(function(test) {
-            spyOn(test.securityBeacon, 'toggleClass');
-            test.setNextResponse(resSuccess);
-            test.form.setPassword('pass');
-            test.form.submit();
-            return Expect.waitForSpyCall(test.successSpy, test);
-          })
-          .then(function(test) {
-            const spyCalls = test.securityBeacon.toggleClass.calls;
-
-            expect(spyCalls.count()).toBe(3);
-            // get fingerprint
-            expect(spyCalls.argsFor(0)).toEqual([BEACON_LOADING_CLS, true]);
-            // model.save
-            expect(spyCalls.argsFor(1)).toEqual([BEACON_LOADING_CLS, true]);
-            // model.save complete
-            expect(spyCalls.mostRecent().args).toEqual([BEACON_LOADING_CLS, false]);
-          });
-      });
       itp('does not show beacon-loading animation when primaryAuth fails', function() {
         return setup({ features: { securityImage: true } })
           .then(function(test) {


### PR DESCRIPTION
## Description:

Migrating a jest test (which was flaky) to testcafe. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-664298](https://oktainc.atlassian.net/browse/OKTA-664298)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



