### PR TITLE
OKTA-798570 : Enable samedevice enrollment page polling test

### DIFF
--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -35,6 +35,9 @@ import xhrAuthenticatorEnrollEnableBiometricsSMS from '../../../playground/mocks
 
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success.json';
 
+const POLLING_INTERVAL = 4000;
+const RESEND_REMINDER_PROMPT_INTERVAL = 30000
+
 const logger = RequestLogger(/introspect|poll|send|enroll/, {
   logRequestBody: true,
   stringifyRequestBody: true,
@@ -397,7 +400,7 @@ test.requestHooks(logger, enrollViaQRcodeMocks1)('should be able to enroll via q
     await t.removeRequestHooks(enrollViaQRcodeMocks1);
     await t.addRequestHooks(enrollViaQRcodeMocks2);
   }
-  await t.wait(4000);
+  await t.wait(POLLING_INTERVAL);
   // V3 - higher poll requests ~ 7
   if (!userVariables.gen3) {
     await t.expect(logger.count(
@@ -512,7 +515,7 @@ test.requestHooks(resendEmailMocks)('after timeout should be able see and click 
   await t.expect(enrollOktaVerifyPage.getEmailInstruction()).contains(emailInstruction1);
   await t.expect(enrollOktaVerifyPage.getEmailInstruction()).contains(emailInstruction2);
   await t.expect(enrollOktaVerifyPage.resendViewExists()).notOk();
-  await t.wait(30000);
+  await t.wait(RESEND_REMINDER_PROMPT_INTERVAL);
   await t.expect(enrollOktaVerifyPage.resendViewExists()).ok();
   const resendView = enrollOktaVerifyPage.resendView();
   await t.expect(resendView.innerText).contains('Haven’t received an email? Check your spam folder or send again');
@@ -603,7 +606,7 @@ test.requestHooks(resendSmsMocks)('after timeout should be able see and click se
   await t.expect(await enrollOktaVerifyPage.getSmsInstruction()).contains(smsInstruction1);
   await t.expect(await enrollOktaVerifyPage.getSmsInstruction()).contains(smsInstruction2);
   await t.expect(enrollOktaVerifyPage.resendView().visible).notOk();
-  await t.wait(30000);
+  await t.wait(RESEND_REMINDER_PROMPT_INTERVAL);
   await t.expect(enrollOktaVerifyPage.resendViewExists()).ok();
   const resendView = enrollOktaVerifyPage.resendView();
   await t.expect(resendView.innerText).contains('Haven’t received an SMS? Send again');
@@ -757,7 +760,7 @@ const testQRcodeMsg = async (t, isIos) => {
 
   // v3 - logger.count = 0
   if (!userVariables.gen3) {
-    await t.wait(4000);
+    await t.wait(POLLING_INTERVAL);
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&
       record.request.url.match(/poll/)
@@ -853,7 +856,7 @@ test.meta('mobile', false).requestHooks(logger, enrollViaQRcodeEnableBiometricsM
   const errorTitle = enrollOktaVerifyPage.getErrorTitle();
   await t.expect(errorTitle.innerText).contains(enableBiometricsMessageTitle);
   if (!userVariables.gen3) {
-    await t.wait(4000);
+    await t.wait(POLLING_INTERVAL);
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&
       record.request.url.match(/poll/)
@@ -987,7 +990,7 @@ test
 
     // expect polling for same device page
     if (!userVariables.gen3) {
-      await t.wait(4000);
+      await t.wait(POLLING_INTERVAL);
       await t.expect(logger.count(
         record => record.response.statusCode === 200 &&
         record.request.url.match(/poll/)

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -36,7 +36,7 @@ import xhrAuthenticatorEnrollEnableBiometricsSMS from '../../../playground/mocks
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success.json';
 
 const POLLING_INTERVAL = 4000;
-const RESEND_REMINDER_PROMPT_INTERVAL = 30000
+const RESEND_REMINDER_PROMPT_INTERVAL = 30000;
 
 const logger = RequestLogger(/introspect|poll|send|enroll/, {
   logRequestBody: true,


### PR DESCRIPTION
## Description:

This PR updates the `EnrollAuthenticatorOktaVerify_spec.js` testcafe test to expect polling from the OV samedevice enrollment page.

Risk level: Low (only test change)

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-798570](https://oktainc.atlassian.net/browse/OKTA-798570)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



