### PR TITLE
Change CSS files export in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
       "default": "./target/js/okta-sign-in.oie.js"
     },
     "./polyfill": "./target/js/okta-sign-in.polyfill.js",
-    "./css/": "./target/css/",
+    "./css/*": "./target/css/*",
     "./mocks": "./playground/mocks/server.js"
   },
   "scripts": {


### PR DESCRIPTION

Copy of https://github.com/okta/okta-signin-widget/pull/3618

## Description:

Updates `./css/` export definition from deprecated directory syntax to star syntax `./css/*`

See [Subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns)

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-733356](https://oktainc.atlassian.net/browse/OKTA-733356)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



