### PR TITLE
fix: remove misleading SIW G3 bundle in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ If your organization has upgraded to [Identity Engine][], the smaller `oie` bund
 | oie        | okta-sign-in.oie.min.js         | 1.3 MB       |                    | :white_check_mark: |                    | Smaller bundle for OIE enabled orgs       |
 | classic    | okta-sign-in.classic.min.js     | 1.1 MB       | :white_check_mark: |                    |                    | Smaller bundle for Classic Engine only    |
 | polyfill   | okta-sign-in.polyfill.min.js    | 108KB        |                    |                    | :white_check_mark: | Standalone polyfill bundle. Can be used along with a widget bundle that does not include the polyfill. |
-| oie        | okta-sign-in.next.min.js        | 1.5 MB       |                    | :white_check_mark: | :white_check_mark: | Smaller bundle (3rd generation) for OIE enabled orgs|
 
 
 To embed the Sign-in Widget via CDN, include links to the JS and CSS files in your HTML:


### PR DESCRIPTION
## Description:

Remove misleading row in bundles table. Okta does not officially support self-hosting SIW Gen3

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-742050](https://oktainc.atlassian.net/browse/OKTA-742050)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



