### PR TITLE
Removed font 'Proxima Nova', replaced with 'Aeonik'

### DIFF
--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -1,45 +1,4 @@
 @font-face {
-    font-family: Proxima Nova;
-    font-style: normal;
-    font-weight: 400;
-    /* OKTA-667070 - address hard-coded preview static URL's */
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.9d5837512674046fa816.eot);
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.9d5837512674046fa816.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.353416ed0ff540352235.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.51ac1a980f546ac17d67.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.f9f2259180c0e36006aa.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.f3b703e6dcd5c6d19922.svg#proxima_nova_rgregular) format("svg")
-}
-
-@font-face {
-    font-family: Proxima Nova;
-    font-style: italic;
-    font-weight: 400;
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.3f0c824b764202106b4e.eot);
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.3f0c824b764202106b4e.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.51be743e399dfee28e6c.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.cda5d20fe3f8cd0ba460.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.fe55183829cda0b7085b.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.15e8ae07b638768b6c83.svg#proxima_novaregular_italic) format("svg")
-}
-
-@font-face {
-    font-family: Proxima Nova;
-    font-style: normal;
-    font-weight: 600;
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.ec5a60c81d1aa5db2a5b.eot);
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.ec5a60c81d1aa5db2a5b.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.41acb8650115f83780fc.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.78cef0e33b9c7cebcf75.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.25ecfa3e3cee8643c95e.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.d1907212b9a82c27bdbf.svg#proxima_nova_ltsemibold) format("svg")
-}
-
-@font-face {
-    font-family: Proxima Nova;
-    font-style: normal;
-    font-weight: 300;
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.e575665f9d85ebce5a75.eot);
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.e575665f9d85ebce5a75.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.aba797dabec6686294a9.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.2d7fad787fa83b607ab0.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.bab6b55ab392cc61dace.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.5b4b0ec11a06ec51e2f3.svg#proxima_nova_ltlight) format("svg")
-}
-
-@font-face {
-    font-family: Proxima Nova;
-    font-style: italic;
-    font-weight: 300;
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.e5901b2bf44424f5b952.eot);
-    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.e5901b2bf44424f5b952.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.d131640268247c92a76a.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.c39ab1f26be9af07bbc8.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.635f41c946ef1429acf9.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.65f213f85f874eb84782.svg#proxima_novalight_italic) format("svg")
-}
-
-@font-face {
     font-family: Public Sans;
     font-style: normal;
     font-weight: 400;

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -1,5 +1,5 @@
 // Page Properties
-$fonts: 'proxima nova', 'montserrat-okta', Arial, Helvetica, sans-serif;
+$fonts: Aeonik, Inter, 'montserrat-okta', Arial, Helvetica, sans-serif;
 $default-border-radius: 3px;
 $container-width: 400px;
 $container-min-width: 300px;

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -2,7 +2,7 @@
 @use 'common/shared/helpers/mixins';
 
 .skip-to-content-link {
-  font-family: "proxima nova", "montserrat-okta", Arial, Helvetica, sans-serif;
+  font-family: Aeonik, Inter, "montserrat-okta", Arial, Helvetica, sans-serif;
   text-decoration: none;
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Description:

Old:
```css
font-family: 'proxima nova', 'montserrat-okta', Arial, Helvetica, sans-serif;
```

New:
```css
font-family: $fonts: Aeonik, Inter, 'montserrat-okta', Arial, Helvetica, sans-serif;
```

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-731216](https://oktainc.atlassian.net/browse/OKTA-731216)

### Reviewers:

### Screenshot/Video:

Old:
<img width="411" alt="font-old" src="https://github.com/okta/okta-signin-widget/assets/72614880/1dae1998-3a02-4049-9699-021d38c6cf18">

New:
<img width="414" alt="font-new" src="https://github.com/okta/okta-signin-widget/assets/72614880/174ad4c4-a473-4765-8beb-83495863bdde">


### Downstream Monolith Build:



