### PR TITLE
fix(gen3): a11y contrast fix for Okta Verify & custom push screen

### DIFF
--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -848,6 +848,7 @@ oie.okta_verify.totp.title = 》Éñţéŕ å çöðé ⾼ئ䀕ヸ€홝한Ӝฐ
 oie.okta_verify.totp.enterCodeText = 》Éñţéŕ çöðé ƒŕöɱ Öķţå Ṽéŕîƒý åþþ ฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.okta_verify.push.title = 》Ĝéţ å þûšĥ ñöţîƒîçåţîöñ 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.okta_verify.push.sent = 》Þûšĥ ñöţîƒîçåţîöñ šéñţ Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+oie.okta_verify.push.sent.respond_to_continue = 》Ŕéšþöñð öñ ýöûŕ ɱöƀîļé ðéṽîçé ţö çöñţîñûé· ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.okta_verify.push.resend = 》Ŕéšéñð þûšĥ ñöţîƒîçåţîöñ 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.okta_verify.sendPushButton = 》Šéñð þûšĥ ئ䀕ヸ€홝한Ӝฐโ《
 oie.okta_verify.signed_nonce.label = 》Ûšé Öķţå ƑåšţÞåšš 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《

--- a/packages/@okta/i18n/src/properties/login_ok_SK.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_SK.properties
@@ -848,6 +848,7 @@ oie.okta_verify.totp.title = [[okta-signin-widget:login: oie.okta_verify.totp.ti
 oie.okta_verify.totp.enterCodeText = [[okta-signin-widget:login: oie.okta_verify.totp.enterCodeText]]
 oie.okta_verify.push.title = [[okta-signin-widget:login: oie.okta_verify.push.title]]
 oie.okta_verify.push.sent = [[okta-signin-widget:login: oie.okta_verify.push.sent]]
+oie.okta_verify.push.sent.respond_to_continue = [[okta-signin-widget:login: oie.okta_verify.push.sent.respond_to_continue]]
 oie.okta_verify.push.resend = [[okta-signin-widget:login: oie.okta_verify.push.resend]]
 oie.okta_verify.sendPushButton = [[okta-signin-widget:login: oie.okta_verify.sendPushButton]]
 oie.okta_verify.signed_nonce.label = [[okta-signin-widget:login: oie.okta_verify.signed_nonce.label]]

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyCustomAppChallengePoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyCustomAppChallengePoll.test.ts.snap
@@ -18,9 +18,15 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "oie.verify.custom_app.title",
+          "content": "oie.custom_app.push.sent",
         },
         "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "noMargin": true,
@@ -28,13 +34,6 @@ Object {
           "content": "oie.custom_app.push.warning",
         },
         "type": "Reminder",
-      },
-      Object {
-        "label": "oie.custom_app.push.sent",
-        "options": Object {
-          "disabled": true,
-        },
-        "type": "Button",
       },
       Object {
         "contentType": "footer",
@@ -69,9 +68,15 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "oie.verify.custom_app.title",
+          "content": "oie.custom_app.push.sent",
         },
         "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "noMargin": true,
@@ -79,13 +84,6 @@ Object {
           "content": "oie.custom_app.push.warning",
         },
         "type": "Reminder",
-      },
-      Object {
-        "label": "oie.custom_app.push.sent",
-        "options": Object {
-          "disabled": true,
-        },
-        "type": "Button",
       },
       Object {
         "contentType": "footer",
@@ -129,9 +127,15 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "oie.verify.custom_app.title",
+          "content": "oie.custom_app.push.sent",
         },
         "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "noMargin": true,
@@ -139,13 +143,6 @@ Object {
           "content": "oie.custom_app.push.warning",
         },
         "type": "Reminder",
-      },
-      Object {
-        "label": "oie.custom_app.push.sent",
-        "options": Object {
-          "disabled": true,
-        },
-        "type": "Button",
       },
       Object {
         "contentType": "footer",
@@ -382,9 +379,15 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "oie.okta_verify.push.title",
+          "content": "oie.okta_verify.push.sent",
         },
         "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "noMargin": true,
@@ -392,13 +395,6 @@ Object {
           "content": "oktaverify.warning",
         },
         "type": "Reminder",
-      },
-      Object {
-        "label": "oie.okta_verify.push.sent",
-        "options": Object {
-          "disabled": true,
-        },
-        "type": "Button",
       },
       Object {
         "contentType": "footer",
@@ -433,9 +429,15 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
-          "content": "oie.okta_verify.push.title",
+          "content": "oie.okta_verify.push.sent",
         },
         "type": "Title",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "noMargin": true,
