### PR TITLE
fix: (Gen2) Hide resend callout after entering wrong MFA code and show after timeout

### DIFF
--- a/src/v2/view-builder/internals/BaseForm.ts
+++ b/src/v2/view-builder/internals/BaseForm.ts
@@ -83,7 +83,12 @@ export default Form.extend({
      * invalid form submissions. For eg resend-warning callout should not be cleared upon invalid form submit.
      * Rerender would clear infoContainer or views classes can clear it explicitly.
      */
-    const infoContainer= '<div class=\'o-form-info-container\'></div>';
+    let infoContainer = this.$el.find('.o-form-info-container');
+    if (!infoContainer.length) {
+      this.add('<div class="o-form-info-container"></div>');
+      infoContainer = this.$el.find('.o-form-info-container');
+    }
+
     this.$el.find('.o-form-error-container')
       .attr('role', 'alert')
       .before(infoContainer);

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -9,7 +9,10 @@ const ResendView = BaseResendView.extend(
   {
     className: 'hide resend-email-view',
     events: {
-      'click a.resend-link' : 'handelResendLink'
+      'click a.resend-link' : 'handleResendLink'
+    },
+    modelEvents: {
+      'error': 'handleError'
     },
 
     initialize() {
@@ -20,13 +23,21 @@ const ResendView = BaseResendView.extend(
       }));
     },
 
-    handelResendLink() {
-      this.options.appState.trigger('invokeAction', this.options.resendEmailAction);
+    hideResendViewAndShowAfterTimeout() {
       // Hide warning, but reinitiate to show warning again after some threshold of polling
       if (!this.$el.hasClass('hide')) {
         this.$el.addClass('hide');
       }
       this.showCalloutAfterTimeout();
+    },
+
+    handleResendLink() {
+      this.options.appState.trigger('invokeAction', this.options.resendEmailAction);
+      this.hideResendViewAndShowAfterTimeout();
+    },
+
+    handleError() {
+      this.hideResendViewAndShowAfterTimeout();
     },
   },
 );
@@ -47,7 +58,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
       // Add 1 instance of resend view
       if (!this.$el.find('.resend-email-view').length) {
         this.add(ResendView, {
-          selector: '.o-form-error-container',
+          selector: '.o-form-info-container',
           prepend: true,
           options: {
             resendEmailAction: this.resendEmailAction,

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -10,7 +10,10 @@ const ResendView = BaseResendView.extend(
     events: {
       'click a.resend-link': 'handleResendLink'
     },
-
+    modelEvents: {
+      'error': 'handleError'
+    },
+    
     // Override this to change the resend action location from response
     resendActionKey: 'currentAuthenticatorEnrollment-resend',
 
@@ -27,13 +30,21 @@ const ResendView = BaseResendView.extend(
       }));
     },
 
-    handleResendLink() {
-      this.options.appState.trigger('invokeAction', this.resendActionKey);
+    hideResendViewAndShowAfterTimeout() {
       // Hide warning, but start a timeout again..
       if (!this.el.classList.contains('hide')) {
         this.el.classList.add('hide');
       }
       this.showCalloutAfterTimeout();
+    },
+
+    handleResendLink() {
+      this.options.appState.trigger('invokeAction', this.resendActionKey);
+      this.hideResendViewAndShowAfterTimeout();
+    },
+
+    handleError() {
+      this.hideResendViewAndShowAfterTimeout();
     },
   },
 );

--- a/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
@@ -15,9 +15,9 @@ export default class ChallengeEmailPageObject extends ChallengeFactorPageObject 
     return this.form.getElement(RESEND_EMAIL_VIEW_SELECTOR).innerText;
   }
 
-  async resendEmailExists() {
+  async resendEmailExists(index = 0) {
     if (userVariables.gen3) {
-      return this.form.hasAlertBox();
+      return this.form.hasAlertBox(index);
     }
 
     const isHidden = await this.form.getElement(RESEND_EMAIL_VIEW_SELECTOR).hasClass('hide');

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -633,6 +633,49 @@ test
   });
 
 test
+  .requestHooks(invalidOTPMock)('Entering invalid passcode results in an error, resend callout should appear after 30 seconds', async t => {
+    const challengeEmailPageObject = await setup(t);
+    await checkA11y(t);
+    await challengeEmailPageObject.clickEnterCodeLink();
+
+    await challengeEmailPageObject.verifyFactor('credentials.passcode', 'xyz');
+    await challengeEmailPageObject.clickNextButton('Verify');
+    await challengeEmailPageObject.waitForErrorBox();
+    await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
+    await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
+
+    // Resend callout should be hidden but appear after 30s
+    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(false);
+    await t.wait(25000);
+    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(false);
+    await t.wait(5500);
+    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(true);
+  });
+
+test
+  .requestHooks(invalidOTPMock)('Callout appears after 30 seconds, hides after entering invalid passcode', async t => {
+    const challengeEmailPageObject = await setup(t);
+    await checkA11y(t);
+    await challengeEmailPageObject.clickEnterCodeLink();
+
+    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(false);
+    await t.wait(31000);
+    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(true);
+    const resendEmailViewText = challengeEmailPageObject.resendEmailViewText();
+    await t.expect(resendEmailViewText).contains('Haven\'t received an email?');
+
+    // After submitting invalid passcode resend callout should be hidden but appear again after 30s
+    await challengeEmailPageObject.verifyFactor('credentials.passcode', 'xyz');
+    await challengeEmailPageObject.clickNextButton('Verify');
+    await challengeEmailPageObject.waitForErrorBox();
+    await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
+    await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
+    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(false);
+    await t.wait(31000);
+    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(true);
+  });
+
+test
   .requestHooks(validOTPResendLogger, validOTPmock)('resend after 30 seconds', async t => {
     const challengeEmailPageObject = await setup(t);
     await checkA11y(t);

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -645,11 +645,11 @@ test
     await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
 
     // Resend callout should be hidden but appear after 30s
-    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(false);
+    await t.expect(await challengeEmailPageObject.resendEmailExists(1)).eql(false);
     await t.wait(25000);
-    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(false);
+    await t.expect(await challengeEmailPageObject.resendEmailExists(1)).eql(false);
     await t.wait(5500);
-    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(true);
+    await t.expect(await challengeEmailPageObject.resendEmailExists(1)).eql(true);
   });
 
 test
@@ -670,9 +670,9 @@ test
     await challengeEmailPageObject.waitForErrorBox();
     await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
     await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
-    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(false);
+    await t.expect(await challengeEmailPageObject.resendEmailExists(1)).eql(false);
     await t.wait(31000);
-    await t.expect(await challengeEmailPageObject.resendEmailExists()).eql(true);
+    await t.expect(await challengeEmailPageObject.resendEmailExists(1)).eql(true);
   });
 
 test

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -654,7 +654,7 @@ test
     await t.expect(challengePhonePageObject.getInvalidOTPError()).contains('We found some errors.');
     await t.expect(await challengePhonePageObject.resendCodeExists(1)).eql(false);
     await t.wait(30500);
