### PR TITLE
Run playground Gen1/2 in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "build:webpack-dev": "webpack --config webpack.dev.config.js",
     "build:webpack-release": "webpack --config webpack.release.config.js",
     "start": "node scripts/buildtools start",
+    "start:ie11": "IE11_COMPAT_MODE=true OKTA_SIW_HOST=0.0.0.0 ENTRY=default yarn start --watch",
     "start:test:app": "yarn workspace @okta/test.app start",
     "mock:device-authenticator": "dyson playground/mocks/spec-device-authenticator/ 6512",
     "clean:types": "grunt clean:types",

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -53,6 +53,15 @@ module.exports = function({
         corejs: '3.9',
       } : {}
     ]);
+  } else if (process.env.IE11_COMPAT_MODE === 'true') {
+    babelOptions.presets.unshift([
+      '@babel/preset-env',
+      {
+        targets: {
+          ie: '11'
+        },
+      }
+    ]);
   } else {
     // In local development, we would prefer not to include any babel transforms as they make debugging more difficult
     // However, there is an issue with testcafe which requires us to include the optional chaining transform

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -24,6 +24,7 @@ module.exports = function({
   cdn = true,
   useBuiltIns = false,
 }) {
+  /* eslint complexity: [2, 11] */
 
   // normalize entry so it is always an array
   entry = Array.isArray(entry) ? entry : [entry];

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -73,6 +73,9 @@ module.exports = (env = {}) => {
       usePolyfill(webpackConfig);
     } else {
       webpackConfig.optimization.minimize = false;
+      if (process.env.IE11_COMPAT_MODE === 'true' && entryName === 'default') {
+        usePolyfill(webpackConfig);
+      }
     }
 
     if (env.mockDuo) {

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -81,7 +81,16 @@ module.exports = {
           presets: [
             // preset-env is disabled for a better debugging experience.
             // It can be enabled if necessary to run playground on IE11
-            // '@babel/preset-env',
+            ...(process.env.IE11_COMPAT_MODE === 'true' ? [
+              [
+                '@babel/preset-env',
+                {
+                  targets: {
+                    ie: '11'
+                  }
+                }
+              ]
+            ] : []),
             '@babel/preset-typescript' // must run before preset-env: https://github.com/babel/babel/issues/12066
           ]
         }

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -42,6 +42,12 @@ if (!process.env.DISABLE_CSP) {
   headers['Content-Security-Policy'] = csp;
 }
 
+const hotReloadOptions = process.env.IE11_COMPAT_MODE === 'true' ? {
+  hot: false,
+  liveReload: false,
+  webSocketServer: false,
+} : {};
+
 module.exports = {
   mode: 'development',
   target: 'web',
@@ -98,6 +104,7 @@ module.exports = {
     ]
   },
   devServer: {
+    ...hotReloadOptions,
     host: HOST,
     watchFiles: [...staticDirs],
     static: [


### PR DESCRIPTION
## Description:

Modified webpack configs to use env var `IE11_COMPAT_MODE` for running playground Gen2 in IE11

Usage:
```
yarn start:ie11
```

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