@@ -443,13 +445,6 @@ Object {
           "content": "oktaverify.warning",
         },
         "type": "Reminder",
-      },
-      Object {
-        "label": "oie.okta_verify.push.sent",
-        "options": Object {
-          "disabled": true,
-        },
-        "type": "Button",
       },
       Object {
         "contentType": "footer",

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.test.ts
@@ -13,7 +13,6 @@
 import { IdxAuthenticator } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
-  ButtonElement,
   DescriptionElement,
   ImageWithTextElement,
   LinkElement,
@@ -139,7 +138,7 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
       .toBe('oie.okta_verify.push.sent');
     expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
       .toBe('oie.okta_verify.push.sent.respond_to_continue');
-      expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
       .toBe('oktaverify.warning');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('oie.verification.switch.authenticator');

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.test.ts
@@ -89,13 +89,11 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.okta_verify.push.title');
-    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
-      .toBe('oktaverify.warning');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
       .toBe('oie.okta_verify.push.sent');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.disabled)
-      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
+    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+      .toBe('oktaverify.warning');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('goback');
   });
@@ -115,17 +113,14 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
       formBag,
       widgetProps,
     });
-
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.verify.custom_app.title');
-    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
-      .toBe('oie.custom_app.push.warning');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
       .toBe('oie.custom_app.push.sent');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.disabled)
-      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
+    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+      .toBe('oie.custom_app.push.warning');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('goback');
   });
@@ -141,11 +136,11 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.okta_verify.push.title');
-    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
-      .toBe('oktaverify.warning');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
       .toBe('oie.okta_verify.push.sent');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
+      expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+      .toBe('oktaverify.warning');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('oie.verification.switch.authenticator');
     expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)
@@ -358,13 +353,11 @@ describe('Transform Custom App Challenge Poll Tests', () => {
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.verify.custom_app.title');
-    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
-      .toBe('oie.custom_app.push.warning');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
       .toBe('oie.custom_app.push.sent');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options.disabled)
-      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
+    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+      .toBe('oie.custom_app.push.warning');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('goback');
   });
@@ -380,11 +373,11 @@ describe('Transform Custom App Challenge Poll Tests', () => {
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
-      .toBe('oie.verify.custom_app.title');
-    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
-      .toBe('oie.custom_app.push.warning');
-    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label)
       .toBe('oie.custom_app.push.sent');
+    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
+    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+      .toBe('oie.custom_app.push.warning');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('oie.verification.switch.authenticator');
     expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.ts
@@ -121,20 +121,19 @@ export const transformOktaVerifyCustomAppChallengePoll: IdxStepTransformer = (op
         },
       } as ReminderElement);
       uischema.elements.unshift({
+        type: 'Description',
+        options: {
+          content: loc('oie.okta_verify.push.sent.respond_to_continue', 'login')
+        },
+      } as DescriptionElement);
+      uischema.elements.unshift({
         type: 'Title',
         options: {
           content: isOV
-            ? loc('oie.okta_verify.push.title', 'login')
-            : loc('oie.verify.custom_app.title', 'login', [getDisplayName(transaction)]),
+            ? loc('oie.okta_verify.push.sent', 'login')
+            : loc('oie.custom_app.push.sent', 'login'),
         },
       } as TitleElement);
