### PR TITLE
OKTA-712752 : Gen 3 : fix : remove restrictive app banner image width

### DIFF
--- a/src/v3/src/components/Widget/style.scss
+++ b/src/v3/src/components/Widget/style.scss
@@ -178,8 +178,7 @@
   margin-block-end: map.get($ods-tokens, 'spacing', '2');
 }
 .okta-container .applogin-banner .applogin-app-logo img {
-  inline-size: map.get($ods-tokens, 'spacing', '8');
-  block-size: map.get($ods-tokens, 'spacing', '8');
+  max-block-size: map.get($ods-tokens, 'spacing', '8');
 }
 
 /* loginpage container styles */


### PR DESCRIPTION
## Description:

The purpose of this PR is to remove the image width restriction set on the app banner logo as it was causing wider logos to be squished. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-712752](https://oktainc.atlassian.net/browse/OKTA-712752)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:
**Before:**
<img width="627" alt="Screenshot 2024-04-09 at 4 49 28 PM" src="https://github.com/okta/okta-signin-widget/assets/97472729/42ff5cea-a54d-4928-b628-abe17b189227">

**After:**
<img width="558" alt="Screenshot 2024-04-09 at 4 51 04 PM" src="https://github.com/okta/okta-signin-widget/assets/97472729/138a42c7-ae52-4f97-89ab-cf0f772a5985">


