### PR TITLE
Passkey autofill bug fixes (Gen 3)

### DIFF
--- a/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.test.tsx
+++ b/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+
+import { cleanup, render } from '@testing-library/preact';
+
+import {
+  ABORT_REASON_CLEANUP,
+  ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND,
+} from '../../constants';
+import { useWidgetContext } from '../../contexts';
+import { useOnSubmit } from '../../hooks';
+import { WebAuthNAutofillElement } from '../../types';
+import WebAuthNAutofill from './WebAuthNAutofill';
+
+jest.mock('../../hooks');
+jest.mock('../../contexts');
+
+jest.mock('../../util', () => ({
+  isPasskeyAutofillAvailable: jest.fn().mockResolvedValue(true),
+  loc: jest.fn().mockReturnValue('translatedMessage'),
+}));
+
+describe('WebAuthNAutofill', () => {
+  const uischema: WebAuthNAutofillElement = {
+    type: 'WebAuthNAutofill',
+    options: {
+      step: 'challenge-webauthn-autofillui-authenticator',
+      getCredentials: jest.fn().mockReturnValue({}),
+    },
+  };
+
+  const mockWidgetContext = {
+    setAbortController: jest.fn(),
+    setMessage: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useWidgetContext as jest.Mock).mockReturnValue(mockWidgetContext);
+    (useOnSubmit as jest.Mock).mockReturnValue(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  });
+
+  it('should render the empty WebAuthNAutofill component', () => {
+    const { container } = render(<WebAuthNAutofill uischema={uischema} />);
+    expect(container).toMatchInlineSnapshot('<div />');
+  });
+
+  it('should call the setMessage method when getCredentials throws', async () => {
+    const setMessageSpy = jest.spyOn(mockWidgetContext, 'setMessage');
+    const uischemaWithError: WebAuthNAutofillElement = {
+      ...uischema,
+      options: {
+        ...uischema.options,
+        getCredentials: jest.fn().mockRejectedValue('TEST'),
+      },
+    };
+    render(<WebAuthNAutofill uischema={uischemaWithError} />);
+    await new Promise(process.nextTick);
+
+    expect(setMessageSpy).toHaveBeenCalledWith({
+      class: 'ERROR',
+      i18n: { key: 'oie.webauthn.error.invalidPasskey' },
+      message: 'translatedMessage',
+    });
+  });
+
+  it.each([ABORT_REASON_CLEANUP, ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND])('should not call the setMessage method for ignored error "%s"', async (err) => {
+    const setMessageSpy = jest.spyOn(mockWidgetContext, 'setMessage');
+    const uischemaWithError: WebAuthNAutofillElement = {
+      ...uischema,
+      options: {
+        ...uischema.options,
+        getCredentials: jest.fn().mockRejectedValue(err),
+      },
+    };
+    render(<WebAuthNAutofill uischema={uischemaWithError} />);
+
+    expect(setMessageSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.test.tsx
+++ b/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.test.tsx
@@ -89,6 +89,7 @@ describe('WebAuthNAutofill', () => {
       },
     };
     render(<WebAuthNAutofill uischema={uischemaWithError} />);
+    await new Promise(process.nextTick);
 
     expect(setMessageSpy).not.toHaveBeenCalled();
   });

--- a/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.tsx
+++ b/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.tsx
@@ -15,7 +15,7 @@ import { useEffect } from 'preact/hooks';
 import {
   ABORT_REASON_CLEANUP,
   ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND,
-  IDX_STEP
+  IDX_STEP,
 } from '../../constants';
 import { useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';

--- a/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.tsx
+++ b/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.tsx
@@ -44,7 +44,7 @@ const WebAuthNAutofill: UISchemaElementComponent<{
           onSubmitHandler({
             params: { credentials },
             step: IDX_STEP.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR,
-            includeData: true,
+            includeData: false,
           });
         }
       } catch (err) {

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -37,7 +37,7 @@ import Bundles from '../../../../util/Bundles';
 import Logger from '../../../../util/Logger';
 import {
   ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND,
-  IDX_STEP
+  IDX_STEP,
 } from '../../constants';
 import { WidgetContextProvider } from '../../contexts';
 import {

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -35,7 +35,10 @@ import { mergeThemes } from 'src/util/mergeThemes';
 
 import Bundles from '../../../../util/Bundles';
 import Logger from '../../../../util/Logger';
-import { IDX_STEP } from '../../constants';
+import {
+  ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND,
+  IDX_STEP
+} from '../../constants';
 import { WidgetContextProvider } from '../../contexts';
 import {
   useInteractionCodeFlow,
@@ -327,7 +330,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
         ({ name }) => name === IDX_STEP.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR,
       )
     ) {
-      abortController?.abort();
+      abortController?.abort(ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND);
     }
 
     prevIdxTransactionRef.current = idxTransaction;

--- a/src/v3/src/constants/index.ts
+++ b/src/v3/src/constants/index.ts
@@ -12,3 +12,4 @@
 
 export * from './idxConstants';
 export * from './passwordConstants';
+export * from './webAuthNConstants';

--- a/src/v3/src/constants/webAuthNConstants.ts
+++ b/src/v3/src/constants/webAuthNConstants.ts
@@ -1,5 +1,16 @@
+/*
+ * Copyright (c) 2024-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import { IDX_STEP } from './idxConstants';
 
 export const ABORT_REASON_CLEANUP = 'WebAuthNAutofill component cleanup';
-export const ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND
-  = `${IDX_STEP.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR} not found in available steps`;
+export const ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND = `${IDX_STEP.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR} not found in available steps`;

--- a/src/v3/src/constants/webAuthNConstants.ts
+++ b/src/v3/src/constants/webAuthNConstants.ts
@@ -1,0 +1,5 @@
+import { IDX_STEP } from './idxConstants';
+
+export const ABORT_REASON_CLEANUP = 'WebAuthNAutofill component cleanup';
+export const ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND
+  = `${IDX_STEP.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR} not found in available steps`;

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -144,7 +144,11 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       payload.identifier = transformIdentifier(widgetProps, step, payload.identifier as string);
 
       // Widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
-      if (features?.rememberMe) {
+      if (
+        features?.rememberMe
+        && typeof payload.identifier === 'string'
+        && payload.identifier !== 'undefined'
+      ) {
         setUsernameCookie(payload.identifier as string);
       } else {
         removeUsernameCookie();

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -144,11 +144,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       payload.identifier = transformIdentifier(widgetProps, step, payload.identifier as string);
 
       // Widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
-      if (
-        features?.rememberMe
-        && typeof payload.identifier === 'string'
-        && payload.identifier !== 'undefined'
-      ) {
+      if (features?.rememberMe) {
         setUsernameCookie(payload.identifier as string);
       } else {
         removeUsernameCookie();

--- a/src/v3/src/transformer/layout/idxTransformerMapping.ts
+++ b/src/v3/src/transformer/layout/idxTransformerMapping.ts
@@ -91,6 +91,25 @@ import {
 import { transformSymantecVipAuthenticator } from './symantecVip';
 import { transformUnlockAccount } from './unlockAccount';
 
+const IdentifyTransformerSettings = {
+  [AUTHENTICATOR_KEY.DEFAULT]: {
+    transform: transformIdentify,
+    buttonConfig: {
+      showDefaultSubmit: false,
+      showDefaultCancel: false,
+      showForgotPassword: true,
+    },
+  },
+  [AUTHENTICATOR_KEY.PASSWORD]: {
+    transform: transformIdentify,
+    buttonConfig: {
+      showDefaultSubmit: false,
+      showDefaultCancel: false,
+      showForgotPassword: true,
+    },
+  },
+};
+
 /**
  * TransformerMap
  *
@@ -403,24 +422,7 @@ const TransformerMap: {
       },
     },
   },
-  [IDX_STEP.IDENTIFY]: {
-    [AUTHENTICATOR_KEY.DEFAULT]: {
-      transform: transformIdentify,
-      buttonConfig: {
-        showDefaultSubmit: false,
-        showDefaultCancel: false,
-        showForgotPassword: true,
-      },
-    },
-    [AUTHENTICATOR_KEY.PASSWORD]: {
-      transform: transformIdentify,
-      buttonConfig: {
-        showDefaultSubmit: false,
-        showDefaultCancel: false,
-        showForgotPassword: true,
-      },
-    },
-  },
+  [IDX_STEP.IDENTIFY]: IdentifyTransformerSettings,
   [IDX_STEP.IDENTIFY_RECOVERY]: {
     [AUTHENTICATOR_KEY.DEFAULT]: {
       transform: transformIdentityRecovery,
@@ -576,6 +578,10 @@ const TransformerMap: {
       transform: transformDeviceCodeAuthenticator,
     },
   },
+  // Because the CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR step
+  // does not contain the sign in form elements and should be treated
+  // as the Identify step for rendering purposes, we use the same transformer settings
+  [IDX_STEP.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR]: IdentifyTransformerSettings,
 };
 
 if (isDevelopmentEnvironment() || isTestEnvironment()) {


### PR DESCRIPTION
## Description:

There were 3 bugs in the Passkey autofill implementation on Gen 3 that this PR is addressing.

- An error message was being shown to the user if they were to continue to the next step without choosing a passkey, but this was not an actual error, as we have 2 expected abort reasons that needed to be ignored.
- The username field was being auto populated with the word `undefined` if the user were to use a passkey without having a username entered.
- When using Password + another authenticator in the policy. the step that was being rendered was incorrect as we were missing mappings for the new remediation.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issues:

- [OKTA-816548](https://oktainc.atlassian.net/browse/OKTA-816548)
- [OKTA-819043](https://oktainc.atlassian.net/browse/OKTA-819043)
- [OKTA-818808](https://oktainc.atlassian.net/browse/OKTA-818808)

### Reviewers:

### Screenshot/Video:

https://drive.google.com/file/d/16Jckks9Rv7G8AD3viBFBd4n7_RnCpxMf/view?usp=sharing
https://drive.google.com/file/d/1QR1UxpuHuSB7-cq-DXybFHpVVlqL5cg-/view?usp=sharing

### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=d1220aa886ecaeca999fdde4fd0ecd0a975f4f00&tab=main

