### PR TITLE
Enable e2e tests on SauceLabs in IE11 for Gen3 and Gen2

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -115,6 +115,13 @@ test_suites:
     script_name: e2e-saucelabs-mobile
     criteria: OPTIONAL
     queue_name: small
+  - name: e2e-saucelabs-mobile-v3
+    script_path: /root/okta/okta-signin-widget/scripts
+    sort_order: '13'
+    timeout: '20'
+    script_name: e2e-saucelabs-mobile-v3
+    criteria: OPTIONAL
+    queue_name: small
   - name: tsd
     script_path: /root/okta/okta-signin-widget/scripts
     sort_order: '16'

--- a/.bacon.yml
+++ b/.bacon.yml
@@ -105,7 +105,7 @@ test_suites:
     sort_order: '15'
     timeout: '30'
     script_name: e2e-saucelabs-v3
-    criteria: MERGE
+    criteria: OPTIONAL
     queue_name: small
   # Optional test suite until Android is enabled
   - name: e2e-saucelabs-mobile

--- a/.bacon.yml
+++ b/.bacon.yml
@@ -117,7 +117,7 @@ test_suites:
     queue_name: small
   - name: e2e-saucelabs-mobile-v3
     script_path: /root/okta/okta-signin-widget/scripts
-    sort_order: '13'
+    sort_order: '16'
     timeout: '20'
     script_name: e2e-saucelabs-mobile-v3
     criteria: OPTIONAL

--- a/.bacon.yml
+++ b/.bacon.yml
@@ -100,6 +100,13 @@ test_suites:
     script_name: e2e-saucelabs
     criteria: MERGE
     queue_name: small
+  - name: e2e-saucelabs-v3
+    script_path: /root/okta/okta-signin-widget/scripts
+    sort_order: '12'
+    timeout: '20'
+    script_name: e2e-saucelabs-v3
+    criteria: MERGE
+    queue_name: small
   # Optional test suite until Android is enabled
   - name: e2e-saucelabs-mobile
     script_path: /root/okta/okta-signin-widget/scripts

--- a/.bacon.yml
+++ b/.bacon.yml
@@ -96,14 +96,14 @@ test_suites:
   - name: e2e-saucelabs
     script_path: /root/okta/okta-signin-widget/scripts
     sort_order: '14'
-    timeout: '20'
+    timeout: '30'
     script_name: e2e-saucelabs
     criteria: MERGE
     queue_name: small
   - name: e2e-saucelabs-v3
     script_path: /root/okta/okta-signin-widget/scripts
-    sort_order: '12'
-    timeout: '20'
+    sort_order: '15'
+    timeout: '30'
     script_name: e2e-saucelabs-v3
     criteria: MERGE
     queue_name: small

--- a/.bacon.yml
+++ b/.bacon.yml
@@ -98,7 +98,7 @@ test_suites:
     sort_order: '14'
     timeout: '30'
     script_name: e2e-saucelabs
-    criteria: MERGE
+    criteria: OPTIONAL
     queue_name: small
   - name: e2e-saucelabs-v3
     script_path: /root/okta/okta-signin-widget/scripts

--- a/scripts/e2e-saucelabs-mobile-v3.sh
+++ b/scripts/e2e-saucelabs-mobile-v3.sh
@@ -4,7 +4,6 @@ export CI=true
 source $OKTA_HOME/$REPO/scripts/setup.sh
 
 setup_service java 1.8.222
-setup_service google-chrome-stable 89.0.4389.72-1
 
 export RUN_SAUCE_TESTS=mobile
 export SAUCE_USERNAME=OktaSignInWidget

--- a/scripts/e2e-saucelabs-mobile-v3.sh
+++ b/scripts/e2e-saucelabs-mobile-v3.sh
@@ -6,7 +6,7 @@ source $OKTA_HOME/$REPO/scripts/setup.sh
 setup_service java 1.8.222
 setup_service google-chrome-stable 89.0.4389.72-1
 
-export RUN_SAUCE_TESTS=ie11,edge
+export RUN_SAUCE_TESTS=mobile
 export SAUCE_USERNAME=OktaSignInWidget
 get_vault_secret_key devex/sauce-labs accessKey SAUCE_ACCESS_KEY
 export TEST_SUITE_TYPE="junit"
@@ -26,7 +26,7 @@ get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
 get_vault_secret_key devex/okta-signin-widget test_org_okta_api_key OKTA_CLIENT_TOKEN
 
 # Build
-if ! yarn build:release; then
+if ! yarn workspace v3 build:release; then
   echo "build failed! Exiting..."
   exit ${TEST_FAILURE}
 fi
@@ -36,9 +36,13 @@ if ! setup_service node v14.18.2 &> /dev/null; then
   exit ${FAILED_SETUP}
 fi
 
+# Run tests
+export DISABLE_CSP=1
 export CDN_ONLY=1
+export BUNDLE="next"
 export TARGET="CROSS_BROWSER"
 export USE_MIN=1
