### PR TITLE
fix(gen3): form submission issue with link button

### DIFF
--- a/src/v3/src/components/Link/Link.test.tsx
+++ b/src/v3/src/components/Link/Link.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+// href can be undefined based on logic in Link.tsx, disable the following eslint rule for this test file
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import { render, RenderResult } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+import { h } from 'preact';
+import { ReactNode } from 'preact/compat';
+
+import { WidgetContextProvider } from '../../contexts';
+import { LinkElement } from '../../types';
+import Link from './Link';
+
+const renderWithForm = (ui: ReactNode) => {
+  const widgetContext = {
+    loading: false,
+    widgetProps: {},
+  };
+  const mockOnSubmit = jest.fn((e) => e.preventDefault());
+
+  return [
+    render(
+      <WidgetContextProvider value={widgetContext}>
+        <form onSubmit={mockOnSubmit}>
+          <input data-se="input" />
+          {ui}
+          <button type="submit">Submit</button>
+        </form>
+      </WidgetContextProvider>,
+    ),
+    mockOnSubmit,
+  ] as [RenderResult, jest.Mock];
+};
+
+const schemaDefaultOptions = {
+  label: 'Test Link',
+  href: undefined,
+  dataSe: 'test-link',
+  actionParams: {},
+  isActionStep: false,
+  step: 'test-step',
+  target: '_self',
+  onClick: jest.fn(),
+  rel: '',
+};
+
+describe('Link Component', () => {
+  it('should not trigger onClick handler when enter key is pressed', async () => {
+    const user = userEvent.setup();
+    const uischema = {
+      focus: false,
+      options: { ...schemaDefaultOptions } as LinkElement['options'],
+    };
+    const [
+      { getByTestId },
+      mockOnSubmit,
+    ] = renderWithForm(<Link uischema={uischema as LinkElement} />);
+
+    const input = getByTestId('input');
+    await user.type(input, 'abc{enter}');
+
+    expect(uischema.options.onClick).not.toHaveBeenCalled();
+    expect(mockOnSubmit).toHaveBeenCalled();
+  });
+
+  it('should not trigger onClick handler when enter key is pressed when renders with href', async () => {
+    const user = userEvent.setup();
+    const uischema = {
+      type: 'Link',
+      focus: false,
+      options: { ...schemaDefaultOptions, href: 'http://mock.abc' } as LinkElement['options'],
+    };
+    const [
+      { getByTestId },
+      mockOnSubmit,
+    ] = renderWithForm(<Link uischema={uischema as LinkElement} />);
+
+    const input = getByTestId('input');
+    await user.type(input, 'abc{enter}');
+
+    expect(uischema.options.onClick).not.toHaveBeenCalled();
+    expect(mockOnSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -66,6 +66,7 @@ const Link: UISchemaElementComponent<{
       <MuiLink
         component="button"
         role="link"
+        type="button" // Explicitly set type to "button"
         onClick={onClick}
         ref={focusRef}
         data-se={dataSe}

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -213,6 +213,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>
@@ -442,6 +443,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>
@@ -671,6 +673,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -168,6 +168,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -1544,6 +1544,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -1555,6 +1556,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -3114,6 +3116,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -3125,6 +3128,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -4718,6 +4722,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -4729,6 +4734,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -212,6 +212,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -223,6 +224,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -180,6 +180,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -191,6 +192,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -236,6 +236,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -247,6 +248,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -489,6 +491,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -500,6 +503,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -737,6 +741,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -748,6 +753,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -990,6 +996,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -1001,6 +1008,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -655,6 +655,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-99"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -666,6 +667,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-99"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -615,6 +615,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-72"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -861,6 +862,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -872,6 +874,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -231,6 +231,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -242,6 +243,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -374,6 +374,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -385,6 +386,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -887,6 +889,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -898,6 +901,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1394,6 +1398,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -1405,6 +1410,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1907,6 +1913,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -1918,6 +1925,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -374,6 +374,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -385,6 +386,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-59"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -714,6 +716,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-49"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -725,6 +728,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-49"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1167,6 +1171,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -1178,6 +1183,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1620,6 +1626,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -1631,6 +1638,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -506,6 +506,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-63"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -1564,6 +1564,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-171"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -274,6 +274,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -285,6 +286,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -343,6 +343,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -655,6 +655,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -666,6 +667,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1242,6 +1244,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-84"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -1253,6 +1256,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-84"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -655,6 +655,7 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1231,6 +1232,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-84"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -792,6 +792,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-123"
                       data-se="skip"
                       role="link"
+                      type="button"
                     >
                       Remind me later
                     </button>
@@ -803,6 +804,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-123"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1511,6 +1513,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-105"
                       data-se="skip"
                       role="link"
+                      type="button"
                     >
                       Remind me later
                     </button>
@@ -1522,6 +1525,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-105"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -254,6 +254,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="forgot-password"
                       role="link"
+                      type="button"
                     >
                       Forgot password?
                     </button>
@@ -265,6 +266,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="unlock"
                       role="link"
+                      type="button"
                     >
                       Unlock account?
                     </button>
@@ -335,6 +337,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>
@@ -605,6 +608,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="forgot-password"
                       role="link"
+                      type="button"
                     >
                       Forgot password?
                     </button>
@@ -616,6 +620,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="unlock"
                       role="link"
+                      type="button"
                     >
                       Unlock account?
                     </button>
@@ -686,6 +691,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>
@@ -956,6 +962,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="forgot-password"
                       role="link"
+                      type="button"
                     >
                       Forgot password?
                     </button>
@@ -967,6 +974,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="unlock"
                       role="link"
+                      type="button"
                     >
                       Unlock account?
                     </button>
@@ -1037,6 +1045,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -681,6 +681,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-104"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -561,6 +561,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-84"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1137,6 +1138,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-84"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
@@ -208,6 +208,7 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -443,6 +443,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -443,6 +443,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-56"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -199,6 +199,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -210,6 +211,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -174,6 +174,7 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-26"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -212,6 +212,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-32"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -180,6 +180,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -429,6 +430,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -660,6 +662,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -951,6 +954,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -962,6 +966,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1307,6 +1312,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -1318,6 +1324,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1433,6 +1440,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-19"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1664,6 +1672,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -223,6 +223,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -234,6 +235,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -311,6 +311,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-47"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -322,6 +323,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-47"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -593,6 +595,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -604,6 +607,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -197,6 +197,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -208,6 +209,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -202,6 +203,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -184,6 +184,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -195,6 +196,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -184,6 +184,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -195,6 +196,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -394,6 +396,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -405,6 +408,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-28"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
@@ -149,6 +149,7 @@ exports[`authenticator-verification-ov-resend-push-notification renders form 1`]
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-23"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -160,6 +161,7 @@ exports[`authenticator-verification-ov-resend-push-notification renders form 1`]
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-23"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -267,6 +267,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -278,6 +279,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -237,6 +237,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -248,6 +249,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -217,6 +217,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -1651,6 +1651,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-174"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -275,6 +275,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                       data-se="forgot-password"
                       role="link"
+                      type="button"
                     >
                       Forgot password?
                     </button>
@@ -286,6 +287,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -362,6 +362,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -373,6 +374,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -732,6 +734,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -743,6 +746,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -1102,6 +1106,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -1113,6 +1118,7 @@ exports[`authenticator-verification-webauthn should render form with required us
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -233,6 +233,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -1544,6 +1544,7 @@ exports[`byol loading custom language should load custom language with "language
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -1555,6 +1556,7 @@ exports[`byol loading custom language should load custom language with "language
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -3114,6 +3116,7 @@ exports[`byol loading custom language should load custom language with assets.ba
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -3125,6 +3128,7 @@ exports[`byol loading custom language should load custom language with assets.ba
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -4684,6 +4688,7 @@ exports[`byol loading default language should not load custom language when the 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -4695,6 +4700,7 @@ exports[`byol loading default language should not load custom language when the 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -6254,6 +6260,7 @@ exports[`byol loading default language should not load custom language with "lan
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -6265,6 +6272,7 @@ exports[`byol loading default language should not load custom language with "lan
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -1872,6 +1872,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-82"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -3615,6 +3616,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -222,6 +222,7 @@ exports[`enroll-profile-new should render form 1`] = `
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -288,6 +288,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -619,6 +620,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -950,6 +952,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -1264,6 +1267,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-52"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -1696,6 +1700,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-72"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -261,6 +261,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="skip"
                       role="link"
+                      type="button"
                     >
                       Skip Profile
                     </button>
@@ -272,6 +273,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -317,6 +317,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-53"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -589,6 +590,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -731,6 +731,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-119"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -1473,6 +1474,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-118"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -2225,6 +2227,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-120"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -2967,6 +2970,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-118"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -3700,6 +3704,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-116"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>
@@ -4374,6 +4379,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-106"
                         data-se="back"
                         role="link"
+                        type="button"
                       >
                         Sign In
                       </button>

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`error-account-creation should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-19"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -144,6 +144,7 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-25"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`error-session-expired should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-19"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -362,6 +362,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button Mui-focusVisible emotion-57"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -373,6 +374,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-57"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/flow-verify-with-piv-as-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-verify-with-piv-as-authenticator.test.tsx.snap
@@ -176,6 +176,7 @@ exports[`flow-verify-with-piv-as-authenticator should render select authenticato
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Verify with something else
                     </button>
@@ -187,6 +188,7 @@ exports[`flow-verify-with-piv-as-authenticator should render select authenticato
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -112,6 +112,7 @@ exports[`identify-recovery renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-21"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -294,6 +294,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                       data-se="forgot-password"
                       role="link"
+                      type="button"
                     >
                       Forgot password?
                     </button>
@@ -364,6 +365,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>
@@ -674,6 +676,7 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                       data-se="forgot-password"
                       role="link"
+                      type="button"
                     >
                       Forgot password?
                     </button>
@@ -744,6 +747,7 @@ exports[`identify-with-password Client-side field change validation tests should
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>
@@ -1054,6 +1058,7 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                       data-se="forgot-password"
                       role="link"
+                      type="button"
                     >
                       Forgot password?
                     </button>
@@ -1124,6 +1129,7 @@ exports[`identify-with-password Client-side field change validation tests should
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>
@@ -1357,6 +1363,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                       data-se="forgot-password"
                       role="link"
+                      type="button"
                     >
                       Forgot password?
                     </button>
@@ -1427,6 +1434,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>
@@ -1660,6 +1668,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                       data-se="forgot-password"
                       role="link"
+                      type="button"
                     >
                       Forgot password?
                     </button>
@@ -1730,6 +1739,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="enroll"
                         role="link"
+                        type="button"
                       >
                         Sign up
                       </button>

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -215,6 +215,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -226,6 +227,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -260,6 +260,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -271,6 +272,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-43"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1482,6 +1482,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -1493,6 +1494,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -2990,6 +2992,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -3001,6 +3004,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-42"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -131,6 +131,7 @@ exports[`terminal-return-email-error should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-20"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`unlock-account-success renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-23"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`user-unlock-account renders form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-22"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -192,6 +192,7 @@ exports[`webauthn-enroll should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -203,6 +204,7 @@ exports[`webauthn-enroll should render form 1`] = `
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-27"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -428,6 +430,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -439,6 +442,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>
@@ -661,6 +665,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                       data-se="switchAuthenticator"
                       role="link"
+                      type="button"
                     >
                       Return to authenticator list
                     </button>
@@ -672,6 +677,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                       data-se="cancel"
                       role="link"
+                      type="button"
                     >
                       Back to sign in
                     </button>


### PR DESCRIPTION
## Description:

adds type="button" to link button, so the onClick handler won't be triggered with Enter button in form context.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-876967](https://oktainc.atlassian.net/browse/OKTA-876967)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



