### PR TITLE
Hide "Back to sign in" link if feature `hideSignOutLinkInMFA` or `mfaOnlyFlow` is set

### DIFF
--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -182,8 +182,11 @@ const Footer = BaseFooter.extend({
       return getReloadPageButtonLink();
     }
     // If cancel object exists idx response then view would take care of rendering back to sign in link
-    if (!this.options.appState.hasActionObject('cancel') &&
-        !this.options.appState.containsMessageWithI18nKey(NO_BACKTOSIGNIN_LINK_VIEWS)) {
+    const shouldShowBackToSignInLink = !this.options.appState.hasActionObject('cancel') &&
+      !this.options.appState.containsMessageWithI18nKey(NO_BACKTOSIGNIN_LINK_VIEWS) &&
+      !this.options.settings.get('features.hideSignOutLinkInMFA') &&
+      !this.options.settings.get('features.mfaOnlyFlow');
+    if (shouldShowBackToSignInLink) {
       // TODO OKTA-432869 "back to sign in" links to org baseUrl, does not work correctly with embedded widget
       return getBackToSignInLink(this.options);
     }


### PR DESCRIPTION
## Description:

Change for Gen2: if `features.hideSignOutLinkInMFA` or `features.mfaOnlyFlow` is true, don't show "Back to sign in" link on terminal page

Note: this fix is already included in Gen3: 
https://github.com/okta/okta-signin-widget/blob/2b69f97725206f3d95588e3e3930a2b28ea81cbe/src/v3/src/util/shouldShowCancelLink.ts#L15-L18
https://github.com/okta/okta-signin-widget/blob/2b69f97725206f3d95588e3e3930a2b28ea81cbe/src/v3/src/transformer/terminal/transformTerminalTransaction.ts#L83

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-718969](https://oktainc.atlassian.net/browse/OKTA-718969)

### Reviewers:

### Screenshot/Video:

(with `hideSignOutLinkInMFA` or `mfaOnlyFlow` feature set to true)

Before:

<img width="423" alt="Screenshot 2024-04-23 at 16 16 11" src="https://github.com/okta/okta-signin-widget/assets/72614880/23d5e1fd-c90d-4653-9b44-a7c164241729">

After:

<img width="419" alt="Screenshot 2024-04-23 at 16 16 22" src="https://github.com/okta/okta-signin-widget/assets/72614880/25e195c2-04ef-4946-9b05-4ad7726db12e">


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-6fa07cb-6628d774&page=1&pageSize=6&sha=f21d73ddeacabdaf71a11262edccb3991f02af72&tab=main

