### PR TITLE
Fix (Classic): Show edit button only after manual push secret key is generated

### DIFF
--- a/src/v1/controllers/ManualSetupPushController.js
+++ b/src/v1/controllers/ManualSetupPushController.js
@@ -30,6 +30,13 @@ function goToFactorActivation(view, step) {
   view.options.appState.trigger('navigate', url);
 }
 
+const sharedSecretIsDefined = {
+  sharedSecret: function(val) {
+    return !_.isUndefined(val);
+  },
+  activationType: 'MANUAL'
+};
+
 function setStateValues(view) {
   let userPhoneNumber;
   let userCountryCode;
@@ -207,7 +214,7 @@ export default FormController.extend({
           View: View.extend({
             template: hbs('<div data-type="next-button-wrap"></div>'),
           }),
-          showWhen: { activationType: 'MANUAL' },
+          showWhen: sharedSecretIsDefined,
         }),
         FormType.Button(
           {

--- a/test/unit/spec/v1/EnrollTotpController_spec.js
+++ b/test/unit/spec/v1/EnrollTotpController_spec.js
@@ -584,6 +584,7 @@ Expect.describe('EnrollTotp', function() {
           test.setNextResponse(resTotpEnrollSuccess);
           test.setNextResponse(resAllFactors);
           test.manualSetupForm.selectManualOption();
+          Expect.isNotVisible(test.manualSetupForm.nextButton());
           return test.manualSetupForm.waitForManual(test);
         })
         .then(function(test) {


### PR DESCRIPTION
## Description:

Bug: `Next` button is clickable even before the secret key is generated. If you click `Next` before the security key loads, you will be stuck in a loop. See JIRA for more details.

Fix: Disable `Next` button until the secret key is generated.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-806901](https://oktainc.atlassian.net/browse/OKTA-806901)

### Reviewers:

### Screenshot/Video:

https://github.com/user-attachments/assets/73e30644-d0dc-4bfd-998d-6dd5768574b2



### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=0ee56b939f38763a63cef6d135389360f0f05a88&tab=main