-    await t.expect(await challengePhonePageObject.resendCodeExists()).eql(true);
+    await t.expect(await challengePhonePageObject.resendCodeExists(1)).eql(true);
   });
 
 test

--- a/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
+++ b/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
@@ -16,7 +16,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form150"
+      id="form158"
       method="POST"
       slot="content"
     >
@@ -86,7 +86,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form111"
+      id="form117"
       method="POST"
       slot="content"
     >
@@ -161,7 +161,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form91"
+      id="form96"
       method="POST"
       slot="content"
     >
@@ -236,7 +236,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form131"
+      id="form138"
       method="POST"
       slot="content"
     >
@@ -295,7 +295,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
 </div>
 `;
 
-exports[`v2/view-builder/views/AutoRedirectView renders custom error message 1`] = `"<div class=\\"siw-main-header\\"><div></div></div><div class=\\"siw-main-body\\"><form method=\\"POST\\" action=\\"/\\" data-se=\\"o-form\\" slot=\\"content\\" id=\\"form69\\" class=\\"ion-form o-form o-form-edit-mode\\"><div data-se=\\"o-form-content\\" class=\\"o-form-content o-form-theme clearfix\\"><h2 data-se=\\"o-form-head\\" class=\\"okta-form-title o-form-head\\">Signing in</h2><div class=\\"o-form-info-container\\"></div><div class=\\"o-form-error-container\\" data-se=\\"o-form-error-container\\" role=\\"alert\\"></div><div class=\\"o-form-fieldset-container\\" data-se=\\"o-form-fieldset-container\\"><div data-se=\\"callout\\" class=\\"infobox clearfix infobox-error\\"><span data-se=\\"icon\\" class=\\"icon error-16\\"></span><div class=\\"custom-access-denied-error-message\\"><p>You do not have permission to perform the requested action.</p><ul class=\\"custom-links\\"><li><a href=\\"https://www.okta.com/\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Help link 1</a></li><li><a href=\\"https://www.okta.com/help?page=1\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Help link 2</a></li></ul></div></div><div class=\\"okta-waiting-spinner\\"></div></div></div></form></div><div class=\\"siw-main-footer\\"><div class=\\"auth-footer\\"></div></div>"`;
+exports[`v2/view-builder/views/AutoRedirectView renders custom error message 1`] = `"<div class=\\"siw-main-header\\"><div></div></div><div class=\\"siw-main-body\\"><form method=\\"POST\\" action=\\"/\\" data-se=\\"o-form\\" slot=\\"content\\" id=\\"form73\\" class=\\"ion-form o-form o-form-edit-mode\\"><div data-se=\\"o-form-content\\" class=\\"o-form-content o-form-theme clearfix\\"><h2 data-se=\\"o-form-head\\" class=\\"okta-form-title o-form-head\\">Signing in</h2><div class=\\"o-form-info-container\\"></div><div class=\\"o-form-error-container\\" data-se=\\"o-form-error-container\\" role=\\"alert\\"></div><div class=\\"o-form-fieldset-container\\" data-se=\\"o-form-fieldset-container\\"><div data-se=\\"callout\\" class=\\"infobox clearfix infobox-error\\"><span data-se=\\"icon\\" class=\\"icon error-16\\"></span><div class=\\"custom-access-denied-error-message\\"><p>You do not have permission to perform the requested action.</p><ul class=\\"custom-links\\"><li><a href=\\"https://www.okta.com/\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Help link 1</a></li><li><a href=\\"https://www.okta.com/help?page=1\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">Help link 2</a></li></ul></div></div><div class=\\"okta-waiting-spinner\\"></div></div></div></form></div><div class=\\"siw-main-footer\\"><div class=\\"auth-footer\\"></div></div>"`;
 
 exports[`v2/view-builder/views/AutoRedirectView renders user identifier in title when features.showIdentifier is false: should show identifier in title 1`] = `
 <div
@@ -313,7 +313,7 @@ exports[`v2/view-builder/views/AutoRedirectView renders user identifier in title
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form53"
+      id="form56"
       method="POST"
       slot="content"
     >
