### PR TITLE
fix: polling issues on ios18 devices

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -27,20 +27,20 @@ test_suites:
     script_name: unit-jest
     criteria: MERGE
     queue_name: small
-  - name: testcafe
-    script_path: /root/okta/okta-signin-widget/scripts
-    sort_order: '5'
-    timeout: '30'
-    script_name: testcafe
-    criteria: OPTIONAL
-    queue_name: small
-  - name: testcafe-mobile
-    script_path: /root/okta/okta-signin-widget/scripts
-    sort_order: '6'
-    timeout: '30'
-    script_name: testcafe-mobile
-    criteria: OPTIONAL
-    queue_name: small
+  # - name: testcafe
+  #   script_path: /root/okta/okta-signin-widget/scripts
+  #   sort_order: '5'
+  #   timeout: '30'
+  #   script_name: testcafe
+  #   criteria: MERGE
+  #   queue_name: small
+  # - name: testcafe-mobile
+  #   script_path: /root/okta/okta-signin-widget/scripts
+  #   sort_order: '6'
+  #   timeout: '30'
+  #   script_name: testcafe-mobile
+  #   criteria: MERGE
+  #   queue_name: small
   - name: lint-v3
     script_path: /root/okta/okta-signin-widget/scripts
     sort_order: '7'

--- a/.bacon.yml
+++ b/.bacon.yml
@@ -32,14 +32,14 @@ test_suites:
     sort_order: '5'
     timeout: '30'
     script_name: testcafe
-    criteria: MERGE
+    criteria: OPTIONAL
     queue_name: small
   - name: testcafe-mobile
     script_path: /root/okta/okta-signin-widget/scripts
     sort_order: '6'
     timeout: '30'
     script_name: testcafe-mobile
