### PR TITLE
Remove unwanted space before "." in phone number on phone voice verification screen.

### DIFF
--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
@@ -44,7 +44,7 @@ const Body = BaseForm.extend(
       const extraNicknameCssClasses = nicknameText ? 'no-translate authenticator-verify-nickname' : '';
 
       const nicknameTemplate = nicknameText 
-        ? `<span ${extraNicknameCssClasses ? ` class="${extraNicknameCssClasses}"` : ''}>${nicknameText}.</span>`
+        ? `<span class="${extraNicknameCssClasses || ''}">${nicknameText}.</span>`
         : '<span class="no-translate">.</span>';
       // Courage doesn't support HTML, hence creating a subtitle here.
       const content = `${sendText} ` + 

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
@@ -6,7 +6,7 @@ const Body = BaseForm.extend(
   {
     className: 'phone-authenticator-challenge',
     events: {
-      'click a.phone-authenticator-challenge__link' : 'handleSecondaryLinkClick'
+      'click a.phone-authenticator-challenge__link': 'handleSecondaryLinkClick'
     },
 
     title() {
@@ -32,27 +32,29 @@ const Body = BaseForm.extend(
       // Then the user clicks primary button (say sms) and right methodType needs to be sent.
       this.model.on('error', () => this.model.set('authenticator.methodType', this.model.get('primaryMode')));
       BaseForm.prototype.initialize.apply(this, arguments);
-      const sendText = ( this.model.get('primaryMode') === 'sms' )
+      const sendText = (this.model.get('primaryMode') === 'sms')
         ? loc('oie.phone.verify.sms.sendText', 'login')
         : loc('oie.phone.verify.call.sendText', 'login');
       const carrierChargesText = loc('oie.phone.carrier.charges', 'login');
       const isPhoneNumberAvailable = this.model.get('phoneNumber') !== loc('oie.phone.alternate.title', 'login');
       const extraCssClasses = isPhoneNumberAvailable ? 'strong no-translate nowrap' : '';
-      let nicknameText = isPhoneNumberAvailable ? this.model.get('nickname') : '';
-      let extraNicknameCssClasses = '';
-      if (nicknameText !== '') {
-        nicknameText = ' (' + nicknameText + ')';
-        extraNicknameCssClasses = 'strong no-translate authenticator-verify-nickname';
-      }
-      const nicknameTemplate = nicknameText ? `<span ${ extraNicknameCssClasses ? 
-        'class="' + extraNicknameCssClasses + '"' : ''}>
-      ${nicknameText}.</span>` : '<span class="no-translate">.</span>';
+      
+      const nickname = isPhoneNumberAvailable ? this.model.get('nickname') : '';
+      const nicknameText = nickname ? ` (${nickname})` : '';
+      const extraNicknameCssClasses = nicknameText ? 'no-translate authenticator-verify-nickname' : '';
+
+      const nicknameTemplate = nicknameText 
+        ? `<span ${extraNicknameCssClasses ? ` class="${extraNicknameCssClasses}"` : ''}>${nicknameText}.</span>`
+        : '<span class="no-translate">.</span>';
       // Courage doesn't support HTML, hence creating a subtitle here.
-      this.add(`<div class="okta-form-subtitle" data-se="o-form-explain">${sendText}
-        <span ${ extraCssClasses ? 'class="' + extraCssClasses + '"' : ''}>
-        ${this.model.escape('phoneNumber')}</span>${nicknameTemplate}
-        <p>${carrierChargesText}</p>
-      </div>`);
+      const content = `${sendText} ` + 
+        `<span ${extraCssClasses ? ` class="${extraCssClasses}"` : ''}>${this.model.escape('phoneNumber')}</span>` + 
+        `${nicknameTemplate}`;
+      this.add('<div class="okta-form-subtitle" data-se="o-form-explain">' + 
+        `${content}` + 
+        `<p>${carrierChargesText}</p>` + 
+        '</div>'
+      );
     },
 
     getUISchema() {

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -65,7 +65,7 @@ const Body = BaseForm.extend(Object.assign(
       const extraNicknameCssClasses = nicknameText ? 'no-translate authenticator-verify-nickname' : '';
 
       const nicknameTemplate = nicknameText 
-        ? `<span${extraNicknameCssClasses ? ` class="${extraNicknameCssClasses}"` : ''}>${nicknameText}.</span>`
+        ? `<span class="${extraNicknameCssClasses || ''}"}>${nicknameText}.</span>`
         : '<span class="no-translate">.</span>';
       
       // Courage doesn't support HTML, hence creating a subtitle here.

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -58,25 +58,24 @@ const Body = BaseForm.extend(Object.assign(
       const enterCodeText = loc('oie.phone.verify.enterCodeText', 'login');
       const carrierChargesText = loc('oie.phone.carrier.charges', 'login');
       const isPhoneNumberAvailable = this.model.get('phoneNumber') !== loc('oie.phone.alternate.title', 'login');
-      let nicknameText = isPhoneNumberAvailable ? this.model.get('nickname') : '';
-      let extraNicknameCssClasses = '';
-      if (nicknameText !== '') {
-        nicknameText = ' (' + nicknameText + ')';
-        extraNicknameCssClasses = 'no-translate authenticator-verify-nickname';
-      }
+      const strongClass = isPhoneNumberAvailable ? 'strong no-translate nowrap' : '';
+      
+      const nickname = isPhoneNumberAvailable ? this.model.get('nickname') : '';
+      const nicknameText = nickname ? ` (${nickname})` : '';
+      const extraNicknameCssClasses = nicknameText ? 'no-translate authenticator-verify-nickname' : '';
 
-      const nicknameTemplate = nicknameText ? `<span ${ extraNicknameCssClasses ? 'class="' + 
-      extraNicknameCssClasses + '"' : ''}>
-      ${nicknameText}.</span>` : '<span class="no-translate">.</span>';
-      const strongClass = this.model.get('phoneNumber') !== loc('oie.phone.alternate.title', 'login') ?
-        'strong no-translate nowrap' : '';
+      const nicknameTemplate = nicknameText 
+        ? `<span${extraNicknameCssClasses ? ` class="${extraNicknameCssClasses}"` : ''}>${nicknameText}.</span>`
+        : '<span class="no-translate">.</span>';
+      
       // Courage doesn't support HTML, hence creating a subtitle here.
-      this.add(`<div class="okta-form-subtitle" data-se="o-form-explain">
-        ${sendText}&nbsp;<span class='${strongClass}'>${this.model.escape('phoneNumber')}</span>
-        ${nicknameTemplate}
-        &nbsp;${enterCodeText}
-        <p>${carrierChargesText}</p>
-        </div>`, {
+      this.add('<div class="okta-form-subtitle" data-se="o-form-explain">' + 
+        `${sendText} ` + 
+        `<span class="${strongClass}">${this.model.escape('phoneNumber')}</span>` + 
+        `${nicknameTemplate}` + 
+        `&nbsp;${enterCodeText}` + 
+        `<p>${carrierChargesText}</p>` + 
+        '</div>', {
         prepend: true,
         selector: '.o-form-fieldset-container',
       });


### PR DESCRIPTION
## Description:
This PR addresses an issue with unwanted spaces appearing after phone numbers and before the following period on the same line. The problem arose from string literals spanning multiple lines, which inadvertently inserted extra spaces when <span></span> tags were split by new lines, tabs, or spaces. To resolve this, string concatenation was used to make spaces explicit and clearer. Additionally, the code has been refactored for improved readability and consistency, and similar logic in ChallengeAuthenticatorDataPhoneView has been updated to align with these changes.

## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-730350](https://oktainc.atlassian.net/browse/OKTA-730350)

### Reviewers:

### Screenshot/Video:
(new AuthenticatorPhoneView -- space removed)
<img width="603" alt="image" src="https://github.com/user-attachments/assets/bcb04b7f-07bd-4422-9adc-54e11bc89503">

(new AuthenticatorDataPhoneView -- no changes)
<img width="517" alt="image" src="https://github.com/user-attachments/assets/0585d321-f0f1-4a92-9d1b-57b5dd394807">


### Downstream Monolith Build:



