### PR TITLE
OKTA-719439 Support HTTPS loopback server call

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -416,6 +416,20 @@ const windowAuthnLoopbackFailfast = {
   ],
 };
 
+const windowAuthnHttpsLoopback = {
+  '/idp/idx/introspect': [
+    'identify-with-device-probing-https-loopback', // 1 (response order)
+  ],
+  '/idp/idx/authenticators/poll': [
+    'identify-with-device-probing-https-loopback', // 2
+    'identify-with-device-probing-https-loopback', // 3
+    'identify', // 4: as a signal of success
+  ],
+  '/idp/idx/authenticators/poll/cancel': [
+    'authenticator-verification-select-authenticator',
+  ]
+};
+
 // device probe: silent probe failed, but probing is still required
 const desktopSmartProbe = {
   '/idp/idx/introspect': [

--- a/playground/mocks/data/idp/idx/identify-with-device-probing-https-loopback.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-probing-https-loopback.json
@@ -1,0 +1,90 @@
+{
+    "stateHandle": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+    "version": "1.0.0",
+    "expiresAt": "2020-10-15T17:28:11.000Z",
+
+    "intent": "LOGIN",
+    "remediation": {
+        "type": "array",
+        "value": [
+            {
+                "rel": ["create-form"],
+                "name": "device-challenge-poll",
+                "relatesTo": "authenticatorChallenge",
+                "href": "http://localhost:3000/idp/idx/authenticators/poll",
+                "method": "POST",
+                "accepts": "application/ion+json;okta-version=1",
+                "produces": "application/ion+json;okta-version=1",
+                "refresh": 2000,
+                "value": [{
+                    "name": "stateHandle",
+                    "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+                    "required": true,
+                    "visible": false
+                }]
+            }
+        ]
+    },
+    "cancel": {
+        "rel": ["create-form"],
+        "name": "cancel",
+        "href": "http://localhost:3000/idp/idx/cancel",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+                "required": true,
+                "visible": false
+            }
+        ]
+    },
+    "context": {
+        "rel": ["create-form"],
+        "name": "context",
+        "href": "http://localhost:3000/idp/idx/context",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+                "required": true,
+                "visible": false
+            }
+        ]
+    },
+    "authenticatorChallenge": {
+        "type": "object",
+        "value": {
+            "challengeMethod": "LOOPBACK",
+            "challengeRequest": "eyJraWQiOiI1aTZaQW5TTlZ4RHlNYlNLS0NDcUhpUDdaNG92Q1Fab0thYlFYVE4zVnFjIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJhdWQiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJleHAiOjE1NzUxNDY0NDEsImlhdCI6MTU3NTE0NjE0MSwibm9uY2UiOiJzYW1wbGVOb25jZSIsInNpZ25hbHMiOlsic2NyZWVuTG9jayIsInJvb3RQcml2aWxlZ2VzIiwiZnVsbERpc2tFbmNyeXB0aW9uIiwiaWQiLCJwbGF0Zm9ybSIsIm9zVmVyc2lvbiIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwiZGV2aWNlQXR0ZXN0YXRpb24iXSwidXNlclZlcmlmaWNhdGlvblJlcXVpcmVtZW50IjpmYWxzZSwidmVyaWZpY2F0aW9uVXJpIjoiaHR0cHM6Ly9yYWluLm9rdGExLmNvbS8vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dGhlbnRpY2F0b3JJZC90cmFuc2FjdGlvbnMvdHJhbnNhY3Rpb25JZC92ZXJpZnkiLCJ2ZXIiOjB9.JEXKJAQE95ANX5u1CEPA7HtH1n4YcHquhee4nd5fCRtD6rvu49OSZhJo7mpd9UjF1UNLBxkektTetpvmq7IXaf0WQ-a0EqMHELbdqmpsLl9jQd7lmVpXN6nrjI-YjxZzgTNqj5GEw_Of_3eMkHo_SM4Em4YYxf8XdQHmtPJUima9gHoGbShZ-XjD1K0feEl1ybCFyflxHXa6qvhqSbhxB0wD81Khb7T-T9-GUmfDGh9FlrypIhexjDghC52puY6N-m9kuJI5IllxeW_ggFD0cB6lx8VImFrbn5CETlFCwvDqZzhbAYWh0v-Nt59w-W-DlyPp-ap0meU4pdyfcGqisQ",
+            "domain": "http://localhost",
+            "httpsDomain": "https://randomOrgId.authenticatorlocaldev.com",
+            "enhancedPollingEnabled": false,
+            "ports": [ "2000", "6511", "6512", "6513" ],
+            "probeTimeoutMillis": 3000,
+            "cancel": {
+                "rel": [
+                    "create-form"
+                ],
+                "name": "cancel-polling",
+                "href": "http://localhost:3000/idp/idx/authenticators/poll/cancel",
+                "method": "POST",
+                "accepts": "application/vnd.okta.v1+json",
+                "value": [
+                    {
+                        "name": "stateHandle",
+                        "required": true,
+                        "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+                        "visible": false,
+                        "mutable": false
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description:

- In supported platform (currently MacOS only), server will send an additional field `httpsDomain` in the `authenticatorChalelnge` object for Loopback server binding
- When this field is present, it will be storing the http loopback domain while the existing `domain` field will store the local host domain
- On SIW, if such httpsDomain exists, we will do https loopback server first and fall back to http server. This is to make sure we always start from the more secure one
- In the future, when OV client roll out reaches 95% rate that supports HTTPS loopback, we will make the change to only probe on httpsDomain
- Server side implementation is https://github.com/atko-eng/okta-core/pull/93940


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-719439](https://oktainc.atlassian.net/browse/OKTA-719439)

### Reviewers:

@vakaevich-okta @SohamKolhatkar-okta @shuowu @lesterchoi-okta 

### Screenshot/Video:


### Downstream Monolith Build:



