### PR TITLE
[Gen3] Remove empty optional fields from form data on submission

### DIFF
--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -136,11 +136,10 @@ export const transformStepInputs = (
 
   const { inputs = [] } = step;
 
-  return inputs
-    .reduce((acc: Input[], input: Input) => {
-      const flattenedInputs = flattenInputs(input);
-      return [...acc, ...flattenedInputs];
-    }, [])
+  const flattenedInputs = inputs
+    .reduce((acc: Input[], input: Input) => [...acc, ...flattenInputs(input)], []);
+
+  const formBag = flattenedInputs
     .filter((input) => input.visible === true
         || (input.visible !== false && input.mutable !== false))
     .reduce((acc: FormBag, input: Input) => {
@@ -178,6 +177,23 @@ export const transformStepInputs = (
 
       return acc;
     }, formbag);
+
+  // Build set of optional input names for quick lookup below
+  const optionalInputNames = new Set(
+    flattenedInputs
+      .filter((input) => !input.required)
+      .map((input) => input.name),
+  );
+
+  // Mark optional fields with empty string values as fieldsToExclude when submitting form data
+  formBag.dataSchema.fieldsToExclude = (data: FormBag['data']) => Object.entries(data).reduce((acc: string[], [fieldName, value]) => {
+    if (typeof value === 'string' && value.trim().length === 0 && optionalInputNames.has(fieldName)) {
+      acc.push(fieldName);
+    }
+    return acc;
+  }, []);
+
+  return formBag;
 };
 
 export const transformFields: TransformStepFnWithOptions = ({

--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -187,7 +187,11 @@ export const transformStepInputs = (
 
   // Mark optional fields with empty string values as fieldsToExclude when submitting form data
   formBag.dataSchema.fieldsToExclude = (data: FormBag['data']) => Object.entries(data).reduce((acc: string[], [fieldName, value]) => {
-    if (typeof value === 'string' && value.trim().length === 0 && optionalInputNames.has(fieldName)) {
+    // Special case for update profile view with all optional fields. Backend expects that secondEmail should be sent with an empty
+    // string (which is set in transformEnrollProfileUpdate), so we should not remove it from the payload here
+    if (fieldName === 'userProfile.secondEmail') {
+      return acc;
+    } else if (typeof value === 'string' && value.trim().length === 0 && optionalInputNames.has(fieldName)) {
       acc.push(fieldName);
     }
     return acc;

--- a/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
+++ b/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
@@ -56,7 +56,7 @@ test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('s
   await t.expect(await profileEnrollmentString.form.getButton('Sign Up').exists).eql(true);
 });
 
-test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('should submit form when all optional fields are empty', async t => {
+test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('should submit form and remove empty optional fields from payload', async t => {
   const profileEnrollmentString = new ProfileEnrollmentStringOptionsViewPageObject(t);
   const identityPage = await setup(t);
   await checkA11y(t);
@@ -65,7 +65,10 @@ test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('s
   await profileEnrollmentString.fillEmailField('test.carlos@mycompany.com');
   await profileEnrollmentString.fillFirstNameField('Test Carlos');
   await profileEnrollmentString.fillLastNameField('Test');
-  await profileEnrollmentString.fillOptionalField('');
+  // To properly test this scenario for both gen2 and gen3, we must explicitly enter a value and then delete it
+  await profileEnrollmentString.fillOptionalField('Value to Delete');
+  // Delete the original string but leave some whitespace to ensure that it is trimmed and deemed an empty string
+  await profileEnrollmentString.fillOptionalField(' ');
 
   requestLogger.clear();
   await profileEnrollmentString.clickSignUpButton();


### PR DESCRIPTION
## Description:
- #2412 introduced explicit logic to remove optional fields with empty strings from the payload for profile enrollment views, but this was missed in gen3
- Adds logic at the generic transformer level to trim and remove empty/whitespace-only strings for optional fields since there is no downside that I am aware of to making this logic apply to all flows (even if profile enrollment is the only flow that this bug currently exists in)
- Updates the spec from #2412 that intended to test the behavior of entering text into an optional field — which adds it to the data schema in the payload — and then deleting that text to get an empty string. The spec actually only directly entered an empty string via TestCafe, which wasn't properly replicating this scenario and giving us a false positive in gen3. Instead, we should explicitly enter a value and then delete it/replace it with an empty or whitespace-only string
- #2219 introduced a special case for the update profile view because the backend requires that the `userProfile.secondEmail` field always have data, so new gen3 logic respects that


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:
- [OKTA-834905](https://oktainc.atlassian.net/browse/OKTA-834905)

### Reviewers:

### Screenshot/Video:
#### Before
https://github.com/user-attachments/assets/a9cd65c6-d1ac-405a-b104-fe0be34fe0ba

#### After
https://github.com/user-attachments/assets/e04137c8-f87d-4d31-8b97-534d1030ddea


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&author=trevor.ing%40okta.com&branch=ti-OKTA-834905-d16t&page=1&pageSize=6&sha=06f5dbc6df9aed0b6bb6c785e3c30c5dc23a6216&tab=main