+
 if ! yarn test:e2e; then
   echo "e2e saucelabs test failed! Exiting..."
   exit ${PUBLISH_TYPE_AND_RESULT_DIR_BUT_ALWAYS_FAIL}

--- a/scripts/e2e-saucelabs-mobile.sh
+++ b/scripts/e2e-saucelabs-mobile.sh
@@ -4,7 +4,6 @@ export CI=true
 source $OKTA_HOME/$REPO/scripts/setup.sh
 
 setup_service java 1.8.222
-setup_service google-chrome-stable 89.0.4389.72-1
 
 export RUN_SAUCE_TESTS=mobile
 export SAUCE_USERNAME=OktaSignInWidget

--- a/scripts/e2e-saucelabs-mobile.sh
+++ b/scripts/e2e-saucelabs-mobile.sh
@@ -6,8 +6,7 @@ source $OKTA_HOME/$REPO/scripts/setup.sh
 setup_service java 1.8.222
 setup_service google-chrome-stable 89.0.4389.72-1
 
-export RUN_SAUCE_TESTS=true
-export MOBILE_BROWSER_TESTS=true
+export RUN_SAUCE_TESTS=mobile
 export SAUCE_USERNAME=OktaSignInWidget
 get_vault_secret_key devex/sauce-labs accessKey SAUCE_ACCESS_KEY
 export TEST_SUITE_TYPE="junit"

--- a/scripts/e2e-saucelabs-mobile.sh
+++ b/scripts/e2e-saucelabs-mobile.sh
@@ -10,6 +10,8 @@ export SAUCE_USERNAME=OktaSignInWidget
 get_vault_secret_key devex/sauce-labs accessKey SAUCE_ACCESS_KEY
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/build2"
+echo ${TEST_SUITE_TYPE} > ${TEST_SUITE_TYPE_FILE}
+echo ${TEST_RESULT_FILE_DIR} > ${TEST_RESULT_FILE_DIR_FILE}
 
 # We use the below OIE enabled org and clients for OIE tests
 export WIDGET_TEST_SERVER=https://oie-signin-widget.okta.com
@@ -28,13 +30,16 @@ if ! yarn build:release; then
   exit ${TEST_FAILURE}
 fi
 
+if ! setup_service node v14.18.2 &> /dev/null; then
+  echo "Failed to install node"
+  exit ${FAILED_SETUP}
+fi
+
 export CDN_ONLY=1
 export TARGET="CROSS_BROWSER"
 if ! yarn test:e2e; then
   echo "e2e sauce.baconlabs mobile test failed! Exiting..."
-  exit ${TEST_FAILURE}
+  exit ${PUBLISH_TYPE_AND_RESULT_DIR_BUT_ALWAYS_FAIL}
 fi
 
-echo ${TEST_SUITE_TYPE} > ${TEST_SUITE_TYPE_FILE}
-echo ${TEST_RESULT_FILE_DIR} > ${TEST_RESULT_FILE_DIR_FILE}
 exit ${PUBLISH_TYPE_AND_RESULT_DIR}

--- a/scripts/e2e-saucelabs-v3.sh
+++ b/scripts/e2e-saucelabs-v3.sh
@@ -6,7 +6,7 @@ source $OKTA_HOME/$REPO/scripts/setup.sh
 setup_service java 1.8.222
 setup_service google-chrome-stable 89.0.4389.72-1
 
-export RUN_SAUCE_TESTS=true
+export RUN_SAUCE_TESTS=ie11
 export SAUCE_USERNAME=OktaSignInWidget
 get_vault_secret_key devex/sauce-labs accessKey SAUCE_ACCESS_KEY
 export TEST_SUITE_TYPE="junit"
@@ -36,6 +36,7 @@ if ! setup_service node v14.18.2 &> /dev/null; then
   exit ${FAILED_SETUP}
 fi
 
+# Run tests
 export DISABLE_CSP=1
 export CDN_ONLY=1
 export BUNDLE="next"

--- a/scripts/e2e-saucelabs-v3.sh
+++ b/scripts/e2e-saucelabs-v3.sh
@@ -4,7 +4,6 @@ export CI=true
 source $OKTA_HOME/$REPO/scripts/setup.sh
 
 setup_service java 1.8.222
-setup_service google-chrome-stable 89.0.4389.72-1
 
 export RUN_SAUCE_TESTS=ie11
 export SAUCE_USERNAME=OktaSignInWidget

--- a/scripts/e2e-saucelabs-v3.sh
+++ b/scripts/e2e-saucelabs-v3.sh
@@ -34,6 +34,7 @@ if ! setup_service node v14.18.2 &> /dev/null; then
   exit ${FAILED_SETUP}
 fi
 
+export DISABLE_CSP=1
 export CDN_ONLY=1
 export BUNDLE="next"
 export TARGET="CROSS_BROWSER"

