### PR TITLE
Increases Min Part Length for Gen1 Password Validation

### DIFF
--- a/src/v1/util/RegistrationFormFactory.js
+++ b/src/v1/util/RegistrationFormFactory.js
@@ -17,7 +17,7 @@ let { SchemaFormFactory } = internal.views.forms.helpers;
 
 const getParts = function(username) {
   const usernameArr = username.split('');
-  const minPartsLength = 3;
+  const minPartsLength = 4;
   const userNameParts = [];
   const delimiters = [',', '.', '-', '_', '#', '@'];
   let userNamePart = '';

--- a/test/unit/spec/v1/RegistrationFormFactory_spec.js
+++ b/test/unit/spec/v1/RegistrationFormFactory_spec.js
@@ -111,28 +111,28 @@ describe('RegistrationFormFactory', function() {
     it('gives the right username parts', function() {
       let result = RegistrationFormFactory.getUsernameParts('first-last.name@okta.com');
 
-      expect(result).toEqual(['first', 'last', 'name', 'okta', 'com']);
+      expect(result).toEqual(['first', 'last', 'name', 'okta']);
 
       result = RegistrationFormFactory.getUsernameParts('first-name@okta.com');
-      expect(result).toEqual(['first', 'name', 'okta', 'com']);
+      expect(result).toEqual(['first', 'name', 'okta']);
 
       result = RegistrationFormFactory.getUsernameParts('firstname@okta.com');
-      expect(result).toEqual(['firstname', 'okta', 'com']);
+      expect(result).toEqual(['firstname', 'okta']);
 
       result = RegistrationFormFactory.getUsernameParts('first_name@okta.com');
-      expect(result).toEqual(['first', 'name', 'okta', 'com']);
+      expect(result).toEqual(['first', 'name', 'okta']);
 
       result = RegistrationFormFactory.getUsernameParts('username');
       expect(result).toEqual(['username']);
 
       result = RegistrationFormFactory.getUsernameParts('user#name@okta.com');
-      expect(result).toEqual(['user', 'name', 'okta', 'com']);
+      expect(result).toEqual(['user', 'name', 'okta']);
 
       result = RegistrationFormFactory.getUsernameParts('user#name@okta#%com');
       expect(result).toEqual(['user', 'name', 'okta', '%com']);
 
       result = RegistrationFormFactory.getUsernameParts('#-name@okta.com');
-      expect(result).toEqual(['name', 'okta', 'com']);
+      expect(result).toEqual(['name', 'okta']);
 
       result = RegistrationFormFactory.getUsernameParts('first_name-@okta#');
       expect(result).toEqual(['first', 'name', 'okta']);
@@ -149,11 +149,12 @@ describe('RegistrationFormFactory', function() {
     it('returns false if password does not contain username or no username ', function() {
       expect(RegistrationFormFactory.passwordContainsFormField('administrator1', 'Abcd1234')).toEqual(false);
       expect(RegistrationFormFactory.passwordContainsFormField(null, 'Abcd1234')).toEqual(false);
+      expect(RegistrationFormFactory.passwordContainsFormField('abcd@okta.com', 'Welcome123')).toEqual(false);
+      expect(RegistrationFormFactory.passwordContainsFormField('abc', 'abc')).toEqual(false);
     });
     it('returns true if password does contain username ', function() {
       expect(RegistrationFormFactory.passwordContainsFormField('abcd@okta.com', 'Abcd1234')).toEqual(true);
-      expect(RegistrationFormFactory.passwordContainsFormField('abc', 'abc')).toEqual(true);
-      expect(RegistrationFormFactory.passwordContainsFormField('abc', 'abc@okta.com')).toEqual(true);
+      expect(RegistrationFormFactory.passwordContainsFormField('abcd', 'abcd@okta.com')).toEqual(true);
     });
   });
 });

--- a/test/unit/spec/v1/Registration_spec.js
+++ b/test/unit/spec/v1/Registration_spec.js
@@ -544,25 +544,25 @@ Expect.describe('Registration', function() {
         expect(test.form.passwordContainsUsernameError()).toBe(true);
       });
     });
-    itp('shows error if password contains part of the username:testing_123', function() {
+    itp('shows error if password contains part of the username:testing_1234', function() {
       return setup().then(function(test) {
-        test.form.setUserName('testing_123');
+        test.form.setUserName('testing_1234');
         test.form.setPassword('testing');
         test.form.focusOutPassword();
         expect(test.form.passwordContainsUsernameError()).toBe(true);
-        test.form.setPassword('testing123');
+        test.form.setPassword('testing1234');
         test.form.focusOutPassword();
         expect(test.form.passwordContainsUsernameError()).toBe(true);
-        test.form.setPassword('123Est123');
+        test.form.setPassword('1234Est123');
         test.form.focusOutPassword();
         expect(test.form.passwordContainsUsernameError()).toBe(true);
         test.form.setPassword('test_123');
         test.form.focusOutPassword();
-        expect(test.form.passwordContainsUsernameError()).toBe(true);
+        expect(test.form.passwordContainsUsernameError()).toBe(false);
         test.form.setPassword('te_12');
         test.form.focusOutPassword();
         expect(test.form.passwordContainsUsernameError()).toBe(false);
-        test.form.setPassword('_abc_123');
+        test.form.setPassword('_abc_1234');
         test.form.focusOutPassword();
         expect(test.form.passwordContainsUsernameError()).toBe(true);
       });


### PR DESCRIPTION
## Description:
- Changes minimum length to 4 characters for a part to be parsed and used during password validation in the gen1 widget. This matches backend monolith logic seen [here](https://github.com/atko-eng/okta-core/blob/c102f1fc574464d9f09b8cf6e675e239ae02e0fa/components/framework/security/api/src/main/java/com/saasure/framework/security/password/PasswordUtil.java#L21)
- This excludes usernames with common top-level domains that are 3 characters (.org, .com, .edu, etc.) from being enforced and excluded from passwords, so a username like abcd@okta.com will not cause the password Welcome123 to fail validation

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-705109](https://oktainc.atlassian.net/browse/OKTA-705109)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



