### PR TITLE
fix: Block identify form on submit before device fingerprint is ready

### DIFF
--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -62,6 +62,9 @@ const Body = BaseForm.extend({
       element: this.$el,
     };
 
+    // Toggle Form saving status (e.g. disabling save button, etc)
+    this.model.trigger('request');
+
     // For certain flows, we need to generate a device fingerprint
     // to determine if we need to send a "New Device Sign-on Notification".
     // In the future, this should be handled completely by okta-auth-js OKTA-418160

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -103,6 +103,10 @@ export default class IdentityPageObject extends BasePageObject {
     return this.form.clickSaveButton('Next');
   }
 
+  isNextButtonDisabled() {
+    return this.form.isSaveButtonDisabled('Next');
+  }
+
   clickVerifyButton() {
     return this.form.clickSaveButton('Verify');
   }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -183,6 +183,14 @@ export default class BaseFormObject {
     await this.clickButton(name);
   }
 
+  isSaveButtonDisabled(name = 'Next') {
+    const button = this.getButton(name);
+    if (userVariables.gen3) {
+      return button.hasAttribute('disabled');
+    }
+    return button.hasClass('link-button-disabled');
+  }
+
   /**
    * @deprecated
    * @see clickSaveButton

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -82,7 +82,7 @@ const identifyMockWithFingerprintError = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(xhrErrorIdentify, 403);
 
-  const identifyMockWithFailedFingerprint = RequestMock()
+const identifyMockWithFailedFingerprint = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrIdentify)
   .onRequestTo('http://localhost:3000/auth/services/devicefingerprint')
@@ -400,9 +400,11 @@ test.requestHooks(identifyRequestLogger, deviceFingerprintRequestLogger, identif
 
   await identityPage.fillIdentifierField('Test Identifier');
 
-  // Click 'Next' 2 times. It shoud result in only 1 fingerprint request.
   await identityPage.clickNextButton();
-  await identityPage.clickNextButton();
+  if (!userVariables.gen3) {
+    // Click 'Next' 2 times. It shoud result in only 1 fingerprint request.
+    await identityPage.clickNextButton();
+  }
   await t.expect(deviceFingerprintRequestLogger.count(() => true)).eql(1);
 
   // The fingerprint will fail to be generated and will not be added as a request header

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -401,7 +401,9 @@ test.requestHooks(identifyRequestLogger, deviceFingerprintRequestLogger, identif
   await identityPage.fillIdentifierField('Test Identifier');
 
   await identityPage.clickNextButton();
-  if (!userVariables.gen3) {
+  if (userVariables.gen3) {
+    await t.expect(identityPage.isNextButtonDisabled()).ok();
+  } else {
     // Click 'Next' 2 times. It shoud result in only 1 fingerprint request.
     await identityPage.clickNextButton();
   }


### PR DESCRIPTION
## Description:

When device fingerprint feature is enabled. User enters username and clicks 'Next' button. Form will not be disabled immediately (only after fingerprint is generated), so user can click  'Next' several times, which can lead to errors (see videos).

This PR just add blocking of Indentify form right after 'Next' button click, before fingerprint is generated.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-730135](https://oktainc.atlassian.net/browse/OKTA-730135)

### Reviewers:

### Screenshot/Video:

https://github.com/okta/okta-signin-widget/assets/72614880/7bd994e9-ac73-4831-b19e-6fbc4661987e


https://github.com/okta/okta-signin-widget/assets/72614880/45a53d35-4c05-48da-a460-27b623a9492e





### Downstream Monolith Build:



