### PR TITLE
Fix warning icon height

### DIFF
--- a/assets/sass/v2/_callout.scss
+++ b/assets/sass/v2/_callout.scss
@@ -3,7 +3,7 @@
   .clearfix:after {
     visibility: visible;
     content: '';
-    height: 102%;
+    height: calc(100% + 2px);
   }
   .infobox {
     a {


### PR DESCRIPTION
## Description:

Fix warning icon height.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- N/A

### Reviewers:

### Screenshot/Video:

Before (notice that the background doesn't fully fill the container):

<img width="1014" alt="Before" src="https://github.com/user-attachments/assets/b2433f9a-72de-4274-91e8-27191764b0c3" />

After:

<img width="1011" alt="After" src="https://github.com/user-attachments/assets/3c344b68-c1e0-4303-bf92-661978c71440" />

### Downstream Monolith Build:



