### PR TITLE
fix: Fixes issue with showing Invalid passkey message on iOS Safari

### DIFF
--- a/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.test.tsx
+++ b/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.test.tsx
@@ -79,7 +79,11 @@ describe('WebAuthNAutofill', () => {
     });
   });
 
-  it.each([ABORT_REASON_CLEANUP, ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND, {}])('should not call the setMessage method for ignored error "%s"', async (err) => {
+  it.each([
+    ABORT_REASON_CLEANUP,
+    ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND,
+    {}, // checks for an empty object being thrown (edge case happening in iOS Safari)
+  ])('should not call the setMessage method for ignored error "%s"', async (err) => {
     const setMessageSpy = jest.spyOn(mockWidgetContext, 'setMessage');
     const uischemaWithError: WebAuthNAutofillElement = {
       ...uischema,

--- a/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.test.tsx
+++ b/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.test.tsx
@@ -79,7 +79,7 @@ describe('WebAuthNAutofill', () => {
     });
   });
 
-  it.each([ABORT_REASON_CLEANUP, ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND])('should not call the setMessage method for ignored error "%s"', async (err) => {
+  it.each([ABORT_REASON_CLEANUP, ABORT_REASON_WEBAUTHN_AUTOFILLUI_STEP_NOT_FOUND, {}])('should not call the setMessage method for ignored error "%s"', async (err) => {
     const setMessageSpy = jest.spyOn(mockWidgetContext, 'setMessage');
     const uischemaWithError: WebAuthNAutofillElement = {
       ...uischema,

--- a/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.tsx
+++ b/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useEffect } from 'preact/hooks';
+import { isEmpty } from 'lodash';
 
 import {
   ABORT_REASON_CLEANUP,
@@ -48,6 +49,10 @@ const WebAuthNAutofill: UISchemaElementComponent<{
           });
         }
       } catch (err) {
+        // iOS Safari throws an empty object when the user does not use passkey autofill
+        if (isEmpty(err)) {
+          return;
+        }
         // if we explicitly abort with the following messages
         // there is no need to display any kind of error to the user as
         // this is expected behavior

--- a/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.tsx
+++ b/src/v3/src/components/WebAuthNAutofill/WebAuthNAutofill.tsx
@@ -10,8 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { useEffect } from 'preact/hooks';
 import { isEmpty } from 'lodash';
+import { useEffect } from 'preact/hooks';
 
 import {
   ABORT_REASON_CLEANUP,


### PR DESCRIPTION
## Description:

Safari iOS throws an empty object when triggering the AbortController that is used for Passkey Autofill.
This PR adds an exception for this, in order not to display the "Invalid passkey" error box when the user is not using a Passkey.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-836910](https://oktainc.atlassian.net/browse/OKTA-836910)

### Reviewers:

### Screenshot/Video:

Issue:
https://github.com/user-attachments/assets/cfbe86b0-1726-46b6-b3d9-1b98923ef966
<img width="529" alt="image" src="https://github.com/user-attachments/assets/c13dc458-6891-4af5-b424-78c4d59fb96e" />

Fix:
https://github.com/user-attachments/assets/c0164971-183d-4f02-b622-8097ded7effe
<img width="529" alt="image" src="https://github.com/user-attachments/assets/134758c9-15d6-459f-9897-cc681f817b46" />

### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=9a4bbd3efd0c31fd525214218d8372a31e9101e3&tab=main

