### PR TITLE
G2: Trigger removeLoading on language load finish

### DIFF
--- a/src/util/LanguageUtil.js
+++ b/src/util/LanguageUtil.js
@@ -19,6 +19,7 @@ function loadLanguage(appState, settings) {
   }, supportedLanguages).then(function() {
     clearTimeout(timeout);
     appState.trigger('loading', false);
+    appState.trigger('removeLoading');
   });
   // TODO: what if load language error?
 }

--- a/src/util/LanguageUtil.js
+++ b/src/util/LanguageUtil.js
@@ -19,7 +19,6 @@ function loadLanguage(appState, settings) {
   }, supportedLanguages).then(function() {
     clearTimeout(timeout);
     appState.trigger('loading', false);
-    appState.trigger('removeLoading');
   });
   // TODO: what if load language error?
 }

--- a/src/v1/views/shared/Header.ts
+++ b/src/v1/views/shared/Header.ts
@@ -178,16 +178,18 @@ export default class Header extends View {
 
   // Show the loading beacon when the security image feature is not enabled.
   setLoadingBeacon(isLoading) {
-    if (!isLoading && isLoadingBeacon(this.currentBeacon)) {
-      this.setBeacon(null, {});
+    if (!isLoading || isLoadingBeacon(this.currentBeacon)) {
+      return;
     }
-    if (isLoading && !isLoadingBeacon(this.currentBeacon)) {
-      this.setBeacon(LoadingBeacon, { loading: true });
-    }
+    this.setBeacon(LoadingBeacon, { loading: true });
   }
 
   // Hide the beacon on primary auth failure. On primary auth success, setBeacon does this job.
   removeLoadingBeacon() {
+    if (!isLoadingBeacon(this.currentBeacon)) {
+      return;
+    }
+
     const container = this.$('[data-type="beacon-container"]');
 
     return Animations.implode(container)

--- a/src/v1/views/shared/Header.ts
+++ b/src/v1/views/shared/Header.ts
@@ -146,6 +146,7 @@ export default class Header extends View {
         })
         .done(); // TODO: can this be removed if fadeOut returns standard ES6 Promise?
     case 'swap':
+      const wasLoading = isLoadingBeacon(this.currentBeacon);
       return Animations.swapBeacons({
         $el: container,
         swap: () => {
@@ -154,7 +155,7 @@ export default class Header extends View {
           // Order of these calls is important for -
           // loader --> security/factor beacon swap.
           removeBeacon(this);
-          if (isLoading) {
+          if (wasLoading || isLoading) {
             container.removeClass(LOADING_BEACON_CLS);
             this.$el.removeClass(NO_BEACON_CLS);
           }
@@ -177,10 +178,12 @@ export default class Header extends View {
 
   // Show the loading beacon when the security image feature is not enabled.
   setLoadingBeacon(isLoading) {
-    if (!isLoading || isLoadingBeacon(this.currentBeacon)) {
-      return;
+    if (!isLoading && isLoadingBeacon(this.currentBeacon)) {
+      this.setBeacon(null, {});
     }
-    this.setBeacon(LoadingBeacon, { loading: true });
+    if (isLoading && !isLoadingBeacon(this.currentBeacon)) {
+      this.setBeacon(LoadingBeacon, { loading: true });
+    }
   }
 
   // Hide the beacon on primary auth failure. On primary auth success, setBeacon does this job.

--- a/src/v1/views/shared/Header.ts
+++ b/src/v1/views/shared/Header.ts
@@ -146,7 +146,6 @@ export default class Header extends View {
         })
         .done(); // TODO: can this be removed if fadeOut returns standard ES6 Promise?
     case 'swap':
-      const wasLoading = isLoadingBeacon(this.currentBeacon);
       return Animations.swapBeacons({
         $el: container,
         swap: () => {
@@ -155,9 +154,9 @@ export default class Header extends View {
           // Order of these calls is important for -
           // loader --> security/factor beacon swap.
           removeBeacon(this);
-          if (wasLoading || isLoading) {
+          this.$el.removeClass(NO_BEACON_CLS);
+          if (isLoading) {
             container.removeClass(LOADING_BEACON_CLS);
-            this.$el.removeClass(NO_BEACON_CLS);
           }
           addBeacon(this, NextBeacon, selector, options);
         },

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -295,6 +295,14 @@ export default class BasePageObject {
     return Selector('.spinner').exists;
   }
 
+  loadingBeaconExists() {
+    if(userVariables.gen3) {
+      return this.form.getSpinner().exists;
+    }
+
+    return Selector('.beacon-loading').exists;
+  }
+
   getSpinnerStyle() {
     return Selector('.spinner').getStyleProperty('display');
   }

--- a/test/testcafe/spec/BYOL_spec.js
+++ b/test/testcafe/spec/BYOL_spec.js
@@ -1,7 +1,22 @@
 import BYOLPageObject from '../framework/page-objects/BYOLPageObject';
+import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import xhrAuthenticatorEnrollDataPhone from '../../../playground/mocks/data/idp/idx/authenticator-enroll-data-phone.json';
-import { ClientFunction, RequestMock } from 'testcafe';
+import xhrIdentify from '../../../playground/mocks/data/idp/idx/identify.json';
+import { ClientFunction, RequestMock, Selector } from 'testcafe';
 
+const mockIdentify = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrIdentify)
+  .onRequestTo('http://localhost:3000/mocks/labels/json/login_foo.json')
+  .respond((_req, res) => {
+    // delay should be > 200 (see timeout in loadLanguage util)
+    return new Promise((resolve) => setTimeout(function() {
+      res.statusCode = '200';
+      res.headers['content-type'] = 'application/json';
+      res.setBody({ 'primaryauth.title': 'Signin', 'primaryauth.submit': 'Submit' });
+      resolve(res);
+    }, 500));
+  })
 
 const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -51,7 +66,25 @@ async function setup(t, options = {}) {
   await pageObject.mockCrypto();
   await renderWidget({
     stateToken: 'abc',
-    ...options
+    ...options,
+  });
+  await t.expect(pageObject.formExists()).eql(true);
+
+  return pageObject;
+}
+
+async function setupIdentify(t, options = {}) {
+  const pageObject = new IdentityPageObject(t);
+  await pageObject.navigateToPage({ render: false });
+
+  // Render the widget for interaction code flow
+  await pageObject.mockCrypto();
+  await renderWidget({
+    stateToken: 'abc',
+    features: {
+      securityImage: false,
+    },
+    ...options,
   });
   await t.expect(pageObject.formExists()).eql(true);
 
@@ -113,4 +146,19 @@ test.requestHooks(mock)('unsupported language from navigator.languages will load
   await t.expect(pageObject.getFormTitle()).eql('Set up foo authentication');
   // Check country dropdown (country_foo.json)
   await t.expect(await pageObject.countryDropdownHasSelectedText('Foonited States')).eql(true);
+});
+
+test.requestHooks(mockIdentify)('shows spinner while translations are loading', async t => {
+  const pageObject = await setupIdentify(t, {
+    language: 'foo',
+    assets: {
+      baseUrl: '/mocks'
+    }
+  });
+
+  // Check title (login_foo.json)
+  await t.expect(pageObject.getFormTitle()).eql('Signin');
+
+  // Check loading beacon
+  await t.expect(pageObject.loadingBeaconExists()).eql(false);
 });

--- a/test/testcafe/spec/BYOL_spec.js
+++ b/test/testcafe/spec/BYOL_spec.js
@@ -2,7 +2,7 @@ import BYOLPageObject from '../framework/page-objects/BYOLPageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import xhrAuthenticatorEnrollDataPhone from '../../../playground/mocks/data/idp/idx/authenticator-enroll-data-phone.json';
 import xhrIdentify from '../../../playground/mocks/data/idp/idx/identify.json';
-import { ClientFunction, RequestMock, Selector } from 'testcafe';
+import { ClientFunction, RequestMock } from 'testcafe';
 
 const mockIdentify = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -16,7 +16,7 @@ const mockIdentify = RequestMock()
       res.setBody({ 'primaryauth.title': 'Signin', 'primaryauth.submit': 'Submit' });
       resolve(res);
     }, 500));
-  })
+  });
 
 const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')


### PR DESCRIPTION
## Description:

To reproduce: 
- add `language: 'uk'` (or any other supported language) in `.widgetrc.js`
- run `yarn start --watch`
- add `localStorage.removeItem('osw.languages');` at the beginning of `playground/main.ts` to load language every time
- change `200` to `0` here:
https://github.com/okta/okta-signin-widget/blob/188eaa601d5cbb8536905b0336d5c4450ff6e35d/src/util/LanguageUtil.js#L14

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-800637](https://oktainc.atlassian.net/browse/OKTA-800637)

### Reviewers:

### Screenshot/Video:

Before :

<img width="430" alt="Screenshot 2024-10-01 at 19 30 55" src="https://github.com/user-attachments/assets/5965d5b2-3894-4513-82e4-ee3b762f6bbb">

After :
<img width="423" alt="Screenshot 2024-10-01 at 19 31 10" src="https://github.com/user-attachments/assets/694fa7b0-bd21-44d9-a6e0-9643b86529e8">



### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=dcf9166f17fd4a6fcc2909d4c46d776e1e761156&tab=main

