### PR TITLE
Open help link in a new tab in Gen2

### DIFF
--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -47,6 +47,7 @@ export default BaseFooter.extend({
         'name': 'help',
         'label': loc('help', 'login'),
         'href': helpLinkHref,
+        'target': '_blank',
       },
     ];
 


### PR DESCRIPTION
Resolves: OKTA-795450

## Description:
When in V1, the code will use this [Footer](https://github.com/okta/okta-signin-widget/blob/8c660a4277d5113e81efe9c9a70cdeaedde32955/src/v1/views/shared/Footer.js#L43) template, so the target=_blank is defined

When in V2, the code will first create help link, use the Link class and set attributes [here](https://github.com/okta/okta-signin-widget/blob/8c660a4277d5113e81efe9c9a70cdeaedde32955/src/v2/view-builder/components/Link.js#L24)
So it misses target=_blank in the help link in V2

Before fix:

https://github.com/user-attachments/assets/df4f4432-6466-4fae-a185-e1df004ed046

After fix:

https://github.com/user-attachments/assets/c295851d-d187-4caa-ae00-1350ca2156dd




## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-795450](https://oktainc.atlassian.net/browse/OKTA-795450)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



