### PR TITLE
chore: bump version to 7.19.3, isolate legacy browser fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,9 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 
 ```html
 <!-- Latest CDN production Javascript and CSS -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.19.2/js/okta-sign-in.min.js" type="text/javascript" integrity="sha384-CSvkrhVswep1Sy9cG26f0bx+y/nHNHnkjq3oWykYsMvkDiAQpLdDYRVU0wzAEoZo" crossorigin="anonymous"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.19.3/js/okta-sign-in.min.js" type="text/javascript" integrity="sha384-WymQotpGWzrovXkAUV+MR2YB4wTxKN51jrP+sjzTmYTK98ZWOhyi6zHX+zOc0B1Y" crossorigin="anonymous"></script>
 
-<link href="https://global.oktacdn.com/okta-signin-widget/7.19.2/css/okta-sign-in.min.css" type="text/css" rel="stylesheet" integrity="sha384-FL6VsXYuwuq1Zo5lnWVgcOMWSo1JuvDue2bQ66/TdWOTwPEU9OgvF4Ks8fNnaiHd" crossorigin="anonymous" />
+<link href="https://global.oktacdn.com/okta-signin-widget/7.19.3/css/okta-sign-in.min.css" type="text/css" rel="stylesheet" integrity="sha384-FL6VsXYuwuq1Zo5lnWVgcOMWSo1JuvDue2bQ66/TdWOTwPEU9OgvF4Ks8fNnaiHd" crossorigin="anonymous" />
 ```
 
 **NOTE:** The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](https://github.com/okta/okta-signin-widget/releases). We recommend using the latest widget version.
@@ -269,13 +269,13 @@ When using one of the bundles without the polyfill included, you may want to con
 
 ```html
 <!-- Polyfill for older browsers -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.19.2/js/okta-sign-in.polyfill.min.js" type="text/javascript" integrity="sha384-QzQIGwIndxyBdHRQOwgjmQJLod6LRMchZyYg7RUq8FUECvPvreqauQhkU2FF9EGD" crossorigin="anonymous"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.19.3/js/okta-sign-in.polyfill.min.js" type="text/javascript" integrity="sha384-QzQIGwIndxyBdHRQOwgjmQJLod6LRMchZyYg7RUq8FUECvPvreqauQhkU2FF9EGD" crossorigin="anonymous"></script>
 
 <!-- Widget bundle for Okta Identity Engine -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.19.2/js/okta-sign-in.oie.min.js" type="text/javascript" integrity="sha384-nnD0YVNPUCj8Y/E/9yQaDjRZCHz8D3sDi87m5TkMb0P2HLvjNgnqrYC+uFzq7DVd" crossorigin="anonymous"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.19.3/js/okta-sign-in.oie.min.js" type="text/javascript" integrity="sha384-wrxovbZUmvGqWTK0ufNbI+vyXUxfzBN4LnwiFy2and+F8G+LAKJnlq+yLzE6wIz/" crossorigin="anonymous"></script>
 
 <!-- CSS for widget -->
-<link href="https://global.oktacdn.com/okta-signin-widget/7.19.2/css/okta-sign-in.min.css" type="text/css" rel="stylesheet" integrity="sha384-FL6VsXYuwuq1Zo5lnWVgcOMWSo1JuvDue2bQ66/TdWOTwPEU9OgvF4Ks8fNnaiHd" crossorigin="anonymous" />
+<link href="https://global.oktacdn.com/okta-signin-widget/7.19.3/css/okta-sign-in.min.css" type="text/css" rel="stylesheet" integrity="sha384-FL6VsXYuwuq1Zo5lnWVgcOMWSo1JuvDue2bQ66/TdWOTwPEU9OgvF4Ks8fNnaiHd" crossorigin="anonymous" />
 ```
 
 

--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -1,4 +1,45 @@
 @font-face {
+    font-family: Proxima Nova;
+    font-style: normal;
+    font-weight: 400;
+    /* OKTA-667070 - address hard-coded preview static URL's */
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.9d5837512674046fa816.eot);
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.9d5837512674046fa816.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.353416ed0ff540352235.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.51ac1a980f546ac17d67.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.f9f2259180c0e36006aa.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-reg-webfont.f3b703e6dcd5c6d19922.svg#proxima_nova_rgregular) format("svg")
+}
+
+@font-face {
+    font-family: Proxima Nova;
+    font-style: italic;
+    font-weight: 400;
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.3f0c824b764202106b4e.eot);
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.3f0c824b764202106b4e.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.51be743e399dfee28e6c.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.cda5d20fe3f8cd0ba460.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.fe55183829cda0b7085b.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-regit-webfont.15e8ae07b638768b6c83.svg#proxima_novaregular_italic) format("svg")
+}
+
+@font-face {
+    font-family: Proxima Nova;
+    font-style: normal;
+    font-weight: 600;
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.ec5a60c81d1aa5db2a5b.eot);
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.ec5a60c81d1aa5db2a5b.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.41acb8650115f83780fc.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.78cef0e33b9c7cebcf75.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.25ecfa3e3cee8643c95e.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-sbold-webfont.d1907212b9a82c27bdbf.svg#proxima_nova_ltsemibold) format("svg")
+}
+
+@font-face {
+    font-family: Proxima Nova;
+    font-style: normal;
+    font-weight: 300;
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.e575665f9d85ebce5a75.eot);
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.e575665f9d85ebce5a75.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.aba797dabec6686294a9.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.2d7fad787fa83b607ab0.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.bab6b55ab392cc61dace.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-light-webfont.5b4b0ec11a06ec51e2f3.svg#proxima_nova_ltlight) format("svg")
+}
+
+@font-face {
+    font-family: Proxima Nova;
+    font-style: italic;
+    font-weight: 300;
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.e5901b2bf44424f5b952.eot);
+    src: url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.e5901b2bf44424f5b952.eot?#iefix) format("embedded-opentype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.d131640268247c92a76a.woff2) format("woff2"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.c39ab1f26be9af07bbc8.woff) format("woff"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.635f41c946ef1429acf9.ttf) format("truetype"), url(https://op3static.oktacdn.com/assets/loginpage/font/assets/proximanova-lightitalic-webfont.65f213f85f874eb84782.svg#proxima_novalight_italic) format("svg")
+}
+
+@font-face {
     font-family: Public Sans;
     font-style: normal;
     font-weight: 400;

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -1,5 +1,5 @@
 // Page Properties
-$fonts: Aeonik, Inter, 'montserrat-okta', Arial, Helvetica, sans-serif;
+$fonts: 'proxima nova', 'montserrat-okta', Arial, Helvetica, sans-serif;
 $default-border-radius: 3px;
 $container-width: 400px;
 $container-min-width: 300px;

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -2,7 +2,7 @@
 @use 'common/shared/helpers/mixins';
 
 .skip-to-content-link {
-  font-family: Aeonik, Inter, "montserrat-okta", Arial, Helvetica, sans-serif;
+  font-family: "proxima nova", "montserrat-okta", Arial, Helvetica, sans-serif;
   text-decoration: none;
   position: absolute;
   top: 0;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "7.19.2",
+  "version": "7.19.3",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -9,13 +9,13 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 
 ```html
 <!-- Polyfill for older browsers -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.19.2/js/okta-sign-in.polyfill.min.js" type="text/javascript" integrity="sha384-QzQIGwIndxyBdHRQOwgjmQJLod6LRMchZyYg7RUq8FUECvPvreqauQhkU2FF9EGD" crossorigin="anonymous"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.19.3/js/okta-sign-in.polyfill.min.js" type="text/javascript" integrity="sha384-QzQIGwIndxyBdHRQOwgjmQJLod6LRMchZyYg7RUq8FUECvPvreqauQhkU2FF9EGD" crossorigin="anonymous"></script>
 
 <!-- Widget bundle for Okta Identity Engine -->
-<script src="https://global.oktacdn.com/okta-signin-widget/7.19.2/js/okta-sign-in.oie.min.js" type="text/javascript" integrity="sha384-nnD0YVNPUCj8Y/E/9yQaDjRZCHz8D3sDi87m5TkMb0P2HLvjNgnqrYC+uFzq7DVd" crossorigin="anonymous"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/7.19.3/js/okta-sign-in.oie.min.js" type="text/javascript" integrity="sha384-wrxovbZUmvGqWTK0ufNbI+vyXUxfzBN4LnwiFy2and+F8G+LAKJnlq+yLzE6wIz/" crossorigin="anonymous"></script>
 
 <!-- CSS for widget -->
-<link href="https://global.oktacdn.com/okta-signin-widget/7.19.2/css/okta-sign-in.min.css" type="text/css" rel="stylesheet" integrity="sha384-FL6VsXYuwuq1Zo5lnWVgcOMWSo1JuvDue2bQ66/TdWOTwPEU9OgvF4Ks8fNnaiHd" crossorigin="anonymous" />
+<link href="https://global.oktacdn.com/okta-signin-widget/7.19.3/css/okta-sign-in.min.css" type="text/css" rel="stylesheet" integrity="sha384-FL6VsXYuwuq1Zo5lnWVgcOMWSo1JuvDue2bQ66/TdWOTwPEU9OgvF4Ks8fNnaiHd" crossorigin="anonymous" />
 ```
 
 **NOTE:** The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](https://github.com/okta/okta-signin-widget/releases). We recommend using the latest widget version.


### PR DESCRIPTION
## Description:

to isolate IE11 fix, revert CSS change removing font

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-736684](https://oktainc.atlassian.net/browse/OKTA-736684)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



