### PR TITLE
fix(Gen2): Fix CSP in Gen2 resend view with a11y plugin

### DIFF
--- a/src/plugins/OktaPluginA11y.ts
+++ b/src/plugins/OktaPluginA11y.ts
@@ -152,7 +152,7 @@ export const init = (widget: OktaSignInAPI & { options: WidgetOptions }): void =
         if (document.querySelector('.resend-link')) {
           console.log('interval: resend-link')
           document.querySelectorAll('.resend-link')
-            .forEach((link) => link.setAttribute('href', 'javascript:void(0);'))
+            .forEach((link) => link.setAttribute('href', '#'))
           console.log('clearing interval: resend-link')
           clearInterval(intervalResend)
         }

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -32,9 +32,9 @@ const ResendView = BaseResendView.extend(
     },
 
     handleResendLink(ev) {
+      ev?.preventDefault();
       this.options.appState.trigger('invokeAction', this.options.resendEmailAction);
       this.hideResendViewAndShowAfterTimeout();
-      ev?.preventDefault();
     },
 
     handleError() {

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -31,9 +31,10 @@ const ResendView = BaseResendView.extend(
       this.showCalloutAfterTimeout();
     },
 
-    handleResendLink() {
+    handleResendLink(ev) {
       this.options.appState.trigger('invokeAction', this.options.resendEmailAction);
       this.hideResendViewAndShowAfterTimeout();
+      ev?.preventDefault();
     },
 
     handleError() {

--- a/src/v2/view-builder/views/ov/OVResendView.js
+++ b/src/v2/view-builder/views/ov/OVResendView.js
@@ -20,10 +20,10 @@ export default BaseResendView.extend({
   },
 
   handelResendLink(ev) {
+    ev?.preventDefault();
     this.options.appState.trigger('invokeAction', 'currentAuthenticator-resend');
     //hide warning, but reinitiate to show warning again after some threshold of polling
     this.$el.addClass('hide');
     this.showCalloutAfterTimeout();
-    ev?.preventDefault();
   },
 });

--- a/src/v2/view-builder/views/ov/OVResendView.js
+++ b/src/v2/view-builder/views/ov/OVResendView.js
@@ -19,10 +19,11 @@ export default BaseResendView.extend({
     }));
   },
 
-  handelResendLink() {
+  handelResendLink(ev) {
     this.options.appState.trigger('invokeAction', 'currentAuthenticator-resend');
     //hide warning, but reinitiate to show warning again after some threshold of polling
     this.$el.addClass('hide');
     this.showCalloutAfterTimeout();
+    ev?.preventDefault();
   },
 });

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -39,9 +39,9 @@ const ResendView = BaseResendView.extend(
     },
 
     handleResendLink(ev) {
+      ev?.preventDefault();
       this.options.appState.trigger('invokeAction', this.resendActionKey);
       this.hideResendViewAndShowAfterTimeout();
-      ev?.preventDefault();
     },
 
     handleError() {

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -38,9 +38,10 @@ const ResendView = BaseResendView.extend(
       this.showCalloutAfterTimeout();
     },
 
-    handleResendLink() {
+    handleResendLink(ev) {
       this.options.appState.trigger('invokeAction', this.resendActionKey);
       this.hideResendViewAndShowAfterTimeout();
+      ev?.preventDefault();
     },
 
     handleError() {


### PR DESCRIPTION
## Description:

Remove usage of `javascript:void(0)` in `href` which causes CSP violation

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-862536](https://oktainc.atlassian.net/browse/OKTA-862536)

### Reviewers:

### Screenshot/Video:

Before:

<img width="410" alt="Screenshot 2025-03-27 at 17 41 42" src="https://github.com/user-attachments/assets/fe5865cb-0c8f-4007-aa60-aae9edacd3d0" />
<img width="488" alt="Screenshot 2025-03-27 at 17 41 46" src="https://github.com/user-attachments/assets/5fba0a05-d428-4053-999e-cf8557461f3e" />
<img width="1453" alt="Screenshot 2025-03-27 at 17 34 39" src="https://github.com/user-attachments/assets/7ccfb572-5e26-4158-89b3-707939a06c20" />

After:

<img width="372" alt="Screenshot 2025-03-27 at 17 42 00" src="https://github.com/user-attachments/assets/c3226ca1-9c47-4c6e-905e-c74eec03a46c" />


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-b571b0f&page=1&pageSize=6&tab=main


