### PR TITLE
Fix: Gen3 - Hide back to signin link in IDV based on IDX response

### DIFF
--- a/src/v3/src/transformer/layout/idp/__snapshots__/transformIdvIdpAuthenticator.test.ts.snap
+++ b/src/v3/src/transformer/layout/idp/__snapshots__/transformIdvIdpAuthenticator.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IDV IDP Authenticator transformer Tests should add correct title, descriptions, and button 1`] = `
+exports[`IDV IDP Authenticator transformer Tests should add back to signin link 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -49,6 +49,68 @@ Object {
           "step": "cancel",
         },
         "type": "Link",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.idv.idp.desc.termsOfUse",
+          "variant": "subtitle1",
+        },
+        "type": "Description",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.idv.idp.desc.agreement",
+          "variant": "subtitle1",
+        },
+        "type": "Description",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`IDV IDP Authenticator transformer Tests should add correct title, descriptions, and button 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.idv.idp.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "contentType": "subtitle",
+        "options": Object {
+          "content": "oie.idv.idp.desc",
+        },
+        "type": "Description",
+      },
+      Object {
+        "label": "oie.optional.authenticator.button.title",
+        "options": Object {
+          "isActionStep": false,
+          "onClick": [Function],
+          "step": "redirect-idverify",
+          "type": "button",
+        },
+        "type": "Button",
+      },
+      Object {
+        "type": "Divider",
       },
       Object {
         "contentType": "subtitle",

--- a/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.test.ts
+++ b/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.test.ts
@@ -57,6 +57,4 @@ describe('IDV IDP Authenticator transformer Tests', () => {
     expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
   });
-
-
 });

--- a/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.test.ts
+++ b/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.test.ts
@@ -23,7 +23,6 @@ import {
   LinkElement,
   TitleElement,
 } from '../../../types';
-
 import { transformIdvIdpAuthenticator } from './transformIdvIdpAuthenticator';
 
 describe('IDV IDP Authenticator transformer Tests', () => {
@@ -62,9 +61,9 @@ describe('IDV IDP Authenticator transformer Tests', () => {
       'oie.optional.authenticator.button.title',
     );
     expect((updatedFormBag.uischema.elements[3] as DividerElement).type)
-    .toBe('Divider');
+      .toBe('Divider');
     expect((updatedFormBag.uischema.elements[4] as LinkElement).type)
-    .not.toBe('Link');
+      .not.toBe('Link');
     expect(
       (updatedFormBag.uischema.elements[4] as DescriptionElement).options
         ?.content,
@@ -97,9 +96,9 @@ describe('IDV IDP Authenticator transformer Tests', () => {
       'oie.optional.authenticator.button.title',
     );
     expect((updatedFormBag.uischema.elements[3] as DividerElement).type)
-    .toBe('Divider');
-    expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label) 
-    .toBe('goback'); 
+      .toBe('Divider');
+    expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)
+      .toBe('goback');
     expect(
       (updatedFormBag.uischema.elements[5] as DescriptionElement).options
         ?.content,

--- a/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.test.ts
+++ b/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.test.ts
@@ -41,7 +41,22 @@ describe('IDV IDP Authenticator transformer Tests', () => {
       transaction,
       widgetProps: {},
     });
+    expect(updatedFormBag.uischema.elements.length).toBe(6);
+    expect(updatedFormBag).toMatchSnapshot();
+  });
+
+  it('should add back to signin link', () => {
+    transaction.availableSteps = [
+      { name: 'cancel' },
+    ];
+    const updatedFormBag = transformIdvIdpAuthenticator({
+      formBag,
+      transaction,
+      widgetProps: {},
+    });
     expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
   });
+
+
 });

--- a/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.test.ts
+++ b/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.test.ts
@@ -16,6 +16,14 @@ import {
   getStubTransactionWithNextStep,
 } from 'src/mocks/utils/utils';
 
+import {
+  ButtonElement,
+  DescriptionElement,
+  DividerElement,
+  LinkElement,
+  TitleElement,
+} from '../../../types';
+
 import { transformIdvIdpAuthenticator } from './transformIdvIdpAuthenticator';
 
 describe('IDV IDP Authenticator transformer Tests', () => {
@@ -43,6 +51,28 @@ describe('IDV IDP Authenticator transformer Tests', () => {
     });
     expect(updatedFormBag.uischema.elements.length).toBe(6);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(
+      (updatedFormBag.uischema.elements[0] as TitleElement).options?.content,
+    ).toBe('oie.idv.idp.title');
+    expect(
+      (updatedFormBag.uischema.elements[1] as DescriptionElement).options
+        ?.content,
+    ).toBe('oie.idv.idp.desc');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe(
+      'oie.optional.authenticator.button.title',
+    );
+    expect((updatedFormBag.uischema.elements[3] as DividerElement).type)
+    .toBe('Divider');
+    expect((updatedFormBag.uischema.elements[4] as LinkElement).type)
+    .not.toBe('Link');
+    expect(
+      (updatedFormBag.uischema.elements[4] as DescriptionElement).options
+        ?.content,
+    ).toBe('oie.idv.idp.desc.termsOfUse');
+    expect(
+      (updatedFormBag.uischema.elements[5] as DescriptionElement).options
+        ?.content,
+    ).toBe('oie.idv.idp.desc.agreement');
   });
 
   it('should add back to signin link', () => {
@@ -56,5 +86,27 @@ describe('IDV IDP Authenticator transformer Tests', () => {
     });
     expect(updatedFormBag.uischema.elements.length).toBe(7);
     expect(updatedFormBag).toMatchSnapshot();
+    expect(
+      (updatedFormBag.uischema.elements[0] as TitleElement).options?.content,
+    ).toBe('oie.idv.idp.title');
+    expect(
+      (updatedFormBag.uischema.elements[1] as DescriptionElement).options
+        ?.content,
+    ).toBe('oie.idv.idp.desc');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe(
+      'oie.optional.authenticator.button.title',
+    );
+    expect((updatedFormBag.uischema.elements[3] as DividerElement).type)
+    .toBe('Divider');
+    expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label) 
+    .toBe('goback'); 
+    expect(
+      (updatedFormBag.uischema.elements[5] as DescriptionElement).options
+        ?.content,
+    ).toBe('oie.idv.idp.desc.termsOfUse');
+    expect(
+      (updatedFormBag.uischema.elements[6] as DescriptionElement).options
+        ?.content,
+    ).toBe('oie.idv.idp.desc.agreement');
   });
 });

--- a/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.ts
+++ b/src/v3/src/transformer/layout/idp/transformIdvIdpAuthenticator.ts
@@ -104,8 +104,8 @@ export const transformIdvIdpAuthenticator: IdxStepTransformer = ({
     submitButton,
     divider,
   ];
-
-  if (shouldShowCancelLink(widgetProps?.features)) {
+  const cancelStep = transaction.availableSteps?.find(({ name }) => name === 'cancel');
+  if (shouldShowCancelLink(widgetProps?.features) && cancelStep) {
     const cancelLink: LinkElement = {
       type: 'Link',
       contentType: 'footer',


### PR DESCRIPTION
## Description:

Hide cancel/back to signin button if `cancel` object is missing in IDX response. similar to V2. Only for IDV View.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-863251](https://oktainc.atlassian.net/browse/OKTA-863251)

### Reviewers:

### Screenshot/Video:

<img width="492" alt="Screenshot 2025-02-04 at 2 16 37 PM" src="https://github.com/user-attachments/assets/09ef7969-4b4f-454a-828f-6bda3ca4ce5d" />

### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=bd4f09c66076c2bae466e21cc1154ac970441c24&tab=main