-      uischema.elements.push({
-        type: 'Button',
-        label: isOV
-          ? loc('oie.okta_verify.push.sent', 'login')
-          : loc('oie.custom_app.push.sent', 'login'),
-        options: { disabled: true },
-      } as ButtonElement);
     }
 
     // Since this transformer is shared, we have to add applicable buttons manually

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.ts
@@ -15,7 +15,6 @@ import { NextStep } from '@okta/okta-auth-js';
 import { PhoneIcon } from '../../components/Images';
 import { AUTHENTICATOR_KEY, CHALLENGE_METHOD, IDX_STEP } from '../../constants';
 import {
-  ButtonElement,
   DescriptionElement,
   FieldElement,
   IdxStepTransformer,
@@ -123,7 +122,7 @@ export const transformOktaVerifyCustomAppChallengePoll: IdxStepTransformer = (op
       uischema.elements.unshift({
         type: 'Description',
         options: {
-          content: loc('oie.okta_verify.push.sent.respond_to_continue', 'login')
+          content: loc('oie.okta_verify.push.sent.respond_to_continue', 'login'),
         },
       } as DescriptionElement);
       uischema.elements.unshift({

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -126,8 +126,23 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                         data-se="o-form-head"
                         tabindex="-1"
                       >
-                        Get a push notification
+                        Push notification sent
                       </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 emotion-22"
+                        data-se="o-form-explain"
+                        tabindex="-1"
+                      >
+                        Respond on your mobile device to continue.
+                      </p>
                     </div>
                   </div>
                   <div
@@ -137,10 +152,10 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                     class="MuiBox-root emotion-11"
                   >
                     <fieldset
-                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-22"
+                      class="MuiFormControl-root MuiFormControl-marginNormal emotion-25"
                     >
                       <legend
-                        class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-23"
+                        class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-26"
                       >
                         
                          
@@ -148,18 +163,18 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                       </legend>
                       <div
                         aria-labelledby="autoChallenge-label"
-                        class="MuiFormGroup-root emotion-24"
+                        class="MuiFormGroup-root emotion-27"
                         id="autoChallenge"
                       >
                         <label
-                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-25"
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-28"
                           id="autoChallenge-checkbox"
                         >
                           <span
-                            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-26"
+                            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-29"
                           >
                             <input
-                              class="PrivateSwitchBase-input emotion-27"
+                              class="PrivateSwitchBase-input emotion-30"
                               data-indeterminate="false"
                               data-se="autoChallenge"
                               name="autoChallenge"
@@ -167,7 +182,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                             />
                           </span>
                           <span
-                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-28"
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-22"
                           >
                             Send push automatically
                           </span>
@@ -179,19 +194,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-30"
-                      disabled=""
-                      tabindex="-1"
-                      type="button"
-                    >
-                      Push notification sent
-                    </button>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-11"
-                  >
-                    <button
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                       data-se="switchAuthenticator"
                       role="link"
                     >
@@ -202,7 +205,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                     class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                       data-se="cancel"
                       role="link"
                     >

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerifyPushOnly_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerifyPushOnly_spec.js
@@ -74,7 +74,7 @@ test.requestHooks(requestLogger, mockChallengeOVSendPush)(
     if(userVariables.gen3) {
       await t.expect(challengeFactorPage.getFormTitle()).eql('Push notification sent');
     } else {
-      await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with Custom Push');
+      await t.expect(challengeFactorPage.getFormTitle()).eql('Get a push notification');
     }
 
     await t.expect(requestLogger.count(() => true)).eql(2);

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerifyPushOnly_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerifyPushOnly_spec.js
@@ -71,8 +71,11 @@ test.requestHooks(requestLogger, mockChallengeOVSendPush)(
 
     challengeOktaVerifyPushPageObject.clickSendPushButton();
     const challengeFactorPage = new ChallengeFactorPageObject(t);
-    await t.expect(challengeFactorPage.getFormTitle()).eql('Push notification sent');
-    await t.expect(challengeFactorPage.getFormSubtitle()).eql('Respond on your mobile device to continue.');
+    if(userVariables.gen3) {
+      await t.expect(challengeFactorPage.getFormTitle()).eql('Push notification sent');
+    } else {
+      await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with Custom Push');
+    }
 
     await t.expect(requestLogger.count(() => true)).eql(2);
     const req1 = requestLogger.requests[0].request;

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerifyPushOnly_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerifyPushOnly_spec.js
@@ -71,7 +71,8 @@ test.requestHooks(requestLogger, mockChallengeOVSendPush)(
 
     challengeOktaVerifyPushPageObject.clickSendPushButton();
     const challengeFactorPage = new ChallengeFactorPageObject(t);
-    await t.expect(challengeFactorPage.getFormTitle()).eql('Get a push notification');
+    await t.expect(challengeFactorPage.getFormTitle()).eql('Push notification sent');
+    await t.expect(challengeFactorPage.getFormSubtitle()).eql('Respond on your mobile device to continue.');
 
     await t.expect(requestLogger.count(() => true)).eql(2);
     const req1 = requestLogger.requests[0].request;

--- a/test/testcafe/spec/ChallengeCustomAppPush_spec.js
+++ b/test/testcafe/spec/ChallengeCustomAppPush_spec.js
@@ -128,16 +128,19 @@ test
     });
 
     const pageTitle = challengeCustomAppPushPageObject.getFormTitle();
+    const pageSubtitle = challengeCustomAppPushPageObject.getFormSubtitle();
     const pushBtn = challengeCustomAppPushPageObject.getPushButton();
     const a11ySpan = challengeCustomAppPushPageObject.getA11ySpan();
-    await t.expect(pushBtn.textContent).contains('Push notification sent');
     // no a11y span in gen 3
     if (!userVariables.gen3) {
+      await t.expect(pushBtn.textContent).contains('Push notification sent');
       await t.expect(a11ySpan.textContent).contains('Push notification sent');
+      await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true);
+      await t.expect(pageTitle).contains('Verify with Custom Push');
+    } else {
+      await t.expect(pageTitle).contains('Push notification sent');
+      await t.expect(pageSubtitle).contains('Respond on your mobile device to continue.');
     }
-    await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true);
-
-    await t.expect(pageTitle).contains('Verify with Custom Push');
 
     // Verify links
     await t.expect(await challengeCustomAppPushPageObject.verifyWithSomethingElseLinkExists()).ok();
@@ -158,16 +161,22 @@ test
     });
 
     const pageTitle = challengeCustomAppPushPageObject.getFormTitle();
+    const pageSubtitle = challengeCustomAppPushPageObject.getFormSubtitle();
     const pushBtn = challengeCustomAppPushPageObject.getPushButton();
     const a11ySpan = challengeCustomAppPushPageObject.getA11ySpan();
     const logoSelector = challengeCustomAppPushPageObject.getBeaconSelector();
     const logoBgImage = challengeCustomAppPushPageObject.getBeaconBgImage();
-    await t.expect(pushBtn.textContent).contains('Push notification sent');
     // no a11y span in gen 3
     if (!userVariables.gen3) {
+      await t.expect(pushBtn.textContent).contains('Push notification sent');
       await t.expect(a11ySpan.textContent).contains('Push notification sent');
+      await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true);
+      await t.expect(pageTitle).contains('Verify with Custom Push Authenticator');
+    } else {
+      await t.expect(pageTitle).contains('Push notification sent');
+      await t.expect(pageSubtitle).contains('Respond on your mobile device to continue.');
     }
