### PR TITLE
Gen2: Fix UI bug with select dropdown

### DIFF
--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -95,6 +95,9 @@ export default Controller.extend({
   },
 
   handleFormNameChange() {
+    // Fix: close opened select
+    this.$el.click();
+
     this.render();
   },
 

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -95,7 +95,7 @@ export default Controller.extend({
   },
 
   handleFormNameChange() {
-    // Fix: close opened dropdown
+    // OKTA-803760 - Fix: close opened dropdown
     this.$el.click();
 
     this.render();

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -95,7 +95,7 @@ export default Controller.extend({
   },
 
   handleFormNameChange() {
-    // Fix: close opened select
+    // Fix: close opened dropdown
     this.$el.click();
 
     this.render();

--- a/test/testcafe/framework/page-objects/EnrollSecurityQuestionPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollSecurityQuestionPageObject.js
@@ -34,8 +34,16 @@ export default class EnrollSecurityQuestionPageObject extends BasePageObject {
     return this.form.selectValueChozenDropdown(QUESTION_KEY_FIELD, index);
   }
 
+  openSecurityQuestionDropdown() {
+    return this.form.openChozenDropdown(QUESTION_KEY_FIELD);
+  }
+
   isSecurityQuestionDropdownVisible() {
     return this.form.findFormFieldInput(QUESTION_KEY_FIELD).visible;
+  }
+
+  isSecurityQuestionDropdownOpened() {
+    return this.form.isChozenDropdownOpened();
   }
 
   isSecurityQuestionTypeSelectVisible() {

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -384,6 +384,21 @@ export default class BaseFormObject {
     await this.t.click(option);
   }
 
+  async openChozenDropdown(fieldName) {
+    if (userVariables.gen3) {
+      const selectEle = this.el.find(`[id="${fieldName}"]`);
+      await this.t.click(selectEle);
+    } else {
+      const selectContainer = await this.findFormFieldInput(fieldName)
+        .find('.chzn-container');
+      await this.t.click(selectContainer);
+    }
+  }
+
+  isChozenDropdownOpened() {
+    return Selector('.chzn-container').exists;
+  }
+
   // =====================================
   // radio button
   // =====================================

--- a/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
@@ -107,7 +107,7 @@ test
     await enrollSecurityQuestionPage.openSecurityQuestionDropdown();
     await enrollSecurityQuestionPage.clickReturnToAuthenticatorListLink();
     await t.expect(enrollSecurityQuestionPage.isSecurityQuestionDropdownOpened()).notOk();
-});
+  });
 
 test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)('enroll custom security question', async t => {
   const enrollSecurityQuestionPage = await setup(t);

--- a/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
@@ -94,6 +94,21 @@ test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)(
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/challenge/answer');
 });
 
+test
+  .meta('gen3', false) // Gen3 uses controlled select component which doesn't have such bug
+  .requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)('shoud hide security question options dropdown after changing page', async t => {
+    const enrollSecurityQuestionPage = await setup(t);
+    await checkA11y(t);
+
+    await enrollSecurityQuestionPage.clickChooseSecurityQuestion();
+    await t.expect(await enrollSecurityQuestionPage.returnToAuthenticatorListLinkExists()).ok();
+    await t.expect(enrollSecurityQuestionPage.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+
+    await enrollSecurityQuestionPage.openSecurityQuestionDropdown();
+    await enrollSecurityQuestionPage.clickReturnToAuthenticatorListLink();
+    await t.expect(enrollSecurityQuestionPage.isSecurityQuestionDropdownOpened()).notOk();
+});
+
 test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)('enroll custom security question', async t => {
   const enrollSecurityQuestionPage = await setup(t);
   await checkA11y(t);


### PR DESCRIPTION
## Description:

Fixes UI bug in Gen2 - [select box](https://harvesthq.github.io/chosen/) remains visible if form is being changed when dropdown is opened (by clicking on "Return to authenticator list" link).

This happens because opened dropdown is being rendered in DOM as child of `body` and not part of `#okta-login-container` (see screenshot) and will not be removed during SIW form rendering

The simplest way to fix the issue without modifying `courage` sources is to just [simulate click](https://github.com/okta/okta-signin-widget/pull/3763/files#diff-72a0e868d27f4dfd26d36bcba1d860aa25999401fa00788f3ac694304043dd4dR99) on form container to trigger dropdown close.


Confirmed this fix works on IE11 and Chrome on Android

P.S. This change fixes similar issues with dropdown on other pages 
<details >
<summary>like this</summary>

https://github.com/user-attachments/assets/e50975cd-abb3-421b-90aa-04fd7f78fd74

</details >

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-803760](https://oktainc.atlassian.net/browse/OKTA-803760)

### Reviewers:

### Screenshot/Video:

https://github.com/user-attachments/assets/4388f97e-042c-4708-bbcb-48292b25b38e

<img width="838" alt="Screenshot 2024-12-11 at 11 31 48" src="https://github.com/user-attachments/assets/868710df-52a7-4094-9a0a-6c34fbd0006e">



### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-65285b1-675729c0&page=1&pageSize=6&tab=main

