### PR TITLE
Gen1: Don't throw unhandled exception if security image fetch failed

### DIFF
--- a/src/v1/models/AppState.js
+++ b/src/v1/models/AppState.js
@@ -133,7 +133,7 @@ export default Model.extend({
             if (BrowserFeatures.corsIsNotEnabled(jqXhr)) {
               self.settings.callGlobalError(new UnsupportedBrowserError(loc('error.enabled.cors')));
             } else {
-              throw jqXhr;
+              self.settings.callGlobalError(new Error(`Failed to fetch security image: ${jqXhr.statusText}`));
             }
           })
           .done();

--- a/test/unit/helpers/xhr/security_image_error.js
+++ b/test/unit/helpers/xhr/security_image_error.js
@@ -1,0 +1,5 @@
+export default {
+  status: 500,
+  responseType: 'text',
+  response: 'Internal Server Error',
+};

--- a/test/unit/spec/v1/PrimaryAuth_spec.js
+++ b/test/unit/spec/v1/PrimaryAuth_spec.js
@@ -23,6 +23,7 @@ import resUnauthenticated from 'helpers/xhr/UNAUTHENTICATED';
 import resUnauthorized from 'helpers/xhr/UNAUTHORIZED_ERROR';
 import resSecurityImage from 'helpers/xhr/security_image';
 import resSecurityImageFail from 'helpers/xhr/security_image_fail';
+import resSecurityImageError from 'helpers/xhr/security_image_error';
 import PrimaryAuth from 'v1/models/PrimaryAuth';
 import Q from 'q';
 import $sandbox from 'sandbox';
@@ -1878,6 +1879,22 @@ Expect.describe('PrimaryAuth', function() {
           expect(err instanceof UnsupportedBrowserError).toBe(true);
           expect(err.name).toBe('UNSUPPORTED_BROWSER_ERROR');
           expect(err.message).toEqual('There was an error sending the request - have you enabled CORS?');
+        });
+    });
+    it('calls globalErrorFn handler if security image fetch failed with error', function() {
+      return setup({
+        features: { securityImage: true },
+      })
+        .then(function(test) {
+          spyOn(test.router.settings, 'callGlobalError');
+          test.setNextResponse(resSecurityImageError);
+          test.form.setUsername('testuser');
+          return Expect.waitForSpyCall(test.router.settings.callGlobalError, test);
+        })
+        .then(function(test) {
+          expect(test.router.settings.callGlobalError.calls.count()).toBe(1);
+          const err = test.router.settings.callGlobalError.calls.mostRecent().args[0];
+          expect(err.message).toEqual('Failed to fetch security image: error');
         });
     });
     itp('has username in field if rememberMe is available', function() {


### PR DESCRIPTION
## Description:

Fixes unhandled promise rejection and Sentry error
```
Error: Object captured as exception with keys: abort, always, catch, done, fail
```

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-755560](https://oktainc.atlassian.net/browse/OKTA-755560)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



