### PR TITLE
OKTA-747278 : Enable polling on OV same device enroll setup view

### DIFF
--- a/src/v2/view-builder/views/ov/EnrollChannelPollDescriptionView.js
+++ b/src/v2/view-builder/views/ov/EnrollChannelPollDescriptionView.js
@@ -257,9 +257,9 @@ function getDeviceMap(appState) {
   const contextualData = appState.get('currentAuthenticator').contextualData;
   let deviceMap = {};
   if (contextualData.samedevice?.setupOVUrl) {
-    deviceMap = contextualData.samedevice;
+    deviceMap = {...contextualData.samedevice};
   } else if (contextualData.devicebootstrap?.setupOVUrl) {
-    deviceMap = contextualData.devicebootstrap;
+    deviceMap = {...contextualData.devicebootstrap};
   }
 
   if (deviceMap.platform) {

--- a/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
@@ -63,9 +63,12 @@ const Body = BaseFormWithPolling.extend(Object.assign(
       } else if (['email', 'sms'].includes(selectedChannel)) {
         selector = '.switch-channel-content';
         shouldStartPolling = true;
-      } else if (['samedevice', 'devicebootstrap'].includes(selectedChannel)) { 
-        // no selector if the channel is same device or device bootstrap
+      } else if (['samedevice'].includes(selectedChannel)) {
+        // no selector if the channel is same device
         shouldStartPolling = true;
+      } else if (['devicebootstrap'].includes(selectedChannel)) {
+        // no selector if the channel is device bootstrap
+        shouldStartPolling = false;
       }
       
       schema.push({

--- a/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
@@ -65,8 +65,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
         shouldStartPolling = true;
       } else if (['samedevice', 'devicebootstrap'].includes(selectedChannel)) { 
         // no selector if the channel is same device or device bootstrap
-        // additionally, stop polling as it should be a terminal page
-        shouldStartPolling = false;
+        shouldStartPolling = true;
       }
       
       schema.push({


### PR DESCRIPTION
## Description:

This PR enables polling on the OV Same device enrollment setup screen.  This allows the SIW to receive the updated response from the backend when enrollment has been completed in the OV app.

Related back-end change: https://github.com/atko-eng/okta-core/pull/100424

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-747278](https://oktainc.atlassian.net/browse/OKTA-747278)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