-    criteria: MERGE
+    criteria: OPTIONAL
     queue_name: small
   - name: lint-v3
     script_path: /root/okta/okta-signin-widget/scripts

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -172,6 +172,7 @@ const idx = {
     // 'authenticator-verification-phone-voice'
   ],
   '/idp/idx/challenge/poll': [
+    // 'authenticator-verification-email2',
     'authenticator-verification-email',
     // 'success',
     // 'authenticator-verification-email-polling-long',

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -166,7 +166,7 @@ Util.callAfterTimeout = function(callback, time) {
 // Invokes the callback after a delay, if the window remains in focus
 // If the window becomes unfocused, the callback execution is delayed until
 // focus has been returned to the window
-Util.callAfterTimeoutOrWindowRefocus = function (callback, time) {
+Util.callAfterTimeoutOrWindowRefocus = function (callback, time, delayAfterRefocus = false) {
   let timeoutId;
   let visHandler;
 
@@ -174,7 +174,12 @@ Util.callAfterTimeoutOrWindowRefocus = function (callback, time) {
     document.removeEventListener('visibilitychange', visHandler);
     // [OKTA-823470] - this setTimeout is required in order for this method to
     // work on safari on iOS18, without fetch requests never fulfill
-    setTimeout(callback(), 200);
+    // setTimeout(callback(), 200);
+    if (!delayAfterRefocus) {
+      return callback();
+    }
+
+    setTimeout(callback, time);
   }
 
   visHandler = () => {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -163,6 +163,39 @@ Util.callAfterTimeout = function(callback, time) {
   return setTimeout(callback, time);
 };
 
+// Invokes the callback after a delay, if the window remains in focus
+// If the window becomes unfocused, the callback execution is delayed until
+// focus has been returned to the window
+Util.callAfterTimeoutOrWindowRefocus = function (callback, time) {
+  let timeoutId;
+  let visHandler;
+
+  const invokeCallbackFn = () => {
+    document.removeEventListener('visibilitychange', visHandler);
+    // [OKTA-823470] - this setTimeout is required in order for this method to
+    // work on safari on iOS18, without fetch requests never fulfill
+    setTimeout(callback(), 200);
+  }
+
+  visHandler = () => {
+    if (document.hidden) {
+      clearTimeout(timeoutId);
+    }
+    else {
+      invokeCallbackFn();
+    }
+  };
+
+  document.addEventListener('visibilitychange', visHandler);
+  timeoutId = setTimeout(invokeCallbackFn, time);
+
+  // returns a "cancel" function, so the execution of the callback can be prevented
+  return () => {
+    clearTimeout(timeoutId);
+    document.removeEventListener('visibilitychange', visHandler);
+  };
+};
+
 // Helper function to provide consistent formatting of template literals
 // that are logged when in development mode.
 Util.debugMessage = function(message) {

--- a/src/v1/models/Factor.js
+++ b/src/v1/models/Factor.js
@@ -310,9 +310,9 @@ const FactorFactor = BaseLoginModel.extend({
         // In Okta verify case we initiate poll.
         if ((trans.status === 'MFA_CHALLENGE' && trans.poll) || (trans.status === 'FACTOR_CHALLENGE' && trans.poll)) {
           const deferred = Q.defer();
-          const initiatePollTimout = Util.callAfterTimeout(deferred.resolve, PUSH_INTERVAL);
+          const cancelPollInitiation = Util.callAfterTimeoutOrWindowRefocus(deferred.resolve, PUSH_INTERVAL);
           self.listenToOnce(self.options.appState, 'factorSwitched', () => {
-            clearTimeout(initiatePollTimout);
+            cancelPollInitiation();
             deferred.reject(new AuthStopPollInitiationError());
           });
           return deferred.promise.then(function() {

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -394,6 +394,7 @@ export default Controller.extend({
       errorObj = { responseJSON: error };
     } else {
       Util.logConsoleError(error);
+      // Current value: There was an unsupported response from server.
       errorObj = { responseJSON: { errorSummary: loc('error.unsupported.response', 'login')}};
     }
 

--- a/src/v2/view-builder/views/shared/polling.js
+++ b/src/v2/view-builder/views/shared/polling.js
@@ -1,11 +1,29 @@
 import { _ } from '@okta/courage';
 import { MS_PER_SEC } from '../../utils/Constants';
+import BrowserFeatures from 'util/BrowserFeatures';
 
 export default {
   startPolling(newRefreshInterval) {
     this.fixedPollingInterval = this.options.currentViewState.refresh;
     this.dynamicPollingInterval = newRefreshInterval;
     this.countDownCounterValue = Math.ceil(this.pollingInterval / MS_PER_SEC);
+    // this._bindWindowFocusListener();
+
+    console.log('polling started')
+
+    this._handleWindowUnfocusWhilePolling();
+    this.listenToOnce(this.model, 'error', (event) => {
+      if (this.pausedForWindowUnfocus) {
+        console.log('ignoring polling error due to tab focus')
+        event.stopImmediatePropagation();
+      }
+    });
+
+    if (this.pausedForWindowUnfocus) {
+      // do not trigger polling request until window has been re-focused (see _handleWindowUnfocus)
+      return;
+    }
+
     // Poll is present in remediation form
     if (this.fixedPollingInterval) {
       this._startRemediationPolling();
@@ -16,7 +34,81 @@ export default {
     }
   },
 
+  _handleWindowUnfocusWhilePolling() {
+    // The only issue with timeout throttling when the tab is not active has been reported in iOS18
+    // for now, this logic will only apply to that environment
+    // if (BrowserFeatures.isIOS()) {
+    if (true) {
+      const pageVisibilityHandler = () => {
+        if (document.hidden && this.polling) {
+          // prevent the next poll network request from being sent
+          this.stopPolling();
+          console.log('POLLING PAUSED')
+          this.pausedForWindowUnfocus = true;
+          this._handleWindowRefocusWhilePolling();
+        }
+        document.removeEventListener('visibilitychange', pageVisibilityHandler);
+      };
+
+      document.addEventListener('visibilitychange', pageVisibilityHandler);
+    }
+  },
+
+  _handleWindowRefocusWhilePolling() {
+    const pageVisibilityHandler = () => {
+      if (!document.hidden && this.pausedForWindowUnfocus) {
+        this.pausedForWindowUnfocus = false;
+        console.log('POLLING RESTARTED')
+        this.startPolling(this.options.appState.get('dynamicRefreshInterval'));
+      }
+
+      document.removeEventListener('visibilitychange', pageVisibilityHandler);
+    }
+
+    document.addEventListener('visibilitychange', pageVisibilityHandler);
+  },
+
+  // _bindWindowFocusListener () {
+  //   if (BrowserFeatures.isIOS()) {
+  //     const pollInterval = this.fixedPollingInterval ?
+  //       this.dynamicPollingInterval || this.fixedPollingInterval :
+  //       this.dynamicPollingInterval || authenticator?.poll?.refresh;
+
+  //     let visibilityTimeoutId;
+  //     this._visibilityChangeListener = () => {
+  //       if (!document.hidden) {
+  //         if (this.polling) {
+  //           visibilityTimeoutId = setTimeout(() => {
+  //             // if polling stops, restart it after a delay
+  //             this.stopPolling();
+  //             this.startPolling();
+  //           }, pollInterval + 100);
+  //         }
+  //         else {
+  //           // if no polling is active, restart it
+  //           this.startPolling();
+  //         }
+  //       }
+  //     };
+  //     document.addEventListener('visibilitychange', this._visibilityChangeListener);
+
+  //     const onPendingRequestResolves = () => {
+  //       clearTimeout(visibilityTimeoutId);
+  //     };
+
+  //     this.listenToOnce(this.options.appState, 'saveForm', onPendingRequestResolves);
+  //     this.listenToOnce(this.options.appState, 'invokeAction', onPendingRequestResolves);
+  //     this.listenToOnce(this.options.appState, 'error', () => {
+  //       onPendingRequestResolves();
+  //       // if form submission errors (because network request fails), restart polling
+  //       this.stopPolling();
+  //       this.startPolling();
+  //     });
+  //   }
+  // },
+
   _startAuthenticatorPolling() {
+    console.log('queued poll action');
     // Authenticator won't co-exists hence it's safe to trigger both.
     [
       'currentAuthenticator',
@@ -28,6 +120,9 @@ export default {
         const pollInterval = this.dynamicPollingInterval || authenticator?.poll?.refresh;
         if (_.isNumber(pollInterval)) {
           this.polling = setTimeout(()=>{
+            // NOTE: listener bound to appState in form controller (L41)
+            // this.polling = null;
+            console.log('invoking action');
             this.options.appState.trigger('invokeAction', authenticatorPollAction);
           }, pollInterval);
         }
@@ -39,15 +134,21 @@ export default {
   },
 
   _startRemediationPolling() {
+    console.log('queued poll remediation');
     const pollInterval = this.dynamicPollingInterval || this.fixedPollingInterval;
     if (_.isNumber(pollInterval)) {
       this.polling = setTimeout(() => {
+        // NOTE: listener bound to appState in form controller (L41)
+        // this.polling = null;
+        console.log('invoking remediation');
         this.options.appState.trigger('saveForm', this.model);
       }, pollInterval);
     }
   },
 
   stopPolling() {
+    console.log('stop polling called')
+
     if (this.polling) {
       clearTimeout(this.polling);
       this.polling = null;

--- a/src/v2/view-builder/views/shared/polling.js
+++ b/src/v2/view-builder/views/shared/polling.js
@@ -9,12 +9,12 @@ export default {
     this.countDownCounterValue = Math.ceil(this.pollingInterval / MS_PER_SEC);
     // this._bindWindowFocusListener();
 
-    console.log('polling started')
+    console.log('polling started');
 
     this._handleWindowUnfocusWhilePolling();
     this.listenToOnce(this.model, 'error', (event) => {
       if (this.pausedForWindowUnfocus) {
-        console.log('ignoring polling error due to tab focus')
+        console.log('ignoring polling error due to tab focus');
         event.stopImmediatePropagation();
       }
     });
@@ -37,13 +37,12 @@ export default {
   _handleWindowUnfocusWhilePolling() {
     // The only issue with timeout throttling when the tab is not active has been reported in iOS18
     // for now, this logic will only apply to that environment
-    // if (BrowserFeatures.isIOS()) {
-    if (true) {
+    if (BrowserFeatures.isIOS()) {
       const pageVisibilityHandler = () => {
         if (document.hidden && this.polling) {
           // prevent the next poll network request from being sent
           this.stopPolling();
-          console.log('POLLING PAUSED')
+          console.log('POLLING PAUSED');
           this.pausedForWindowUnfocus = true;
           this._handleWindowRefocusWhilePolling();
         }
@@ -58,12 +57,12 @@ export default {
     const pageVisibilityHandler = () => {
       if (!document.hidden && this.pausedForWindowUnfocus) {
         this.pausedForWindowUnfocus = false;
-        console.log('POLLING RESTARTED')
+        console.log('POLLING RESTARTED');
         this.startPolling(this.options.appState.get('dynamicRefreshInterval'));
       }
 
       document.removeEventListener('visibilitychange', pageVisibilityHandler);
-    }
+    };
 
     document.addEventListener('visibilitychange', pageVisibilityHandler);
   },
@@ -147,7 +146,7 @@ export default {
   },
 
   stopPolling() {
-    console.log('stop polling called')
+    console.log('stop polling called');
 
     if (this.polling) {
       clearTimeout(this.polling);

--- a/src/v2/view-builder/views/shared/polling.js
+++ b/src/v2/view-builder/views/shared/polling.js
@@ -41,24 +41,15 @@ export default {
           this.pausedForWindowUnfocus = true;
           this._handleWindowRefocusWhilePolling();
         }
-        document.removeEventListener('visibilitychange', pageVisibilityHandler);
+        else if (!document.hidden && this.pausedForWindowUnfocus) {
+          document.removeEventListener('visibilitychange', pageVisibilityHandler);
+          this.pausedForWindowUnfocus = false;
+          this.startPolling(100);
+        }
       };
 
       document.addEventListener('visibilitychange', pageVisibilityHandler);
     }
-  },
-
-  _handleWindowRefocusWhilePolling() {
-    const pageVisibilityHandler = () => {
-      if (!document.hidden && this.pausedForWindowUnfocus) {
-        this.pausedForWindowUnfocus = false;
-        this.startPolling(100);
-      }
-
-      document.removeEventListener('visibilitychange', pageVisibilityHandler);
-    };
-
-    document.addEventListener('visibilitychange', pageVisibilityHandler);
   },
 
   _startAuthenticatorPolling() {


### PR DESCRIPTION
## Description:
When the browser window (either Safari or Chrome) is hidden during a polling flow, requests made while the browser is not active fail causing the overall flow to fail


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



