### PR TITLE
feat: replace app store button for ov enrollment

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -114,8 +114,6 @@ const idx = {
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-enroll-custom-app-push',
     // 'request-activation-email'    
-    // 'authenticator-enroll-google-authenticator',
-    // 'authenticator-enroll-ov-via-sms',
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',
@@ -124,11 +122,11 @@ const idx = {
     // 'enroll-profile-with-idps'
   ],
   '/idp/idx/credential/enroll': [
-    'authenticator-enroll-ov-via-sms',
+    // 'authenticator-enroll-ov-via-sms',
     // 'authenticator-enroll-security-question',
     // 'authenticator-enroll-google-authenticator',
     // 'authenticator-enroll-email-first-emailmagiclink-true',
-    // 'error-authenticator-enroll-phone-invalid-number',
+    'error-authenticator-enroll-phone-invalid-number',
   ],
   '/idp/idx/identify': [
     // 'authenticator-verification-data-ov-only-without-device-known',
@@ -174,7 +172,7 @@ const idx = {
     // 'authenticator-verification-phone-voice'
   ],
   '/idp/idx/challenge/poll': [
-    // 'authenticator-verification-email',
+    'authenticator-verification-email',
     // 'success',
     // 'authenticator-verification-email-polling-long',
     // 'error-429-too-many-request',
@@ -184,7 +182,7 @@ const idx = {
     // 'authenticator-enroll-email-emailmagiclink-true',
     // 'authenticator-enroll-email-emailmagiclink-false',
     // 'authenticator-verification-okta-verify-push',
-    'authenticator-verification-custom-app-push',
+    // 'authenticator-verification-custom-app-push',
     // 'authenticator-verification-custom-app-push-reject',
     // 'authenticator-enroll-ov-sms-enable-biometrics',
     // 'okta-verify-version-upgrade',
@@ -221,9 +219,6 @@ const idx = {
   '/idp/idx/device/activate': [
     'identify-with-password',
     // 'error-invalid-device-code',
-  ],
-  '/idp/idx/authenticators/poll/cancel': [
-    'identify',
   ]
 };
 

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -19,7 +19,8 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    'identify',
+    'authenticator-enroll-ov-same-device-ios-any-security',
+    // 'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -114,6 +115,8 @@ const idx = {
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-enroll-custom-app-push',
     // 'request-activation-email'    
+    // 'authenticator-enroll-google-authenticator',
+    // 'authenticator-enroll-ov-via-sms',
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',
@@ -122,11 +125,11 @@ const idx = {
     // 'enroll-profile-with-idps'
   ],
   '/idp/idx/credential/enroll': [
-    // 'authenticator-enroll-ov-via-sms',
+    'authenticator-enroll-ov-via-sms',
     // 'authenticator-enroll-security-question',
     // 'authenticator-enroll-google-authenticator',
     // 'authenticator-enroll-email-first-emailmagiclink-true',
-    'error-authenticator-enroll-phone-invalid-number',
+    // 'error-authenticator-enroll-phone-invalid-number',
   ],
   '/idp/idx/identify': [
     // 'authenticator-verification-data-ov-only-without-device-known',
@@ -172,7 +175,7 @@ const idx = {
     // 'authenticator-verification-phone-voice'
   ],
   '/idp/idx/challenge/poll': [
-    'authenticator-verification-email',
+    // 'authenticator-verification-email',
     // 'success',
     // 'authenticator-verification-email-polling-long',
     // 'error-429-too-many-request',
@@ -182,7 +185,7 @@ const idx = {
     // 'authenticator-enroll-email-emailmagiclink-true',
     // 'authenticator-enroll-email-emailmagiclink-false',
     // 'authenticator-verification-okta-verify-push',
-    // 'authenticator-verification-custom-app-push',
+    'authenticator-verification-custom-app-push',
     // 'authenticator-verification-custom-app-push-reject',
     // 'authenticator-enroll-ov-sms-enable-biometrics',
     // 'okta-verify-version-upgrade',
@@ -219,6 +222,9 @@ const idx = {
   '/idp/idx/device/activate': [
     'identify-with-password',
     // 'error-invalid-device-code',
+  ],
+  '/idp/idx/authenticators/poll/cancel': [
+    'identify',
   ]
 };
 

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -19,8 +19,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    'authenticator-enroll-ov-same-device-ios-any-security',
-    // 'identify',
+    'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',

--- a/src/v2/view-builder/views/ov/EnrollChannelPollDescriptionView.js
+++ b/src/v2/view-builder/views/ov/EnrollChannelPollDescriptionView.js
@@ -41,32 +41,44 @@ export default View.extend({
                 {{i18n code="oie.enroll.okta_verify.setup.customUri.noPrompt"
                 bundle="login" $1="<span class='semi-strong'>$1</span>"}}
               </div>
-              <div class="desktop-instructions">
-                {{i18n code="oie.enroll.okta_verify.setup.customUri.makeSureHaveOV" bundle="login"}}
-              </div>            
+              {{#unless sameDeviceOVEnrollmentEnabled}}
+                <div class="desktop-instructions">
+                  {{i18n code="oie.enroll.okta_verify.setup.customUri.makeSureHaveOV" bundle="login"}}
+                </div>
+              {{/unless}}
             {{else}}
               {{i18n code="oie.enroll.okta_verify.setup.customUri.makeSureHaveOVToContinue" bundle="login"}}
             {{/if}}
           </p>      
           <ol class="ov-info">
-            {{#if deviceMap.platformLC}}
+            {{#unless sameDeviceOVEnrollmentEnabled}}
+              {{#if deviceMap.platformLC}}
+                <li>
+                  <a aria-label='{{i18n code="customUri.required.content.download.linkText" bundle="login"}}'
+                  href="{{deviceMap.downloadHref}}"
+                  class="app-store-logo {{deviceMap.platformLC}}-app-store-logo"></a>
+                </li>
+              {{/if}}            
+                          
               <li>
-                <a aria-label='{{i18n code="customUri.required.content.download.linkText" bundle="login"}}'
-                href="{{deviceMap.downloadHref}}"
-                class="app-store-logo {{deviceMap.platformLC}}-app-store-logo"></a>
-              </li>
-            {{/if}}            
-                        
-            <li>
-              {{i18n code="oie.enroll.okta_verify.setup.customUri.setup"
-              bundle="login" $1="<span class='semi-strong'>$1</span>"}}
-            </li>            
-            
+                {{i18n code="oie.enroll.okta_verify.setup.customUri.setup"
+                bundle="login" $1="<span class='semi-strong'>$1</span>"}}
+              </li>     
+            {{/unless}}
             <li>
               <a href="{{deviceMap.setupOVUrl}}" class="button button-primary setup-button">
               {{i18n code="oie.enroll.okta_verify.setup.title" bundle="login"}}
               </a>
             </li>
+
+            {{#if sameDeviceOVEnrollmentEnabled}}
+              <li>
+                <span>{{i18n code="customUri.required.content.download.title" bundle="login"}}</span>&nbsp;
+                <a href="{{deviceMap.downloadHref}}" target="_blank" id="download-ov" class="orOnMobileLink">
+                  {{i18n code="customUri.required.content.download.linkText" bundle="login"}}
+                </a>
+              </li>
+            {{/if}}
 
             {{#if showAnotherDeviceLink}}
               <li>
@@ -157,6 +169,9 @@ export default View.extend({
     if (deviceMap.securityLevel && deviceMap.securityLevel === 'ANY') {
       showAnotherDeviceLink = true;
     }
+
+    const sameDeviceOVEnrollmentEnabled = this.options.settings.get('features.sameDeviceOVEnrollmentEnabled');
+
     return {
       href: contextualData.qrcode?.href,
       email: _.escape(contextualData?.email),
@@ -166,6 +181,7 @@ export default View.extend({
       enrolledDeviceName: enrolledDeviceName,
       deviceMap: deviceMap,
       showAnotherDeviceLink: showAnotherDeviceLink,
+      sameDeviceOVEnrollmentEnabled,
     };
   },
   postRender: function() {

--- a/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
@@ -154,6 +154,11 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
     return this.getNthInstructionBulletPoint(3);
   }
 
+  async getSameDeviceDownloadText() {
+    return this.form.getElement('#download-ov').parent().innerText;
+
+  }
+
   async sameDeviceSetupOnMobileTextExist() {
     if (userVariables.gen3) {
       return this.form.getLink(SETUP_ON_ANOTHER_MOBILE_DEVICE_TEXT).exists;
@@ -299,5 +304,9 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
       return this.form.getSubtitle(5);
     }
     return this.getTextContent(CLOSING_CLASS);
+  }
+
+  async appStoreElementExists() {
+    return this.form.el.find(APP_STORE_LINK_CLASS).exists;
   }
 }

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -1015,16 +1015,18 @@ test
 
     await t.expect(await enrollOktaVerifyPage.orAnotherMobileDeviceLinkExists()).eql(true);
 
-    // re-render widget with sameDeviceOVEnrollmentEnabled FF on
-    await rerenderWidget({
-      features: { sameDeviceOVEnrollmentEnabled: true }
-    });
-    await checkA11y(t);
-    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
-    const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
-    await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
-    await t.expect(downloadInstruction).contains('Download here');
-    await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
+    if (!userVariables.gen3) {
+      // re-render widget with sameDeviceOVEnrollmentEnabled FF on
+      await rerenderWidget({
+        features: { sameDeviceOVEnrollmentEnabled: true }
+      });
+      await checkA11y(t);
+      await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
+      const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
+      await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
+      await t.expect(downloadInstruction).contains('Download here');
+      await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
+    }
   });
 
 test
@@ -1044,16 +1046,18 @@ test
       await t.expect(enrollOktaVerifyPage.getOVSetupHref()).eql(sameDeviceOVEnrollmentSetupLink);
     }
 
-    // re-render widget with sameDeviceOVEnrollmentEnabled FF on
-    await rerenderWidget({
-      features: { sameDeviceOVEnrollmentEnabled: true }
-    });
-    await checkA11y(t);
-    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
-    const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
-    await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
-    await t.expect(downloadInstruction).contains('Download here');
-    await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
+    if (!userVariables.gen3) {
+      // re-render widget with sameDeviceOVEnrollmentEnabled FF on
+      await rerenderWidget({
+        features: { sameDeviceOVEnrollmentEnabled: true }
+      });
+      await checkA11y(t);
+      await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
+      const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
+      await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
+      await t.expect(downloadInstruction).contains('Download here');
+      await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
+    }
   });
 
 test
@@ -1073,17 +1077,19 @@ test
     if (!userVariables.gen3) {
       await t.expect(enrollOktaVerifyPage.getOVSetupHref()).eql(sameDeviceOVEnrollmentDesktopSetupLink);
     }
-
-    // re-render widget with sameDeviceOVEnrollmentEnabled FF on
-    await rerenderWidget({
-      features: { sameDeviceOVEnrollmentEnabled: true }
-    });
-    await checkA11y(t);
-    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
-    const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
-    await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
-    await t.expect(downloadInstruction).contains('Download here');
-    await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
+    
+    if (!userVariables.gen3) {
+      // re-render widget with sameDeviceOVEnrollmentEnabled FF on
+      await rerenderWidget({
+        features: { sameDeviceOVEnrollmentEnabled: true }
+      });
+      await checkA11y(t);
+      await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
+      const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
+      await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
+      await t.expect(downloadInstruction).contains('Download here');
+      await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
+    }
   });
 
 test
@@ -1103,14 +1109,16 @@ test
       await t.expect(enrollOktaVerifyPage.getOVSetupHref()).eql(sameDeviceOVEnrollmentDesktopSetupLink);
     }
 
-    // re-render widget with sameDeviceOVEnrollmentEnabled FF on
-    await rerenderWidget({
-      features: { sameDeviceOVEnrollmentEnabled: true }
-    });
-    await checkA11y(t);
-    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
-    const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
-    await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
-    await t.expect(downloadInstruction).contains('Download here');
-    await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
+    if (!userVariables.gen3) {
+      // re-render widget with sameDeviceOVEnrollmentEnabled FF on
+      await rerenderWidget({
+        features: { sameDeviceOVEnrollmentEnabled: true }
+      });
+      await checkA11y(t);
+      await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
+      const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
+      await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
+      await t.expect(downloadInstruction).contains('Download here');
+      await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
+    }
   });

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -1014,6 +1014,17 @@ test
     await t.expect(await enrollOktaVerifyPage.getSameDeviceSetupOnMobileText()).contains(sameDeviceOVEnrollmentInstructions3);
 
     await t.expect(await enrollOktaVerifyPage.orAnotherMobileDeviceLinkExists()).eql(true);
+
+    // re-render widget with sameDeviceOVEnrollmentEnabled FF on
+    await rerenderWidget({
+      features: { sameDeviceOVEnrollmentEnabled: true }
+    });
+    await checkA11y(t);
+    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
+    const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
+    await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
+    await t.expect(downloadInstruction).contains('Download here');
+    await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
   });
 
 test
@@ -1032,6 +1043,17 @@ test
     if (!userVariables.gen3) {
       await t.expect(enrollOktaVerifyPage.getOVSetupHref()).eql(sameDeviceOVEnrollmentSetupLink);
     }
+
+    // re-render widget with sameDeviceOVEnrollmentEnabled FF on
+    await rerenderWidget({
+      features: { sameDeviceOVEnrollmentEnabled: true }
+    });
+    await checkA11y(t);
+    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
+    const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
+    await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
+    await t.expect(downloadInstruction).contains('Download here');
+    await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
   });
 
 test
@@ -1051,6 +1073,17 @@ test
     if (!userVariables.gen3) {
       await t.expect(enrollOktaVerifyPage.getOVSetupHref()).eql(sameDeviceOVEnrollmentDesktopSetupLink);
     }
+
+    // re-render widget with sameDeviceOVEnrollmentEnabled FF on
+    await rerenderWidget({
+      features: { sameDeviceOVEnrollmentEnabled: true }
+    });
+    await checkA11y(t);
+    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
+    const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
+    await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
+    await t.expect(downloadInstruction).contains('Download here');
+    await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
   });
 
 test
@@ -1069,4 +1102,15 @@ test
     if (!userVariables.gen3) {
       await t.expect(enrollOktaVerifyPage.getOVSetupHref()).eql(sameDeviceOVEnrollmentDesktopSetupLink);
     }
+
+    // re-render widget with sameDeviceOVEnrollmentEnabled FF on
+    await rerenderWidget({
+      features: { sameDeviceOVEnrollmentEnabled: true }
+    });
+    await checkA11y(t);
+    await t.expect(enrollOktaVerifyPage.getFormTitle()).eql(sameDeviceOVEnrollmentTitle);
+    const downloadInstruction = await enrollOktaVerifyPage.getSameDeviceDownloadText();
+    await t.expect(downloadInstruction).contains('Don’t have Okta Verify?');
+    await t.expect(downloadInstruction).contains('Download here');
+    await t.expect(await enrollOktaVerifyPage.appStoreElementExists()).eql(false);
   });


### PR DESCRIPTION
## Description:

UX change to replace app store button for ov enrolment


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-744565](https://oktainc.atlassian.net/browse/OKTA-744565)

### Reviewers:

### Screenshot/Video:

**Mobile**
![Screenshot 2024-07-10 at 2 13 31 PM](https://github.com/okta/okta-signin-widget/assets/60160041/e47453c4-d507-4e37-9cac-f5385dba4576)
![Screenshot 2024-07-10 at 2 19 17 PM](https://github.com/okta/okta-signin-widget/assets/60160041/c47adad6-4934-4143-aaa1-c707eb820f06)

**Desktop**
![Screenshot 2024-07-10 at 2 24 18 PM](https://github.com/okta/okta-signin-widget/assets/60160041/ec7750bd-0e37-49ab-b565-070f3cfbabc5)
![Screenshot 2024-07-10 at 2 24 39 PM](https://github.com/okta/okta-signin-widget/assets/60160041/c837f4bf-6b32-4f70-b503-db5da2980772)



### Downstream Monolith Build:



