### PR TITLE
Okta 719439 https loopback

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -417,7 +417,7 @@ const windowAuthnLoopbackFailfast = {
   ],
 };
 
-const windowAuthnHttpsLoopback = {
+const macOSAuthnHttpsLoopback = {
   '/idp/idx/introspect': [
     'identify-with-device-probing-https-loopback', // 1 (response order)
   ],

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -417,6 +417,20 @@ const windowAuthnLoopbackFailfast = {
   ],
 };
 
+const windowAuthnHttpsLoopback = {
+  '/idp/idx/introspect': [
+    'identify-with-device-probing-https-loopback', // 1 (response order)
+  ],
+  '/idp/idx/authenticators/poll': [
+    'identify-with-device-probing-https-loopback', // 2
+    'identify-with-device-probing-https-loopback', // 3
+    'identify', // 4: as a signal of success
+  ],
+  '/idp/idx/authenticators/poll/cancel': [
+    'authenticator-verification-select-authenticator',
+  ]
+};
+
 // device probe: silent probe failed, but probing is still required
 const desktopSmartProbe = {
   '/idp/idx/introspect': [

--- a/playground/mocks/data/idp/idx/identify-with-device-probing-https-loopback.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-probing-https-loopback.json
@@ -1,0 +1,90 @@
+{
+    "stateHandle": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+    "version": "1.0.0",
+    "expiresAt": "2020-10-15T17:28:11.000Z",
+
+    "intent": "LOGIN",
+    "remediation": {
+        "type": "array",
+        "value": [
+            {
+                "rel": ["create-form"],
+                "name": "device-challenge-poll",
+                "relatesTo": "authenticatorChallenge",
+                "href": "http://localhost:3000/idp/idx/authenticators/poll",
+                "method": "POST",
+                "accepts": "application/ion+json;okta-version=1",
+                "produces": "application/ion+json;okta-version=1",
+                "refresh": 2000,
+                "value": [{
+                    "name": "stateHandle",
+                    "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+                    "required": true,
+                    "visible": false
+                }]
+            }
+        ]
+    },
+    "cancel": {
+        "rel": ["create-form"],
+        "name": "cancel",
+        "href": "http://localhost:3000/idp/idx/cancel",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+                "required": true,
+                "visible": false
+            }
+        ]
+    },
+    "context": {
+        "rel": ["create-form"],
+        "name": "context",
+        "href": "http://localhost:3000/idp/idx/context",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+                "required": true,
+                "visible": false
+            }
+        ]
+    },
+    "authenticatorChallenge": {
+        "type": "object",
+        "value": {
+            "challengeMethod": "LOOPBACK",
+            "challengeRequest": "eyJraWQiOiI1aTZaQW5TTlZ4RHlNYlNLS0NDcUhpUDdaNG92Q1Fab0thYlFYVE4zVnFjIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJhdWQiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJleHAiOjE1NzUxNDY0NDEsImlhdCI6MTU3NTE0NjE0MSwibm9uY2UiOiJzYW1wbGVOb25jZSIsInNpZ25hbHMiOlsic2NyZWVuTG9jayIsInJvb3RQcml2aWxlZ2VzIiwiZnVsbERpc2tFbmNyeXB0aW9uIiwiaWQiLCJwbGF0Zm9ybSIsIm9zVmVyc2lvbiIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwiZGV2aWNlQXR0ZXN0YXRpb24iXSwidXNlclZlcmlmaWNhdGlvblJlcXVpcmVtZW50IjpmYWxzZSwidmVyaWZpY2F0aW9uVXJpIjoiaHR0cHM6Ly9yYWluLm9rdGExLmNvbS8vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dGhlbnRpY2F0b3JJZC90cmFuc2FjdGlvbnMvdHJhbnNhY3Rpb25JZC92ZXJpZnkiLCJ2ZXIiOjB9.JEXKJAQE95ANX5u1CEPA7HtH1n4YcHquhee4nd5fCRtD6rvu49OSZhJo7mpd9UjF1UNLBxkektTetpvmq7IXaf0WQ-a0EqMHELbdqmpsLl9jQd7lmVpXN6nrjI-YjxZzgTNqj5GEw_Of_3eMkHo_SM4Em4YYxf8XdQHmtPJUima9gHoGbShZ-XjD1K0feEl1ybCFyflxHXa6qvhqSbhxB0wD81Khb7T-T9-GUmfDGh9FlrypIhexjDghC52puY6N-m9kuJI5IllxeW_ggFD0cB6lx8VImFrbn5CETlFCwvDqZzhbAYWh0v-Nt59w-W-DlyPp-ap0meU4pdyfcGqisQ",
+            "domain": "http://localhost",
+            "httpsDomain": "https://randomOrgId.authenticatorlocaldev.com",
+            "enhancedPollingEnabled": false,
+            "ports": [ "2000", "6511", "6512", "6513" ],
+            "probeTimeoutMillis": 3000,
+            "cancel": {
+                "rel": [
+                    "create-form"
+                ],
+                "name": "cancel-polling",
+                "href": "http://localhost:3000/idp/idx/authenticators/poll/cancel",
+                "method": "POST",
+                "accepts": "application/vnd.okta.v1+json",
+                "value": [
+                    {
+                        "name": "stateHandle",
+                        "required": true,
+                        "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cq",
+                        "visible": false,
+                        "mutable": false
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -1,3 +1,4 @@
+/* eslint max-statements: [2, 21] */
 import { $, View } from '@okta/courage';
 import { BaseFormWithPolling } from '../internals';
 import Logger from 'util/Logger';
@@ -163,6 +164,7 @@ const Body = BaseFormWithPolling.extend({
     // This only applies to MacOS for now
     if (authenticatorHttpsDomainUrl) {
       // if https domain are included, max number of ports to be probed should be doubled
+      Logger.info('httpsDomain enabled, will probe and challenge https first');
       maxNumberOfPorts += maxNumberOfPorts;
       ports.forEach(port => {
         probeChain = probeChain

--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -142,7 +142,7 @@ const Body = BaseFormWithPolling.extend({
                   AUTHENTICATION_CANCEL_REASONS.OV_ERROR,
                   xhr.status
                 );
-              } else if (countFailedPorts === ports.length) {
+              } else if (countFailedPorts === maxNumberOfPorts) {
                 // when challenge is responded by the wrong OS profile and
                 // all the ports are exhausted,
                 // cancel the polling like the probing has failed

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -126,16 +126,16 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
     const doLoopback = async () => {
       let foundPort = false;
 
-      let urls = ports.map((port) => `${domain}:${port}`);
+      let baseUrls = ports.map((port) => `${domain}:${port}`);
       if (httpsDomain) {
         Logger.info('httpsDomain enabled, will probe and challenge https first');
-        const httpsUrls = ports.map((port) => `${httpsDomain}:${port}`);
-        urls = [...httpsUrls, ...urls];
+        const httpsBaseUrls = ports.map((port) => `${httpsDomain}:${port}`);
+        baseUrls = [...httpsBaseUrls, ...baseUrls];
       }
 
       // loop over each domain:port
       // eslint-disable-next-line no-restricted-syntax
-      for (const url of urls) {
+      for (const baseUrl of baseUrls) {
         try {
           // probe the url
           const probeResponse = await makeRequest({
@@ -149,18 +149,18 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
             customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
             */
             timeout: isAndroid() ? 3_000 : probeTimeoutMillis,
-            url: `${url}/probe`,
+            url: `${baseUrl}/probe`,
           });
 
           if (!probeResponse.ok) {
-            Logger.error(`Authenticator is not listening on url ${url}.`);
+            Logger.error(`Authenticator is not listening on url ${baseUrl}.`);
             // there's more ports to try, continue with next port
             continue;
           }
 
           // try port with challenge request
           const challengeResponse = await makeRequest({
-            url: `${url}/challenge`,
+            url: `${baseUrl}/challenge`,
             method: 'POST',
             timeout: 300_000,
             data: JSON.stringify({ challengeRequest }),
@@ -189,7 +189,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
           break;
         } catch (e) {
           // only for unexpected error conditions (e.g. fetch throws an error)
-          Logger.error(`Something unexpected happened while we were checking url ${url}`);
+          Logger.error(`Something unexpected happened while we were checking url ${baseUrl}`);
         }
       }
 

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -92,6 +92,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
   const ports: string[] = deviceChallengePayload.ports || [];
   const {
     domain,
+    httpsDomain,
     challengeRequest,
   } = deviceChallengePayload;
 
@@ -124,11 +125,19 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
   useEffect(() => {
     const doLoopback = async () => {
       let foundPort = false;
-      // loop over each port
+
+      let urls = ports.map((port) => `${domain}:${port}`);
+      if (httpsDomain) {
+        Logger.info('httpsDomain enabled, will probe and challenge https first');
+        const httpsUrls = ports.map((port) => `${httpsDomain}:${port}`);
+        urls = [...httpsUrls, ...urls];
+      }
+
+      // loop over each domain:port
       // eslint-disable-next-line no-restricted-syntax
-      for (const port of ports) {
+      for (const url of urls) {
         try {
-          // probe the port
+          // probe the url
           const probeResponse = await makeRequest({
             method: 'GET',
             /*
@@ -140,18 +149,18 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
             customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
             */
             timeout: isAndroid() ? 3_000 : probeTimeoutMillis,
-            url: `${domain}:${port}/probe`,
+            url: `${url}/probe`,
           });
 
           if (!probeResponse.ok) {
-            Logger.error(`Authenticator is not listening on port ${port}.`);
+            Logger.error(`Authenticator is not listening on url ${url}.`);
             // there's more ports to try, continue with next port
             continue;
           }
 
           // try port with challenge request
           const challengeResponse = await makeRequest({
-            url: `${domain}:${port}/challenge`,
+            url: `${url}/challenge`,
             method: 'POST',
             timeout: 300_000,
             data: JSON.stringify({ challengeRequest }),
@@ -180,7 +189,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
           break;
         } catch (e) {
           // only for unexpected error conditions (e.g. fetch throws an error)
-          Logger.error(`Something unexpected happened while we were checking port ${port}`);
+          Logger.error(`Something unexpected happened while we were checking url ${url}`);
         }
       }
 

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -382,6 +382,7 @@ export interface LoopbackProbeElement extends UISchemaElement {
     deviceChallengePayload: {
       ports: string[];
       domain: string;
+      httpsDomain?: string;
       challengeRequest: string;
       probeTimeoutMillis?: number;
     };

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -83,7 +83,7 @@ const loopbackSuccessWithHttpsMock = RequestMock()
     'access-control-allow-methods': 'POST, GET, OPTIONS'
   });
 
-  const loopbackSuccessWithHttpMock = RequestMock()
+const loopbackSuccessWithHttpMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/introspect/)
   .respond(identifyWithDeviceProbingHttpsLoopback)
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
@@ -417,6 +417,9 @@ test.skip
 
 test
   .requestHooks(loopbackSuccessLogger, loopbackSuccessWithHttpsMock)('in loopback server approach, https loopback succeeds', async t => {
+    failureCount = 0;
+    // after OKTA-715718 is fixed, should use ".eql(0)" for ".lte(otherProbeCount)" assertions
+    const otherProbeCount = process.env.OKTA_SIW_GEN3 === 'true' ? 0 : 1;
     const deviceChallengePollPageObject = await setup(t);
     await checkA11y(t);
     await t.expect(deviceChallengePollPageObject.getBeaconSelector()).contains(BEACON_CLASS);
@@ -429,11 +432,11 @@ test
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 500 &&
         record.request.url.match(/randomorgid.authenticatorlocaldev.com:6512\/probe/)
-    )).eql(1);
+    )).lte(otherProbeCount);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 500 &&
         record.request.url.match(/randomorgid.authenticatorlocaldev.com:6513\/probe/)
-    )).eql(1);
+    )).lte(otherProbeCount);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
         record.request.method === 'get' &&
@@ -454,6 +457,7 @@ test
 
 test
   .requestHooks(loopbackSuccessLogger, loopbackSuccessWithHttpMock)('in loopback server approach, https loopback fails then http loopback succeeds', async t => {
+    failureCount = 0;
     const deviceChallengePollPageObject = await setup(t);
     await checkA11y(t);
     await t.expect(deviceChallengePollPageObject.getBeaconSelector()).contains(BEACON_CLASS);


### PR DESCRIPTION
## Description:

Add https loopback support to SIW v2 and v3

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-719439](https://oktainc.atlassian.net/browse/OKTA-719439)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