-    await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true);
+    
     await t.expect(logoSelector).contains('custom-app-logo');
     // gen 3 uses img element with src attribute while gen 2 uses background-image style prop
     if(userVariables.gen3) {
@@ -176,7 +185,6 @@ test
       await t.expect(logoBgImage).match(/^url\(".*\/img\/icons\/mfa\/customPushLogo\.svg"\)$/);
     }
 
-    await t.expect(pageTitle).contains('Verify with Custom Push Authenticator');
     await t.expect(await challengeCustomAppPushPageObject.autoChallengeInputExists()).eql(true);
     await t.expect(challengeCustomAppPushPageObject.isAutoChallengeChecked()).ok();
 
@@ -201,16 +209,21 @@ test
     
     // all UI elements should be present except the checkbox
     const pageTitle = challengeCustomAppPushPageObject.getFormTitle();
+    const pageSubtitle = challengeCustomAppPushPageObject.getFormSubtitle();
     const pushBtn = challengeCustomAppPushPageObject.getPushButton();
     const a11ySpan = challengeCustomAppPushPageObject.getA11ySpan();
     const logoSelector = challengeCustomAppPushPageObject.getBeaconSelector();
     const logoBgImage = challengeCustomAppPushPageObject.getBeaconBgImage();
-    await t.expect(pushBtn.textContent).contains('Push notification sent');
     // no a11y span in gen 3
     if (!userVariables.gen3) {
+      await t.expect(pushBtn.textContent).contains('Push notification sent');
       await t.expect(a11ySpan.textContent).contains('Push notification sent');
+      await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true);
+      await t.expect(pageTitle).contains('Verify with Custom Push');
+    } else {
+      await t.expect(pageTitle).contains('Push notification sent');
+      await t.expect(pageSubtitle).contains('Respond on your mobile device to continue.');
     }
-    await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true);
     await t.expect(logoSelector).contains('custom-app-logo');
     // gen 3 uses img element with src attribute while gen 2 uses background-image style prop
     if(userVariables.gen3) {
@@ -218,7 +231,6 @@ test
     } else {
       await t.expect(logoBgImage).match(/^url\(".*\/img\/icons\/mfa\/customPushLogo\.svg"\)$/);
     }
