### PR TITLE
Gen 2/3: Use redirect URI from IDX response for `Util.isAndroidOVEnrollment`

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -19,7 +19,7 @@ import Logger from './Logger';
 import BrowserFeatures from './BrowserFeatures';
 
 const Util = {};
-const ovDeepLink = 'redirect_uri=https://login.okta.com/oauth/callback';
+const ovDeepLink = 'https://login.okta.com/oauth/callback';
 
 const buildInputForParameter = function(name, value) {
   const input = document.createElement('input');
@@ -248,8 +248,9 @@ Util.executeOnVisiblePage = function(cb) {
   }
 };
 
-Util.isAndroidOVEnrollment = function() {
-  const ovEnrollment = decodeURIComponent(window.location.href).includes(ovDeepLink);
+Util.isAndroidOVEnrollment = function(authentication) {
+  const redirectUri = authentication?.request?.redirect_uri;
+  const ovEnrollment = redirectUri?.includes(ovDeepLink);
   return BrowserFeatures.isAndroid() && ovEnrollment;
 };
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -251,7 +251,7 @@ Util.executeOnVisiblePage = function(cb) {
 Util.isAndroidOVEnrollment = function(authentication) {
   const redirectUri = authentication?.request?.redirect_uri;
   const ovEnrollment = redirectUri?.includes(ovDeepLink);
-  return BrowserFeatures.isAndroid() && ovEnrollment;
+  return BrowserFeatures.isAndroid() && !!ovEnrollment;
 };
 
 /**

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -260,8 +260,8 @@ export default Controller.extend({
       sessionStorageHelper.removeStateHandle();
 
       // OKTA-635926: do not redirect without user gesture for ov enrollment on android
-      // if Util.isAndroidOVEnrollment() returns true we use a user gesture to complete the redirect in AutoRedirectView
-      if (!Util.isAndroidOVEnrollment()) {
+      // if Util.isAndroidOVEnrollment() returns true we use a user gesture to complete the redirect in AutoRedirectView    
+      if (!Util.isAndroidOVEnrollment(this.options.appState.get('authentication'))) {
         const currentViewState = this.options.appState.getCurrentViewState();
         // OKTA-702402: redirect only if/when the page is visible
         Util.executeOnVisiblePage(() => {

--- a/src/v2/view-builder/utils/AutoRedirectUtil.js
+++ b/src/v2/view-builder/utils/AutoRedirectUtil.js
@@ -12,8 +12,8 @@ function getHeader() {
         this.HeaderBeacon = BaseAuthenticatorBeacon.extend({
           authenticatorKey: AUTHENTICATOR_KEY.OV,
         });
-        this.add(this.HeaderBeacon);
       }
+      BaseHeader.prototype.initialize.apply(this, arguments);
     },
   });
 }

--- a/src/v2/view-builder/utils/AutoRedirectUtil.js
+++ b/src/v2/view-builder/utils/AutoRedirectUtil.js
@@ -4,15 +4,18 @@ import {BaseAuthenticatorBeacon} from '../components/BaseAuthenticatorView';
 import {AUTHENTICATOR_KEY} from '../../ion/RemediationConstants';
 
 function getHeader() {
-  if (Util.isAndroidOVEnrollment()) {
-    return BaseHeader.extend({
-      HeaderBeacon: BaseAuthenticatorBeacon.extend({
-        authenticatorKey: AUTHENTICATOR_KEY.OV,
-      })
-    });
-  } else {
-    return BaseHeader;
-  }
+  return BaseHeader.extend({
+    HeaderBeacon: null,
+  
+    initialize() {
+      if (Util.isAndroidOVEnrollment(this.options.appState.get('authentication'))) {
+        this.HeaderBeacon = BaseAuthenticatorBeacon.extend({
+          authenticatorKey: AUTHENTICATOR_KEY.OV,
+        });
+        this.add(this.HeaderBeacon);
+      }
+    },
+  });
 }
 
 export { getHeader };

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -16,7 +16,7 @@ const Body = BaseForm.extend({
     const user = this.options.appState.get('user');
 
     // OKTA-635926: add user gesture for ov enrollment on android
-    if (Util.isAndroidOVEnrollment()) {
+    if (Util.isAndroidOVEnrollment(this.options.appState.get('authentication'))) {
       titleString = loc('oie.success.text.signingIn.with.appName.android.ov.enrollment', 'login');
       return titleString;
     }
@@ -76,7 +76,7 @@ const Body = BaseForm.extend({
 
   render() {
     BaseForm.prototype.render.apply(this, arguments);
-    if (Util.isAndroidOVEnrollment()) {
+    if (Util.isAndroidOVEnrollment(this.options.appState.get('authentication'))) {
       const currentViewState = this.options.appState.getCurrentViewState();
       this.add(createButton({
         className: 'ul-button button button-wide button-primary hide-underline',

--- a/src/v3/src/transformer/redirect/redirectTransformer.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.ts
@@ -40,7 +40,7 @@ export const redirectTransformer = (
   const { context } = transaction;
 
   // OKTA-635926: add user gesture for ov enrollment on android
-  if (Util.isAndroidOVEnrollment()) {
+  if (Util.isAndroidOVEnrollment(context?.authentication?.value)) {
     createIdentifierContainer({
       transaction,
       widgetProps,

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -140,7 +140,7 @@ export const buildAuthCoinProps = (
   }
 
   const { nextStep, messages } = transaction;
-  if (Util.isAndroidOVEnrollment()
+  if (Util.isAndroidOVEnrollment(transaction.context?.authentication?.value)
     && transaction.context.success?.name === IDX_STEP.SUCCESS_REDIRECT) {
     return { authenticatorKey: AUTHENTICATOR_KEY.OV };
   }

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -5,6 +5,27 @@ import Logger from 'util/Logger';
 import Util from 'util/Util';
 import BrowserFeatures from '../../../src/util/BrowserFeatures';
 
+const authenticationForAndroidOVEnrollment = {
+  protocol: 'OAUTH2.0',
+  issuer: {
+    name: 'Test App',
+    uri: 'http://localhost:3000'
+  },
+  request: {
+    max_age: -1,
+    scope: 'openid profile email okta.authenticators.read okta.authenticators.manage.self',
+    display: 'page',
+    response_type: 'code',
+    redirect_uri: 'https://login.okta.com/oauth/callback',
+    state: 'i41VVuProw96htTUmvRP9A',
+    code_challenge_method: 'S256',
+    nonce: 'ASDF4343SDFS3-GhS8SQCw',
+    code_challenge: 'abcd_8asd8asdf8as98fasdf_-_9sadif9rasd9fasdf-cc',
+    response_mode: 'query'
+  }
+};
+
+
 describe('util/Util', () => {
   describe('transformErrorXHR', () => {
     it('errorSummary shows network connection error when status is 0', () => {
@@ -358,62 +379,36 @@ describe('util/Util', () => {
 
     it('Test is Android and OV Enrollment', () => {
       jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
-            '&code_challenge=challenge&client_id=id',
-        },
-        writeable: true,
-        configurable: true
-      });
-
-      expect(Util.isAndroidOVEnrollment()).toBe(true);
+      expect(Util.isAndroidOVEnrollment(authenticationForAndroidOVEnrollment)).toBe(true);
     });
 
     it('Test is Android and not OV Enrollment', () => {
       jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(true);
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Forg.com%2Fenduser%2Fcallback&nonce=nonce' +
-            '&code_challenge=challenge&client_id=id',
-        },
-        writeable: true,
-        configurable: true
-      });
+      const authentication = {
+        protocol: 'OAUTH2.0',
+        issuer: {
+          uri: 'http://localhost:3000'
+        }
+      };
 
-      expect(Util.isAndroidOVEnrollment()).toBe(false);
+      expect(Util.isAndroidOVEnrollment(authentication)).toBe(false);
     });
 
     it('Test is not Android and is OV Enrollment', () => {
       jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(false);
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=nonce' +
-            '&code_challenge=challenge&client_id=id',
-        },
-        writeable: true,
-        configurable: true
-      });
-
-      expect(Util.isAndroidOVEnrollment()).toBe(false);
+      expect(Util.isAndroidOVEnrollment(authenticationForAndroidOVEnrollment)).toBe(false);
     });
 
     it('Test is not Android and not OV Enrollment', () => {
       jest.spyOn(BrowserFeatures, 'isAndroid').mockReturnValue(false);
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: 'https://org.com/oauth2/v1/authorize?response_type=code&state=state' +
-            '&code_challenge_method=S256&redirect_uri=https%3A%2F%2Forg.com%2Fenduser%2Fcallback&nonce=nonce' +
-            '&code_challenge=challenge&client_id=id',
-        },
-        writeable: true,
-        configurable: true
-      });
+      const authentication = {
+        protocol: 'OAUTH2.0',
+        issuer: {
+          uri: 'http://localhost:3000'
+        }
+      };
 
-      expect(Util.isAndroidOVEnrollment()).toBe(false);
+      expect(Util.isAndroidOVEnrollment(authentication)).toBe(false);
     });
   });
 

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -1,4 +1,4 @@
-/* eslint max-len: [2, 140] */
+/* eslint max-len: [2, 140], camelcase: 0 */
 import { $ } from '@okta/courage';
 import $sandbox from 'sandbox';
 import Logger from 'util/Logger';

--- a/test/unit/spec/v2/view-builder/utils/AutoRedirectUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/AutoRedirectUtil_spec.js
@@ -17,7 +17,10 @@ describe('v2/view-builder/utils/AutoRedirectUtil', () => {
 
   it('Not Android OV Enrollment', ()=> {
     jest.spyOn(Util, 'isAndroidOVEnrollment').mockReturnValue(false);
-    expect(getHeader()).toBe(BaseHeader);
+    const beaconHeader = BaseHeader.extend({
+      HeaderBeacon: null
+    });
+    expect(getHeader().toString()).toBe(beaconHeader.toString());
   });
 
 });

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -10,7 +10,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
   const wait = (timeout) => {
     return new Promise((resolve) => {
       setTimeout(resolve, timeout);
-    })
+    });
   };
 
   let testContext;

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -7,6 +7,12 @@ import { INTERSTITIAL_REDIRECT_VIEW } from 'v2/ion/RemediationConstants';
 import utilSpy from '../../../../../../src/util/Util';
 
 describe('v2/view-builder/views/AutoRedirectView', function() {
+  const wait = (timeout) => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, timeout);
+    })
+  };
+
   let testContext;
   let settings = new Settings({
     baseUrl: 'http://localhost:3000',
@@ -127,13 +133,14 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
       'NONE',
       'DEFAULT',
       null,
-    ])('should add user gesture if OV enrollment on Android with interstitialBeforeLoginRedirect = "%s"', function(interstitialBeforeLoginRedirect) {
+    ])('should add user gesture if OV enrollment on Android with interstitialBeforeLoginRedirect = "%s"', async function(interstitialBeforeLoginRedirect) {
       settings = new Settings({
         baseUrl: 'http://localhost:3000',
         'interstitialBeforeLoginRedirect': interstitialBeforeLoginRedirect,
       });
       jest.spyOn(utilSpy, 'isAndroidOVEnrollment').mockReturnValue(true);
       testContext.init();
+      await wait(300); // wait for beacon animation
       expect(testContext.view.el).toMatchSnapshot('should show user gesture');
     });
 

--- a/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
+++ b/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
@@ -16,7 +16,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment Do not add
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form158"
+      id="form161"
       method="POST"
       slot="content"
     >
@@ -77,7 +77,31 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
   <div
     class="siw-main-header"
   >
-    <div />
+    <div>
+      <div>
+        <div
+          class="beacon-container"
+          data-type="beacon-container"
+          style="transform: scale(1, 1); text-indent: 1px;"
+        >
+          <div
+            class="beacon-blank auth-beacon"
+          >
+            <div
+              class="beacon-blank js-blank-beacon-border auth-beacon-border"
+            />
+          </div>
+          <div
+            class="bg-helper auth-beacon auth-beacon-factor mfa-okta-verify"
+            data-se="factor-beacon"
+          >
+            <div
+              class="okta-sign-in-beacon-border auth-beacon-border"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div
     class="siw-main-body"
@@ -86,7 +110,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form117"
+      id="form119"
       method="POST"
       slot="content"
     >
@@ -152,7 +176,31 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
   <div
     class="siw-main-header"
   >
-    <div />
+    <div>
+      <div>
+        <div
+          class="beacon-container"
+          data-type="beacon-container"
+          style="transform: scale(1, 1); text-indent: 1px;"
+        >
+          <div
+            class="beacon-blank auth-beacon"
+          >
+            <div
+              class="beacon-blank js-blank-beacon-border auth-beacon-border"
+            />
+          </div>
+          <div
+            class="bg-helper auth-beacon auth-beacon-factor mfa-okta-verify"
+            data-se="factor-beacon"
+          >
+            <div
+              class="okta-sign-in-beacon-border auth-beacon-border"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div
     class="siw-main-body"
@@ -161,7 +209,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form96"
+      id="form97"
       method="POST"
       slot="content"
     >
@@ -227,7 +275,31 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
   <div
     class="siw-main-header"
   >
-    <div />
+    <div>
+      <div>
+        <div
+          class="beacon-container"
+          data-type="beacon-container"
+          style="transform: scale(1, 1); text-indent: 1px;"
+        >
+          <div
+            class="beacon-blank auth-beacon"
+          >
+            <div
+              class="beacon-blank js-blank-beacon-border auth-beacon-border"
+            />
+          </div>
+          <div
+            class="bg-helper auth-beacon auth-beacon-factor mfa-okta-verify"
+            data-se="factor-beacon"
+          >
+            <div
+              class="okta-sign-in-beacon-border auth-beacon-border"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div
     class="siw-main-body"
@@ -236,7 +308,7 @@ exports[`v2/view-builder/views/AutoRedirectView Android OV Enrollment should add
       action="/"
       class="ion-form o-form o-form-edit-mode"
       data-se="o-form"
-      id="form138"
+      id="form141"
       method="POST"
       slot="content"
     >


### PR DESCRIPTION
## Description:

Change logic of `Util.isAndroidOVEnrollment` (util to detect enroll OV on Android flow [by using sign-in URL](https://help.okta.com/eu/en-us/content/topics/end-user/ov-new-install-signin-ios.htm))

Before it was relying on `redirect_uri` query param of sign-in URL.
Now it relies on `redirect_uri` of `authentication.value.request` object in IDX response.

Example of IDX response:
https://github.com/okta/okta-signin-widget/blob/master/playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json#L63

Example of sign-in URL:
`https://<your-domain>/oauth2/v1/authorize?scope=openid%20profile%20email%20okta.authenticators.read%20okta.authenticators.manage.self&response_type=code&state=XXX&code_challenge_method=S256&redirect_uri=https%3A%2F%2Flogin.okta.com%2Foauth%2Fcallback&nonce=XXX&code_challenge=XXX&client_id=XXX`

Alternatively we can consider checking `app.value.name === 'Okta_Authenticator'` in [IDX response](https://github.com/okta/okta-signin-widget/blob/master/playground/mocks/data/idp/idx/terminal-okta-verify-enrollment-android-device.json#L45)


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-722272](https://oktainc.atlassian.net/browse/OKTA-722272)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:


https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=deb2045162509fa58629cf8808441f742c7e3118&tab=main
