### PR TITLE
feat(oie): supports device assurance custom errors

### DIFF
--- a/playground/mocks/data/idp/idx/end-user-remediation-custom-message-custom-url.json
+++ b/playground/mocks/data/idp/idx/end-user-remediation-custom-message-custom-url.json
@@ -1,0 +1,56 @@
+{
+  "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "version": "1.0.0",
+  "expiresAt": "2020-05-18T20:42:23.000Z",
+
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Your device doesn't meet the security requirements",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.title"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "To sign in, make the following updates. Then, access the app again.",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.explanation_one_rule"
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://myremediationurl.com/docs"}
+        ],
+        "message": "It's our company policy that you upgrade your Android OS",
+        "i18n": {
+          "key": "device.assurance.custom.remediation.idx.error.code.access_denied.device_assurance.remediation.android.upgrade_os_version"
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://okta.com/android-biometric-lock"}
+        ],
+        "message": "Enable lock screen and biometrics",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.android.use_biometric_lock_screen"
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://okta.com/help"}
+        ],
+        "message": "For more information, follow the instructions on the help page or contact your administrator for help",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.additional_help_default"
+        },
+        "class": "ERROR"
+      }
+    ]
+  }
+}

--- a/playground/mocks/data/idp/idx/end-user-remediation-custom-message-multiple-options.json
+++ b/playground/mocks/data/idp/idx/end-user-remediation-custom-message-multiple-options.json
@@ -1,0 +1,89 @@
+{
+  "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "version": "1.0.0",
+  "expiresAt": "2020-05-18T20:42:23.000Z",
+
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Your device doesn't meet the security requirements",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.title"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "To sign in, pick an option and make the updates. Then, access the app again.",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.explanation_multiple_rules"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "Option 1:",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.option_index",
+          "params": ["1"]
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://myremediationurl.com/docs"}
+        ],
+        "message": "It's our company policy that you upgrade your Android OS",
+        "i18n": {
+          "key": "device.assurance.custom.remediation.idx.error.code.access_denied.device_assurance.remediation.android.upgrade_os_version"
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://okta.com/android-biometric-lock"}
+        ],
+        "message": "Enable lock screen and biometrics",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.android.use_biometric_lock_screen"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "Option 2:",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.option_index",
+          "params": ["2"]
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://okta.com/android-lock-screen"}
+        ],
+        "message": "Enable lock screen",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.android.use_lock_screen"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "It's our company policy that your Android device cannot be rooted",
+        "i18n": {
+          "key": "device.assurance.custom.remediation.ANDROID.Okta:DeviceAssurance.Jailbreak"
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://okta.com/help"}
+        ],
+        "message": "For more information, follow the instructions on the help page or contact your administrator for help",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.additional_help_default"
+        },
+        "class": "ERROR"
+      }
+    ]
+  }
+}

--- a/playground/mocks/data/idp/idx/end-user-remediation-custom-message-no-url.json
+++ b/playground/mocks/data/idp/idx/end-user-remediation-custom-message-no-url.json
@@ -1,0 +1,53 @@
+{
+  "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "version": "1.0.0",
+  "expiresAt": "2020-05-18T20:42:23.000Z",
+
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Your device doesn't meet the security requirements",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.title"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "To sign in, make the following updates. Then, access the app again.",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.explanation_one_rule"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "It's our company policy that your Android device cannot be rooted",
+        "i18n": {
+          "key": "device.assurance.custom.remediation.ANDROID.Okta:DeviceAssurance.Jailbreak"
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://okta.com/android-biometric-lock"}
+        ],
+        "message": "Enable lock screen and biometrics",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.android.use_biometric_lock_screen"
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://okta.com/help"}
+        ],
+        "message": "For more information, follow the instructions on the help page or contact your administrator for help",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.additional_help_default"
+        },
+        "class": "ERROR"
+      }
+    ]
+  }
+}