-    await t.expect(pageTitle).contains('Verify with Custom Push');
 
     // Verify links
     await t.expect(await challengeCustomAppPushPageObject.verifyWithSomethingElseLinkExists()).ok();
@@ -242,16 +254,21 @@ test
     });
 
     const pageTitle = challengeCustomAppPushPageObject.getFormTitle();
+    const pageSubtitle = challengeCustomAppPushPageObject.getFormSubtitle();
     const pushBtn = challengeCustomAppPushPageObject.getPushButton();
     const a11ySpan = challengeCustomAppPushPageObject.getA11ySpan();
     const logoSelector = challengeCustomAppPushPageObject.getBeaconSelector();
     const logoBgImage = challengeCustomAppPushPageObject.getBeaconBgImage();
-    await t.expect(pushBtn.textContent).contains('Push notification sent');
     // no a11y span in gen 3
     if (!userVariables.gen3) {
+      await t.expect(pushBtn.textContent).contains('Push notification sent');
       await t.expect(a11ySpan.textContent).contains('Push notification sent');
+      await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true);
+      await t.expect(pageTitle).contains('Verify with Custom Push');
+    } else {
+      await t.expect(pageTitle).contains('Push notification sent');
+      await t.expect(pageSubtitle).contains('Respond on your mobile device to continue.');
     }
-    await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true );
     await t.expect(logoSelector).contains('custom-app-logo');
     // gen 3 uses img element with src attribute while gen 2 uses background-image style prop
     if(userVariables.gen3) {
@@ -260,7 +277,6 @@ test
       await t.expect(logoBgImage).match(/^url\(".*\/img\/icons\/mfa\/customPushLogo\.svg"\)$/);
       await t.expect(logoSelector).contains('mfa-custom-app');
     }
-    await t.expect(pageTitle).contains('Verify with Custom Push');
     await t.expect(await challengeCustomAppPushPageObject.autoChallengeInputExists()).notOk();
 
     // Verify links
@@ -278,17 +294,21 @@ test
     
     // all UI elements should be present except the checkbox
     const pageTitle = challengeCustomAppPushPageObject.getFormTitle();
+    const pageSubtitle = challengeCustomAppPushPageObject.getFormSubtitle();
     const pushBtn = challengeCustomAppPushPageObject.getPushButton();
     const a11ySpan = challengeCustomAppPushPageObject.getA11ySpan();
     const logoSelector = challengeCustomAppPushPageObject.getBeaconSelector();
-    await t.expect(pushBtn.textContent).contains('Push notification sent');
     // no a11y span in gen 3
     if (!userVariables.gen3) {
+      await t.expect(pushBtn.textContent).contains('Push notification sent');
       await t.expect(a11ySpan.textContent).contains('Push notification sent');
+      await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true);
+      await t.expect(pageTitle).contains('Verify with Custom Push');
+    } else {
+      await t.expect(pageTitle).contains('Push notification sent');
+      await t.expect(pageSubtitle).contains('Respond on your mobile device to continue.');
     }
-    await t.expect(challengeCustomAppPushPageObject.isPushButtonDisabled()).eql(true);
     await t.expect(logoSelector).contains('custom-app-logo');
-    await t.expect(pageTitle).contains('Verify with Custom Push');
 
     // Verify links
     await t.expect(await challengeCustomAppPushPageObject.verifyWithSomethingElseLinkExists()).ok();

--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -70,18 +70,22 @@ test
     });
 
     const pageTitle = challengeOktaVerifyPushPageObject.getFormTitle();
+    const pageSubtitle = challengeOktaVerifyPushPageObject.getFormSubtitle();
     const pushBtn = challengeOktaVerifyPushPageObject.getPushButton();
     const a11ySpan = challengeOktaVerifyPushPageObject.getA11ySpan();
     const logoSelector = challengeOktaVerifyPushPageObject.getBeaconSelector();
-    await t.expect(pushBtn.textContent).contains('Push notification sent');
     if (!userVariables.gen3) {
+      await t.expect(pushBtn.textContent).contains('Push notification sent');
       await t.expect(a11ySpan.textContent).contains('Push notification sent');
+      await t.expect(await challengeOktaVerifyPushPageObject.isPushButtonDisabled()).ok();
+      await t.expect(pageTitle).contains('Get a push notification');
+    } else {
+      await t.expect(pageTitle).contains('Push notification sent');
+      await t.expect(pageSubtitle).contains('Respond on your mobile device to continue.');
     }
 
