### PR TITLE
testfixes: increase timeout in OV loopback specs

### DIFF
--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -65,7 +65,7 @@ const loopbackSuccessWithHttpsMock = RequestMock()
     } else {
       res.setBody(identifyWithDeviceProbingHttpsLoopback);
     }
-  }) 
+  })
   .onRequestTo(/https:\/\/randomorgid.authenticatorlocaldev.com:(2000|6512|6513)\/probe/)
   .respond(null, 500, {
     'access-control-allow-origin': '*',
@@ -95,7 +95,7 @@ const loopbackSuccessWithHttpMock = RequestMock()
     } else {
       res.setBody(identifyWithDeviceProbingHttpsLoopback);
     }
-  }) 
+  })
   .onRequestTo(/http:\/\/localhost:(2000|6512|6513)\/probe/)
   .respond(null, 500, {
     'access-control-allow-origin': '*',
@@ -544,7 +544,7 @@ test
       record => record.response.statusCode === 200 &&
                 record.request.url.match(/introspect/)
     )).eql(1);
-    await t.wait(1000); // wait a moment for all probes to fail
+    await t.wait(2000); // wait a moment for all probes to fail
     await t.expect(loopbackChallengeErrorLogger.count(
       record => record.response.statusCode === 500 &&
                 record.request.url.match(/2000/)
@@ -620,7 +620,7 @@ test
       record => record.response.statusCode === 200 &&
         record.request.url.match(/introspect/)
     )).eql(1);
-    await t.wait(1000);
+    await t.wait(2000);
     await t.expect(loopbackSuccessButNotAssignedLogger.count(
       record => record.response.statusCode === 200 &&
         record.request.method === 'get' &&
@@ -680,7 +680,7 @@ test
       record => record.response.statusCode === 200 &&
         record.request.url.match(/introspect/)
     )).eql(1);
-    await t.wait(1000);
+    await t.wait(2000);
     await t.expect(appLinkWithoutLaunchLogger.count(
       record => record.response.statusCode === 500 &&
         record.request.url.match(/2000|6511|6512|6513/)

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -648,7 +648,7 @@ test
       record => record.response.statusCode === 200 &&
         record.request.url.match(/introspect/)
     )).eql(1);
-    await t.wait(1000);
+    await t.wait(2000);
     await t.expect(loopbackFallbackLogger.count(
       record => record.response.statusCode === 500 &&
         record.request.url.match(/2000|6511|6512|6513/)


### PR DESCRIPTION
## Description:

Increase OV loopback test timeouts to reduce flakiness

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-796074](https://oktainc.atlassian.net/browse/OKTA-796074)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



