### PR TITLE
Gen2: Fix rendering of non-IDX errors (for views with custom error callout)

### DIFF
--- a/playground/mocks/server.js
+++ b/playground/mocks/server.js
@@ -52,13 +52,6 @@ function registerService(app, config) {
     if (config.delay) {
       await sleep(Array.isArray(config.delay) ? getRandomDelay(config.delay) : config.delay);
     }
-    // Render
-    if (config.template) {
-      const resp = typeof config.template === 'function' ? config.template(req.params, req.query) : config.template;
-      res.send(resp);
-    } else if (typeof config.render === 'function') {
-      config.render(req, res);
-    }
     // Status
     if (config.status) {
       if (typeof config.status === 'function') {
@@ -66,6 +59,13 @@ function registerService(app, config) {
       } else {
         res.status(config.status);
       }
+    }
+    // Render
+    if (config.template) {
+      const resp = typeof config.template === 'function' ? config.template(req.params, req.query) : config.template;
+      res.send(resp);
+    } else if (typeof config.render === 'function') {
+      config.render(req, res);
     }
     res.end();
   });

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -387,7 +387,7 @@ export default Controller.extend({
     }
 
     if(_.isFunction(form?.showCustomFormErrorCallout)) {
-      showErrorBanner = !form.showCustomFormErrorCallout(errorObj, idxStateError.messages);
+      showErrorBanner = !form.showCustomFormErrorCallout(errorObj, idxStateError?.messages);
     }
 
     // show error before updating app state.

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -178,7 +178,7 @@ const Body = BaseForm.extend({
       return false;
     }
 
-    const message = messages.find(message => message.i18n.key === CUSTOM_ACCESS_DENIED_KEY);
+    const message = messages?.find(message => message.i18n.key === CUSTOM_ACCESS_DENIED_KEY);
     if (!message) {
       return false;
     }

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -10,6 +10,7 @@ import xhrAuthenticatorVerifySelect from '../../../playground/mocks/data/idp/idx
 import xhrAuthenticatorOVTotp from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-totp';
 import xhrIdentifyWithUser from '../../../playground/mocks/data/idp/idx/identify-with-user';
 import xhrErrorIdentifyMultipleErrors from '../../../playground/mocks/data/idp/idx/error-identify-multiple-errors';
+import xhrOAuthError from '../../../playground/mocks/data/idp/idx/error-feature-not-enabled';
 
 import config from '../../../src/config/config.json';
 
@@ -22,6 +23,12 @@ const identifyMockWithUnsupportedResponseError = RequestMock()
   .respond(xhrIdentify)
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond({}, 403);
+
+const identifyMockWithOAuthError = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrIdentify)
+  .onRequestTo('http://localhost:3000/idp/idx/identify')
+  .respond(xhrOAuthError);
 
 const identifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -201,6 +208,15 @@ test.requestHooks(identifyMockWithUnsupportedResponseError)('should show error i
   await identityPage.clickNextButton();
   await identityPage.waitForErrorBox();
   await t.expect(identityPage.getErrorBoxText()).contains('There was an unsupported response from server.');
+});
+
+test.requestHooks(identifyMockWithOAuthError)('should show errors if server returns OAuth error', async t => {
+  const identityPage = await setup(t);
+  await checkA11y(t);
+  await identityPage.fillIdentifierField('test');
+  await identityPage.clickNextButton();
+  await identityPage.waitForErrorBox();
+  await t.expect(identityPage.getErrorBoxText()).contains('The requested feature is not enabled in this environment.');
 });
 
 test.requestHooks(identifyMock)('should show customized error if required field identifier is empty', async t => {


### PR DESCRIPTION
## Description:

Sentry issues: https://oktainc.atlassian.net/browse/OKTA-733894

```
TypeError: Cannot read properties of undefined (reading 'messages')
  at None (/assets/js/sdk/okta-signin-widget/7.18.1/js/okta-sign-in.min.js:73:696260)
```

Error cause:

https://github.com/okta/okta-signin-widget/blob/e1e0711764dac18980a0b96e6a41cf3224e942ef/src/v2/controllers/FormController.ts#L390

`idxStateError` can be undefined if it's non-terminal non-IDX error (line 335)
https://github.com/okta/okta-signin-widget/blob/e1e0711764dac18980a0b96e6a41cf3224e942ef/src/v2/controllers/FormController.ts#L332-L335
Or if `showFormErrors` is called with custom error eg.
https://github.com/okta/okta-signin-widget/blob/e1e0711764dac18980a0b96e6a41cf3224e942ef/src/v2/controllers/FormController.ts#L199-L201
https://github.com/okta/okta-signin-widget/blob/e1e0711764dac18980a0b96e6a41cf3224e942ef/src/v2/controllers/FormController.ts#L275-L276

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-733894](https://oktainc.atlassian.net/browse/OKTA-733894)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