@@ -438,7 +438,7 @@ exports[`v2/view-builder/views/AutoRedirectView view renders correctly according
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form22"
+      id="form23"
       method="POST"
       slot="content"
     >
@@ -504,7 +504,7 @@ exports[`v2/view-builder/views/AutoRedirectView view renders correctly according
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form37"
+      id="form39"
       method="POST"
       slot="content"
     >


### PR DESCRIPTION
## Description:

Situation: A warning callout with text "Haven't received an SMS/email? [Send again]" is shown after timeout. User enters wrong MFA code and error callout with text "We found some errors" is being shown. Should warning callout be hidden then?
![Screenshot 2024-09-19 at 9 46 37 AM](https://github.com/user-attachments/assets/f2ed5047-2c4d-49bb-bcb2-3486152210c5)


There is a discrepancy in ways of handling this situation between Gen2 and Gen3.
- In Gen2 for email verification/enroll flow warning callout will be hidden and will not be shown after timeout (so user won't be able to ask for code resending).
- In Gen2 for SMS flow warning callout will remain visible (see [PR](https://github.com/okta/okta-signin-widget/pull/2218)).
- In Gen3 warning callout will be hidden but will appear after timeout.

This PR changes logic in Gen2 for both SMS and Email flows to be same as in Gen3.



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-819536](https://oktainc.atlassian.net/browse/OKTA-819536)

### Reviewers:

### Screenshot/Video:

Before:

https://github.com/user-attachments/assets/eac4b3c9-64bb-4b01-9a44-d2e067d67fe0

https://github.com/user-attachments/assets/1f1b54d4-3fbe-4911-ba72-64cfaf2274af

After:

https://github.com/user-attachments/assets/2a46ed02-836e-41af-90a9-3a48f4533ca9


https://github.com/user-attachments/assets/43c054db-9a4a-48e6-9eb3-29b94c2d069d




### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=ff976fff157edc90696ee46cefca40dfc6f9b116&tab=main



