### PR TITLE
Gen1: Render boolean registration field as Checkbox

### DIFF
--- a/playground/mocks/data/api/v1/registration/form.json
+++ b/playground/mocks/data/api/v1/registration/form.json
@@ -49,6 +49,10 @@
         "title": "Email",
         "format": "email",
         "default": "Email"
+      },
+      "custom_bool": {
+        "type": "boolean",
+        "title": "Custom bool"
       }
     },
     "required": [

--- a/src/v1/util/RegistrationFormFactory.js
+++ b/src/v1/util/RegistrationFormFactory.js
@@ -14,6 +14,7 @@
 import { _, internal, $ } from '@okta/courage';
 import TextBox from 'v1/views/shared/TextBox';
 let { SchemaFormFactory } = internal.views.forms.helpers;
+let { CheckBox } = internal.views.forms.inputs;
 
 const getParts = function(username) {
   const usernameArr = username.split('');
@@ -149,6 +150,10 @@ const checkSubSchemas = function(fieldName, model, subSchemas, showError) {
 
 const fnCreateInputOptions = function(schemaProperty) {
   let inputOptions = SchemaFormFactory.createInputOptions(schemaProperty);
+  if (schemaProperty.options?.type === 'boolean') {
+    // change BooleanSelect to CheckBox
+    inputOptions.input = CheckBox;
+  }
 
   if (inputOptions.type === 'select') {
     inputOptions = _.extend(inputOptions, {

--- a/test/unit/helpers/dom/RegistrationForm.js
+++ b/test/unit/helpers/dom/RegistrationForm.js
@@ -5,6 +5,7 @@ const USERNAME_FIELD = 'userName';
 const EMAIL_FIELD = 'email';
 const PASSWORD_FIELD = 'password';
 const REFERRER_FIELD = 'referrer';
+const AGREEMENT_FIELD = 'agreement';
 export default Form.extend({
   firstnameField: function() {
     return this.input(FIRSTNAME_FIELD);
@@ -46,6 +47,21 @@ export default Form.extend({
 
   setReferrer: function(val) {
     const field = this.referrerField();
+
+    field.val(val);
+    field.trigger('change');
+  },
+
+  agreementField: function() {
+    return this.input(AGREEMENT_FIELD);
+  },
+
+  agreementErrorField: function() {
+    return this.error(AGREEMENT_FIELD);
+  },
+
+  setAgreement: function(val) {
+    const field = this.agreementField();
 
     field.val(val);
     field.trigger('change');

--- a/test/unit/spec/v1/Registration_spec.js
+++ b/test/unit/spec/v1/Registration_spec.js
@@ -69,6 +69,10 @@ const testData = {
       preferredLanguage: {
         type: 'language_code',
       },
+      agreement: {
+        type: 'boolean',
+        description: 'I agreee to the Terms and Conditions'
+      },
       password: {
         type: 'string',
         description: 'Password',
@@ -96,7 +100,7 @@ const testData = {
         ],
       },
     },
-    required: ['firstName', 'lastName', 'userName', 'password', 'referrer'],
+    required: ['firstName', 'lastName', 'userName', 'password', 'referrer', 'agreement'],
     fieldOrder: [
       'userName',
       'password',
@@ -106,6 +110,7 @@ const testData = {
       'referrer',
       'preferredLanguage',
       'countryCode',
+      'agreement',
     ],
   },
 };
@@ -262,6 +267,7 @@ Expect.describe('Registration', function() {
         test.form.setFirstname('firstName');
         test.form.setLastname('lastName');
         test.form.setReferrer('referrer');
+        test.form.setAgreement(true);
         test.setNextResponse(resErrorNotUnique);
         test.form.submit();
         Util.callAllTimeouts();
@@ -280,6 +286,7 @@ Expect.describe('Registration', function() {
       test.form.setFirstname('firstName');
       test.form.setLastname('lastName');
       test.form.setReferrer('referrer');
+      test.form.setAgreement(true);
       test.setNextResponse(resErrorInvalidEmailDomain);
       test.form.submit();
       Util.callAllTimeouts();
@@ -365,6 +372,14 @@ Expect.describe('Registration', function() {
         expect(password.attr('type')).toEqual('password');
       });
     });
+    itp('has an agreement field', function() {
+      return setup().then(function(test) {
+        const agreement = test.form.agreementField();
+
+        expect(agreement.length).toBe(1);
+        expect(agreement.attr('type')).toEqual('checkbox');
+      });
+    });
     itp('shows label for required field', function() {
       return setup().then(function(test) {
         const requiredLabel = test.form.requiredFieldLabel();
@@ -408,6 +423,12 @@ Expect.describe('Registration', function() {
         test.form.setFirstname(Util.LoremIpsum);
         test.form.submit();
         expect(test.form.firstnameErrorField().length).toBe(1);
+      });
+    });
+    itp('shows an error if agreement is not true', function() {
+      return setup().then(function(test) {
+        test.form.submit();
+        expect(test.form.agreementErrorField().length).toBe(1);
       });
     });
   });
@@ -912,6 +933,7 @@ Expect.describe('Registration', function() {
           test.form.setFirstname('firstName');
           test.form.setLastname('lastName');
           test.form.setReferrer('referrer');
+          test.form.setAgreement(true);
           test.form.submit();
           return Expect.waitForRegistrationComplete(test);
         })
@@ -1080,6 +1102,7 @@ Expect.describe('Registration', function() {
           test.form.setFirstname('firstName');
           test.form.setLastname('lastName');
           test.form.setReferrer('referrer');
+          test.form.setAgreement(true);
           expect($('input.button-primary').length).toBe(1);
           expect($('input.button-primary.btn-disabled').length).toBe(0);
           test.form.submit();


### PR DESCRIPTION
## Description:

`@okta/courage` renders `BooleanSelect`  for `boolean` field type:

https://github.com/okta/okta-signin-widget/blob/030b2cde5a25fbd635c93d68af84d9e6ef0b5117/packages/%40okta/courage-dist/esm/src/courage/views/forms/helpers/SchemaFormFactory.js#L109-L110

(probably to have 3 possible values to select - undefined, true, false)

This PR changes input component to `CheckBox`

Follow-up for okta-core: https://github.com/atko-eng/okta-core/pull/99432

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-185091](https://oktainc.atlassian.net/browse/OKTA-185091)

### Reviewers:

### Screenshot/Video:

Before:

<img width="418" alt="Screenshot 2024-08-02 at 17 02 58" src="https://github.com/user-attachments/assets/5f37561b-1f12-4217-9304-066ccb5e50ea">

<img width="414" alt="Screenshot 2024-08-02 at 17 03 03" src="https://github.com/user-attachments/assets/a64ebeb8-b7f6-4d9f-90ad-0f23a35d6adf">

After:

<img width="421" alt="Screenshot 2024-08-02 at 17 02 17" src="https://github.com/user-attachments/assets/03b77d10-38db-4a4b-923f-f8beb51b15f4">


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=e45f4b71dd58947f91ac2da9ea8d683cf26cdd3f&tab=main