-    await t.expect(await challengeOktaVerifyPushPageObject.isPushButtonDisabled()).ok();
     await t.expect(logoSelector).contains('mfa-okta-verify');
     await t.expect(logoSelector).notContains('custom-app-logo');
-    await t.expect(pageTitle).contains('Get a push notification');
     await t.expect(await challengeOktaVerifyPushPageObject.autoChallengeInputExists()).notOk();
 
     // Verify links
@@ -102,17 +106,21 @@ test
     });
 
     const pageTitle = challengeOktaVerifyPushPageObject.getFormTitle();
+    const pageSubtitle = challengeOktaVerifyPushPageObject.getFormSubtitle();
     const pushBtn = challengeOktaVerifyPushPageObject.getPushButton();
     const a11ySpan = challengeOktaVerifyPushPageObject.getA11ySpan();
     const checkbox = challengeOktaVerifyPushPageObject.getAutoChallengeCheckbox();
     const checkboxLabelText = challengeOktaVerifyPushPageObject.getAutoChallengeCheckboxLabelText();
-    await t.expect(pushBtn.textContent).contains('Push notification sent');
     if (!userVariables.gen3) {
+      await t.expect(pushBtn.textContent).contains('Push notification sent');
       await t.expect(a11ySpan.textContent).contains('Push notification sent');
+      await t.expect(await challengeOktaVerifyPushPageObject.isPushButtonDisabled()).ok();
+      await t.expect(pageTitle).contains('Get a push notification');
+    } else {
+      await t.expect(pageTitle).contains('Push notification sent');
+      await t.expect(pageSubtitle).contains('Respond on your mobile device to continue.');
     }
 
-    await t.expect(await challengeOktaVerifyPushPageObject.isPushButtonDisabled()).ok();
-    await t.expect(pageTitle).contains('Get a push notification');
     await t.expect(await challengeOktaVerifyPushPageObject.autoChallengeInputExists()).ok();
     await t.expect(checkbox.checked).ok();
     await t.expect(checkboxLabelText).eql('Send push automatically');

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -750,7 +750,7 @@ test.requestHooks(requestLogger, mockChallengeOVPush)('should navigate to okta v
   if(userVariables.gen3) {
     await t.expect(challengeFactorPage.getFormTitle()).eql('Push notification sent');
   } else {
-    await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with Custom Push');
+    await t.expect(challengeFactorPage.getFormTitle()).eql('Get a push notification');
   }
 
   await t.expect(requestLogger.count(() => true)).eql(2);

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -747,7 +747,11 @@ test.requestHooks(requestLogger, mockChallengeOVPush)('should navigate to okta v
 
   selectFactorPage.selectFactorByIndex(0);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
-  await t.expect(challengeFactorPage.getFormTitle()).eql('Get a push notification');
+  if(userVariables.gen3) {
+    await t.expect(challengeFactorPage.getFormTitle()).eql('Push notification sent');
+  } else {
+    await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with Custom Push');
+  }
 
   await t.expect(requestLogger.count(() => true)).eql(2);
   const req1 = requestLogger.requests[0].request;
@@ -872,5 +876,9 @@ test.requestHooks(mockChallengeCustomApp)('should navigate to Custom App challen
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   selectFactorPage.selectFactorByIndex(9);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
-  await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with Custom Push');
+  if(userVariables.gen3) {
+    await t.expect(challengeFactorPage.getFormTitle()).eql('Push notification sent');
+  } else {
+    await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with Custom Push');
+  }
 });


### PR DESCRIPTION
## Description:
Updates the Okta Verify & Custom push screens: the color contrast of the send push button is too low when disabled. The button is from Odyssey and to avoid hacking apart Odyssey buttons and to improve usability, we are updating this view to hide the button instead and acknowledge the push notification is sent through the title text and add description text below the title of Respond on your mobile device to continue.

Before:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/f1c1e5d9-c7d0-4f60-91ba-495d6e21fa39" />

After:
![image](https://github.com/user-attachments/assets/d42b7940-bbf2-49d5-ae7c-c60d1c034124)
![image](https://github.com/user-attachments/assets/57f06dbd-ebe5-4149-910e-48997aee33e7)
![image](https://github.com/user-attachments/assets/bfc9f561-10cc-407f-9bed-b75e11e2adfc)


## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-856183](https://oktainc.atlassian.net/browse/OKTA-856183)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



