### PR TITLE
fix: Disallows a line break on phone number

### DIFF
--- a/assets/sass/v2/_enroll-profile.scss
+++ b/assets/sass/v2/_enroll-profile.scss
@@ -9,6 +9,10 @@
       color: $dark-text-color;
       word-break: break-all;
     }
+
+    span.nowrap {
+      white-space: nowrap;
+    }
   }
 }
 

--- a/scripts/parity-v3.sh
+++ b/scripts/parity-v3.sh
@@ -9,9 +9,6 @@ export TEST_RESULT_FILE_DIR="${REPO}/build2/reports/junit"
 echo $TEST_SUITE_TYPE > $TEST_SUITE_TYPE_FILE
 echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
 
-# NOTE: add a testcafe fixture to the list of specs to run for parity testing by
-# adding fixture metadata {"v3": true}. See example in
-# test/testcafe/spec/Smoke_spec.js
 echo 'starting testcafe v2->v3 parity tests'
 if ! yarn test:parity-ci --no-color; then
 	echo "testcafe v2->v3 parity tests failed! Exiting..."

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
@@ -37,7 +37,7 @@ const Body = BaseForm.extend(
         : loc('oie.phone.verify.call.sendText', 'login');
       const carrierChargesText = loc('oie.phone.carrier.charges', 'login');
       const isPhoneNumberAvailable = this.model.get('phoneNumber') !== loc('oie.phone.alternate.title', 'login');
-      const extraCssClasses = isPhoneNumberAvailable ? 'strong no-translate' : '';
+      const extraCssClasses = isPhoneNumberAvailable ? 'strong no-translate nowrap' : '';
       let nicknameText = isPhoneNumberAvailable ? this.model.get('nickname') : '';
       let extraNicknameCssClasses = '';
       if (nicknameText !== '') {

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -69,7 +69,7 @@ const Body = BaseForm.extend(Object.assign(
       extraNicknameCssClasses + '"' : ''}>
       ${nicknameText}.</span>` : '<span class="no-translate">.</span>';
       const strongClass = this.model.get('phoneNumber') !== loc('oie.phone.alternate.title', 'login') ?
-        'strong no-translate' : '';
+        'strong no-translate nowrap' : '';
       // Courage doesn't support HTML, hence creating a subtitle here.
       this.add(`<div class="okta-form-subtitle" data-se="o-form-explain">
         ${sendText}&nbsp;<span class='${strongClass}'>${this.model.escape('phoneNumber')}</span>

--- a/src/v3/src/components/Widget/style.scss
+++ b/src/v3/src/components/Widget/style.scss
@@ -279,6 +279,10 @@
   }
 }
 
+.nowrap {
+  white-space: nowrap;
+}
+
 /*
  * NOTE: widget styles below, login page styles above. Take care when moving CSS
  * from SIW to loginpage (okta-ui) in OKTA-602545

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
@@ -67,7 +67,7 @@ describe('PhoneChallengeTransformer Tests', () => {
       subtitleKey,
       'login',
       [`&lrm;${redactedPhone}`],
-      { $1: { element: 'span', attributes: { class: 'strong no-translate' } } },
+      { $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } } },
     );
 
     expect(updatedFormBag.uischema.elements[3].type).toBe('Description');
@@ -109,7 +109,7 @@ describe('PhoneChallengeTransformer Tests', () => {
       subtitleKey,
       'login',
       [`&lrm;${redactedPhone}`],
-      { $1: { element: 'span', attributes: { class: 'strong no-translate' } } },
+      { $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } } },
     );
 
     expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
@@ -153,7 +153,7 @@ describe('PhoneChallengeTransformer Tests', () => {
       'login',
       [`&lrm;${redactedPhone}`, mockNickname],
       {
-        $1: { element: 'span', attributes: { class: 'strong no-translate' } },
+        $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } },
         $2: {
           element: 'span',
           attributes: { class: 'strong no-translate authenticator-verify-nickname' },
@@ -262,7 +262,7 @@ describe('PhoneChallengeTransformer Tests', () => {
       subtitleKey,
       'login',
       [`&lrm;${redactedPhone}`],
-      { $1: { element: 'span', attributes: { class: 'strong no-translate' } } },
+      { $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } } },
     );
 
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).type).toBe('Description');
@@ -306,7 +306,7 @@ describe('PhoneChallengeTransformer Tests', () => {
       'login',
       [`&lrm;${redactedPhone}`, mockNickname],
       {
-        $1: { element: 'span', attributes: { class: 'strong no-translate' } },
+        $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } },
         $2: {
           element: 'span',
           attributes: { class: 'strong no-translate authenticator-verify-nickname' },

--- a/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneVerificationTransformer.test.ts
@@ -193,7 +193,7 @@ describe('Phone verification Transformer Tests', () => {
       subtitleKey,
       'login',
       [`&lrm;${mockPhoneNumber}`],
-      { $1: { element: 'span', attributes: { class: 'strong no-translate' } } },
+      { $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } } },
     );
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
       .toBe('oie.phone.carrier.charges');
@@ -242,7 +242,7 @@ describe('Phone verification Transformer Tests', () => {
       subtitleKey,
       'login',
       [`&lrm;${mockPhoneNumber}`],
-      { $1: { element: 'span', attributes: { class: 'strong no-translate' } } },
+      { $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } } },
     );
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
       .toBe('oie.phone.carrier.charges');
@@ -295,7 +295,7 @@ describe('Phone verification Transformer Tests', () => {
       'login',
       [`&lrm;${mockPhoneNumber}`, mockNickname],
       {
-        $1: { element: 'span', attributes: { class: 'strong no-translate' } },
+        $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } },
         $2: {
           element: 'span',
           attributes: { class: 'strong no-translate authenticator-verify-nickname' },
@@ -352,7 +352,7 @@ describe('Phone verification Transformer Tests', () => {
       'login',
       [`&lrm;${mockPhoneNumber}`, mockNickname],
       {
-        $1: { element: 'span', attributes: { class: 'strong no-translate' } },
+        $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } },
         $2: {
           element: 'span',
           attributes: { class: 'strong no-translate authenticator-verify-nickname' },

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -442,7 +442,7 @@ const getPhoneVerificationSubtitleTextContent = (
         'login',
         [phoneNumberWithUnicode, nickname],
         {
-          $1: { element: 'span', attributes: { class: 'strong no-translate' } },
+          $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } },
           $2: {
             element: 'span',
             attributes: { class: 'strong no-translate authenticator-verify-nickname' },
@@ -453,7 +453,7 @@ const getPhoneVerificationSubtitleTextContent = (
         i18nMap[step][primaryMethod].withPhoneWithoutNickName,
         'login',
         [phoneNumberWithUnicode],
-        { $1: { element: 'span', attributes: { class: 'strong no-translate' } } },
+        { $1: { element: 'span', attributes: { class: 'strong no-translate nowrap' } } },
       );
   }
   return loc(i18nMap[step][primaryMethod].withoutPhone, 'login');

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                       >
                         Send a code via SMS to 
                         <span
-                          class="strong no-translate"
+                          class="strong no-translate nowrap"
                         >
                           ‎+1 XXX-XXX-4601
                         </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                       >
                         A code was sent to 
                         <span
-                          class="strong no-translate"
+                          class="strong no-translate nowrap"
                         >
                           ‎+1 XXX-XXX-4601
                         </span>

--- a/test/testcafe/framework/page-objects/ChallengePhonePageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengePhonePageObject.js
@@ -47,4 +47,8 @@ export default class ChallengePhonePageObject extends ChallengeFactorPageObject 
     const isHidden = await this.form.getElement(RESEND_VIEW_SELECTOR).hasClass('hide');
     return !isHidden;
   }
+
+  subtitleContainsNoWrapElement() {
+    return this.elementExists('[data-se="o-form-explain"] > span.nowrap');
+  }
 }

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -207,7 +207,7 @@ test
     await t.expect(pageTitle).contains('Verify with your phone');
     await t.expect(pageSubtitle).contains('Send a code via SMS to');
     await t.expect(pageSubtitle).contains('+1 XXX-XXX-2342');
-    await t.expect(challengePhonePageObject.elementExists('.okta-form-subtitle > span.no-translate.nowrap')).ok();
+    await t.expect(challengePhonePageObject.subtitleContainsNoWrapElement()).ok();
     await t.expect(primaryButtonText).contains('Receive a code via SMS');
     await t.expect(secondaryButtonText).contains('Receive a voice call instead');
 
@@ -397,7 +397,7 @@ test
     await t.expect(challengePhonePageObject.getSaveButtonLabel()).eql('Verify');
     await t.expect(pageSubtitle).contains('A code was sent to');
     await t.expect(pageSubtitle).contains('Enter the code below to verify.');
-    await t.expect(challengePhonePageObject.elementExists('.okta-form-subtitle > span.no-translate.nowrap')).ok();
+    await t.expect(challengePhonePageObject.subtitleContainsNoWrapElement()).ok();
   });
 
 test

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -207,6 +207,7 @@ test
     await t.expect(pageTitle).contains('Verify with your phone');
     await t.expect(pageSubtitle).contains('Send a code via SMS to');
     await t.expect(pageSubtitle).contains('+1 XXX-XXX-2342');
+    await t.expect(challengePhonePageObject.elementExists('.okta-form-subtitle > span.no-translate.nowrap')).ok();
     await t.expect(primaryButtonText).contains('Receive a code via SMS');
     await t.expect(secondaryButtonText).contains('Receive a voice call instead');
 
@@ -396,6 +397,7 @@ test
     await t.expect(challengePhonePageObject.getSaveButtonLabel()).eql('Verify');
     await t.expect(pageSubtitle).contains('A code was sent to');
     await t.expect(pageSubtitle).contains('Enter the code below to verify.');
+    await t.expect(challengePhonePageObject.elementExists('.okta-form-subtitle > span.no-translate.nowrap')).ok();
   });
 
 test


### PR DESCRIPTION
## Description:

Fixes an issue with phone number having a line break in Japanese language or English on smaller screens.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-611152](https://oktainc.atlassian.net/browse/OKTA-611152)

### Reviewers:

### Screenshot/Video:

Before:

![Screenshot 2024-06-11 at 3 15 26 PM](https://github.com/okta/okta-signin-widget/assets/99218766/172533da-06b1-4880-8c36-c54179c132ed)
![Screenshot 2024-06-11 at 3 16 50 PM](https://github.com/okta/okta-signin-widget/assets/99218766/b809f6a7-788f-47ef-9248-0a3d850dbb9b)

After:

![Screenshot 2024-06-11 at 3 15 53 PM](https://github.com/okta/okta-signin-widget/assets/99218766/32a51c14-c0b0-41b5-878a-10e6c6462d5b)
![Screenshot 2024-06-11 at 3 17 17 PM](https://github.com/okta/okta-signin-widget/assets/99218766/fb8cb670-44a1-47ff-b62c-3028615143b7)

Gen 3:

![Screenshot 2024-06-12 at 2 07 03 PM](https://github.com/okta/okta-signin-widget/assets/99218766/11957fc8-3c37-4300-8bdf-086112f7748a)
![Screenshot 2024-06-12 at 2 07 16 PM](https://github.com/okta/okta-signin-widget/assets/99218766/a0f3f511-7066-45ff-8b99-11b3eae41c18)

### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=d950c1be0858c6f266358b82612ad774f280adf8&tab=main