### PR TITLE
Gen1: Don't translate API error E0000014 message (password requirements)

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -103,6 +103,8 @@ Util.transformErrorXHR = function(xhr) {
     const untranslatedErrorCodes = [
       // API already provides localized and factor specific error message in errorCauses
       'E0000068',
+      // API provides localized error message for password requirements in errorCauses
+      'E0000014',
     ];
     const errorMsg = errorCode && !untranslatedErrorCodes.includes(errorCode)
       // We don't pass parameters to the `loc()` util

--- a/test/unit/spec/v1/PasswordExpired_spec.js
+++ b/test/unit/spec/v1/PasswordExpired_spec.js
@@ -499,6 +499,8 @@ Expect.describe('PasswordExpiration', function() {
         });
     });
     itp('shows an error if the server returns a wrong old pass error', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
       return setup()
         .then(function(test) {
           test.setNextResponse(resErrorOldPass);
@@ -536,9 +538,12 @@ Expect.describe('PasswordExpiration', function() {
               },
             },
           ]);
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
     });
     itp('shows an error if the server returns a complexity error', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
       return setup()
         .then(function(test) {
           test.setNextResponse(resErrorComplexity);
@@ -580,11 +585,14 @@ Expect.describe('PasswordExpiration', function() {
               },
             },
           ]);
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
     });
     itp(
       'shows an simple error if showPasswordRequirementsAsHtmlList is on and if the server returns a complexity error',
       function() {
+        // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+        const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
         return setup({ 'features.showPasswordRequirementsAsHtmlList': true })
           .then(function(test) {
             test.setNextResponse(resErrorComplexity);
@@ -622,12 +630,15 @@ Expect.describe('PasswordExpiration', function() {
                 },
               },
             ]);
+            expect(dispatchEventSpy).not.toHaveBeenCalled();
           });
       }
     );
     itp(
       'shows an simple error if no error cause and if showPasswordRequirementsAsHtmlList is on and if the server returns a complexity error',
       function() {
+        // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+        const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
         return setup({ 'features.showPasswordRequirementsAsHtmlList': true })
           .then(function(test) {
             test.setNextResponse(resErrorNoCause);
@@ -660,6 +671,7 @@ Expect.describe('PasswordExpiration', function() {
                 },
               },
             ]);
+            expect(dispatchEventSpy).not.toHaveBeenCalled();
           });
       }
     );


### PR DESCRIPTION
## Description:



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-727378](https://oktainc.atlassian.net/browse/OKTA-727378)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



