### PR TITLE
Gen2: Don't save username from failed IDX transaction and don't prefill it to reset password form and enroll form

### DIFF
--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -176,7 +176,6 @@ export default Controller.extend({
       settings.getAuthClient().transactionManager.clear({ clearIdxResponse: false });
       sessionStorageHelper.removeStateHandle();
       appState.clearAppStateCache();
-      appState.unset('lastIdentifier');
 
       if (settings.get('oauth2Enabled')) {
         // In this case we need to restart login flow and recreate transaction meta
@@ -374,7 +373,6 @@ export default Controller.extend({
    */
   async showFormErrors(model, error, form) {
     /* eslint max-statements: [2, 24] */
-    const formName = model.get('formName');
     let errorObj;
     let idxStateError;
     let showErrorBanner = true;
@@ -408,14 +406,6 @@ export default Controller.extend({
     idxStateError = Object.assign({}, idxStateError, {hasFormError: true});
 
     // OKTA-725716: Don't save failed IDX response to state
-
-    // Save identifier to be auto filled on EnrollProfileView and IdentifyRecoveryView
-    if (formName === FORMS.IDENTIFY) {
-      const identifier = model.get('identifier');
-      this.options.appState.set('lastIdentifier', identifier);
-    } else {
-      this.options.appState.unset('lastIdentifier');
-    }
   },
 
   async handleIdxResponse(idxResp) {

--- a/src/v2/models/AppState.ts
+++ b/src/v2/models/AppState.ts
@@ -36,7 +36,6 @@ const UNKNOWN_USER_I8N_KEY = "idx.unknown.user";
 const local: Record<string, ModelProperty> = {
   user: 'object',        // optional
   currentFormName: 'string',
-  lastIdentifier: 'string',
   idx: 'object',
   remediations: 'array',
   dynamicRefreshInterval: 'number',
@@ -259,7 +258,7 @@ export default class AppState extends Model {
     // clear appState before setting new values
     const attrs = {};
     for (const key in this.attributes) {
-      if (key !== 'currentFormName' && key !== 'lastIdentifier') {
+      if (key !== 'currentFormName') {
         attrs[key] = void 0;
       }
     }

--- a/src/v2/view-builder/views/EnrollProfileView.js
+++ b/src/v2/view-builder/views/EnrollProfileView.js
@@ -31,10 +31,6 @@ const Body = BaseForm.extend({
     return loc('oie.registration.form.submit', 'login');
 
   },
-  initialize() {
-    BaseForm.prototype.initialize.apply(this, arguments);
-    this.model.set('userProfile.email', this.options.appState.get('lastIdentifier'));
-  },
   saveForm() {
     // SIW customization hook for registration
     this.settings.preRegistrationSubmit(this.model.toJSON(),

--- a/src/v2/view-builder/views/IdentifyRecoveryView.js
+++ b/src/v2/view-builder/views/IdentifyRecoveryView.js
@@ -12,14 +12,6 @@ const Body = BaseForm.extend({
     return loc('oform.next', 'login');
   },
 
-  initialize() {
-    BaseForm.prototype.initialize.apply(this, arguments);
-    const identifier = this.options.appState.get('lastIdentifier');
-    if (identifier) {
-      this.model.set('identifier', identifier);
-    }
-  },
-
   getUISchema() {
     const schemas = BaseForm.prototype.getUISchema.apply(this, arguments);
     let newSchemas = schemas.map(schema => {


### PR DESCRIPTION
## Description:

Remove unnecessary logic to populate user's email into password recovery form if user was trying to login before clicking on "Forgot password?"
This logic was introduced by [PR #3648 (Don't save failed transaction on identify form)](https://github.com/okta/okta-signin-widget/pull/3648/files#r1636667036) just to fix monolith tests, but now it's not necessary after https://github.com/atko-eng/okta-core/pull/100667

<!--
Fixed issue introduced with [PR #3648 (Don't save failed transaction on identify form)](https://github.com/okta/okta-signin-widget/pull/3648/files#r1636667036)
To fix monolith tests in #3648 I've added logic to auto populate identifier and submit password reset request automatically when:
1) user enters username on login form
2) clicks 'Sign in'
3) error 'Unable to sign in' is returned
4) user clicks 'Forgot password'
(See [video](https://github.com/okta/okta-signin-widget/pull/3648#pullrequestreview-2113360736))

In this PR auto-submit logic has been removed.
Monolith tests fixes should be applied: https://github.com/atko-eng/okta-core/pull/100667
-->

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-797799](https://oktainc.atlassian.net/browse/OKTA-797799)

### Reviewers:

### Screenshot/Video:

Before:

https://github.com/user-attachments/assets/e1254c5b-ddc1-4c95-b7ed-7593a6dd1ac0

https://github.com/user-attachments/assets/f453dbaa-e18d-43ee-8f46-140794896718

After:

https://github.com/user-attachments/assets/d050c5d2-0ebe-4881-a651-c3ca435b15c7


https://github.com/user-attachments/assets/d7b3d680-796a-4fed-a2ca-6e83666d52f4




### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=8b4a49618fd0adfb48642df6eb73c13c45402ad6&tab=main
