### PR TITLE
fix(gen2): transformUsername should only be used for background data request

### DIFF
--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -273,8 +273,10 @@ export default Controller.extend({
     }
 
     const payload = transformPayload(formName, model);
+    // NOTE: this line should be called before triggering transformIdentifier
+    const originalIdentifier = payload.identifier;
     // Run hook: transform the user name (a.k.a identifier)
-    const [values, originalIdentifier] = this.transformIdentifier(formName, payload);
+    const values = this.transformIdentifier(formName, payload);
 
     // widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
     if (this.options.settings.get('features.rememberMe')) {
@@ -356,7 +358,6 @@ export default Controller.extend({
   },
 
   transformIdentifier(formName, modelJSON) {
-    const originalIdentifier = modelJSON.identifier;
     if (Object.prototype.hasOwnProperty.call(modelJSON, 'identifier')) {
       // The callback function is passed two arguments:
       // 1) username: The name entered by the user
@@ -367,7 +368,7 @@ export default Controller.extend({
       const operation = FORM_NAME_TO_OPERATION_MAP[formName];
       modelJSON.identifier = this.settings.transformUsername(modelJSON.identifier, operation);
     }
-    return [modelJSON, originalIdentifier];
+    return modelJSON;
   },
 
   /**

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -274,12 +274,12 @@ export default Controller.extend({
 
     const payload = transformPayload(formName, model);
     // Run hook: transform the user name (a.k.a identifier)
-    const values = this.transformIdentifier(formName, payload);
+    const [values, originalIdentifier] = this.transformIdentifier(formName, payload);
 
     // widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
     if (this.options.settings.get('features.rememberMe')) {
-      if (values.identifier) {
-        CookieUtil.setUsernameCookie(values.identifier);
+      if (originalIdentifier) {
+        CookieUtil.setUsernameCookie(originalIdentifier);
       }
     }
     else {
@@ -356,6 +356,7 @@ export default Controller.extend({
   },
 
   transformIdentifier(formName, modelJSON) {
+    const originalIdentifier = modelJSON.identifier;
     if (Object.prototype.hasOwnProperty.call(modelJSON, 'identifier')) {
       // The callback function is passed two arguments:
       // 1) username: The name entered by the user
@@ -366,7 +367,7 @@ export default Controller.extend({
       const operation = FORM_NAME_TO_OPERATION_MAP[formName];
       modelJSON.identifier = this.settings.transformUsername(modelJSON.identifier, operation);
     }
-    return modelJSON;
+    return [modelJSON, originalIdentifier];
   },
 
   /**

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -141,11 +141,12 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
 
     // Allow username transformation if applicable
     if ('identifier' in payload) {
+      const originalIdentifier = payload.identifier;
       payload.identifier = transformIdentifier(widgetProps, step, payload.identifier as string);
 
       // Widget rememberMe feature stores the entered identifier in a cookie, to pre-fill the form on subsequent visits to page
       if (features?.rememberMe) {
-        setUsernameCookie(payload.identifier as string);
+        setUsernameCookie(originalIdentifier as string);
       } else {
         removeUsernameCookie();
       }

--- a/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
+++ b/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
@@ -308,13 +308,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('transformUse
   await t.expect(identifyRequestLogger.count(() => true)).eql(1);
   const req = identifyRequestLogger.requests[0].request;
   const reqBody = JSON.parse(req.body);
-  await t.expect(reqBody).eql({
-    identifier: 'test.identifier@acme.com',
-    credentials: {
-      passcode: 'password',
-    },
-    stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw',
-  });
+  await t.expect(reqBody.identifier).eql('test.identifier@acme.com');
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
 

--- a/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
+++ b/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
@@ -279,3 +279,49 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should store transformed
     .expect(cookie[0].name).eql('ln')
     .expect(cookie[0].value).eql('TestIdentifier@acme.com');
 });
+
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('transformUsername should map identifier in request, but only display user typed identifier in form', async t => {
+  const identityPage = await setup(t, { render: false });
+
+  await t.setCookies({name: 'ln', value: 'PREFILL VALUE', httpOnly: false});
+
+  await rerenderWidget({
+    features: {
+      rememberMe: true
+    },
+    transformUsername: (username) => {
+      // This example will append the '@acme.com' domain if the user has
+      // not entered it
+      return username.includes('@acme.com')
+        ? username
+        : username + '@acme.com';
+    }
+  });
+  await t.expect(identityPage.formExists()).ok();
+
+  await t.expect(identityPage.getIdentifierValue()).eql('PREFILL VALUE');
+
+  await identityPage.fillIdentifierField('test.identifier');
+  await identityPage.fillPasswordField('password');
+  await identityPage.clickSignInButton();
+
+  await t.expect(identifyRequestLogger.count(() => true)).eql(1);
+  const req = identifyRequestLogger.requests[0].request;
+  const reqBody = JSON.parse(req.body);
+  await t.expect(reqBody).eql({
+    identifier: 'test.identifier@acme.com',
+    credentials: {
+      passcode: 'password',
+    },
+    stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw',
+  });
+  await t.expect(req.method).eql('post');
+  await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
+
+  // Ensure identifier field is pre-filled with saved username cookie
+  await identityPage.navigateToPage({ render: false });
+  await rerenderWidget(baseConfig);
+  await t.expect(identityPage.formExists()).ok();
+  const identifier = identityPage.getIdentifierValue();
+  await t.expect(identifier).eql('test.identifier');
+});

--- a/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
+++ b/test/testcafe/spec/IdentifyWithRememberUsername_spec.js
@@ -277,7 +277,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should store transformed
 
   await t
     .expect(cookie[0].name).eql('ln')
-    .expect(cookie[0].value).eql('TestIdentifier@acme.com');
+    .expect(cookie[0].value).eql('TestIdentifier');
 });
 
 test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('transformUsername should map identifier in request, but only display user typed identifier in form', async t => {


### PR DESCRIPTION
## Description:

transformUsername should only be applied to network request payload 

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-858517](https://oktainc.atlassian.net/browse/OKTA-858517)

### Reviewers:

### Screenshot/Video:

before fix:

https://github.com/user-attachments/assets/8195d73f-20b3-4a5e-b983-ce1697f61735


after fix:



https://github.com/user-attachments/assets/aef71bea-2289-4554-a7d0-eb13e2cf0ed4





### Downstream Monolith Build:



