### PR TITLE
fix(Gen3): Fix CSP for ReminderPrompt

### DIFF
--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -18,7 +18,7 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';
-import { ReminderElement, UISchemaElementComponent, ClickHandler } from '../../types';
+import { ClickHandler, ReminderElement, UISchemaElementComponent } from '../../types';
 import { getLinkReplacerFn, parseHtmlContent, SessionStorage } from '../../util';
 import TextWithActionLink from '../TextWithActionLink';
 

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -18,7 +18,7 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';
-import { ReminderElement, UISchemaElementComponent } from '../../types';
+import { ReminderElement, UISchemaElementComponent, ClickHandler } from '../../types';
 import { getLinkReplacerFn, parseHtmlContent, SessionStorage } from '../../util';
 import TextWithActionLink from '../TextWithActionLink';
 
@@ -79,7 +79,8 @@ const ReminderPrompt: UISchemaElementComponent<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const resendHandler = async () => {
+  const resendHandler: ClickHandler<HTMLAnchorElement> = async (e) => {
+    e.preventDefault();
     if (loading) {
       return;
     }
@@ -96,10 +97,9 @@ const ReminderPrompt: UISchemaElementComponent<{
     return (
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
       <Link
-        // eslint-disable-next-line no-script-url
-        href="javascript:void(0);"
+        href="#"
         variant="monochrome"
-        onClick={() => resendHandler()}
+        onClick={resendHandler}
       >
         {buttonText}
       </Link>

--- a/src/v3/src/components/ReminderPrompt/__snapshots__/ReminderPrompt.test.tsx.snap
+++ b/src/v3/src/components/ReminderPrompt/__snapshots__/ReminderPrompt.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`ReminderPrompt should show prompt with working link after default timeo
           </div>
           <a
             class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-8"
-            href="javascript:void(0);"
+            href="#"
           >
             Send again?
           </a>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -366,7 +366,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                               </div>
                               <a
                                 class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-27"
-                                href="javascript:void(0);"
+                                href="#"
                               >
                                 Send again
                               </a>
@@ -1195,7 +1195,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                               </div>
                               <a
                                 class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-34"
-                                href="javascript:void(0);"
+                                href="#"
                               >
                                 Send again
                               </a>


### PR DESCRIPTION
## Description:

Using `<a href="javascript:void(0);"` causes CSP violation on click, see screenahot

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-862536](https://oktainc.atlassian.net/browse/OKTA-862536)

### Reviewers:

### Screenshot/Video:

<img width="375" alt="Screenshot 2025-03-25 at 18 55 10" src="https://github.com/user-attachments/assets/e4241937-8bfc-4b8b-8274-20b382fcf48f" />

Before:

<img width="621" alt="Screenshot 2025-03-25 at 18 54 47" src="https://github.com/user-attachments/assets/d2430302-5c67-43bc-8cd1-ddf3284b4d87" />

<img width="640" alt="Screenshot 2025-03-25 at 18 55 16" src="https://github.com/user-attachments/assets/59045b64-27b2-4018-9c18-810314302079" />

After:

<img width="663" alt="Screenshot 2025-03-25 at 18 56 04" src="https://github.com/user-attachments/assets/93823f5d-0aa1-4527-aaf8-7beb4883257e" />



### Downstream Monolith Build:



