### PR TITLE
OKTA-815020 : SIW gen 3: Same device enrollment Android OV setup link fix 

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device-android-high-security.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device-android-high-security.json
@@ -202,7 +202,7 @@
           "orgUrl": "okta.okta.com",
           "downloadHref": "https://play.google.com/store/apps/details?id=com.okta.android.auth",
           "platform": "ANDROID",
-          "setupOVUrl": "https://login.okta.com/actions/enroll?display_url=okta.okta.com&login_hint=testUser@okta.com&pipeline=idx&app_name=office%20365",
+          "setupOVUrl": "okta-verify.html",
           "securityLevel": "HIGH"
         },
         "selectedChannel": "samedevice"

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device-ios-any-security.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device-ios-any-security.json
@@ -221,7 +221,7 @@
           "orgUrl": "okta.okta.com",
           "downloadHref": "https://apps.apple.com/us/app/okta-verify/id490179405",
           "platform": "IOS",
-          "setupOVUrl": "https://login.okta.com/actions/enroll?display_url=okta.okta.com&login_hint=testUser@okta.com&pipeline=idx&app_name=office%20365",
+          "setupOVUrl": "okta-verify.html",
           "securityLevel": "ANY"
         },
         "selectedChannel": "samedevice"

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device-osx-any-security.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device-osx-any-security.json
@@ -229,7 +229,7 @@
           "orgUrl": "okta.okta.com",
           "downloadHref": "https://apps.apple.com/us/app/okta-verify/id490179405",
           "platform": "OSX",
-          "setupOVUrl": "com-okta-authenticator://actions/enroll?display_url=okta.okta.com&login_hint=testUser@okta.com&pipeline=idx",
+          "setupOVUrl": "okta-verify.html",
           "securityLevel": "ANY"
         },
         "selectedChannel": "samedevice"

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device-windows-high-security.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-same-device-windows-high-security.json
@@ -202,7 +202,7 @@
           "orgUrl": "okta.okta.com",
           "downloadHref": "https://microsoft.com/app/ov",
           "platform": "WINDOWS",
