### PR TITLE
Marking e2e bacon suite as optional for merge

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -70,7 +70,7 @@ test_suites:
     sort_order: '10'
     timeout: '40'
     script_name: e2e
-    criteria: OPTIONAL
+    criteria: OPTIONAL # OKTA-561398 - skipping due to SMS scenario failure
     queue_name: small
   - name: e2e-lang
     script_path: /root/okta/okta-signin-widget/scripts

--- a/.bacon.yml
+++ b/.bacon.yml
@@ -70,7 +70,7 @@ test_suites:
     sort_order: '10'
     timeout: '40'
     script_name: e2e
-    criteria: MERGE
+    criteria: OPTIONAL
     queue_name: small
   - name: e2e-lang
     script_path: /root/okta/okta-signin-widget/scripts


### PR DESCRIPTION
## Description:

Mark e2e suite as optional due to flaky test.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-733811](https://oktainc.atlassian.net/browse/OKTA-733811)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