--- a/scripts/e2e-saucelabs-v3.sh
+++ b/scripts/e2e-saucelabs-v3.sh
@@ -11,6 +11,8 @@ export SAUCE_USERNAME=OktaSignInWidget
 get_vault_secret_key devex/sauce-labs accessKey SAUCE_ACCESS_KEY
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/build2"
+echo ${TEST_SUITE_TYPE} > ${TEST_SUITE_TYPE_FILE}
+echo ${TEST_RESULT_FILE_DIR} > ${TEST_RESULT_FILE_DIR_FILE}
 
 # We use the below OIE enabled org and clients for OIE tests
 export WIDGET_TEST_SERVER=https://oie-signin-widget.okta.com
@@ -24,7 +26,7 @@ get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
 get_vault_secret_key devex/okta-signin-widget test_org_okta_api_key OKTA_CLIENT_TOKEN
 
 # Build
-if ! yarn build:release; then
+if ! yarn workspace v3 build:release; then
   echo "build failed! Exiting..."
   exit ${TEST_FAILURE}
 fi
@@ -39,11 +41,10 @@ export CDN_ONLY=1
 export BUNDLE="next"
 export TARGET="CROSS_BROWSER"
 export USE_MIN=1
+
 if ! yarn test:e2e; then
   echo "e2e saucelabs test failed! Exiting..."
-  exit ${TEST_FAILURE}
+  exit ${PUBLISH_TYPE_AND_RESULT_DIR_BUT_ALWAYS_FAIL}
 fi
 
-echo ${TEST_SUITE_TYPE} > ${TEST_SUITE_TYPE_FILE}
-echo ${TEST_RESULT_FILE_DIR} > ${TEST_RESULT_FILE_DIR_FILE}
 exit ${PUBLISH_TYPE_AND_RESULT_DIR}

--- a/scripts/e2e-saucelabs-v3.sh
+++ b/scripts/e2e-saucelabs-v3.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+export CI=true
+
+source $OKTA_HOME/$REPO/scripts/setup.sh
+
+setup_service java 1.8.222
+setup_service google-chrome-stable 89.0.4389.72-1
+
+export RUN_SAUCE_TESTS=true
+export SAUCE_USERNAME=OktaSignInWidget
+get_vault_secret_key devex/sauce-labs accessKey SAUCE_ACCESS_KEY
+export TEST_SUITE_TYPE="junit"
+export TEST_RESULT_FILE_DIR="${REPO}/build2"
+
+# We use the below OIE enabled org and clients for OIE tests
+export WIDGET_TEST_SERVER=https://oie-signin-widget.okta.com
+export WIDGET_SPA_CLIENT_ID=0oa8lrg7ojTsbJgRQ696
+export WIDGET_WEB_CLIENT_ID=0oa8ls36zUZj7oFJ2696
+export WIDGET_BASIC_USER=testuser
+get_vault_secret_key devex/okta-signin-widget widget_basic_password WIDGET_BASIC_PASSWORD
+
+export ORG_OIE_ENABLED=true
+get_vault_secret_key devex/auth-js-sdk-vars a18n_api_key A18N_API_KEY
+get_vault_secret_key devex/okta-signin-widget test_org_okta_api_key OKTA_CLIENT_TOKEN
+
+# Build
+if ! yarn build:release; then
+  echo "build failed! Exiting..."
+  exit ${TEST_FAILURE}
+fi
+
+if ! setup_service node v14.18.2 &> /dev/null; then
+  echo "Failed to install node"
+  exit ${FAILED_SETUP}
+fi
+
+export CDN_ONLY=1
+export BUNDLE="next"
+export TARGET="CROSS_BROWSER"
+export USE_MIN=1
+if ! yarn test:e2e; then
+  echo "e2e saucelabs test failed! Exiting..."
+  exit ${TEST_FAILURE}
+fi
+
+echo ${TEST_SUITE_TYPE} > ${TEST_SUITE_TYPE_FILE}
+echo ${TEST_RESULT_FILE_DIR} > ${TEST_RESULT_FILE_DIR_FILE}
+exit ${PUBLISH_TYPE_AND_RESULT_DIR}

--- a/scripts/e2e-saucelabs.sh
+++ b/scripts/e2e-saucelabs.sh
@@ -4,7 +4,6 @@ export CI=true
 source $OKTA_HOME/$REPO/scripts/setup.sh
 
 setup_service java 1.8.222
-setup_service google-chrome-stable 89.0.4389.72-1
 
 export RUN_SAUCE_TESTS=ie11,edge
 export SAUCE_USERNAME=OktaSignInWidget

--- a/scripts/e2e-saucelabs.sh
+++ b/scripts/e2e-saucelabs.sh
@@ -11,6 +11,8 @@ export SAUCE_USERNAME=OktaSignInWidget
 get_vault_secret_key devex/sauce-labs accessKey SAUCE_ACCESS_KEY
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/build2"
+echo ${TEST_SUITE_TYPE} > ${TEST_SUITE_TYPE_FILE}
+echo ${TEST_RESULT_FILE_DIR} > ${TEST_RESULT_FILE_DIR_FILE}
 
 # We use the below OIE enabled org and clients for OIE tests
 export WIDGET_TEST_SERVER=https://oie-signin-widget.okta.com