-          "setupOVUrl": "com-okta-authenticator://actions/enroll?display_url=okta.okta.com&login_hint=testUser@okta.com&pipeline=idx",
+          "setupOVUrl": "okta-verify.html",
           "securityLevel": "HIGH"
         },
         "selectedChannel": "samedevice"

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
@@ -1,5 +1,240 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TransformOktaVerifyEnrollPoll Tests Setup OV button should use APP_LINK challenge method when selectedChannel is samedevice and platform is android 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "elements": Array [
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 0,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.email.info.updated",
+                },
+                "type": "Description",
+                "viewIndex": 1,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
+                  "step": "select-enrollment-channel",
+                  "stepToRender": "select-enrollment-channel",
+                },
+                "type": "TextWithActionLink",
+                "viewIndex": 1,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 2,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.sms.info.updated",
+                },
+                "type": "Description",
+                "viewIndex": 2,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.switch.channel.link.text",
+                  "contentClassname": "switch-channel-link",
+                  "step": "select-enrollment-channel",
+                  "stepToRender": "select-enrollment-channel",
+                },
+                "type": "TextWithActionLink",
+                "viewIndex": 2,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 3,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 3,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.subtitle",
+                },
+                "type": "Description",
+                "viewIndex": 4,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "items": Array [],
+                  "type": "ol",
+                },
+                "type": "List",
+                "viewIndex": 4,
+              },
+              Object {
+                "contentType": "subtitle",
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.skipAuth.canBeClosed",
+                },
+                "type": "Description",
+                "viewIndex": 4,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.title",
+                },
+                "type": "Title",
+                "viewIndex": 5,
+              },
+              Object {
+                "noMargin": true,
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.customUri.makeSureHaveOVToContinue",
+                },
+                "type": "Description",
+                "viewIndex": 5,
+              },
+              Object {
+                "options": Object {
+                  "alignment": "center",
+                  "altText": "enroll.oda.step3",
+                  "dataSe": "app-store-link",
+                  "href": "https://apps.test.com/us/app/okta-verify/id490179405",
+                  "marginBlockStart": "20px",
+                  "svgIcon": [Function],
+                },
+                "type": "ImageLink",
+                "viewIndex": 5,
+              },
+              Object {
+                "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.customUri.setup",
+                },
+                "type": "Description",
+                "viewIndex": 5,
+              },
+              Object {
+                "options": Object {
+                  "challengeMethod": "APP_LINK",
+                  "href": "www.testSetupUrl.com",
+                  "i18nKey": "oie.enroll.okta_verify.setup.title",
+                  "step": "",
+                },
+                "type": "OpenOktaVerifyFPButton",
+                "viewIndex": 5,
+              },
+            ],
+            "type": "VerticalLayout",
+          },
+        ],
+        "key": "stepper_sameDeviceOVEnrollment",
+        "options": Object {
+          "defaultStepIndex": [Function],
+        },
+        "type": "Stepper",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
 exports[`TransformOktaVerifyEnrollPoll Tests should add Stepper elements when selectedChannel is devicebootstrap 1`] = `
 Object {
   "data": Object {},

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
@@ -465,22 +465,22 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
 
       expect(updatedFormBag).toMatchSnapshot();
       const [stepperLayout] = updatedFormBag.uischema.elements;
-      const layoutSix = (stepperLayout as StepperLayout).elements[5];
+      const sameDeviceEnrollmentLayout = (stepperLayout as StepperLayout).elements[5];
 
-      expect(layoutSix.elements.length).toBe(5);
-      expect((layoutSix.elements[0] as TitleElement).options.content)
+      expect(sameDeviceEnrollmentLayout.elements.length).toBe(5);
+      expect((sameDeviceEnrollmentLayout.elements[0] as TitleElement).options.content)
         .toBe('oie.enroll.okta_verify.setup.title');
-      expect((layoutSix.elements[1] as DescriptionElement).options.content)
+      expect((sameDeviceEnrollmentLayout.elements[1] as DescriptionElement).options.content)
         .toBe('oie.enroll.okta_verify.setup.customUri.makeSureHaveOVToContinue');
-      expect((layoutSix.elements[2] as ImageLinkElement).options.href)
+      expect((sameDeviceEnrollmentLayout.elements[2] as ImageLinkElement).options.href)
         .toBe('https://apps.test.com/us/app/okta-verify/id490179405');
-      expect((layoutSix.elements[3] as DescriptionElement).options.content)
+      expect((sameDeviceEnrollmentLayout.elements[3] as DescriptionElement).options.content)
         .toBe('oie.enroll.okta_verify.setup.customUri.setup');
-      expect((layoutSix.elements[4] as OpenOktaVerifyFPButtonElement).options.i18nKey)
+      expect((sameDeviceEnrollmentLayout.elements[4] as OpenOktaVerifyFPButtonElement).options.i18nKey)
         .toBe('oie.enroll.okta_verify.setup.title');
-      expect((layoutSix.elements[4] as OpenOktaVerifyFPButtonElement).options.href)
+      expect((sameDeviceEnrollmentLayout.elements[4] as OpenOktaVerifyFPButtonElement).options.href)
         .toBe('www.testSetupUrl.com');
-      expect((layoutSix.elements[4] as OpenOktaVerifyFPButtonElement).options.challengeMethod)
+      expect((sameDeviceEnrollmentLayout.elements[4] as OpenOktaVerifyFPButtonElement).options.challengeMethod)
         .toBe(CHALLENGE_METHOD.APP_LINK);
     });
 });

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
@@ -15,7 +15,9 @@ import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/
 import {
   ButtonElement,
   DescriptionElement,
+  ImageLinkElement,
   ListElement,
+  OpenOktaVerifyFPButtonElement,
   QRCodeElement,
   ReminderElement,
   StepperLayout,
@@ -25,6 +27,7 @@ import {
   WidgetProps,
 } from 'src/types';
 
+import { CHALLENGE_METHOD } from '../../constants';
 import { transformOktaVerifyEnrollPoll } from './transformOktaVerifyEnrollPoll';
 
 describe('TransformOktaVerifyEnrollPoll Tests', () => {
@@ -438,4 +441,46 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
     expect((layoutFive.elements[3] as DescriptionElement).options.content)
       .toBe('oie.enroll.okta_verify.setup.skipAuth.canBeClosed');
   });
+
+  it('Setup OV button should use APP_LINK challenge method when selectedChannel is samedevice and platform is android',
+    () => {
+      transaction.context = {
+      // TODO: OKTA-503490 temporary sln access missing relatesTo obj
+        currentAuthenticator: {
+          value: {
+            contextualData: {
+              samedevice: {
+                orgUrl: 'okta.okta.com',
+                setupOVUrl: 'www.testSetupUrl.com',
+                downloadHref: 'https://apps.test.com/us/app/okta-verify/id490179405',
+                platform: 'android',
+              },
+              selectedChannel: 'samedevice',
+            },
+          },
+        },
+      } as unknown as IdxContext;
+
+      const updatedFormBag = transformOktaVerifyEnrollPoll({ transaction, formBag, widgetProps });
+
+      expect(updatedFormBag).toMatchSnapshot();
+      const [stepperLayout] = updatedFormBag.uischema.elements;
+      const layoutSix = (stepperLayout as StepperLayout).elements[5];
+
+      expect(layoutSix.elements.length).toBe(5);
+      expect((layoutSix.elements[0] as TitleElement).options.content)
+        .toBe('oie.enroll.okta_verify.setup.title');
+      expect((layoutSix.elements[1] as DescriptionElement).options.content)
+        .toBe('oie.enroll.okta_verify.setup.customUri.makeSureHaveOVToContinue');
+      expect((layoutSix.elements[2] as ImageLinkElement).options.href)
+        .toBe('https://apps.test.com/us/app/okta-verify/id490179405');
+      expect((layoutSix.elements[3] as DescriptionElement).options.content)
+        .toBe('oie.enroll.okta_verify.setup.customUri.setup');
+      expect((layoutSix.elements[4] as OpenOktaVerifyFPButtonElement).options.i18nKey)
+        .toBe('oie.enroll.okta_verify.setup.title');
+      expect((layoutSix.elements[4] as OpenOktaVerifyFPButtonElement).options.href)
+        .toBe('www.testSetupUrl.com');
+      expect((layoutSix.elements[4] as OpenOktaVerifyFPButtonElement).options.challengeMethod)
+        .toBe(CHALLENGE_METHOD.APP_LINK);
+    });
 });

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
@@ -285,6 +285,16 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
     );
 
     if (deviceMap.setupOVUrl) {
+      let challengeMethod;
+      if (deviceMap.isDesktop) {
+        challengeMethod = CHALLENGE_METHOD.CUSTOM_URI;
+      } else if (deviceMap.platformLC === 'android') {
+        challengeMethod = CHALLENGE_METHOD.APP_LINK;
+      } else {
+        challengeMethod = CHALLENGE_METHOD.UNIVERSAL_LINK;
+      }
+
+      // Setup Okta Verify on same device button
       sameDeviceOVElements.push(
         {
           type: 'OpenOktaVerifyFPButton',
@@ -292,9 +302,7 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
             step: '',
             i18nKey: 'oie.enroll.okta_verify.setup.title',
             href: deviceMap.setupOVUrl,
-            challengeMethod: deviceMap.isDesktop
-              ? CHALLENGE_METHOD.CUSTOM_URI
-              : CHALLENGE_METHOD.UNIVERSAL_LINK,
+            challengeMethod,
           },
         } as OpenOktaVerifyFPButtonElement,
       );

--- a/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
@@ -312,7 +312,7 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
 
   async clickOVSetupButton() {
     if (userVariables.gen3) {
-      await this.t.click(this.form.getButton("Set up Okta Verify"));
+      await this.t.click(this.form.getButton(SETUP_OV_BUTTON_TEXT));
     } else {
       await this.t.click(this.form.el.find(OV_SETUP_LINK_CLASS));
     }

--- a/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
@@ -310,6 +310,14 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
     await this.form.clickElement(BACK_LINK_CLASS);
   }
 
+  async clickOVSetupButton() {
+    if (userVariables.gen3) {
+      await this.t.click(this.form.getButton("Set up Okta Verify"));
+    } else {
+      await this.t.click(this.form.el.find(OV_SETUP_LINK_CLASS));
+    }
+  }
+
   async nthDesktopInstructions(index) {
     return Selector(DESKTOP_INSTRUCTIONS_CLASS).nth(index).innerText;
   }

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -332,8 +332,6 @@ const sameDeviceOVEnrollmentDesktopInstructions4 = 'Didn’t get a prompt?';
 const sameDeviceOVEnrollmentAppleLink = 'https://apps.apple.com/us/app/okta-verify/id490179405';
 const sameDeviceOVEnrollmentAndroidLink = 'https://play.google.com/store/apps/details?id=com.okta.android.auth';
 const sameDeviceOVEnrollmentWindowsLink = 'https://microsoft.com/app/ov';
-const sameDeviceOVEnrollmentSetupLink = 'https://login.okta.com/actions/enroll?display_url=okta.okta.com&login_hint=testUser@okta.com&pipeline=idx&app_name=office%20365';
-const sameDeviceOVEnrollmentDesktopSetupLink = 'com-okta-authenticator://actions/enroll?display_url=okta.okta.com&login_hint=testUser@okta.com&pipeline=idx';
 const deviceBootstrapSubtitle = 'To set up Okta Verify on additional devices, you can copy an existing Okta Verify account onto a new device.';
 const deviceBootstrapInstruction1 = 'Open Okta Verify on any of your other Okta Verify devices (Such as your testDevice1).';
 const deviceBootstrapInstruction2 = 'In the app, select your account.';
@@ -1139,7 +1137,7 @@ test
     await t.expect(await enrollOktaVerifyPage.sameDeviceSetupOnMobileTextExist()).eql(false);
 
     await t.expect(enrollOktaVerifyPage.getAppStoreHref()).eql(sameDeviceOVEnrollmentWindowsLink);
-    
+
     // desktop platform auto-launches CUSTOM_URI on page load, so we expect 1 here
     await t.expect(customURILogger.count(
       record => record.request.url.match(/okta-verify.html/)

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -1139,6 +1139,8 @@ test
     await t.expect(await enrollOktaVerifyPage.sameDeviceSetupOnMobileTextExist()).eql(false);
 
     await t.expect(enrollOktaVerifyPage.getAppStoreHref()).eql(sameDeviceOVEnrollmentWindowsLink);
+    
+    // desktop platform auto-launches CUSTOM_URI on page load, so we expect 1 here
     await t.expect(customURILogger.count(
       record => record.request.url.match(/okta-verify.html/)
     )).eql(1);
@@ -1179,6 +1181,7 @@ test
 
     await t.expect(enrollOktaVerifyPage.getAppStoreHref()).eql(sameDeviceOVEnrollmentAppleLink);
 
+    // desktop platform auto-launches CUSTOM_URI on page load, so we expect 1 here
     await t.expect(customURILogger.count(
       record => record.request.url.match(/okta-verify.html/)
     )).eql(1);


### PR DESCRIPTION
## Description:

This PR fixes an issue in SIW gen 3 where the Setup OV button in the Same device enrollment flow was failing to launch the OV app on Android devices.

Customer bug ticket: https://oktainc.atlassian.net/browse/OKTA-808391

Video:

https://github.com/user-attachments/assets/8da06874-0e8c-4208-98ad-860fd206ccd7



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-815020](https://oktainc.atlassian.net/browse/OKTA-815020)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



