### PR TITLE
[DO NOT MERGE]hackathon2024Dec-send device challenge payload to extension

### DIFF
--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -66,6 +66,20 @@ const Body = BaseFormWithPolling.extend({
     throw new Error('getDeviceChallengePayload needs to be implemented');
   },
 
+  doWebExtMessaging(deviceChallenge) {
+    if (chrome && chrome.runtime && chrome.runtime.sendMessage) {
+      // can use WebExt API
+      const WebExtUUID = 'kpkilehcpjaeglkmjmodnbijmcphnmfm'; // replace with your own UUID
+      const challenge = this.options.currentViewState.relatesTo.value.challengeRequest;
+      chrome.runtime.sendMessage(WebExtUUID, {
+        type: 'SIW-Challenge-Message',
+        data: deviceChallenge
+      });
+      return;
+    }
+    console.warn('you don not have web ext API');
+  },
+
   doLoopback(deviceChallenge) {
     let authenticatorDomainUrl = deviceChallenge.domain !== undefined ? deviceChallenge.domain : '';
     let authenticatorHttpsDomainUrl = deviceChallenge.httpsDomain !== undefined ? deviceChallenge.httpsDomain : '';

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -41,7 +41,10 @@ export function doChallenge(view, fromView) {
       className: 'loopback-content',
       template: hbs`<div class="spinner"></div>`
     }));
-    view.doLoopback(deviceChallenge);
+    //console.log(44, document.URL);
+    // Hackathon experiment, we do not doLoopback but doWebExtMessaging
+    //view.doLoopback(deviceChallenge);
+    view.doWebExtMessaging(deviceChallenge);
     break;
   case Enums.CUSTOM_URI_CHALLENGE:
     view.title = loc('customUri.title', 'login');

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -42,7 +42,7 @@ export function doChallenge(view, fromView) {
       template: hbs`<div class="spinner"></div>`
     }));
     // Hackathon experiment, we do not doLoopback but doWebExtMessaging
-    if (deviceChallenge.isPluginNativeMsg) {
+    if (deviceChallenge.pluginNativeMsg) {
       view.doWebExtMessaging(deviceChallenge);
     } else {
       view.doLoopback(deviceChallenge);

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -47,7 +47,6 @@ export function doChallenge(view, fromView) {
     } else {
       view.doLoopback(deviceChallenge);
     }
-    view.doWebExtMessaging(deviceChallenge);
     break;
   case Enums.CUSTOM_URI_CHALLENGE:
     view.title = loc('customUri.title', 'login');

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -41,9 +41,12 @@ export function doChallenge(view, fromView) {
       className: 'loopback-content',
       template: hbs`<div class="spinner"></div>`
     }));
-    //console.log(44, document.URL);
     // Hackathon experiment, we do not doLoopback but doWebExtMessaging
-    //view.doLoopback(deviceChallenge);
+    if (deviceChallenge.isPluginNativeMsg) {
+      view.doWebExtMessaging(deviceChallenge);
+    } else {
+      view.doLoopback(deviceChallenge);
+    }
     view.doWebExtMessaging(deviceChallenge);
     break;
   case Enums.CUSTOM_URI_CHALLENGE:

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -18,16 +18,6 @@ const Body = BaseOktaVerifyChallengeView.extend({
   pollingCancelAction: CANCEL_POLLING_ACTION,
 
   getDeviceChallengePayload() {
-    if (chrome && chrome.runtime && chrome.runtime.sendMessage) {
-      // can use WebExt API
-      const WebExtUUID = 'kpkilehcpjaeglkmjmodnbijmcphnmfm'; // replace with your own UUID
-      chrome.runtime.sendMessage(WebExtUUID, {
-        type: 'WebApp-Message',
-        data: {
-          deviceChallengePayload: this.options.currentViewState.relatesTo.value
-        }
-      });
-    }
     return this.options.currentViewState.relatesTo.value;
   },
 

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -18,6 +18,16 @@ const Body = BaseOktaVerifyChallengeView.extend({
   pollingCancelAction: CANCEL_POLLING_ACTION,
 
   getDeviceChallengePayload() {
+    if (chrome && chrome.runtime && chrome.runtime.sendMessage) {
+      // can use WebExt API
+      const WebExtUUID = 'kpkilehcpjaeglkmjmodnbijmcphnmfm'; // replace with your own UUID
+      chrome.runtime.sendMessage(WebExtUUID, {
+        type: 'WebApp-Message',
+        data: {
+          deviceChallengePayload: this.options.currentViewState.relatesTo.value
+        }
+      });
+    }
     return this.options.currentViewState.relatesTo.value;
   },
 


### PR DESCRIPTION
## Description:
* use a FF flag `deviceChallenge.pluginNativeMsg` to replace loopback with the extension native messaging, monolith change in this [PR](https://github.com/atko-eng/okta-core/pull/104992)
* also add [externally_connectable](https://github.com/atko-devices/fastpasschromeextensionhack/blob/main/manifest.json) in extension manifest, so that the SIW can directly call the WebExtension API `chrome.runtime.sendMessage`

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