@@ -39,9 +41,7 @@ export TARGET="CROSS_BROWSER"
 export USE_MIN=1
 if ! yarn test:e2e; then
   echo "e2e saucelabs test failed! Exiting..."
-  exit ${TEST_FAILURE}
+  exit ${PUBLISH_TYPE_AND_RESULT_DIR_BUT_ALWAYS_FAIL}
 fi
 
-echo ${TEST_SUITE_TYPE} > ${TEST_SUITE_TYPE_FILE}
-echo ${TEST_RESULT_FILE_DIR} > ${TEST_RESULT_FILE_DIR_FILE}
 exit ${PUBLISH_TYPE_AND_RESULT_DIR}

--- a/test/e2e/features/widget-flows.feature
+++ b/test/e2e/features/widget-flows.feature
@@ -1,5 +1,3 @@
-# https://oktainc.atlassian.net/browse/OKTA-545127
-@skip(browserName=/internet.*explorer/)
 Feature: Widget Flows
 
   Background:

--- a/test/e2e/page-objects/primary-auth-oie.page.js
+++ b/test/e2e/page-objects/primary-auth-oie.page.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { waitForLoad } from '../util/waitUtil';
+import { waitForLoad, waitForText } from '../util/waitUtil';
 
 const { BUNDLE } = process.env;
 
