### PR TITLE
removed nowrap to properly wrap text on OV verify w/o QR code screen

### DIFF
--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
@@ -160,7 +160,7 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
     },
   };
 
-  const tokenReplacement: TokenReplacement = { $1: { element: 'span', attributes: { class: 'strong no-translate' } } };
+  const tokenReplacement: TokenReplacement = { $1: { element: 'span', attributes: { class: 'strong' } } };
 
   const canBeClosed = {
     type: 'Description',


### PR DESCRIPTION
## Description:
This PR fixes the bug where Japanese text fails to wrap properly on the Okta Verify without QR code screen. The issue was with the way spans are being styled, and is not specific to only Japanese text. Removing the nowrap property for span.no-translate fixed this issue.


## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-745200](https://oktainc.atlassian.net/browse/OKTA-745200)

### Reviewers:

### Screenshot/Video:
Before:
<img width="898" alt="image" src="https://github.com/user-attachments/assets/1ce6c298-5dda-4918-a0cd-4450e5e5457f">

After:
<img width="566" alt="image" src="https://github.com/user-attachments/assets/87972e90-3b74-4253-aed1-cfcf61c193d3">

### Downstream Monolith Build: