### PR TITLE
Make Inter default font for gen1 and gen2

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -1,5 +1,5 @@
 // Page Properties
-$fonts: Aeonik, Inter, 'montserrat-okta', Arial, Helvetica, sans-serif;
+$fonts: Inter, 'montserrat-okta', Arial, Helvetica, sans-serif;
 $default-border-radius: 3px;
 $container-width: 400px;
 $container-min-width: 300px;

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -2,7 +2,7 @@
 @use 'common/shared/helpers/mixins';
 
 .skip-to-content-link {
-  font-family: Aeonik, Inter, "montserrat-okta", Arial, Helvetica, sans-serif;
+  font-family: Inter, "montserrat-okta", Arial, Helvetica, sans-serif;
   text-decoration: none;
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Description:
- #3653 accidentally made Aeonik the default font for all font weights in gen1 and gen2. We should use Inter for the time being and then decide if we want to add Aeonik back for headings only


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-742100](https://oktainc.atlassian.net/browse/OKTA-742100)

### Reviewers:

### Screenshot/Video:
#### SIW deployed to Rain using Inter as default font
![Screenshot 2024-06-25 at 2 19 43 PM](https://github.com/okta/okta-signin-widget/assets/106110543/b53af227-d9f9-4a19-9f14-6442a73baa28)



### Downstream Monolith Build:



