### PR TITLE
fix: Respect translation overrides for `errors.E0xxx` in `i18n` of widget config

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -13,7 +13,7 @@
 
 /* eslint complexity: [2, 13], max-depth: [2, 3] */
 import _ from 'underscore';
-import { loc } from './loc';
+import { loc, doesTranslationExist } from './loc';
 import Enums from './Enums';
 import Logger from './Logger';
 import BrowserFeatures from './BrowserFeatures';
@@ -100,13 +100,7 @@ Util.transformErrorXHR = function(xhr) {
   // Replace error messages
   if (!_.isEmpty(xhr.responseJSON)) {
     const { errorCode } = xhr.responseJSON;
-    const untranslatedErrorCodes = [
-      // API already provides localized and factor specific error message in errorCauses
-      'E0000068',
-      // API provides localized error message for password requirements in errorCauses
-      'E0000014',
-    ];
-    const errorMsg = errorCode && !untranslatedErrorCodes.includes(errorCode)
+    const errorMsg = errorCode && doesTranslationExist('errors.' + errorCode, 'login')
       // We don't pass parameters to the `loc()` util
       // However some i18n keys like `errors.E0000001` require one parameter
       // Don't dispatch custom 'okta-i18n-error' event in this case

--- a/src/util/loc.ts
+++ b/src/util/loc.ts
@@ -41,6 +41,20 @@ declare global {
 }
 
 /**
+ * Checks whether a translation for key exists in the bundle
+ * @param  {String} key The key
+ * @param  {String} [bundle="login"] The name of the i18n bundle. Defaults to "login".
+ * @return {Boolean}
+ */
+export const doesTranslationExist = (
+  key: string,
+  bundleName: BundleName = 'login'
+) => {
+  const bundle = getBundle(bundleName);
+  return !!bundle?.[key];
+};
+
+/**
  * Translate a key to the localized value
  * @param  {String} key The key
  * @param  {String} [bundle="login"] The name of the i18n bundle. Defaults to "login".

--- a/test/unit/spec/v1/MfaVerify_spec.js
+++ b/test/unit/spec/v1/MfaVerify_spec.js
@@ -2122,7 +2122,7 @@ Expect.describe('MFA Verify', function() {
       return setupFn({
         i18n: {
           en: {
-            'errors.E0000068': 'Invalid answer!'
+            'errors.E0000068': 'Invalid passcode!'
           }
         }
       })
@@ -2134,7 +2134,7 @@ Expect.describe('MFA Verify', function() {
       })
       .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
-        expect(test.form.errorMessage()).toBe('Invalid answer!');
+        expect(test.form.errorMessage()).toBe('Invalid passcode!');
         expect(dispatchEventSpy).not.toHaveBeenCalled();
       });
     });
@@ -2600,12 +2600,6 @@ Expect.describe('MFA Verify', function() {
     });
 
     Expect.describe('TOTP', function() {
-      beforeEach(() => {
-        // BaseLoginRouter will render twice if language bundles are not loaded:
-        // https://github.com/okta/okta-signin-widget/blob/master/src/util/BaseLoginRouter.js#L202
-        // We are not testing i18n, so we can mock language bundles as loaded
-        Util.mockBundles();
-      });
       testGoogleTOTP(setupGoogleTOTP, 'testStateToken');
       itp('shows the right beacon for Okta TOTP', function() {
         return setupOktaTOTP().then(function(test) {
@@ -4866,12 +4860,6 @@ Expect.describe('MFA Verify', function() {
       });
     });
     Expect.describe('Password', function() {
-      beforeEach(() => {
-        // BaseLoginRouter will render twice if language bundles are not loaded:
-        // https://github.com/okta/okta-signin-widget/blob/master/src/util/BaseLoginRouter.js#L202
-        // We are not testing i18n, so we can mock language bundles as loaded
-        Util.mockBundles();
-      });
       testPassword(setupPassword, 'testStateToken');
     });
   });

--- a/test/unit/spec/v1/MfaVerify_spec.js
+++ b/test/unit/spec/v1/MfaVerify_spec.js
@@ -2126,17 +2126,17 @@ Expect.describe('MFA Verify', function() {
           }
         }
       })
-      .then(function(test) {
-        test.setNextResponse(resInvalidTotp);
-        test.form.setAnswer('wrong');
-        test.form.submit();
-        return Expect.waitForFormError(test.form, test);
-      })
-      .then(function(test) {
-        expect(test.form.hasErrors()).toBe(true);
-        expect(test.form.errorMessage()).toBe('Invalid passcode!');
-        expect(dispatchEventSpy).not.toHaveBeenCalled();
-      });
+        .then(function(test) {
+          test.setNextResponse(resInvalidTotp);
+          test.form.setAnswer('wrong');
+          test.form.submit();
+          return Expect.waitForFormError(test.form, test);
+        })
+        .then(function(test) {
+          expect(test.form.hasErrors()).toBe(true);
+          expect(test.form.errorMessage()).toBe('Invalid passcode!');
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
+        });
     });
     itp('shows errors if verify button is clicked and answer is empty', function() {
       return setupFn()
@@ -2315,17 +2315,17 @@ Expect.describe('MFA Verify', function() {
           }
         }
       })
-      .then(function(test) {
-        test.setNextResponse(resInvalidPassword);
-        test.form.setPassword('wrong');
-        test.form.submit();
-        return Expect.waitForFormError(test.form, test);
-      })
-      .then(function(test) {
-        expect(test.form.hasErrors()).toBe(true);
-        expect(test.form.errorMessage()).toBe('Invalid password!');
-        expect(dispatchEventSpy).not.toHaveBeenCalled();
-      });
+        .then(function(test) {
+          test.setNextResponse(resInvalidPassword);
+          test.form.setPassword('wrong');
+          test.form.submit();
+          return Expect.waitForFormError(test.form, test);
+        })
+        .then(function(test) {
+          expect(test.form.hasErrors()).toBe(true);
+          expect(test.form.errorMessage()).toBe('Invalid password!');
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
+        });
     });
     itp('shows errors if verify button is clicked and password is empty', function() {
       return setupFn()

--- a/test/unit/spec/v1/MfaVerify_spec.js
+++ b/test/unit/spec/v1/MfaVerify_spec.js
@@ -1132,6 +1132,28 @@ Expect.describe('MFA Verify', function() {
           expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
     });
+    itp('shows a custom error if there is an overridden translation for error E0000068', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
+      return setupFn({
+        i18n: {
+          en: {
+            'errors.E0000068': 'Invalid answer!'
+          }
+        }
+      })
+        .then(function(test) {
+          test.setNextResponse(resInvalid);
+          test.form.setAnswer('wrong');
+          test.form.submit();
+          return Expect.waitForFormError(test.form, test);
+        })
+        .then(function(test) {
+          expect(test.form.hasErrors()).toBe(true);
+          expect(test.form.errorMessage()).toBe('Invalid answer!');
+          expect(dispatchEventSpy).not.toHaveBeenCalled();
+        });
+    });
     itp('shows errors if verify button is clicked and answer is empty', function() {
       return setupFn()
         .then(function(test) {
@@ -2094,6 +2116,28 @@ Expect.describe('MFA Verify', function() {
           expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
     });
+    itp('shows a custom error if there is an overridden translation for error E0000068', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
+      return setupFn({
+        i18n: {
+          en: {
+            'errors.E0000068': 'Invalid answer!'
+          }
+        }
+      })
+      .then(function(test) {
+        test.setNextResponse(resInvalidTotp);
+        test.form.setAnswer('wrong');
+        test.form.submit();
+        return Expect.waitForFormError(test.form, test);
+      })
+      .then(function(test) {
+        expect(test.form.hasErrors()).toBe(true);
+        expect(test.form.errorMessage()).toBe('Invalid answer!');
+        expect(dispatchEventSpy).not.toHaveBeenCalled();
+      });
+    });
     itp('shows errors if verify button is clicked and answer is empty', function() {
       return setupFn()
         .then(function(test) {
@@ -2260,6 +2304,28 @@ Expect.describe('MFA Verify', function() {
           });
           expect(dispatchEventSpy).not.toHaveBeenCalled();
         });
+    });
+    itp('shows a custom error if there is an overridden translation for error E0000068', function() {
+      // spy on emitting of CustomEvent with type 'okta-i18n-error' in `loc()` util
+      const dispatchEventSpy = jest.spyOn(document, 'dispatchEvent');
+      return setupFn({
+        i18n: {
+          en: {
+            'errors.E0000068': 'Invalid password!'
+          }
+        }
+      })
+      .then(function(test) {
+        test.setNextResponse(resInvalidPassword);
+        test.form.setPassword('wrong');
+        test.form.submit();
+        return Expect.waitForFormError(test.form, test);
+      })
+      .then(function(test) {
+        expect(test.form.hasErrors()).toBe(true);
+        expect(test.form.errorMessage()).toBe('Invalid password!');
+        expect(dispatchEventSpy).not.toHaveBeenCalled();
+      });
     });
     itp('shows errors if verify button is clicked and password is empty', function() {
       return setupFn()


### PR DESCRIPTION
## Description:

Fixes an issue introduced in https://github.com/okta/okta-signin-widget/pull/3579

In that PR error message for code `E0000068` stoped to being localized (because there is no localization for it in default translation files bundled with SIW) and started to be taken from `errorSummary` in Authn API response.
But customer should be allowed to add translation overrides for any error codes in `i18n` of widget config.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-819400](https://oktainc.atlassian.net/browse/OKTA-819400)

### Reviewers:

### Screenshot/Video:


https://github.com/user-attachments/assets/c6c633e0-be0d-492a-9225-d995b0993983



### Downstream Monolith Build:



