### PR TITLE
fix for auto redirect for IDV

### DIFF
--- a/src/v2/view-builder/views/idp/BaseIdpAuthenticator.js
+++ b/src/v2/view-builder/views/idp/BaseIdpAuthenticator.js
@@ -1,5 +1,6 @@
 import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from 'v2/view-builder/components/BaseAuthenticatorView';
+import { FORMS as REMEDIATION_FORMS } from 'v2/ion/RemediationConstants';
 
 export const BaseIdPAuthenticatorBody =  BaseForm.extend({
   initialize() {
@@ -16,8 +17,11 @@ export const BaseIdpAuthenticatorView = BaseAuthenticatorView.extend({
     const messages = this.options.appState.get('messages') || {};
     // In case of failure, don't auto-redirect which will result in infinite redirects.
     // so catch the error and render to the user.
-    if (this.settings.get('features.skipIdpFactorVerificationBtn') && !Array.isArray(messages.value)) {
-      this.$('.o-form-button-bar').hide();
+    if (
+      this.settings.get('features.skipIdpFactorVerificationBtn') &&
+      !Array.isArray(messages.value) &&
+      this.model.get('formName') !== REMEDIATION_FORMS.REDIRECT_IDVERIFY
+    ) {  this.$('.o-form-button-bar').hide();
       this.$('.okta-waiting-spinner').show();
       this.form.trigger('save', this.model);
     } else {

--- a/src/v2/view-builder/views/idp/BaseIdpAuthenticator.js
+++ b/src/v2/view-builder/views/idp/BaseIdpAuthenticator.js
@@ -21,7 +21,8 @@ export const BaseIdpAuthenticatorView = BaseAuthenticatorView.extend({
       this.settings.get('features.skipIdpFactorVerificationBtn') &&
       !Array.isArray(messages.value) &&
       this.model.get('formName') !== REMEDIATION_FORMS.REDIRECT_IDVERIFY
-    ) {  this.$('.o-form-button-bar').hide();
+    ) { 
+      this.$('.o-form-button-bar').hide();
       this.$('.okta-waiting-spinner').show();
       this.form.trigger('save', this.model);
     } else {

--- a/test/unit/spec/v2/view-builder/views/RedirectIdvView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/RedirectIdvView_spec.js
@@ -6,6 +6,7 @@ import { loc } from '@okta/courage';
 
 describe('v2/view-builder/views/idp/RedirectIdvView', function() {
   let testContext;
+  let appStateTriggerSpy;
 
   beforeEach(function() {
 
@@ -28,6 +29,8 @@ describe('v2/view-builder/views/idp/RedirectIdvView', function() {
         }
         return [];
       });
+
+      appStateTriggerSpy = jest.spyOn(appState, 'trigger');
 
       const currentViewState = {
         name: 'redirect-idverify',
@@ -52,6 +55,7 @@ describe('v2/view-builder/views/idp/RedirectIdvView', function() {
   it.each([true, false])('Do not hide button and auto redirect when skipIdpFactorVerificationBtn is %s', async (skipIdpFactorVerificationBtn) => {
     testContext.init(skipIdpFactorVerificationBtn);
     expect(testContext.view.$el.find('.o-form-button-bar').attr('style')).toBeUndefined();
+    expect(appStateTriggerSpy).toHaveBeenCalledTimes(0);
   });
 
 });

--- a/test/unit/spec/v2/view-builder/views/RedirectIdvView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/RedirectIdvView_spec.js
@@ -6,15 +6,14 @@ import { loc } from '@okta/courage';
 
 describe('v2/view-builder/views/idp/RedirectIdvView', function() {
   let testContext;
-  let settings = new Settings({ baseUrl: 'http://localhost:3000' });
 
   beforeEach(function() {
 
     testContext = {};
-    testContext.init = (
-    ) => {
+    testContext.init = (skipIdpFactorVerificationBtn = false) => {
       let currentAuthenticator =  [];
       let authenticatorEnrollments = {};
+      let settings = new Settings({ baseUrl: 'http://localhost:3000', 'features.skipIdpFactorVerificationBtn': skipIdpFactorVerificationBtn });
       let app = {};
       const appState = new AppState({
         currentAuthenticator,
@@ -31,10 +30,7 @@ describe('v2/view-builder/views/idp/RedirectIdvView', function() {
       });
 
       const currentViewState = {
-        name: 'challenge-authenticator',
-        relatesTo: {
-          value: currentAuthenticator,
-        },
+        name: 'redirect-idverify',
       };
       testContext.view = new RedirectIdvView({
         appState,
@@ -51,6 +47,11 @@ describe('v2/view-builder/views/idp/RedirectIdvView', function() {
     expect(testContext.view.$el.find('.okta-form-title').text()).toBe(loc('oie.idv.idp.title', 'login', ['Persona']));
     expect(testContext.view.$el.find('.okta-form-subtitle').text()).toBe(loc('oie.idv.idp.description', 'login'));
     expect(testContext.view.$el.find('.o-form-button-bar input').attr('value')).toBe(loc('oie.optional.authenticator.button.title', 'login'));
+  });
+
+  it.each([true, false])('Do not hide button and auto redirect when skipIdpFactorVerificationBtn is %s', async (skipIdpFactorVerificationBtn) => {
+    testContext.init(skipIdpFactorVerificationBtn);
+    expect(testContext.view.$el.find('.o-form-button-bar').attr('style')).toBeUndefined();
   });
 
 });


### PR DESCRIPTION
## Description:

Bug:  Only in SIW2. When `SKIP_IDP_FACTOR_VERIFICATION_BUTTON` FF is enabled, Continue button in IDV Persona Screen is hidden and the form is auto-redirected. This fix is to avoid the auto-redirect.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-798448](https://oktainc.atlassian.net/browse/OKTA-798448)

### Reviewers:

### Screenshot/Video:

#### Before Fix


https://github.com/user-attachments/assets/de83fdda-ab99-4d8c-81af-578db9b60be7



#### After Fix
https://github.com/user-attachments/assets/9cc57a90-d4d1-4499-b3c5-05dbce41162f


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-fd4bb16-66df25a5&page=1&pageSize=6&sha=71981bf960f9304cef2ca27f3ae32505b9bdd1ca&tab=main


