### PR TITLE
fix(a11y, Gen3): Auto announce processing status in Spinner

### DIFF
--- a/src/v3/src/components/PIVButton/PIVButton.test.tsx
+++ b/src/v3/src/components/PIVButton/PIVButton.test.tsx
@@ -12,8 +12,8 @@
 
 import { IdxTransaction } from '@okta/okta-auth-js';
 import { render, waitFor } from '@testing-library/preact';
-import { act } from 'preact/test-utils';
 import { h } from 'preact';
+import { act } from 'preact/test-utils';
 import { getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 
 import {

--- a/src/v3/src/components/PIVButton/PIVButton.test.tsx
+++ b/src/v3/src/components/PIVButton/PIVButton.test.tsx
@@ -12,6 +12,7 @@
 
 import { IdxTransaction } from '@okta/okta-auth-js';
 import { render, waitFor } from '@testing-library/preact';
+import { act } from 'preact/test-utils';
 import { h } from 'preact';
 import { getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 
@@ -40,6 +41,7 @@ describe('PIVButton Tests', () => {
   let props: UISchemaElementComponentProps & { uischema: PIVButtonElement; };
 
   beforeEach(() => {
+    jest.useFakeTimers();
     mockLoading.mockReturnValue(false);
     mockTransaction.messages = undefined;
     props = {
@@ -68,6 +70,11 @@ describe('PIVButton Tests', () => {
 
   it('should render PIV button and trigger redirect with spinner visible', async () => {
     const { queryByTestId } = render(<PIVButton {...props} />);
+
+    await act(async () => {
+      // Wait for Spinner to appear
+      jest.runAllTimers();
+    });
 
     const button = queryByTestId('button');
     const spinner = queryByTestId('okta-spinner');

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -47,12 +47,12 @@ const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
       aria-live="polite"
     >
       {showProgress && (
-      <CircularProgress
-        testId={dataSe}
-        // Using loc here because this component is not only used by transformers
-        // but also directly in widget component
-        ariaLabel={loc('processing.alt.text', 'login')}
-      />
+        <CircularProgress
+          testId={dataSe}
+          // Using loc here because this component is not only used by transformers
+          // but also directly in widget component
+          ariaLabel={loc('processing.alt.text', 'login')}
+        />
       )}
     </Box>
   );

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -44,7 +44,6 @@ const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
       justifyContent="center"
       alignItems="center"
       role="status"
-      aria-live="polite"
     >
       {showProgress && (
         <CircularProgress

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -46,12 +46,14 @@ const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
       role="status"
       aria-live="polite"
     >
-      {showProgress && (<CircularProgress
+      {showProgress && (
+      <CircularProgress
         testId={dataSe}
         // Using loc here because this component is not only used by transformers
         // but also directly in widget component
         ariaLabel={loc('processing.alt.text', 'login')}
-      />)}
+      />
+      )}
     </Box>
   );
 };

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -13,6 +13,7 @@
 import { Box } from '@mui/material';
 import { CircularProgress } from '@okta/odyssey-react-mui';
 import { FunctionComponent, h } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
 
 import { SpinnerElement } from '../../types';
 import { loc } from '../../util';
@@ -24,19 +25,33 @@ const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
   const { dataSe = undefined } = 'type' in props
     ? {}
     : props as SpinnerProps;
+
+  const [showProgress, setShowProgress] = useState<boolean>(false);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setShowProgress(true);
+    }, 10);
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, []);
+
   return (
     <Box
       display="flex"
       flexDirection="column"
       justifyContent="center"
       alignItems="center"
+      role="status"
+      aria-live="polite"
     >
-      <CircularProgress
+      {showProgress && <CircularProgress
         testId={dataSe}
         // Using loc here because this component is not only used by transformers
         // but also directly in widget component
         ariaLabel={loc('processing.alt.text', 'login')}
-      />
+      />}
     </Box>
   );
 };

--- a/src/v3/src/components/Spinner/Spinner.tsx
+++ b/src/v3/src/components/Spinner/Spinner.tsx
@@ -46,12 +46,12 @@ const Spinner: FunctionComponent<SpinnerProps | SpinnerElement> = (
       role="status"
       aria-live="polite"
     >
-      {showProgress && <CircularProgress
+      {showProgress && (<CircularProgress
         testId={dataSe}
         // Using loc here because this component is not only used by transformers
         // but also directly in widget component
         ariaLabel={loc('processing.alt.text', 'login')}
-      />}
+      />)}
     </Box>
   );
 };

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -993,24 +993,67 @@ exports[`authenticator-enroll-security-question-error predefined question should
                   class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="MuiBox-root emotion-11"
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutError MuiAlert-callout emotion-11"
+                    role="alert"
                   >
                     <div
-                      class="MuiBox-root emotion-12"
+                      class="MuiAlert-icon emotion-12"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
+                        fill="none"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="MuiAlert-message emotion-14"
+                    >
+                      <span
+                        class="MuiBox-root emotion-15"
+                        translate="no"
+                      >
+                        error
+                      </span>
+                      <div
+                        class="MuiBox-root emotion-1"
+                      >
+                        We found some errors. Please review the form and make corrections.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <div
+                    class="MuiBox-root emotion-18"
+                  >
+                    <div
+                      class="MuiBox-root emotion-19"
                       data-se="identifier-container"
                       title="tester35@test.com"
                     >
                       <div
-                        class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-13"
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-20"
                         data-se="identifier"
                         translate="no"
                       >
                         <div
-                          class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-14"
+                          class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-21"
                         >
                           <svg
                             aria-label="User"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-22"
                             fill="none"
                             focusable="false"
                             role="img"
@@ -1029,7 +1072,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </svg>
                         </div>
                         <span
-                          class="MuiChip-label MuiChip-labelMedium emotion-16"
+                          class="MuiChip-label MuiChip-labelMedium emotion-23"
                         >
                           tester35@test.com
                         </span>
@@ -1037,16 +1080,16 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-10"
+                    class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiBox-root emotion-19"
+                        class="MuiBox-root emotion-26"
                       >
                         <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-20"
+                          class="MuiTypography-root MuiTypography-h4 emotion-27"
                           data-se="o-form-head"
                           tabindex="-1"
                         >
@@ -1055,64 +1098,58 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <fieldset
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-22"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-29"
                       >
                         <legend
-                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-23"
+                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-30"
                         >
                           
                            
                         </legend>
                         <div
                           aria-labelledby="questionType-label"
-                          class="MuiFormGroup-root emotion-24"
+                          class="MuiFormGroup-root emotion-31"
                           data-se="questionType"
                           id="questionType"
                           role="radiogroup"
                         >
                           <label
-                            class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd emotion-25"
+                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-32"
                           >
                             <span
-                              aria-disabled="true"
-                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-26"
-                              tabindex="-1"
+                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-checked MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-33"
                             >
                               <input
-                                class="PrivateSwitchBase-input emotion-27"
-                                disabled=""
+                                class="PrivateSwitchBase-input emotion-34"
                                 name="questionType"
                                 type="radio"
                                 value="predefined"
                               />
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled emotion-28"
+                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-35"
                             >
                               Choose a security question
                             </span>
                           </label>
                           <label
-                            class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd emotion-25"
+                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-32"
                           >
                             <span
-                              aria-disabled="true"
-                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-26"
-                              tabindex="-1"
+                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-33"
                             >
                               <input
-                                class="PrivateSwitchBase-input emotion-27"
-                                disabled=""
+                                class="PrivateSwitchBase-input emotion-34"
                                 name="questionType"
                                 type="radio"
                                 value="custom"
                               />
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled emotion-28"
+                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-35"
                             >
                               Create my own security question
                             </span>
@@ -1121,13 +1158,13 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </fieldset>
                     </div>
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-22"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-29"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
                           data-shrink="false"
                           for="credentials.questionKey"
                           id="credentials.questionKey-label"
@@ -1137,14 +1174,13 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl  emotion-36"
+                          class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-43"
                         >
                           <select
                             aria-invalid="false"
                             aria-labelledby="credentials.questionKey-label"
-                            class="MuiNativeSelect-select MuiNativeSelect-standard Mui-disabled MuiInputBase-input MuiInput-input Mui-disabled emotion-37"
+                            class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-44"
                             data-se="credentials.questionKey"
-                            disabled=""
                             id="credentials.questionKey"
                             name="credentials.questionKey"
                           >
@@ -1251,7 +1287,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </select>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard Mui-disabled emotion-38"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-45"
                             fill="none"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1268,13 +1304,13 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-40"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-47"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
                           data-shrink="false"
                           for="credentials.answer"
                           id="credentials.answer-label"
@@ -1284,7 +1320,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-42"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-49"
                           required="true"
                           translate="no"
                         >
@@ -1294,9 +1330,8 @@ exports[`authenticator-enroll-security-question-error predefined question should
                             aria-invalid="true"
                             aria-labelledby="credentials.answer-label"
                             autocomplete="off"
-                            class="MuiInputBase-input Mui-disabled MuiInputBase-inputAdornedEnd emotion-43"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-50"
                             data-se="credentials.answer"
-                            disabled=""
                             id="credentials.answer"
                             name="credentials.answer"
                             required=""
@@ -1304,19 +1339,19 @@ exports[`authenticator-enroll-security-question-error predefined question should
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-44"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-51"
                           >
                             <button
                               aria-controls="credentials.answer"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-45"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-52"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-46"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1333,11 +1368,11 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </div>
                         </div>
                         <p
-                          class="MuiFormHelperText-root Mui-disabled Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-47"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-54"
                           id="credentials.answer-error"
                         >
                           <span
-                            class="MuiBox-root emotion-48"
+                            class="MuiBox-root emotion-15"
                           >
                             Error:
                           </span>
@@ -1350,32 +1385,23 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-58"
                         data-se="save"
-                        disabled=""
-                        tabindex="-1"
+                        tabindex="0"
                         type="submit"
                       >
-                        <span
-                          class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-52"
-                        >
-                          <div
-                            class="MuiBox-root emotion-53"
-                            role="status"
-                          />
-                        </span>
                         Verify
                       </button>
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-11"
+                    class="MuiBox-root emotion-18"
                   >
                     <button
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                       data-se="switchAuthenticator"
                       role="link"
                       type="button"
@@ -1384,10 +1410,10 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     </button>
                   </div>
                   <div
-                    class="MuiBox-root emotion-11"
+                    class="MuiBox-root emotion-18"
                   >
                     <button
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                       data-se="cancel"
                       role="link"
                       type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -1363,7 +1363,9 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-52"
                         >
                           <div
+                            aria-live="polite"
                             class="MuiBox-root emotion-53"
+                            role="status"
                           >
                             <span
                               aria-label="Processing..."

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -993,67 +993,24 @@ exports[`authenticator-enroll-security-question-error predefined question should
                   class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutError MuiAlert-callout emotion-11"
-                    role="alert"
+                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiAlert-icon emotion-12"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
-                        fill="none"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          clip-rule="evenodd"
-                          d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
-                          fill="currentColor"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="MuiAlert-message emotion-14"
-                    >
-                      <span
-                        class="MuiBox-root emotion-15"
-                        translate="no"
-                      >
-                        error
-                      </span>
-                      <div
-                        class="MuiBox-root emotion-1"
-                      >
-                        We found some errors. Please review the form and make corrections.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-17"
-                >
-                  <div
-                    class="MuiBox-root emotion-18"
-                  >
-                    <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-12"
                       data-se="identifier-container"
                       title="tester35@test.com"
                     >
                       <div
-                        class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-20"
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-13"
                         data-se="identifier"
                         translate="no"
                       >
                         <div
-                          class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-21"
+                          class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-14"
                         >
                           <svg
                             aria-label="User"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-22"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
                             fill="none"
                             focusable="false"
                             role="img"
@@ -1072,7 +1029,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </svg>
                         </div>
                         <span
-                          class="MuiChip-label MuiChip-labelMedium emotion-23"
+                          class="MuiChip-label MuiChip-labelMedium emotion-16"
                         >
                           tester35@test.com
                         </span>
@@ -1080,16 +1037,16 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-17"
+                    class="MuiBox-root emotion-10"
                   >
                     <div
-                      class="MuiBox-root emotion-18"
+                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-26"
+                        class="MuiBox-root emotion-19"
                       >
                         <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-27"
+                          class="MuiTypography-root MuiTypography-h4 emotion-20"
                           data-se="o-form-head"
                           tabindex="-1"
                         >
@@ -1098,58 +1055,64 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-18"
+                      class="MuiBox-root emotion-11"
                     >
                       <fieldset
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-29"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-22"
                       >
                         <legend
-                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-30"
+                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-23"
                         >
                           
                            
                         </legend>
                         <div
                           aria-labelledby="questionType-label"
-                          class="MuiFormGroup-root emotion-31"
+                          class="MuiFormGroup-root emotion-24"
                           data-se="questionType"
                           id="questionType"
                           role="radiogroup"
                         >
                           <label
-                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-32"
+                            class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd emotion-25"
                           >
                             <span
-                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-checked MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-33"
+                              aria-disabled="true"
+                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-26"
+                              tabindex="-1"
                             >
                               <input
-                                class="PrivateSwitchBase-input emotion-34"
+                                class="PrivateSwitchBase-input emotion-27"
+                                disabled=""
                                 name="questionType"
                                 type="radio"
                                 value="predefined"
                               />
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-35"
+                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled emotion-28"
                             >
                               Choose a security question
                             </span>
                           </label>
                           <label
-                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-32"
+                            class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd emotion-25"
                           >
                             <span
-                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-33"
+                              aria-disabled="true"
+                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-26"
+                              tabindex="-1"
                             >
                               <input
-                                class="PrivateSwitchBase-input emotion-34"
+                                class="PrivateSwitchBase-input emotion-27"
+                                disabled=""
                                 name="questionType"
                                 type="radio"
                                 value="custom"
                               />
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-35"
+                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled emotion-28"
                             >
                               Create my own security question
                             </span>
@@ -1158,13 +1121,13 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </fieldset>
                     </div>
                     <div
-                      class="MuiBox-root emotion-18"
+                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-29"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-22"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
                           data-shrink="false"
                           for="credentials.questionKey"
                           id="credentials.questionKey-label"
@@ -1174,13 +1137,14 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-43"
+                          class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl  emotion-36"
                         >
                           <select
                             aria-invalid="false"
                             aria-labelledby="credentials.questionKey-label"
-                            class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-44"
+                            class="MuiNativeSelect-select MuiNativeSelect-standard Mui-disabled MuiInputBase-input MuiInput-input Mui-disabled emotion-37"
                             data-se="credentials.questionKey"
+                            disabled=""
                             id="credentials.questionKey"
                             name="credentials.questionKey"
                           >
@@ -1287,7 +1251,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </select>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-45"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard Mui-disabled emotion-38"
                             fill="none"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1304,13 +1268,13 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-18"
+                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-47"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-40"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
                           data-shrink="false"
                           for="credentials.answer"
                           id="credentials.answer-label"
@@ -1320,7 +1284,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-49"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-42"
                           required="true"
                           translate="no"
                         >
@@ -1330,8 +1294,9 @@ exports[`authenticator-enroll-security-question-error predefined question should
                             aria-invalid="true"
                             aria-labelledby="credentials.answer-label"
                             autocomplete="off"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-50"
+                            class="MuiInputBase-input Mui-disabled MuiInputBase-inputAdornedEnd emotion-43"
                             data-se="credentials.answer"
+                            disabled=""
                             id="credentials.answer"
                             name="credentials.answer"
                             required=""
@@ -1339,19 +1304,19 @@ exports[`authenticator-enroll-security-question-error predefined question should
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-51"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-44"
                           >
                             <button
                               aria-controls="credentials.answer"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-52"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-45"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-46"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1368,11 +1333,11 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </div>
                         </div>
                         <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-54"
+                          class="MuiFormHelperText-root Mui-disabled Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-47"
                           id="credentials.answer-error"
                         >
                           <span
-                            class="MuiBox-root emotion-15"
+                            class="MuiBox-root emotion-48"
                           >
                             Error:
                           </span>
@@ -1385,23 +1350,32 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-18"
+                      class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-58"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
                         data-se="save"
-                        tabindex="0"
+                        disabled=""
+                        tabindex="-1"
                         type="submit"
                       >
+                        <span
+                          class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-52"
+                        >
+                          <div
+                            class="MuiBox-root emotion-53"
+                            role="status"
+                          />
+                        </span>
                         Verify
                       </button>
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-18"
+                    class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
                       data-se="switchAuthenticator"
                       role="link"
                       type="button"
@@ -1410,10 +1384,10 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     </button>
                   </div>
                   <div
-                    class="MuiBox-root emotion-18"
+                    class="MuiBox-root emotion-11"
                   >
                     <button
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-55"
                       data-se="cancel"
                       role="link"
                       type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -993,24 +993,67 @@ exports[`authenticator-enroll-security-question-error predefined question should
                   class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="MuiBox-root emotion-11"
+                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutError MuiAlert-callout emotion-11"
+                    role="alert"
                   >
                     <div
-                      class="MuiBox-root emotion-12"
+                      class="MuiAlert-icon emotion-12"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
+                        fill="none"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M9.879 1.707a3 3 0 0 1 4.242 0l8.172 8.172a3 3 0 0 1 0 4.242l-8.172 8.172a3 3 0 0 1-4.242 0L1.707 14.12a3 3 0 0 1 0-4.242L9.88 1.707ZM12 13a1 1 0 0 1-1-1V7h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="MuiAlert-message emotion-14"
+                    >
+                      <span
+                        class="MuiBox-root emotion-15"
+                        translate="no"
+                      >
+                        error
+                      </span>
+                      <div
+                        class="MuiBox-root emotion-1"
+                      >
+                        We found some errors. Please review the form and make corrections.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <div
+                    class="MuiBox-root emotion-18"
+                  >
+                    <div
+                      class="MuiBox-root emotion-19"
                       data-se="identifier-container"
                       title="tester35@test.com"
                     >
                       <div
-                        class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-13"
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-20"
                         data-se="identifier"
                         translate="no"
                       >
                         <div
-                          class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-14"
+                          class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-21"
                         >
                           <svg
                             aria-label="User"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-22"
                             fill="none"
                             focusable="false"
                             role="img"
@@ -1029,7 +1072,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </svg>
                         </div>
                         <span
-                          class="MuiChip-label MuiChip-labelMedium emotion-16"
+                          class="MuiChip-label MuiChip-labelMedium emotion-23"
                         >
                           tester35@test.com
                         </span>
@@ -1037,16 +1080,16 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-10"
+                    class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiBox-root emotion-19"
+                        class="MuiBox-root emotion-26"
                       >
                         <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-20"
+                          class="MuiTypography-root MuiTypography-h4 emotion-27"
                           data-se="o-form-head"
                           tabindex="-1"
                         >
@@ -1055,64 +1098,58 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <fieldset
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-22"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-29"
                       >
                         <legend
-                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-23"
+                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-30"
                         >
                           
                            
                         </legend>
                         <div
                           aria-labelledby="questionType-label"
-                          class="MuiFormGroup-root emotion-24"
+                          class="MuiFormGroup-root emotion-31"
                           data-se="questionType"
                           id="questionType"
                           role="radiogroup"
                         >
                           <label
-                            class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd emotion-25"
+                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-32"
                           >
                             <span
-                              aria-disabled="true"
-                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-26"
-                              tabindex="-1"
+                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-checked MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-33"
                             >
                               <input
-                                class="PrivateSwitchBase-input emotion-27"
-                                disabled=""
+                                class="PrivateSwitchBase-input emotion-34"
                                 name="questionType"
                                 type="radio"
                                 value="predefined"
                               />
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled emotion-28"
+                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-35"
                             >
                               Choose a security question
                             </span>
                           </label>
                           <label
-                            class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd emotion-25"
+                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-32"
                           >
                             <span
-                              aria-disabled="true"
-                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-26"
-                              tabindex="-1"
+                              class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall emotion-33"
                             >
                               <input
-                                class="PrivateSwitchBase-input emotion-27"
-                                disabled=""
+                                class="PrivateSwitchBase-input emotion-34"
                                 name="questionType"
                                 type="radio"
                                 value="custom"
                               />
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled emotion-28"
+                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-35"
                             >
                               Create my own security question
                             </span>
@@ -1121,13 +1158,13 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </fieldset>
                     </div>
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-22"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-29"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
                           data-shrink="false"
                           for="credentials.questionKey"
                           id="credentials.questionKey-label"
@@ -1137,14 +1174,13 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl  emotion-36"
+                          class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  emotion-43"
                         >
                           <select
                             aria-invalid="false"
                             aria-labelledby="credentials.questionKey-label"
-                            class="MuiNativeSelect-select MuiNativeSelect-standard Mui-disabled MuiInputBase-input MuiInput-input Mui-disabled emotion-37"
+                            class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input emotion-44"
                             data-se="credentials.questionKey"
-                            disabled=""
                             id="credentials.questionKey"
                             name="credentials.questionKey"
                           >
@@ -1251,7 +1287,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </select>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard Mui-disabled emotion-38"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit MuiNativeSelect-icon MuiNativeSelect-iconStandard emotion-45"
                             fill="none"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1268,13 +1304,13 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-40"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-47"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-42"
                           data-shrink="false"
                           for="credentials.answer"
                           id="credentials.answer-label"
@@ -1284,7 +1320,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-disabled Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-42"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-49"
                           required="true"
                           translate="no"
                         >
@@ -1294,9 +1330,8 @@ exports[`authenticator-enroll-security-question-error predefined question should
                             aria-invalid="true"
                             aria-labelledby="credentials.answer-label"
                             autocomplete="off"
-                            class="MuiInputBase-input Mui-disabled MuiInputBase-inputAdornedEnd emotion-43"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-50"
                             data-se="credentials.answer"
-                            disabled=""
                             id="credentials.answer"
                             name="credentials.answer"
                             required=""
@@ -1304,19 +1339,19 @@ exports[`authenticator-enroll-security-question-error predefined question should
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-44"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-51"
                           >
                             <button
                               aria-controls="credentials.answer"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-45"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-52"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-46"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1333,11 +1368,11 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           </div>
                         </div>
                         <p
-                          class="MuiFormHelperText-root Mui-disabled Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-47"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-54"
                           id="credentials.answer-error"
                         >
                           <span
-                            class="MuiBox-root emotion-48"
+                            class="MuiBox-root emotion-15"
                           >
                             Error:
                           </span>
@@ -1350,54 +1385,23 @@ exports[`authenticator-enroll-security-question-error predefined question should
                       </div>
                     </div>
                     <div
-                      class="MuiBox-root emotion-11"
+                      class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-51"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-58"
                         data-se="save"
-                        disabled=""
-                        tabindex="-1"
+                        tabindex="0"
                         type="submit"
                       >
-                        <span
-                          class="MuiButton-startIcon MuiButton-iconSizeMedium emotion-52"
-                        >
-                          <div
-                            aria-live="polite"
-                            class="MuiBox-root emotion-53"
-                            role="status"
-                          >
-                            <span
-                              aria-label="Processing..."
-                              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-54"
-                              role="progressbar"
-                              style="width: 1.71428571rem; height: 1.71428571rem;"
-                            >
-                              <svg
-                                class="MuiCircularProgress-svg emotion-55"
-                                viewBox="22 22 44 44"
-                              >
-                                <circle
-                                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-56"
-                                  cx="44"
-                                  cy="44"
-                                  fill="none"
-                                  r="17"
-                                  stroke-width="10"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </span>
                         Verify
                       </button>
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-11"
+                    class="MuiBox-root emotion-18"
                   >
                     <button
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                       data-se="switchAuthenticator"
                       role="link"
                       type="button"
@@ -1406,10 +1410,10 @@ exports[`authenticator-enroll-security-question-error predefined question should
                     </button>
                   </div>
                   <div
-                    class="MuiBox-root emotion-11"
+                    class="MuiBox-root emotion-18"
                   >
                     <button
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-58"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-60"
                       data-se="cancel"
                       role="link"
                       type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -1178,7 +1178,6 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
                       class="MuiBox-root emotion-18"
                     >
                       <div
-                        aria-live="polite"
                         class="MuiBox-root emotion-19"
                         role="status"
                       >

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -1178,7 +1178,9 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
                       class="MuiBox-root emotion-18"
                     >
                       <div
+                        aria-live="polite"
                         class="MuiBox-root emotion-19"
+                        role="status"
                       >
                         <span
                           aria-label="Processing..."

--- a/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
@@ -61,7 +61,6 @@ exports[`enduser-consent-without-logo should render form 1`] = `
                 </span>
               </div>
               <div
-                aria-live="polite"
                 class="MuiBox-root emotion-13"
                 role="status"
               >

--- a/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
@@ -61,7 +61,9 @@ exports[`enduser-consent-without-logo should render form 1`] = `
                 </span>
               </div>
               <div
+                aria-live="polite"
                 class="MuiBox-root emotion-13"
+                role="status"
               >
                 <span
                   aria-label="Processing..."

--- a/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
@@ -101,7 +101,6 @@ exports[`enduser-consent should render form with logo 1`] = `
                 </span>
               </div>
               <div
-                aria-live="polite"
                 class="MuiBox-root emotion-17"
                 role="status"
               >

--- a/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
@@ -101,7 +101,9 @@ exports[`enduser-consent should render form with logo 1`] = `
                 </span>
               </div>
               <div
+                aria-live="polite"
                 class="MuiBox-root emotion-17"
+                role="status"
               >
                 <span
                   aria-label="Processing..."

--- a/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
@@ -97,7 +97,6 @@ exports[`granular-consent should render form with logo 1`] = `
                 </div>
               </div>
               <div
-                aria-live="polite"
                 class="MuiBox-root emotion-16"
                 role="status"
               >

--- a/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
@@ -97,7 +97,9 @@ exports[`granular-consent should render form with logo 1`] = `
                 </div>
               </div>
               <div
+                aria-live="polite"
                 class="MuiBox-root emotion-16"
+                role="status"
               >
                 <span
                   aria-label="Processing..."

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -1792,7 +1792,9 @@ exports[`identify-with-password renders the loading state first 1`] = `
               class="MuiBox-root emotion-7"
             >
               <div
+                aria-live="polite"
                 class="MuiBox-root emotion-8"
+                role="status"
               >
                 <span
                   aria-label="Processing..."

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -1792,7 +1792,6 @@ exports[`identify-with-password renders the loading state first 1`] = `
               class="MuiBox-root emotion-7"
             >
               <div
-                aria-live="polite"
                 class="MuiBox-root emotion-8"
                 role="status"
               >

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -60,14 +60,6 @@ describe('authenticator-enroll-security-question-error', () => {
   });
 
   describe('predefined question', () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
-  
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
     it('should show field level character count error message when invalid number of characters are sent and field should retain characters', async () => {
       const {
         user, authClient, container, findByText, findByLabelText,
@@ -99,7 +91,7 @@ describe('authenticator-enroll-security-question-error', () => {
 
     it('should show field level character count error message on multiple attempts to submit with invalid character count', async () => {
       const {
-        user, authClient, container, findByLabelText, findByText,
+        user, authClient, container, findByLabelText, findByText, queryByLabelText,
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       expect(await findByText(/Set up security question/)).toBeInTheDocument();
@@ -129,11 +121,9 @@ describe('authenticator-enroll-security-question-error', () => {
           },
         }),
       );
-      expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/);
-      await act(() => {
-        // Wait for Spinner to appear
-        jest.runAllTimers();
-      });
+      await waitFor(() => expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/));
+      // Wait for Spinner to disappear
+      await waitFor(() => queryByLabelText('Processing...') !== null);
       expect(container).toMatchSnapshot();
     });
 

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { HttpRequestClient } from '@okta/okta-auth-js';
-import { act, waitFor } from '@testing-library/preact';
+import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup, updateStateHandleInMock } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/credential/enroll/securityquestion-enroll-mfa.json';

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -60,14 +60,6 @@ describe('authenticator-enroll-security-question-error', () => {
   });
 
   describe('predefined question', () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
-  
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
     it('should show field level character count error message when invalid number of characters are sent and field should retain characters', async () => {
       const {
         user, authClient, container, findByText, findByLabelText,
@@ -98,43 +90,48 @@ describe('authenticator-enroll-security-question-error', () => {
     });
 
     it('should show field level character count error message on multiple attempts to submit with invalid character count', async () => {
-      const {
-        user, authClient, container, findByLabelText, findByText,
-      } = await setup({ mockRequestClient: mockRequestClientWithError });
+      jest.useFakeTimers();
+      try {
+        const {
+          user, authClient, container, findByLabelText, findByText,
+        } = await setup({ mockRequestClient: mockRequestClientWithError });
 
-      expect(await findByText(/Set up security question/)).toBeInTheDocument();
-      const submitButton = await findByText('Verify', { selector: 'button' });
-      const answerEle = await findByLabelText('Answer') as HTMLInputElement;
+        expect(await findByText(/Set up security question/)).toBeInTheDocument();
+        const submitButton = await findByText('Verify', { selector: 'button' });
+        const answerEle = await findByLabelText('Answer') as HTMLInputElement;
 
-      const answer = 'pi';
-      await user.type(answerEle, answer);
-      expect(answerEle.value).toEqual(answer);
+        const answer = 'pi';
+        await user.type(answerEle, answer);
+        expect(answerEle.value).toEqual(answer);
 
-      await user.click(submitButton);
-      expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
-        ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
-          credentials: {
-            questionKey: 'disliked_food',
-            answer,
-          },
-        }),
-      );
-      await waitFor(() => expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/));
-      await user.click(await findByText('Verify', { selector: 'button' }));
-      expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
-        ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
-          credentials: {
-            questionKey: 'disliked_food',
-            answer,
-          },
-        }),
-      );
-      expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/);
-      await act(() => {
-        // Wait for Spinner to appear
-        jest.runAllTimers();
-      });
-      expect(container).toMatchSnapshot();
+        await user.click(submitButton);
+        expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+          ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
+            credentials: {
+              questionKey: 'disliked_food',
+              answer,
+            },
+          }),
+        );
+        await waitFor(() => expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/));
+        await user.click(await findByText('Verify', { selector: 'button' }));
+        expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+          ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
+            credentials: {
+              questionKey: 'disliked_food',
+              answer,
+            },
+          }),
+        );
+        expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/);
+        await act(() => {
+          // Wait for Spinner to appear
+          jest.runAllTimers();
+        });
+        expect(container).toMatchSnapshot();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('should send correct payload when toggling between question types and submitted form with incorrect number of characters', async () => {

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { HttpRequestClient } from '@okta/okta-auth-js';
-import { waitFor } from '@testing-library/preact';
+import { act, waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup, updateStateHandleInMock } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/credential/enroll/securityquestion-enroll-mfa.json';
@@ -20,6 +20,7 @@ import responseWithCharacterLimitError from '../../src/mocks/response/idp/idx/ch
 describe('authenticator-enroll-security-question-error', () => {
   let mockRequestClientWithError: HttpRequestClient;
   beforeEach(() => {
+    jest.useFakeTimers();
     mockRequestClientWithError = jest.fn().mockImplementation((_, url, options) => {
       updateStateHandleInMock(mockResponse);
       updateStateHandleInMock(responseWithCharacterLimitError);
@@ -122,6 +123,10 @@ describe('authenticator-enroll-security-question-error', () => {
         }),
       );
       expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/);
+      await act(() => {
+        // Wait for Spinner to appear
+        jest.runAllTimers();
+      });
       expect(container).toMatchSnapshot();
     });
 

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -121,7 +121,7 @@ describe('authenticator-enroll-security-question-error', () => {
           },
         }),
       );
-      await waitFor(() => expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/));
+      expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/);
       // Wait for Spinner to disappear
       await waitFor(() => queryByLabelText('Processing...') !== null);
       expect(container).toMatchSnapshot();

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -122,8 +122,6 @@ describe('authenticator-enroll-security-question-error', () => {
         }),
       );
       expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/);
-      // Wait for Spinner to disappear
-      await waitFor(() => queryByLabelText('Processing...') !== null);
       expect(container).toMatchSnapshot();
     });
 

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -121,7 +121,9 @@ describe('authenticator-enroll-security-question-error', () => {
           },
         }),
       );
-      expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/);
+      await waitFor(() => expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/));
+      // Wait for Spinner to disappear
+      await waitFor(() => expect(queryByLabelText('Processing...')).toBeNull());
       expect(container).toMatchSnapshot();
     });
 

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -60,6 +60,10 @@ describe('authenticator-enroll-security-question-error', () => {
     });
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   describe('predefined question', () => {
     it('should show field level character count error message when invalid number of characters are sent and field should retain characters', async () => {
       const {

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -20,7 +20,6 @@ import responseWithCharacterLimitError from '../../src/mocks/response/idp/idx/ch
 describe('authenticator-enroll-security-question-error', () => {
   let mockRequestClientWithError: HttpRequestClient;
   beforeEach(() => {
-    jest.useFakeTimers();
     mockRequestClientWithError = jest.fn().mockImplementation((_, url, options) => {
       updateStateHandleInMock(mockResponse);
       updateStateHandleInMock(responseWithCharacterLimitError);
@@ -60,11 +59,15 @@ describe('authenticator-enroll-security-question-error', () => {
     });
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
   describe('predefined question', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+  
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('should show field level character count error message when invalid number of characters are sent and field should retain characters', async () => {
       const {
         user, authClient, container, findByText, findByLabelText,

--- a/src/v3/test/integration/authenticator-piv-cac-verification.test.tsx
+++ b/src/v3/test/integration/authenticator-piv-cac-verification.test.tsx
@@ -39,7 +39,7 @@ describe('authenticator-piv-cac-verification', () => {
 
   it('should render PIV/CAC view when clicking PIV button', async () => {
     const {
-      container, user, findByRole,
+      container, user, findByRole, findByLabelText,
     } = await setup({ mockResponse });
 
     const pivButton = await findByRole('button', { name: 'Sign in with PIV / CAC card' });
@@ -48,6 +48,8 @@ describe('authenticator-piv-cac-verification', () => {
 
     const heading = await findByRole('heading', { level: 2 });
     expect(heading.textContent).toBe('PIV / CAC card');
+    // Wait for Spinner to appear
+    await findByLabelText('Processing...');
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/v3/test/integration/enduser-consent-without-logo.test.tsx
+++ b/src/v3/test/integration/enduser-consent-without-logo.test.tsx
@@ -23,7 +23,7 @@ describe('enduser-consent-without-logo', () => {
         value: { ...enduserConsentResponse.app.value, logo: undefined },
       },
     };
-    const { container, findByRole, queryByAltText } = await setup({
+    const { container, findByRole, findByLabelText, queryByAltText } = await setup({
       mockResponse: enduserConsentResponseWithoutLogo,
     });
     const appNameHeading = await findByRole('heading', { level: 2 });
@@ -31,6 +31,8 @@ describe('enduser-consent-without-logo', () => {
 
     expect(logo).toBeNull();
     expect(appNameHeading.textContent).toBe('Native client');
+    // Wait for Spinner to appear
+    await findByLabelText('Processing...');
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/v3/test/integration/enduser-consent-without-logo.test.tsx
+++ b/src/v3/test/integration/enduser-consent-without-logo.test.tsx
@@ -23,7 +23,9 @@ describe('enduser-consent-without-logo', () => {
         value: { ...enduserConsentResponse.app.value, logo: undefined },
       },
     };
-    const { container, findByRole, findByLabelText, queryByAltText } = await setup({
+    const {
+      container, findByRole, findByLabelText, queryByAltText,
+    } = await setup({
       mockResponse: enduserConsentResponseWithoutLogo,
     });
     const appNameHeading = await findByRole('heading', { level: 2 });

--- a/src/v3/test/integration/enduser-consent.test.tsx
+++ b/src/v3/test/integration/enduser-consent.test.tsx
@@ -16,7 +16,9 @@ import enduserConsentResponse from '../../../../playground/mocks/data/idp/idx/co
 
 describe('enduser-consent', () => {
   it('should render form with logo', async () => {
-    const { container, findByRole, findByLabelText, queryByAltText } = await setup({
+    const {
+      container, findByRole, findByLabelText, queryByAltText,
+    } = await setup({
       mockResponse: enduserConsentResponse,
     });
     const appNameHeading = await findByRole('heading', { level: 2 });

--- a/src/v3/test/integration/enduser-consent.test.tsx
+++ b/src/v3/test/integration/enduser-consent.test.tsx
@@ -16,7 +16,7 @@ import enduserConsentResponse from '../../../../playground/mocks/data/idp/idx/co
 
 describe('enduser-consent', () => {
   it('should render form with logo', async () => {
-    const { container, findByRole, queryByAltText } = await setup({
+    const { container, findByRole, findByLabelText, queryByAltText } = await setup({
       mockResponse: enduserConsentResponse,
     });
     const appNameHeading = await findByRole('heading', { level: 2 });
@@ -24,6 +24,8 @@ describe('enduser-consent', () => {
 
     expect(logo).toBeDefined();
     expect(appNameHeading.textContent).toBe('Native client');
+    // Wait for Spinner to appear
+    await findByLabelText('Processing...');
     expect(container).toMatchSnapshot();
   });
 

--- a/src/v3/test/integration/granular-consent.test.tsx
+++ b/src/v3/test/integration/granular-consent.test.tsx
@@ -26,7 +26,7 @@ describe('granular-consent', () => {
         },
       },
     };
-    const { container, findByRole, queryByAltText } = await setup({
+    const { container, findByRole, findByLabelText, queryByAltText } = await setup({
       mockResponse: granularConsentResponseWithLogo,
     });
     const appNameHeading = await findByRole('heading', { level: 2 });
@@ -34,6 +34,8 @@ describe('granular-consent', () => {
 
     expect(logo).toBeDefined();
     expect(appNameHeading.textContent).toBe('Native client');
+    // Wait for Spinner to appear
+    await findByLabelText('Processing...');
     expect(container).toMatchSnapshot();
   });
 

--- a/src/v3/test/integration/granular-consent.test.tsx
+++ b/src/v3/test/integration/granular-consent.test.tsx
@@ -26,7 +26,9 @@ describe('granular-consent', () => {
         },
       },
     };
-    const { container, findByRole, findByLabelText, queryByAltText } = await setup({
+    const {
+      container, findByRole, findByLabelText, queryByAltText,
+    } = await setup({
       mockResponse: granularConsentResponseWithLogo,
     });
     const appNameHeading = await findByRole('heading', { level: 2 });


### PR DESCRIPTION
## Description:

See ticket https://axeauditor.dequecloud.com/test-run/c52484e0-8f71-11ef-ac64-07f2f3b31366/issue/ef923c24-8fa1-11ef-919c-27b7ec4a7b89

Screen reader should be able to auto announce loading/processing state of SIW

Changes to the `Spinner` component: https://github.com/okta/okta-signin-widget/pull/3809/files#diff-3a6cdf3633a0fdb7bdccc43da66d5a137a93da8779a930baf92cb19b31eaac0c

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-874322](https://oktainc.atlassian.net/browse/OKTA-874322)

### Reviewers:

### Screenshot/Video:

Recording of playground app with `mocks: androidAuthnLoopbackFailfast` in `responseConfig` with VoiceOver.
Note that in "before" video a "Processing..." message of standalone Spinner is not being announced but is being announced twice when Spinner is used as icon for "Open Okta Verify" button.
First issue is fixed by using timer to show content.
Second issue is fixed by using `role="status"`

before:

https://github.com/user-attachments/assets/9569599a-123e-417d-8841-12c2a75248d4

after:

https://github.com/user-attachments/assets/66297817-cd87-4e64-948a-f7fe1b88fa7c



### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&author=denys.oblohin%40okta.com&branch=d16t-okta-signin-widget-4a73c7e&page=1&pageSize=6&tab=main

