### PR TITLE
OKTA-874304: updates aria label for Select Okta Verify to match visible label

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1048,7 +1048,7 @@ oie.select.authenticator.verify.webauthn.label = Select Security Key or Biometri
 oie.select.authenticator.verify.security.question.label = Select Security Question.
 oie.select.authenticator.okta_verify.totp.label = Select to enter a code from the Okta Verify app.
 oie.select.authenticator.okta_verify.push.label = Select to get a push notification to the Okta Verify app.
-oie.select.authenticator.okta_verify.signed_nonce.label = Select Okta FastPass.
+oie.select.authenticator.okta_verify.signed_nonce.label = Select Okta Verify.
 oie.select.authenticator.verify.okta_verify.label = Select Okta Verify.
 # {0} is the name of a Proper authenticator i.e. Okta Verify, DUO, RSA, etc
 oie.select.authenticator.verify.named.authenticator.label = Select {0}.

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                       >
                         <button
                           aria-describedby="okta_verify_2-description"
-                          aria-label="Select Okta FastPass."
+                          aria-label="Select Okta Verify."
                           class="MuiBox-root emotion-26"
                           data-se="authenticator-button"
                           tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -345,7 +345,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                       >
                         <button
                           aria-describedby="okta_verify_2-description"
-                          aria-label="Select Okta FastPass."
+                          aria-label="Select Okta Verify."
                           class="MuiBox-root emotion-26"
                           data-se="authenticator-button"
                           tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -730,7 +730,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       >
                         <button
                           aria-describedby="okta_verify_6-description"
-                          aria-label="Select Okta FastPass."
+                          aria-label="Select Okta Verify."
                           class="MuiBox-root emotion-25"
                           data-se="authenticator-button"
                           tabindex="0"

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -218,7 +218,7 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(5)).eql('security_question');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(6)).eql(userVariables.gen3 ? 'Okta Verify' : 'Use Okta FastPass');
-  await t.expect(await selectFactorPage.getFactorButtonAriaLabelByIndex(6)).eql('Select Okta FastPass.');
+  await t.expect(await selectFactorPage.getFactorButtonAriaLabelByIndex(6)).eql('Select Okta Verify.');
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(6)).eql(userVariables.gen3 ? 'Use Okta FastPass' : 'Okta Verify');
   await t.expect(selectFactorPage.getFactorIconSelectorByIndex(6)).contains('mfa-okta-verify');
   await t.expect(await selectFactorPage.factorCustomLogoExist(6)).eql(false);
@@ -632,7 +632,7 @@ test.requestHooks(mockChallengeOVTotp)(`should load signed_nonce at bottom when 
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('okta_password');
 
-  await t.expect(await selectFactorPage.getFactorButtonAriaLabelByIndex(3)).eql('Select Okta FastPass.');
+  await t.expect(await selectFactorPage.getFactorButtonAriaLabelByIndex(3)).eql('Select Okta Verify.');
   await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql(userVariables.gen3 ? 'Okta Verify' : 'Use Okta FastPass');
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(3)).eql(userVariables.gen3 ? 'Use Okta FastPass' : 'Okta Verify');
   await t.expect(selectFactorPage.getFactorIconSelectorByIndex(3)).contains('mfa-okta-verify');

--- a/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
@@ -480,7 +480,7 @@ describe('v2/view-builder/internals/FormInputFactory', function() {
         buttonDataSeAttr: 'okta_verify-push',
       },
       {
-        ariaLabel: 'Select Okta FastPass.',
+        ariaLabel: 'Select Okta Verify.',
         label: 'Use Okta FastPass',
         value: {
           id: 'auttheidkwh282hv8g3',


### PR DESCRIPTION
## Description:
The aria-label property of Okta Fastpass on the select authenticator screen did not match the visible label (`Select Okta Verify. Use Okta Fastpass`). This a11y issue was detected by deque. This PR updates the aria-label to match the visible label.

Deque ticket: https://axeauditor.dequecloud.com/test-run/c52484e0-8f71-11ef-ac64-07f2f3b31366/issue/8eb3d04a-8f81-11ef-8984-c7db8bec7091

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-874304](https://oktainc.atlassian.net/browse/OKTA-874304)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



