### PR TITLE
Bump `siw-platform-scripts` and update release script to execute local build

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "find-internal-packages": "node scripts/find-internal-packages",
     "generate-phone-codes": "node scripts/buildtools generate-phone-codes",
     "generate-config": "node scripts/buildtools generate-language-config",
-    "weekly-release-update": "./scripts/weekly-release-update.sh",
+    "release-update": "./scripts/release-update.sh",
     "retirejs": "retire --js --jspath target/js --package",
     "lint:ci": "yarn codegen && yarn lint",
     "lint:esm": "eslint --no-ignore --no-eslintrc --no-inline-config --config scripts/buildtools/eslint/.eslintrc.esm.js --ext .js target/esm",

--- a/scripts/release-update.sh
+++ b/scripts/release-update.sh
@@ -16,7 +16,7 @@ fi
 # get latest
 git fetch origin && \
 
-# weekly release branch
+# release branch
 git checkout $RELEASE_BRANCH
 
 # update files
@@ -30,8 +30,8 @@ jq --arg RELEASE_VERSION "${RELEASE_VERSION}" '.version=$RELEASE_VERSION' packag
 yarn install --frozen-lockfile
 yarn build:release
 
-if ! siw-platform weekly-release-update --ver=$RELEASE_VERSION --repoPath=$REPO_PATH ; then
-	echo "weekly-release-update script failed : repo path: $REPO_PATH : release version: $RELEASE_VERSION"
+if ! siw-platform release-update --ver=$RELEASE_VERSION --repoPath=$REPO_PATH ; then
+	echo "release-update script failed : repo path: $REPO_PATH : release version: $RELEASE_VERSION"
 	exit ${FAILED_SETUP}
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,7 +52,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn global add @okta/siw-platform-scripts@0.13.0-gfdbbc91
+  yarn global add @okta/siw-platform-scripts@0.13.0-gd64419b
 
   if ! siw-platform install-downstream @okta/okta-auth-js ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,7 +52,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn global add @okta/siw-platform-scripts@0.13.0-gc19cc07
+  yarn global add @okta/siw-platform-scripts@0.13.0-gd1bdc78
 
   if ! siw-platform install-downstream @okta/okta-auth-js ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,7 +52,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn global add @okta/siw-platform-scripts@0.12.0
+  yarn global add @okta/siw-platform-scripts@0.13.0-gfdbbc91
 
   if ! siw-platform install-downstream @okta/okta-auth-js ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,7 +52,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn global add @okta/siw-platform-scripts@0.13.0-gd64419b
+  yarn global add @okta/siw-platform-scripts@0.13.0-g1c53b5b
 
   if ! siw-platform install-downstream @okta/okta-auth-js ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,7 +52,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn global add @okta/siw-platform-scripts@0.13.0-g1c53b5b
+  yarn global add @okta/siw-platform-scripts@0.13.0-gc19cc07
 
   if ! siw-platform install-downstream @okta/okta-auth-js ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,7 +52,7 @@ fi
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
 
-  yarn global add @okta/siw-platform-scripts@0.13.0-gd1bdc78
+  yarn global add @okta/siw-platform-scripts@0.13.0
 
   if ! siw-platform install-downstream @okta/okta-auth-js ${AUTHJS_VERSION} ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"

--- a/scripts/weekly-release-update.sh
+++ b/scripts/weekly-release-update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-INTERNAL_REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-okta-release"
+INTERNAL_REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-okta-all"
 REPO_PATH=$OKTA_HOME/$REPO
 
 if ! setup_service node v16.19.1 &> /dev/null; then

--- a/scripts/weekly-release-update.sh
+++ b/scripts/weekly-release-update.sh
@@ -26,7 +26,7 @@ yarn global add @okta/siw-platform-scripts@0.13.0-gd1bdc78
 cd ${REPO_PATH}
 tmp=$(mktemp)
 
-jq ".version=$RELEASE_VERSION" package.json > "$tmp" && mv "$tmp" package.json
+jq "'.version=\"$RELEASE_VERSION\"" package.json > "$tmp" && mv "$tmp" package.json
 yarn install --frozen-lockfile
 yarn build:release
 

--- a/scripts/weekly-release-update.sh
+++ b/scripts/weekly-release-update.sh
@@ -21,7 +21,7 @@ git checkout $RELEASE_BRANCH
 
 # update files
 npm config set @okta:registry ${INTERNAL_REGISTRY}
-yarn global add @okta/siw-platform-scripts@0.13.0-gd64419b
+yarn global add @okta/siw-platform-scripts@0.13.0-g1c53b5b
 
 if ! siw-platform weekly-release-update --ver=$RELEASE_VERSION --repoPath=$REPO_PATH ; then
 	echo "weekly-release-update script failed : repo path: $REPO_PATH : release version: $RELEASE_VERSION"

--- a/scripts/weekly-release-update.sh
+++ b/scripts/weekly-release-update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-INTERNAL_REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-okta-all"
+INTERNAL_REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-okta-release"
 REPO_PATH=$OKTA_HOME/$REPO
 
 if ! setup_service node v16.19.1 &> /dev/null; then
@@ -21,7 +21,7 @@ git checkout $RELEASE_BRANCH
 
 # update files
 npm config set @okta:registry ${INTERNAL_REGISTRY}
-yarn global add @okta/siw-platform-scripts@0.13.0-gd1bdc78
+yarn global add @okta/siw-platform-scripts@0.13.0
 
 cd ${REPO_PATH}
 tmp=$(mktemp)

--- a/scripts/weekly-release-update.sh
+++ b/scripts/weekly-release-update.sh
@@ -21,7 +21,7 @@ git checkout $RELEASE_BRANCH
 
 # update files
 npm config set @okta:registry ${INTERNAL_REGISTRY}
-yarn global add @okta/siw-platform-scripts@0.13.0-g1c53b5b
+yarn global add @okta/siw-platform-scripts@0.13.0-gc19cc07
 
 if ! siw-platform weekly-release-update --ver=$RELEASE_VERSION --repoPath=$REPO_PATH ; then
 	echo "weekly-release-update script failed : repo path: $REPO_PATH : release version: $RELEASE_VERSION"

--- a/scripts/weekly-release-update.sh
+++ b/scripts/weekly-release-update.sh
@@ -21,7 +21,7 @@ git checkout $RELEASE_BRANCH
 
 # update files
 npm config set @okta:registry ${INTERNAL_REGISTRY}
-yarn global add @okta/siw-platform-scripts@0.12.0
+yarn global add @okta/siw-platform-scripts@0.13.0-gfdbbc91
 
 if ! siw-platform weekly-release-update --ver=$RELEASE_VERSION --repoPath=$REPO_PATH ; then
 	echo "weekly-release-update script failed : repo path: $REPO_PATH : release version: $RELEASE_VERSION"

--- a/scripts/weekly-release-update.sh
+++ b/scripts/weekly-release-update.sh
@@ -21,7 +21,7 @@ git checkout $RELEASE_BRANCH
 
 # update files
 npm config set @okta:registry ${INTERNAL_REGISTRY}
-yarn global add @okta/siw-platform-scripts@0.13.0-gfdbbc91
+yarn global add @okta/siw-platform-scripts@0.13.0-gd64419b
 
 if ! siw-platform weekly-release-update --ver=$RELEASE_VERSION --repoPath=$REPO_PATH ; then
 	echo "weekly-release-update script failed : repo path: $REPO_PATH : release version: $RELEASE_VERSION"

--- a/scripts/weekly-release-update.sh
+++ b/scripts/weekly-release-update.sh
@@ -26,7 +26,7 @@ yarn global add @okta/siw-platform-scripts@0.13.0-gd1bdc78
 cd ${REPO_PATH}
 tmp=$(mktemp)
 
-jq "'.version=\"$RELEASE_VERSION\"" package.json > "$tmp" && mv "$tmp" package.json
+jq --arg RELEASE_VERSION "${RELEASE_VERSION}" '.version=$RELEASE_VERSION' package.json > "$tmp" && mv "$tmp" package.json
 yarn install --frozen-lockfile
 yarn build:release
 

--- a/scripts/weekly-release-update.sh
+++ b/scripts/weekly-release-update.sh
@@ -21,7 +21,14 @@ git checkout $RELEASE_BRANCH
 
 # update files
 npm config set @okta:registry ${INTERNAL_REGISTRY}
-yarn global add @okta/siw-platform-scripts@0.13.0-gc19cc07
+yarn global add @okta/siw-platform-scripts@0.13.0-gd1bdc78
+
+cd ${REPO_PATH}
+tmp=$(mktemp)
+
+jq ".version=$RELEASE_VERSION" package.json > "$tmp" && mv "$tmp" package.json
+yarn install --frozen-lockfile
+yarn build:release
 
 if ! siw-platform weekly-release-update --ver=$RELEASE_VERSION --repoPath=$REPO_PATH ; then
 	echo "weekly-release-update script failed : repo path: $REPO_PATH : release version: $RELEASE_VERSION"


### PR DESCRIPTION
## Description:
- Corresponding version bump to use new changes that will be merged for `siw-platform-scripts-0.13.0` (see [PR here](https://github.com/atko-eng/siw-platform-scripts/pull/18))
- Executes bumping version in `package.json` followed by local `yarn install` and `yarn build:release` _before_ running `siw-platform-scripts` release update script


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-747363](https://oktainc.atlassian.net/browse/OKTA-747363)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