@@ -24,10 +24,7 @@ class PrimaryAuthOIEPage {
 
   async waitForForgotPassword() {
     if (BUNDLE === 'next') {
-      await browser.waitUntil(async () => {
-        const formTitle = await this.formTitle;
-        return (await formTitle.isDisplayed()) && (await formTitle.getText()) === 'Reset your password';
-      }, 10_000, 'wait for page title');
+      await waitForText(this.formTitle, 'Reset your password');
     } else {
       await waitForLoad(this.forgotPassword);
     }
@@ -83,10 +80,7 @@ class PrimaryAuthOIEPage {
 
   async waitForSignupForm() {
     if (BUNDLE === 'next') {
-      await browser.waitUntil(async () => {
-        const formTitle = await this.formTitle;
-        return (await formTitle.isDisplayed()) && (await formTitle.getText()) === 'Sign up';
-      }, 10_000, 'wait for page title');
+      await waitForText(this.formTitle, 'Sign up');
     } else {
       await waitForLoad(this.signupForm);
     }
@@ -94,10 +88,7 @@ class PrimaryAuthOIEPage {
 
   async waitForUnlockAccountForm() {
     if (BUNDLE === 'next') {
-      await browser.waitUntil(async () => {
-        const formTitle = await this.formTitle;
-        return (await formTitle.isDisplayed()) && (await formTitle.getText()) === 'Unlock account?';
-      }, 10_000, 'wait for page title');
+      await waitForText(this.formTitle, 'Unlock account?');
     } else {
       await waitForLoad(this.unlockAccountForm);
     }

--- a/test/e2e/page-objects/primary-auth-oie.page.js
+++ b/test/e2e/page-objects/primary-auth-oie.page.js
@@ -1,26 +1,36 @@
+/* eslint-disable max-len */
 import { waitForLoad } from '../util/waitUtil';
+
+const { BUNDLE } = process.env;
 
 class PrimaryAuthOIEPage {
   identifierFieldSelector = 'input[name="identifier"]';
 
   get enrollProfileButton() { return $('[data-se=enroll]'); }
 
-  get forgotPassword() { return $('.siw-main-view.identify-recovery.forgot-password'); }
+  get forgotPassword() { return $(BUNDLE === 'next' ? 'form[data-se="o-form"]' : '.siw-main-view.identify-recovery.forgot-password'); }
   get forgotPasswordButton() { return $('[data-se="forgot-password"]'); }
   get unlockButton() {return $('[data-se="unlock"]');}
   get nextButton() { return $('[value="Next"]'); }
-  get signupForm() { return $('.siw-main-view.enroll-profile.registration'); }
+  get signupForm() { return $(BUNDLE === 'next' ? 'form[data-se="o-form"]' : '.siw-main-view.enroll-profile.registration'); }
   get signupLink() { return $('a[data-se="enroll"]'); }
-  get unlockAccountForm() { return $('.siw-main-view.select-authenticator-unlock-account'); }
-  get primaryAuthForm() { return $('.siw-main-view.primary-auth'); }
+  get unlockAccountForm() { return $(BUNDLE === 'next' ? 'form[data-se="o-form"]' : '.siw-main-view.select-authenticator-unlock-account'); }
+  get primaryAuthForm() { return $(BUNDLE === 'next' ? 'form[data-se="o-form"]' : '.siw-main-view.primary-auth'); }
   get identifierField() { return $(this.identifierFieldSelector); }
   get passwordField() { return $('input[name="credentials.passcode"]'); }
-  get submitButton() { return $('input[data-type="save"]'); }
+  get submitButton() { return $(BUNDLE === 'next' ? 'button[data-se="save"]' : 'input[data-type="save"]'); }
   get formTitle() { return $('[data-se="o-form-head"]'); }
   get oktaOidcIdPButton() { return $('[data-se="social-auth-general-idp-button"]'); }
 
   async waitForForgotPassword() {
-    await waitForLoad(this.forgotPassword);
+    if (BUNDLE === 'next') {
+      await browser.waitUntil(async () => {
+        const formTitle = await this.formTitle;
+        return (await formTitle.isDisplayed()) && (await formTitle.getText()) === 'Reset your password';
+      }, 10_000, 'wait for page title');
+    } else {
+      await waitForLoad(this.forgotPassword);
+    }
   }
 
   async waitForSubmitButton() {
@@ -28,7 +38,13 @@ class PrimaryAuthOIEPage {
   }
 
   async waitForPrimaryAuthForm() {
-    await waitForLoad(this.primaryAuthForm);
+    if (BUNDLE === 'next') {
+      await waitForLoad(this.identifierField);
+      await waitForLoad(this.passwordField);
+      await waitForLoad(this.submitButton);
+    } else {
+      await waitForLoad(this.primaryAuthForm);
+    }
   }
 
   async clickEnrollProfileButton() {
@@ -66,11 +82,25 @@ class PrimaryAuthOIEPage {
   }
 
   async waitForSignupForm() {
-    await waitForLoad(this.signupForm);
+    if (BUNDLE === 'next') {
+      await browser.waitUntil(async () => {
+        const formTitle = await this.formTitle;
+        return (await formTitle.isDisplayed()) && (await formTitle.getText()) === 'Sign up';
+      }, 10_000, 'wait for page title');
+    } else {
+      await waitForLoad(this.signupForm);
+    }
   }
 
   async waitForUnlockAccountForm() {
-    await waitForLoad(this.unlockAccountForm);
+    if (BUNDLE === 'next') {
+      await browser.waitUntil(async () => {
+        const formTitle = await this.formTitle;
+        return (await formTitle.isDisplayed()) && (await formTitle.getText()) === 'Unlock account?';
+      }, 10_000, 'wait for page title');
+    } else {
+      await waitForLoad(this.unlockAccountForm);
+    }
   }
 }
 

--- a/test/e2e/page-objects/primary-auth-oie.page.js
+++ b/test/e2e/page-objects/primary-auth-oie.page.js
@@ -88,7 +88,7 @@ class PrimaryAuthOIEPage {
 
   async waitForUnlockAccountForm() {
     if (BUNDLE === 'next') {
-      await waitForText(this.formTitle, 'Unlock account?');
+      await waitForText(this.formTitle, 'Unlock account');
     } else {
       await waitForLoad(this.unlockAccountForm);
     }

--- a/test/e2e/page-objects/test-app.page.js
+++ b/test/e2e/page-objects/test-app.page.js
@@ -65,7 +65,8 @@ class TestAppPage {
 
   async setConfig(config) {
     await waitForLoad(this.configEditor);
-    await this.configEditor.then(el => el.setValue(JSON.stringify(config)));
+    const $configEditor = await this.configEditor;
+    await $configEditor.setValue(JSON.stringify(config));
   }
 
   async getCspErrors() {

--- a/test/e2e/runner.js
+++ b/test/e2e/runner.js
@@ -31,7 +31,7 @@ const getTask = ({ bundle }) => {
           console.log('RUN_FEATURE_TESTS is true, using configuration: cucumber.wdio.conf.ts');
           wdioConfig = path.resolve(__dirname, 'cucumber.wdio.conf.ts');  
         } else if (process.env.RUN_SAUCE_TESTS) {
-          console.log('RUN_SAUCE_TESTS is true, using configuration: sauce.wdio.conf.ts');
+          console.log(`RUN_SAUCE_TESTS is ${process.env.RUN_SAUCE_TESTS}, using configuration: sauce.wdio.conf.ts`);
           wdioConfig = path.resolve(__dirname, 'sauce.wdio.conf.ts');
         } else {
           console.log('Using default wdio configuration: wdio.conf.js');

--- a/test/e2e/sauce.wdio.conf.ts
+++ b/test/e2e/sauce.wdio.conf.ts
@@ -20,9 +20,9 @@ exports.config = {
   path: '/wd/hub',
   user: process.env.SAUCE_USERNAME,
   key: process.env.SAUCE_ACCESS_KEY,
-  cucumberOpts: {...conf.cucumberOpts, timeout: 20000},
+  cucumberOpts: {...conf.cucumberOpts, timeout: 30000},
   maxInstances: 1,
-  waitforTimeout: 15000,
+  waitforTimeout: 25000,
   specs: [
     path.resolve(__dirname, 'features/**/widget-flows.feature')
   ],

--- a/test/e2e/sauce.wdio.conf.ts
+++ b/test/e2e/sauce.wdio.conf.ts
@@ -22,7 +22,7 @@ exports.config = {
   key: process.env.SAUCE_ACCESS_KEY,
   cucumberOpts: {...conf.cucumberOpts, timeout: 30000},
   maxInstances: 1,
-  waitforTimeout: 25000,
+  waitforTimeout: 20000,
   specs: [
     path.resolve(__dirname, 'features/**/widget-flows.feature')
   ],

--- a/test/e2e/steps/after.ts
+++ b/test/e2e/steps/after.ts
@@ -20,7 +20,7 @@ import TestAppPage from '../page-objects/test-app.page';
 
 // eslint-disable-next-line no-unused-vars
 AfterStep(async function (this: ActionContext) {
-  this.saveScreenshot('afterStep');
+  await this.saveScreenshot('afterStep');
 });
 
 After(deleteUserAndCredentials);
@@ -41,10 +41,14 @@ After(async function(this: ActionContext) {
   }
 });
 
-After(() => browser.deleteCookies());
-
 // eslint-disable-next-line no-unused-vars
 After(async function(this: ActionContext) {
-  await TestAppPage.ssoLogout();
+  if (this.scenario?.gherkinDocument?.feature?.name !== 'Widget Flows') {
+    await TestAppPage.ssoLogout();
+  }
+  await this.saveScreenshot('ssoLogout');
 });
 
+After(async () => {
+  await browser.deleteCookies();
+});

--- a/test/e2e/steps/after.ts
+++ b/test/e2e/steps/after.ts
@@ -45,8 +45,8 @@ After(async function(this: ActionContext) {
 After(async function(this: ActionContext) {
   if (this.scenario?.gherkinDocument?.feature?.name !== 'Widget Flows') {
     await TestAppPage.ssoLogout();
+    await this.saveScreenshot('ssoLogout');
   }
-  await this.saveScreenshot('ssoLogout');
 });
 
 After(async () => {

--- a/test/e2e/steps/before.ts
+++ b/test/e2e/steps/before.ts
@@ -1,6 +1,7 @@
 import { Before, BeforeAll } from '@cucumber/cucumber';
 import ActionContext from '../support/context';
 import { saveScreenshot } from '../support/screenshots';
+import type { Capabilities } from '@wdio/types';
 
 // Add support for screenshots
 let scenarioCounter = 0;
@@ -15,9 +16,14 @@ Before(async function(this: ActionContext, scenario) {
   this.saveScreenshot = async function(this: ActionContext, fileName: string | undefined) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const scenario = this.scenario!;
+    const browserName = (browser.requestedCapabilities as Capabilities.Capabilities)?.browserName ?? 'unknown';
     const feature = scenario.gherkinDocument.feature?.name;
     const step = scenario.pickle.name;
-    fileName = `${feature}-${scenarioNum}-${++screenshotCounter}-${step}-${fileName}`;
-    await saveScreenshot(fileName);
+    fileName = `${browserName}-${feature}-${scenarioNum}-${++screenshotCounter}-${step}-${fileName}`;
+    try {
+      await saveScreenshot(fileName);
+    } catch (e) {
+      console.error(`Failed to save screenshot ${fileName}: ${e}`);
+    }
   }
 });

--- a/test/e2e/steps/given.ts
+++ b/test/e2e/steps/given.ts
@@ -177,7 +177,7 @@ Given(
         await TestAppPage.showSignInToGetTokens.click();
         break;
     }
-    this.saveScreenshot(`user-opens-login-page-using-${buttonName}`);
+    await this.saveScreenshot(`user-opens-login-page-using-${buttonName}`);
     return await waitForLoad(TestAppPage.widget);
   }
 );

--- a/test/e2e/steps/then.ts
+++ b/test/e2e/steps/then.ts
@@ -82,7 +82,6 @@ Then(
 Then(
   /^user sees forgot password form$/,
   async function() {
-    this.saveScreenshot('user-sees-forgot-password-form');
     return await PrimaryAuthPage.waitForForgotPassword();
   }
 );

--- a/test/e2e/steps/when.ts
+++ b/test/e2e/steps/when.ts
@@ -184,7 +184,7 @@ When(
       emailMagicLink = await this.a18nClient!.getEmailMagicLink(this.credentials.profileId!);
     }
     await browser.url(emailMagicLink);
-    this.saveScreenshot('click-magic-link');
+    await this.saveScreenshot('click-magic-link');
   }
 );
 

--- a/test/e2e/util/waitUtil.js
+++ b/test/e2e/util/waitUtil.js
@@ -1,3 +1,11 @@
 export const waitForLoad = async (element) => {
-  await browser.waitUntil(async () => element.then(el => el.isDisplayed()), 5000, 'wait for element to load');
+  const $element = await element;
+  await $element.waitForDisplayed({ timeout: 10_000 });
+};
+
+export const waitForText = async (element, expectedText) => {
+  await browser.waitUntil(async () => {
+    const $element = await element;
+    return (await $element.isDisplayed()) && (await $element.getText()) === expectedText;
+  }, 10_000, `wait for element to load and have text: ${expectedText}`);
 };

--- a/test/e2e/util/waitUtil.js
+++ b/test/e2e/util/waitUtil.js
@@ -1,11 +1,11 @@
 export const waitForLoad = async (element) => {
   const $element = await element;
-  await $element.waitForDisplayed({ timeout: 10_000 });
+  await $element.waitForDisplayed({ timeout: 20_000 });
 };
 
 export const waitForText = async (element, expectedText) => {
   await browser.waitUntil(async () => {
     const $element = await element;
     return (await $element.isDisplayed()) && (await $element.getText()) === expectedText;
-  }, 10_000, `wait for element to load and have text: ${expectedText}`);
+  }, 20_000, `wait for element to load and have text: ${expectedText}`);
 };

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -261,35 +261,35 @@ if (process.env.MOBILE_BROWSER_TESTS) {
     ];
 } else if (process.env.RUN_SAUCE_TESTS) {
     conf.capabilities = [
-    {
-      maxInstances: 1, // all tests use the same user and local storage. they must run in series
-      browserName: 'MicrosoftEdge',
-      browserVersion: 'latest',
-      platformName: 'Windows 10',
-      "ms:edgeOptions": {} // don't delete this line, edge tests won't run
-    },
-    {
-      maxInstances: 1, // all tests use the same user and local storage. they must run in series
-      browserName: 'internet explorer',
-      browserVersion: 'latest',
-      platformName: 'Windows 10',
-      "se:ieOptions": {
-          acceptUntrustedCertificates: true,
-          "ie.ensureCleanSession": true
+      {
+        maxInstances: 1, // all tests use the same user and local storage. they must run in series
+        browserName: 'internet explorer',
+        browserVersion: 'latest',
+        platformName: 'Windows 10',
+        "se:ieOptions": {
+            acceptUntrustedCertificates: true,
+            "ie.ensureCleanSession": true
+        },
+        timeouts: { "implicit": 20_000 }
       },
-      timeouts: { "implicit": 20_000 }
-    },
-    {
-      platformName: 'iOS',
-      browserName: 'Safari',
-      'appium:deviceName': 'iPad Pro (12.9 inch) (5th generation) Simulator',
-      'appium:platformVersion': '15.4',
-      'sauce:options': {
-        appiumVersion: '1.22.3',
-        build: "iOS-Widget-Build",
-        name: "iOS-Widget-Test",
-      }
-    }
+      {
+        platformName: 'iOS',
+        browserName: 'Safari',
+        'appium:deviceName': 'iPad Pro (12.9 inch) (5th generation) Simulator',
+        'appium:platformVersion': '15.4',
+        'sauce:options': {
+          appiumVersion: '1.22.3',
+          build: "iOS-Widget-Build",
+          name: "iOS-Widget-Test",
+        }
+      },
+      {
+        maxInstances: 1, // all tests use the same user and local storage. they must run in series
+        browserName: 'MicrosoftEdge',
+        browserVersion: 'latest',
+        platformName: 'Windows 10',
+        "ms:edgeOptions": {} // don't delete this line, edge tests won't run
+      },
     ];
 }
 

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -233,8 +233,11 @@ if (process.env.TEST_LANG) {
 }
 
 // overrides for saucelabs test
-if (process.env.MOBILE_BROWSER_TESTS) {
-    conf.capabilities = [
+if (process.env.RUN_SAUCE_TESTS) {
+  conf.capabilities = [];
+  const testTypes = process.env.RUN_SAUCE_TESTS.split(',');
+  if (testTypes.includes('mobile')) {
+    conf.capabilities.push(...[
       {
         platformName: 'iOS',
         browserName: 'Safari',
@@ -258,40 +261,41 @@ if (process.env.MOBILE_BROWSER_TESTS) {
       //     name: "Android-Widget-Test",
       //   }
       // }
-    ];
-} else if (process.env.RUN_SAUCE_TESTS) {
-    conf.capabilities = [
-      {
-        maxInstances: 1, // all tests use the same user and local storage. they must run in series
-        browserName: 'internet explorer',
-        browserVersion: 'latest',
-        platformName: 'Windows 10',
-        "se:ieOptions": {
-            acceptUntrustedCertificates: true,
-            "ie.ensureCleanSession": true
-        },
-        timeouts: { "implicit": 20_000 }
+    ]);
+  }
+  if (testTypes.includes('ie11')) {
+    conf.capabilities.push({
+      maxInstances: 1, // all tests use the same user and local storage. they must run in series
+      browserName: 'internet explorer',
+      browserVersion: 'latest',
+      platformName: 'Windows 10',
+      "se:ieOptions": {
+          acceptUntrustedCertificates: true,
+          "ie.ensureCleanSession": true
       },
-      {
-        platformName: 'iOS',
-        browserName: 'Safari',
-        'appium:deviceName': 'iPad Pro (12.9 inch) (5th generation) Simulator',
-        'appium:platformVersion': '15.4',
-        'sauce:options': {
-          appiumVersion: '1.22.3',
-          build: "iOS-Widget-Build",
-          name: "iOS-Widget-Test",
-        }
+      timeouts: {
+        implicit: 20_000,
+        script: 40_000,
+        pageLoad: 300_000,
       },
-      {
-        maxInstances: 1, // all tests use the same user and local storage. they must run in series
-        browserName: 'MicrosoftEdge',
-        browserVersion: 'latest',
-        platformName: 'Windows 10',
-        "ms:edgeOptions": {} // don't delete this line, edge tests won't run
+    });
+  }
+  if (testTypes.includes('edge')) {
+    conf.capabilities.push({
+      maxInstances: 1, // all tests use the same user and local storage. they must run in series
+      browserName: 'MicrosoftEdge',
+      browserVersion: 'latest',
+      platformName: 'Windows 10',
+      "ms:edgeOptions": {}, // don't delete this line, edge tests won't run
+      timeouts: {
+        implicit: 20_000,
+        script: 40_000,
+        pageLoad: 300_000,
       },
-    ];
+    });
+  }
 }
+
 
 // Enable skipping certain tests when running against local monolith
 // Can be removed when epic is complete: https://oktainc.atlassian.net/browse/OKTA-528454

--- a/test/e2e/wdio.conf.js
+++ b/test/e2e/wdio.conf.js
@@ -2,10 +2,16 @@
 const path = require('path');
 require('@okta/env').config();
 
+// You can use Firefox for e2e testing locally if there is an issue with `chromedriver`
+// You need to have `geckodriver` process running (https://github.com/mozilla/geckodriver/releases)
+const USE_FIREFOX = !!process.env.USE_FIREFOX;
 const CI = process.env.CI;
 const logLevel = 'warn';
-const browserOptions = {
-    args: []
+const chromeOptions = {
+  args: []
+};
+const firefoxOptions = {
+  args: []
 };
 
 const IS_RELEASE_BRANCH = process.env.BRANCH &&
@@ -25,24 +31,29 @@ if (process.env.DEBUG) {
 }
 
 if (process.env.CHROMIUM_BINARY) {
-  browserOptions.binary = process.env.CHROMIUM_BINARY;
+  chromeOptions.binary = process.env.CHROMIUM_BINARY;
 }
 
-if (process.env.CI || process.env.CHROME_HEADLESS) {
-    browserOptions.args = browserOptions.args.concat([
-        '--headless',
-        '--disable-gpu',
-        '--window-size=1600x1200',
-        '--no-sandbox',
-        '--whitelisted-ips',
-        '--disable-extensions',
-        '--verbose',
-        '--disable-dev-shm-usage'
-    ]);
+if (CI || process.env.CHROME_HEADLESS) {
+  chromeOptions.args = chromeOptions.args.concat([
+    '--headless',
+    '--disable-gpu',
+    '--window-size=1600x1200',
+    '--no-sandbox',
+    '--whitelisted-ips',
+    '--disable-extensions',
+    '--verbose',
+    '--disable-dev-shm-usage'
+  ]);
+}
+if (CI) {
+  firefoxOptions.args = firefoxOptions.args.concat([
+    '-headless'
+  ]);
 }
 
 const CHROMEDRIVER_VERSION = process.env.CHROMEDRIVER_VERSION || '89.0.4389.23';
-const drivers = {
+const drivers = USE_FIREFOX ? undefined : {
   chrome: { version: CHROMEDRIVER_VERSION }
 };
 
@@ -105,8 +116,9 @@ const conf = {
         // grid with only 5 firefox instances available you can make sure that not more than
         // 5 instances get started at a time.
         maxInstances: 1, // all tests use the same user and local storage. they must run in series
-        browserName: 'chrome',
-        'goog:chromeOptions': browserOptions
+        browserName: USE_FIREFOX ? 'firefox' : 'chrome',
+        'goog:chromeOptions': chromeOptions,
+        'moz:firefoxOptions': firefoxOptions,
         // If outputDir is provided WebdriverIO can capture driver session logs
         // it is possible to configure which logTypes to include/exclude.
         // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
@@ -159,7 +171,7 @@ const conf = {
     // Services take over a specific job you don't want to take care of. They enhance
     // your test setup with almost no effort. Unlike plugins, they don't add new
     // commands. Instead, they hook themselves up into the test process.
-    services: [
+    services: USE_FIREFOX ? [] : [
         ['selenium-standalone', {
             installArgs: {
                 drivers


### PR DESCRIPTION
## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-738533](https://oktainc.atlassian.net/browse/OKTA-738533)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