--- a/playground/mocks/data/idp/idx/end-user-remediation-default-message-custom-url.json
+++ b/playground/mocks/data/idp/idx/end-user-remediation-default-message-custom-url.json
@@ -1,0 +1,57 @@
+{
+  "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "version": "1.0.0",
+  "expiresAt": "2020-05-18T20:42:23.000Z",
+
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Your device doesn't meet the security requirements",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.title"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "To sign in, make the following updates. Then, access the app again.",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.explanation_one_rule"
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://myremediationurl.com/docs"}
+        ],
+        "message": "Update to Android 100",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.android.upgrade_os_version",
+          "params": ["100"]
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://okta.com/android-biometric-lock"}
+        ],
+        "message": "Enable lock screen and biometrics",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.android.use_biometric_lock_screen"
+        },
+        "class": "ERROR"
+      },
+      {
+        "links": [
+          {"url": "https://okta.com/help"}
+        ],
+        "message": "For more information, follow the instructions on the help page or contact your administrator for help",
+        "i18n": {
+          "key": "idx.error.code.access_denied.device_assurance.remediation.additional_help_default"
+        },
+        "class": "ERROR"
+      }
+    ]
+  }
+}

--- a/src/v2/ion/i18nUtils.js
+++ b/src/v2/ion/i18nUtils.js
@@ -21,6 +21,7 @@ import { FORMS, AUTHENTICATOR_KEY } from './RemediationConstants';
 import { I18N_BASE_ATTRIBUTE_ENROLL_PROFILE_MAPPINGS } from '../view-builder/views/enroll-profile/i18nBaseAttributeMappings';
 
 const WEBAUTHN_API_GENERIC_ERROR_KEY = 'authfactor.webauthn.error';
+const DEVICE_ASSURANCE_CUSTOM_REMEDIATION_I18N_KEY_PREFIX = 'device.assurance.custom.remediation.';
 
 const SECURITY_QUESTION_PREFIXES = [
   'enroll-authenticator.security_question.credentials.questionKey.',
@@ -338,6 +339,11 @@ const getMessage = (message) => {
       // The WebAuthn api error doesn't make much sense to a typical end user, but useful for developer.
       // So keep the api message in response, but show a generic error message on UI.
       return loc(WEBAUTHN_API_GENERIC_ERROR_KEY, 'login');
+    }
+
+    // Return unlocalized IDX `message.message` for admin-defined custom device assurance remediation keys
+    if (i18nKey.startsWith(DEVICE_ASSURANCE_CUSTOM_REMEDIATION_I18N_KEY_PREFIX)) {
+      return message.message;
     }
   }
 

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -25,7 +25,7 @@ import {
   ClickEvent,
   ListStyleType,
   WidgetMessage,
-  WidgetMessageLink,
+  WidgetMessageOption,
 } from '../../types';
 import { parseHtmlContent } from '../../util';
 
@@ -46,49 +46,54 @@ const WidgetMessageContainer: FunctionComponent<{
     </Typography>
   ));
 
-  const getLinkElement = (link: WidgetMessageLink) => {
-    if (link.isLinkButton) {
-      return (
-        // @ts-expect-error error due to variant type applied, can be ignored
-        <MuiLink
-          component="button"
-          role="link"
-          onClick={(event: ClickEvent) => {
-            event.preventDefault();
-            link.onClick();
-          }}
-          // @ts-expect-error MUI variant type does not include monochrome but functions appropriately when set
-          variant={linkVariant}
-          sx={{
-            textAlign: 'start',
-            fontSize: tokens.TypographySizeBody,
-            verticalAlign: 'text-top',
-          }}
-          data-se={link.dataSe}
-        >
-          {link.label}
-        </MuiLink>
-      );
-    } if (link.url) {
-      return (
-        <Link
-          href={link.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          variant={linkVariant}
-        >
-          {link.label}
-        </Link>
-      );
+  const getOptionElement = (option: WidgetMessageOption) => {
+    switch (option.type) {
+      case 'button':
+        return (
+          // @ts-expect-error error due to variant type applied, can be ignored
+          <MuiLink
+            component="button"
+            role="link"
+            onClick={(event: ClickEvent) => {
+              event.preventDefault();
+              option.onClick();
+            }}
+            // @ts-expect-error MUI variant type does not include monochrome but functions appropriately when set
+            variant={linkVariant}
+            sx={{
+              textAlign: 'start',
+              fontSize: tokens.TypographySizeBody,
+              verticalAlign: 'text-top',
+            }}
+            data-se={option.dataSe}
+          >
+            {option.label}
+          </MuiLink>
+        );
+      case 'link':
+        return (
+          <Link
+            href={option.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant={linkVariant}
+          >
+            {option.label}
+          </Link>
+        );
+      default:
+      case 'text':
+        // Custom error remediation allows admins to define a message without a URL
+        return option.label;
     }
-
-    // Custom error remediation allows admins to define a message without a URL
-    return link.label;
   };
 
-  const renderLinks = (links?: WidgetMessageLink[], listStyleType?: ListStyleType) => (links && (
+  const renderOptions = (
+    options?: WidgetMessageOption[],
+    listStyleType?: ListStyleType,
+  ) => (options && (
     <List
-      data-se="custom-links"
+      data-se="custom-options"
       disablePadding
       dense
       sx={{
@@ -96,15 +101,15 @@ const WidgetMessageContainer: FunctionComponent<{
         listStyle: listStyleType ?? 'none',
       }}
     >
-      {links.map((link) => (
+      {options.map((option) => (
         <ListItem
           sx={{
             paddingLeft: 0,
             display: 'list-item',
           }}
-          key={link.label}
+          key={option.label}
         >
-          {getLinkElement(link)}
+          {getOptionElement(option)}
         </ListItem>
       ))}
     </List>
@@ -162,7 +167,8 @@ const WidgetMessageContainer: FunctionComponent<{
       <React.Fragment>
         {renderTitle(message.title)}
         {Array.isArray(message.message) ? createListMessages(message) : parsedContent}
-        {renderLinks(message.links, message.listStyleType)}
+        {/* `message.options` is an augmented version of `message.links`, so they are mutually exclusive */}
+        {renderOptions(message.options ?? message.links?.map((link) => ({ type: 'link', ...link })), message.listStyleType)}
       </React.Fragment>
     );
   }

--- a/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
+++ b/src/v3/src/components/WidgetMessageContainer/WidgetMessageContainer.tsx
@@ -46,6 +46,46 @@ const WidgetMessageContainer: FunctionComponent<{
     </Typography>
   ));
 
+  const getLinkElement = (link: WidgetMessageLink) => {
+    if (link.isLinkButton) {
+      return (
+        // @ts-expect-error error due to variant type applied, can be ignored
+        <MuiLink
+          component="button"
+          role="link"
+          onClick={(event: ClickEvent) => {
+            event.preventDefault();
+            link.onClick();
+          }}
+          // @ts-expect-error MUI variant type does not include monochrome but functions appropriately when set
+          variant={linkVariant}
+          sx={{
+            textAlign: 'start',
+            fontSize: tokens.TypographySizeBody,
+            verticalAlign: 'text-top',
+          }}
+          data-se={link.dataSe}
+        >
+          {link.label}
+        </MuiLink>
+      );
+    } if (link.url) {
+      return (
+        <Link
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          variant={linkVariant}
+        >
+          {link.label}
+        </Link>
+      );
+    }
+
+    // Custom error remediation allows admins to define a message without a URL
+    return link.label;
+  };
+
   const renderLinks = (links?: WidgetMessageLink[], listStyleType?: ListStyleType) => (links && (
     <List
       data-se="custom-links"
@@ -64,36 +104,7 @@ const WidgetMessageContainer: FunctionComponent<{
           }}
           key={link.label}
         >
-          {link.isLinkButton ? (
-            // @ts-expect-error error due to variant type applied, can be ignored
-            <MuiLink
-              component="button"
-              role="link"
-              onClick={(event: ClickEvent) => {
-                event.preventDefault();
-                link.onClick();
-              }}
-              // @ts-expect-error MUI variant type does not include monochrome but functions appropriately when set
-              variant={linkVariant}
-              sx={{
-                textAlign: 'start',
-                fontSize: tokens.TypographySizeBody,
-                verticalAlign: 'text-top',
-              }}
-              data-se={link.dataSe}
-            >
-              {link.label}
-            </MuiLink>
-          ) : (
-            <Link
-              href={link.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              variant={linkVariant}
-            >
-              {link.label}
-            </Link>
-          )}
+          {getLinkElement(link)}
         </ListItem>
       ))}
     </List>

--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -191,7 +191,9 @@ export const transformStepInputs = (
     // string (which is set in transformEnrollProfileUpdate), so we should not remove it from the payload here
     if (fieldName === 'userProfile.secondEmail') {
       return acc;
-    } else if (typeof value === 'string' && value.trim().length === 0 && optionalInputNames.has(fieldName)) {
+    }
+
+    if (typeof value === 'string' && value.trim().length === 0 && optionalInputNames.has(fieldName)) {
       acc.push(fieldName);
     }
     return acc;

--- a/src/v3/src/transformer/layout/deviceAssuranceGracePeriod/__snapshots__/transformDeviceAssuranceGracePeriod.test.ts.snap
+++ b/src/v3/src/transformer/layout/deviceAssuranceGracePeriod/__snapshots__/transformDeviceAssuranceGracePeriod.test.ts.snap
@@ -26,14 +26,14 @@ Object {
           "dataSe": "callout",
           "message": Array [
             Object {
-              "links": Array [
+              "listStyleType": "disc",
+              "options": Array [
                 Object {
-                  "isLinkButton": false,
                   "label": "idx.error.code.access_denied.device_assurance.remediation.android.upgrade_os_version",
+                  "type": "link",
                   "url": "https://okta.com/android-upgrade-os",
                 },
               ],
-              "listStyleType": "disc",
               "title": "idx.device_assurance.grace_period.warning.title.due_by_date",
             },
             Object {

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -58,33 +58,33 @@ export type WidgetMessage = Modify<IdxMessage, {
   title?: string;
   name?: string;
   description?: string;
-  links?: WidgetMessageLink[];
+  links?: MessageLink[];
+  options?: WidgetMessageOption[];
   listStyleType?: ListStyleType,
 }>;
 
 export type ListStyleType = 'circle' | 'disc' | 'square' | 'decimal';
+
+export type WidgetMessageOption = WidgetMessageLinkButton | WidgetMessageLink | WidgetMessageText;
 
 export type MessageLink = {
   label: string;
   url: string;
 };
 
-/**
- * When URL is missing from object, link will be treated as a button link
- * utilizing the onClick handler
- */
-export type WidgetMessageLink<TIsLinkButton = boolean> = TIsLinkButton extends true
-  ? {
-    isLinkButton: TIsLinkButton;
-    label: MessageLink['label'];
-    onClick: () => void;
-    dataSe: string;
-  }
-  : {
-    isLinkButton: TIsLinkButton;
-    label: MessageLink['label'];
-    url?: MessageLink['url'];
-  };
+export type WidgetMessageLinkButton = {
+  type: 'button';
+  label: MessageLink['label'];
+  onClick: () => void;
+  dataSe: string;
+};
+
+export type WidgetMessageLink = MessageLink & { type: 'link' };
+
+export type WidgetMessageText = {
+  type: 'text';
+  label: MessageLink['label'],
+};
 
 export type DeviceRemediationType = 'LOOPBACK';
 export type DeviceRemediationFallBackType = 'MESSAGE' | 'APP_LINK';

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -65,25 +65,31 @@ export type WidgetMessage = Modify<IdxMessage, {
 
 export type ListStyleType = 'circle' | 'disc' | 'square' | 'decimal';
 
-export type WidgetMessageOption = WidgetMessageLinkButton | WidgetMessageLink | WidgetMessageText;
-
 export type MessageLink = {
   label: string;
   url: string;
 };
 
-export type WidgetMessageLinkButton = {
+export type WidgetMessageOption = WidgetMessageLinkButton | WidgetMessageLink | WidgetMessageText;
+
+type BaseWidgetMessageOption = {
+  type: 'link' | 'button' | 'text';
+  label: string;
+};
+
+export type WidgetMessageLinkButton = BaseWidgetMessageOption & {
   type: 'button';
-  label: MessageLink['label'];
   onClick: () => void;
   dataSe: string;
 };
 
-export type WidgetMessageLink = MessageLink & { type: 'link' };
+export type WidgetMessageLink = BaseWidgetMessageOption & {
+  type: 'link';
+  url: string;
+};
 
-export type WidgetMessageText = {
+export type WidgetMessageText = BaseWidgetMessageOption & {
   type: 'text';
-  label: MessageLink['label'],
 };
 
 export type DeviceRemediationType = 'LOOPBACK';

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -83,7 +83,7 @@ export type WidgetMessageLink<TIsLinkButton = boolean> = TIsLinkButton extends t
   : {
     isLinkButton: TIsLinkButton;
     label: MessageLink['label'];
-    url: MessageLink['url'];
+    url?: MessageLink['url'];
   };
 
 export type DeviceRemediationType = 'LOOPBACK';

--- a/src/v3/src/util/formUtils.ts
+++ b/src/v3/src/util/formUtils.ts
@@ -30,11 +30,11 @@ import {
   DeviceRemediation,
   IWidgetContext,
   LaunchAuthenticatorButtonElement,
-  MessageLink,
   PhoneVerificationMethodType,
   RequiredKeys,
   WidgetMessage,
   WidgetMessageLink,
+  WidgetMessageOption,
   WidgetProps,
 } from '../types';
 import { idpIconMap } from './idpIconMap';
@@ -308,32 +308,31 @@ const isLoopbackDeviceRemediation = (
 ): deviceRemediation is RequiredKeys<DeviceRemediation, 'remediationType' | 'action'> => !!deviceRemediation
   && deviceRemediation.remediationType === 'LOOPBACK' && !!deviceRemediation.action;
 
-const buildEnduserRemediationWidgetMessageLink = (
-  links: MessageLink[],
+const buildEnduserRemediationWidgetMessageOption = (
+  links: WidgetMessageLink[],
   message: string,
   deviceRemediation: DeviceRemediation | undefined,
   isLinklessMessage: boolean,
-): WidgetMessageLink | undefined => {
+): WidgetMessageOption | undefined => {
   if (links?.[0]?.url) {
     return {
-      isLinkButton: false,
+      type: 'link',
       url: links[0].url,
       label: message,
     };
-  } else if (isLoopbackDeviceRemediation(deviceRemediation)) {
+  } if (isLoopbackDeviceRemediation(deviceRemediation)) {
     return {
-      isLinkButton: true,
+      type: 'button',
       label: message,
       onClick: () => {
         probeLoopbackAndExecute(deviceRemediation);
       },
       dataSe: deviceRemediation.action,
     };
-  } else if (isLinklessMessage) {
+  } if (isLinklessMessage) {
     // Custom error remediation allows admins to define a message without a URL
     return {
-      isLinkButton: false,
-      url: undefined,
+      type: 'text',
       label: message,
     };
   }
@@ -404,20 +403,20 @@ export const buildEndUserRemediationMessages = (
       if (lastIndex < 0) {
         return;
       }
-      const linkObject = buildEnduserRemediationWidgetMessageLink(
+      const optionObject = buildEnduserRemediationWidgetMessageOption(
         links,
         message,
         deviceRemediation?.value,
         isLinklessMessage,
       );
-      if (linkObject === undefined) {
+      if (optionObject === undefined) {
         return;
       }
 
-      if (resultMessageArray[lastIndex].links) {
-        resultMessageArray[lastIndex].links?.push(linkObject);
+      if (resultMessageArray[lastIndex].options) {
+        resultMessageArray[lastIndex].options?.push(optionObject);
       } else {
-        resultMessageArray[lastIndex].links = [linkObject];
+        resultMessageArray[lastIndex].options = [optionObject];
       }
       return;
     } else {

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -77,4 +77,8 @@ export default class TerminalPageObject extends BasePageObject {
   async clickADPInstallRememdiationLink() {
     await this.t.click(this.getADPInstallRemediationLink());
   }
+
+  getErrorBoxAnchorsWithText(text) {
+    return Selector('a').withText(text);
+  }
 }

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -36,6 +36,9 @@ const ignoredMocks = [
   'enroll-profile-new-custom-labels.json', // custom message/label
   'terminal-okta-verify-enrollment-android-device.json', // Automatic redirect, in app logic handles this view, no english leak.
   'error-429-api-limit-exceeded.json', // Gen3 has english leak on UI. But in real world this response can be received on polling only, no english leak in this case.
+  'end-user-remediation-custom-message-custom-url.json', // custom error remediation message
+  'end-user-remediation-custom-message-multiple-options.json', // custom error remediation message
+  'end-user-remediation-custom-message-no-url.json' // custom error remediation message
 ];
 if (userVariables.gen3) {
   // TODO: Re-enable in OKTA-654489

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -21,6 +21,10 @@ import endUserRemediationOneOption from '../../../playground/mocks/data/idp/idx/
 import endUserRemediationMultipleOptions from '../../../playground/mocks/data/idp/idx/end-user-remediation-multiple-options.json';
 import endUserRemediationMultipleOptionsWithCustomHelpUrl from '../../../playground/mocks/data/idp/idx/end-user-remediation-multiple-options-with-custom-help-url.json';
 import endUserRemediationNoOptions from '../../../playground/mocks/data/idp/idx/end-user-remediation-no-options.json';
+import endUserRemediationMultipleOptionsWithCustomRemediation from '../../../playground/mocks/data/idp/idx/end-user-remediation-custom-message-multiple-options.json';
+import endUserRemediationCustomMessageCustomUrl from '../../../playground/mocks/data/idp/idx/end-user-remediation-custom-message-custom-url.json';
+import endUserRemediationCustomMessageNoUrl from '../../../playground/mocks/data/idp/idx/end-user-remediation-custom-message-no-url.json';
+import endUserRemediationDefaultMessageCustomUrl from '../../../playground/mocks/data/idp/idx/end-user-remediation-default-message-custom-url.json';
 import { within } from '@testing-library/testcafe';
 
 const terminalTransferredEmailMock = RequestMock()
@@ -94,6 +98,22 @@ const endUserRemediationMultipleOptionsWithCustomHelpUrlMock = RequestMock()
 const endUserRemediationNoOptionsMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(endUserRemediationNoOptions);  
+
+const endUserRemediationMultipleOptionsWithCustomRemediationMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(endUserRemediationMultipleOptionsWithCustomRemediation);
+
+const endUserRemediationCustomMessageCustomUrlMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(endUserRemediationCustomMessageCustomUrl);
+
+const endUserRemediationCustomMessageNoUrlMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(endUserRemediationCustomMessageNoUrl);
+
+const endUserRemediationDefaultMessageCustomUrlMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(endUserRemediationDefaultMessageCustomUrl);
 
 fixture('Terminal view');
 
@@ -300,5 +320,64 @@ test.requestHooks(endUserRemediationNoOptionsMock)('should render end user remed
   await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, make the following updates. Then, access the app again.').exists).eql(false);
 
   await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('follow the instructions on your organization\'s help page').find('a[href="https://okta1.com/custom-help-me"]').exists).eql(true);
+  await t.expect(terminalViewPage.form.getAnchorsWithBlankTargetsWithoutRelevantAttributes().exists).eql(false);
+});
+
+test.requestHooks(endUserRemediationMultipleOptionsWithCustomRemediationMock)('should render end user remediation when there are multiple options with custom messages and URLs', async t => {
+  const terminalViewPage = await setup(t);
+  await checkA11y(t);
+
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('Your device doesn\'t meet the security requirements').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, pick an option and make the updates. Then, access the app again.').exists).eql(true);
+
+  await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://myremediationurl.com/docs').withExactText('It\'s our company policy that you upgrade your Android OS').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-biometric-lock').withExactText('Enable lock screen and biometrics').exists).eql(true);
+
+  await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-lock-screen').withExactText('Enable lock screen').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('It\'s our company policy that your Android device cannot be rooted').exists).eql(true);
+
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('follow the instructions on the help page').find('a[href="https://okta.com/help"]').exists).eql(true);
+  await t.expect(terminalViewPage.form.getAnchorsWithBlankTargetsWithoutRelevantAttributes().exists).eql(false);
+});
+
+test.requestHooks(endUserRemediationCustomMessageCustomUrlMock)('should render end user remediation when there is an option with a custom message and custom URL', async t => {
+  const terminalViewPage = await setup(t);
+  await checkA11y(t);
+
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('Your device doesn\'t meet the security requirements').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, make the following updates. Then, access the app again.').exists).eql(true);
+
+  await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://myremediationurl.com/docs').withExactText('It\'s our company policy that you upgrade your Android OS').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-biometric-lock').withExactText('Enable lock screen and biometrics').exists).eql(true);
+
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('follow the instructions on the help page').find('a[href="https://okta.com/help"]').exists).eql(true);
+  await t.expect(terminalViewPage.form.getAnchorsWithBlankTargetsWithoutRelevantAttributes().exists).eql(false);
+});
+
+test.requestHooks(endUserRemediationCustomMessageNoUrlMock)('should render end user remediation when there is an option with a custom message and no URL', async t => {
+  const terminalViewPage = await setup(t);
+  await checkA11y(t);
+
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('Your device doesn\'t meet the security requirements').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, make the following updates. Then, access the app again.').exists).eql(true);
+
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('It\'s our company policy that your Android device cannot be rooted').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-biometric-lock').withExactText('Enable lock screen and biometrics').exists).eql(true);
+
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('follow the instructions on the help page').find('a[href="https://okta.com/help"]').exists).eql(true);
+  await t.expect(terminalViewPage.form.getAnchorsWithBlankTargetsWithoutRelevantAttributes().exists).eql(false);
+});
+
+test.requestHooks(endUserRemediationDefaultMessageCustomUrlMock)('should render end user remediation when there is an option with a default message and custom URL', async t => {
+  const terminalViewPage = await setup(t);
+  await checkA11y(t);
+
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('Your device doesn\'t meet the security requirements').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, make the following updates. Then, access the app again.').exists).eql(true);
+
+  await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://myremediationurl.com/docs').withExactText('Update to Android 100').exists).eql(true);
+  await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-biometric-lock').withExactText('Enable lock screen and biometrics').exists).eql(true);
+
+  await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('follow the instructions on the help page').find('a[href="https://okta.com/help"]').exists).eql(true);
   await t.expect(terminalViewPage.form.getAnchorsWithBlankTargetsWithoutRelevantAttributes().exists).eql(false);
 });

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -334,6 +334,7 @@ test.requestHooks(endUserRemediationMultipleOptionsWithCustomRemediationMock)('s
   await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-biometric-lock').withExactText('Enable lock screen and biometrics').exists).eql(true);
 
   await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-lock-screen').withExactText('Enable lock screen').exists).eql(true);
+  await t.expect(terminalViewPage.getErrorBoxAnchorsWithText('It\'s our company policy that your Android device cannot be rooted').exists).eql(false);
   await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('It\'s our company policy that your Android device cannot be rooted').exists).eql(true);
 
   await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('follow the instructions on the help page').find('a[href="https://okta.com/help"]').exists).eql(true);
@@ -361,6 +362,7 @@ test.requestHooks(endUserRemediationCustomMessageNoUrlMock)('should render end u
   await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('Your device doesn\'t meet the security requirements').exists).eql(true);
   await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('To sign in, make the following updates. Then, access the app again.').exists).eql(true);
 
+  await t.expect(terminalViewPage.getErrorBoxAnchorsWithText('It\'s our company policy that your Android device cannot be rooted').exists).eql(false);
   await t.expect(terminalViewPage.form.getErrorBoxCallout().withText('It\'s our company policy that your Android device cannot be rooted').exists).eql(true);
   await t.expect(terminalViewPage.form.getErrorBoxAnchor('https://okta.com/android-biometric-lock').withExactText('Enable lock screen and biometrics').exists).eql(true);
 


### PR DESCRIPTION
## Description:
- Adds IDX mocks and extends terminal TestCafe spec for Device Assurance Custom Error Remediation (an extension of the existing end user remediation feature)
    - Tech design for feature [here](https://oktawiki.atlassian.net/wiki/x/UIfEv) 
- Minimal source code changes needed for this feature since it just allows admins to customize the text and link for the end user remediation options
    - Updated gen3 code specifically since it was not properly rendering remediation options w/o a link (which is now possible w/ this feature) within the bullet list


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-839975](https://oktainc.atlassian.net/browse/OKTA-839975)

### Reviewers:

### Screenshot/Video:
#### Gen2 Custom Message w/ Custom Link and Custom Message w/ No Link Demo
https://github.com/user-attachments/assets/a1104875-3986-4e6d-9a9a-f38286a3355e

#### Gen3 Custom Message w/ Custom Link and Custom Message w/ No Link Demo
https://github.com/user-attachments/assets/5231072d-86d3-47dc-ba0c-5b53cb36615b


### Downstream Monolith Build:



