### PR TITLE
fix: Don't trigger auto save on identify-recovery form

### DIFF
--- a/src/v2/view-builder/views/IdentifyRecoveryView.js
+++ b/src/v2/view-builder/views/IdentifyRecoveryView.js
@@ -17,10 +17,6 @@ const Body = BaseForm.extend({
     const identifier = this.options.appState.get('lastIdentifier');
     if (identifier) {
       this.model.set('identifier', identifier);
-      // Toggle Form saving status (e.g. disabling save button, etc)
-      this.model.trigger('request');
-      // Auto submit
-      this.trigger('save', this.model);
     }
   },
 


### PR DESCRIPTION
## Description:

branched from [od-fix-pass-reset-flow-OKTA-793288](https://github.com/okta/okta-signin-widget/tree/od-fix-pass-reset-flow-OKTA-793288) (#3705)

This branch isolates the first commit containing bugfix and ignores 2 subsequent commits that cause downstream test failures.

https://github.com/okta/okta-signin-widget/pull/3705/commits

- keep [e62e14dbf43d66f6ec35cce8c83750ed554df26a](https://github.com/okta/okta-signin-widget/pull/3705/commits/e62e14dbf43d66f6ec35cce8c83750ed554df26a)
- discard [6e961bafa02151f207f74f3820c479a3ae859d3e](https://github.com/okta/okta-signin-widget/pull/3705/commits/6e961bafa02151f207f74f3820c479a3ae859d3e)
- discard [4a1e7feb5450e767fb0a59be7453f3769820d95b](https://github.com/okta/okta-signin-widget/pull/3705/commits/4a1e7feb5450e767fb0a59be7453f3769820d95b)

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-793288](https://oktainc.atlassian.net/browse/OKTA-793288)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



