### PR TITLE
Add Device Assurance Grace Period strings

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1645,7 +1645,9 @@ idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_tr
 
 # Device Assurance Grace Period
 idx.device_assurance.grace_period.title = Device assurance reminder
+# {0} is the number of days until the grace period expires
 idx.device_assurance.grace_period.warning.title.due_by_days = Your device doesn't meet the security requirements. Fix the issue within {0} days to prevent lockout.
+# {0} is the date that the grace period expires
 idx.device_assurance.grace_period.warning.title.due_by_date = Your device doesn't meet the security requirements. Fix the issue by {0} to prevent lockout.
 idx.device_assurance.grace_period.continue_to_app = Continue to app
 

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1643,5 +1643,11 @@ idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.upgrad
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.verified_mode = Switch your device to verified mode
 idx.error.code.access_denied.device_assurance.remediation.chrome.chromeos.key_trust_level.developer_mode = Switch your device to developer mode
 
+# Device Assurance Grace Period
+idx.device_assurance.grace_period.title = Device assurance reminder
+idx.device_assurance.grace_period.warning.title.due_by_days = Your device doesn't meet the security requirements. Fix the issue within {0} days to prevent lockout.
+idx.device_assurance.grace_period.warning.title.due_by_date = Your device doesn't meet the security requirements. Fix the issue by {0} to prevent lockout.
+idx.device_assurance.grace_period.continue_to_app = Continue to app
+
 # OAMP Strings
 api.policy.okta.account.management.insufficient.authenticators.unable.to.sign.in = Unable to sign in. Contact support for assistance.


### PR DESCRIPTION
## Description:
Since we are targeting the 2024.09.0 CF, we must get all new translation strings into their respective repositories by the translation handoff on 8/21 (see [translation calendar](https://oktawiki.atlassian.net/wiki/display/eng/calendar/cdc89a24-5840-48ae-8d08-db9c95a12e3b#))

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-795151](https://oktainc.atlassian.net/browse/OKTA-795151)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



