### PR TITLE
fix(Gen3): Always render ReminderPrompt after Title for consistency

### DIFF
--- a/src/v3/src/transformer/layout/email/__snapshots__/transformEmailAuthenticatorEnroll.test.ts.snap
+++ b/src/v3/src/transformer/layout/email/__snapshots__/transformEmailAuthenticatorEnroll.test.ts.snap
@@ -16,6 +16,12 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
           "actionParams": Object {
             "resend": true,
           },
@@ -25,12 +31,6 @@ Object {
           "step": "resend",
         },
         "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.email.mfa.title",
-        },
-        "type": "Title",
       },
       Object {
         "options": Object {
@@ -126,6 +126,12 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
           "actionParams": Object {
             "resend": true,
           },
@@ -135,12 +141,6 @@ Object {
           "step": "resend",
         },
         "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.email.mfa.title",
-        },
-        "type": "Title",
       },
       Object {
         "options": Object {
@@ -191,6 +191,12 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -200,12 +206,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
               },
               Object {
                 "options": Object {
@@ -229,6 +229,12 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -238,12 +244,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
               },
               Object {
                 "options": Object {
@@ -385,6 +385,12 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -394,12 +400,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
               },
               Object {
                 "options": Object {
@@ -423,6 +423,12 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -432,12 +438,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
               },
               Object {
                 "options": Object {
@@ -490,6 +490,12 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
           "actionParams": Object {
             "resend": true,
           },
@@ -499,12 +505,6 @@ Object {
           "step": "resend",
         },
         "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.email.mfa.title",
-        },
-        "type": "Title",
       },
       Object {
         "options": Object {
@@ -600,6 +600,12 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
           "actionParams": Object {
             "resend": true,
           },
@@ -609,12 +615,6 @@ Object {
           "step": "resend",
         },
         "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.email.mfa.title",
-        },
-        "type": "Title",
       },
       Object {
         "options": Object {

--- a/src/v3/src/transformer/layout/email/__snapshots__/transformEmailAuthenticatorVerify.test.ts.snap
+++ b/src/v3/src/transformer/layout/email/__snapshots__/transformEmailAuthenticatorVerify.test.ts.snap
@@ -16,6 +16,12 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
           "actionParams": Object {
             "resend": true,
           },
@@ -25,12 +31,6 @@ Object {
           "step": "resend",
         },
         "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.email.mfa.title",
-        },
-        "type": "Title",
       },
       Object {
         "contentType": "subtitle",
@@ -128,6 +128,12 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
+          "content": "oie.email.mfa.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
           "actionParams": Object {
             "resend": true,
           },
@@ -137,12 +143,6 @@ Object {
           "step": "resend",
         },
         "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.email.mfa.title",
-        },
-        "type": "Title",
       },
       Object {
         "contentType": "subtitle",
@@ -194,6 +194,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -203,13 +210,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 0,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
                 "viewIndex": 0,
               },
               Object {
@@ -237,6 +237,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -246,13 +253,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 1,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
                 "viewIndex": 1,
               },
               Object {
@@ -408,6 +408,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -417,13 +424,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 0,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
                 "viewIndex": 0,
               },
               Object {
@@ -451,6 +451,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -460,13 +467,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 1,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
                 "viewIndex": 1,
               },
               Object {
@@ -528,6 +528,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -537,13 +544,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 0,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
                 "viewIndex": 0,
               },
               Object {
@@ -571,6 +571,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -580,13 +587,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 1,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
                 "viewIndex": 1,
               },
               Object {
@@ -742,6 +742,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -751,13 +758,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 0,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
                 "viewIndex": 0,
               },
               Object {
@@ -785,6 +785,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.email.mfa.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -794,13 +801,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 1,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.email.mfa.title",
-                },
-                "type": "Title",
                 "viewIndex": 1,
               },
               Object {

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.test.ts
@@ -77,16 +77,16 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
       expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutOne.elements.length).toBe(4);
 
-      expect((layoutOne.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutOne.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+      expect((layoutOne.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutOne.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutOne.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutOne.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutOne.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutOne.elements[2].type).toBe('Description');
       expect((layoutOne.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
@@ -98,16 +98,16 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
 
       expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutTwo.elements.length).toBe(5);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+      expect((layoutTwo.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutTwo.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutTwo.elements[2].type).toBe('Description');
       expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
@@ -141,16 +141,16 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
       expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutOne.elements.length).toBe(4);
 
-      expect((layoutOne.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutOne.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+      expect((layoutOne.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutOne.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutOne.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutOne.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutOne.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutOne.elements[2].type).toBe('Description');
       expect((layoutOne.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
@@ -162,16 +162,16 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
 
       expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutTwo.elements.length).toBe(5);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+      expect((layoutTwo.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutTwo.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutTwo.elements[2].type).toBe('Description');
       expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
@@ -259,16 +259,16 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
 
       expect(updatedFormBag).toMatchSnapshot();
       expect(updatedFormBag.uischema.elements.length).toBe(5);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
       expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.verificationCode.instructions');
@@ -297,16 +297,16 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
 
       expect(updatedFormBag).toMatchSnapshot();
       expect(updatedFormBag.uischema.elements.length).toBe(5);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
       expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.verificationCode.instructions');
@@ -372,16 +372,16 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
 
       expect(updatedFormBag).toMatchSnapshot();
       expect(updatedFormBag.uischema.elements.length).toBe(5);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
       expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.enroll.subtitle');
@@ -410,16 +410,16 @@ describe('Email Authenticator Enroll Transformer Tests', () => {
 
       expect(updatedFormBag).toMatchSnapshot();
       expect(updatedFormBag.uischema.elements.length).toBe(5);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
       expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.enroll.subtitle');

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorEnroll.ts
@@ -98,8 +98,8 @@ export const transformEmailAuthenticatorEnroll: IdxStepTransformer = ({ transact
   };
 
   const codeEntryDisplayElements: UISchemaElement[] = [
-    ...(reminderElement ? [reminderElement] : []),
     titleElement,
+    ...(reminderElement ? [reminderElement] : []),
     subTitleElement,
     passcodeElement!,
     submitButtonElement,
@@ -127,8 +127,8 @@ export const transformEmailAuthenticatorEnroll: IdxStepTransformer = ({ transact
       {
         type: UISchemaLayoutType.VERTICAL,
         elements: [
-          ...(reminderElement ? [reminderElement] : []),
           titleElement,
+          ...(reminderElement ? [reminderElement] : []),
           subTitleElement,
           showCodeStepperButton,
         ],

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.test.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.test.ts
@@ -82,16 +82,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
       expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutOne.elements.length).toBe(4);
 
-      expect((layoutOne.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutOne.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+      expect((layoutOne.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutOne.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutOne.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutOne.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutOne.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutOne.elements[2].type).toBe('Description');
       expect((layoutOne.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
@@ -103,16 +103,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
 
       expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutTwo.elements.length).toBe(5);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+      expect((layoutTwo.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutTwo.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutTwo.elements[2].type).toBe('Description');
       expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
@@ -146,16 +146,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
       expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutOne.elements.length).toBe(4);
 
-      expect((layoutOne.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutOne.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+      expect((layoutOne.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutOne.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutOne.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutOne.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutOne.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutOne.elements[2].type).toBe('Description');
       expect((layoutOne.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
@@ -167,16 +167,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
 
       expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutTwo.elements.length).toBe(5);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+      expect((layoutTwo.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutTwo.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutTwo.elements[2].type).toBe('Description');
       expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
@@ -276,16 +276,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
 
       expect(updatedFormBag).toMatchSnapshot();
       expect(updatedFormBag.uischema.elements.length).toBe(5);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
       expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.verificationCode.instructions');
@@ -314,16 +314,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
 
       expect(updatedFormBag).toMatchSnapshot();
       expect(updatedFormBag.uischema.elements.length).toBe(5);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options?.content)
+      expect((updatedFormBag.uischema.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
       expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.verificationCode.instructions');
@@ -410,16 +410,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
       expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutOne.elements.length).toBe(4);
 
-      expect((layoutOne.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutOne.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+      expect((layoutOne.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutOne.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutOne.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutOne.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutOne.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutOne.elements[2].type).toBe('Description');
       expect((layoutOne.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
@@ -431,16 +431,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
 
       expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutTwo.elements.length).toBe(5);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+      expect((layoutTwo.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutTwo.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutTwo.elements[2].type).toBe('Description');
       expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToEmailAddressoie.email.verify.alternate.instructions');
@@ -474,16 +474,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
       expect(layoutOne.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutOne.elements.length).toBe(4);
 
-      expect((layoutOne.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutOne.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutOne.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutOne.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutOne.elements[1] as DescriptionElement).options?.content)
+      expect((layoutOne.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutOne.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutOne.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutOne.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutOne.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutOne.elements[2].type).toBe('Description');
       expect((layoutOne.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');
@@ -495,16 +495,16 @@ describe('Email Authenticator Verify Transformer Tests', () => {
 
       expect(layoutTwo.type).toBe(UISchemaLayoutType.VERTICAL);
       expect(layoutTwo.elements.length).toBe(5);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.content)
-        .toBe('email.code.not.received');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.actionParams?.resend)
-        .toBe(true);
-      expect((layoutTwo.elements[0] as ReminderElement).options?.step)
-        .toBe('resend');
-      expect((layoutTwo.elements[0] as ReminderElement).options?.isActionStep)
-        .toBe(true);
-      expect((layoutTwo.elements[1] as DescriptionElement).options?.content)
+      expect((layoutTwo.elements[0] as DescriptionElement).options?.content)
         .toBe('oie.email.mfa.title');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.content)
+        .toBe('email.code.not.received');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.actionParams?.resend)
+        .toBe(true);
+      expect((layoutTwo.elements[1] as ReminderElement).options?.step)
+        .toBe('resend');
+      expect((layoutTwo.elements[1] as ReminderElement).options?.isActionStep)
+        .toBe(true);
       expect(layoutTwo.elements[2].type).toBe('Description');
       expect((layoutTwo.elements[2] as DescriptionElement).options?.content)
         .toBe('oie.email.verify.alternate.magicLinkToYourEmailoie.email.verify.alternate.instructions');

--- a/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.ts
+++ b/src/v3/src/transformer/layout/email/transformEmailAuthenticatorVerify.ts
@@ -111,8 +111,8 @@ export const transformEmailAuthenticatorVerify: IdxStepTransformer = ({ transact
   };
 
   const codeEntryDisplayElements: UISchemaElement[] = [
-    ...(reminderElement ? [reminderElement] : []),
     titleElement,
+    ...(reminderElement ? [reminderElement] : []),
     informationalText,
     passcodeElement!,
     submitButtonElement,
@@ -140,8 +140,8 @@ export const transformEmailAuthenticatorVerify: IdxStepTransformer = ({ transact
       {
         type: UISchemaLayoutType.VERTICAL,
         elements: [
-          ...(reminderElement ? [reminderElement] : []),
           titleElement,
+          ...(reminderElement ? [reminderElement] : []),
           informationalText,
           showCodeStepperButton,
         ].map((ele: UISchemaElement) => ({ ...ele, viewIndex: 0 })),

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyCustomAppChallengePoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyCustomAppChallengePoll.test.ts.snap
@@ -23,17 +23,17 @@ Object {
         "type": "Title",
       },
       Object {
-        "options": Object {
-          "content": "oie.okta_verify.push.sent.respond_to_continue",
-        },
-        "type": "Description",
-      },
-      Object {
         "noMargin": true,
         "options": Object {
           "content": "oie.custom_app.push.warning",
         },
         "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "contentType": "footer",
@@ -73,17 +73,17 @@ Object {
         "type": "Title",
       },
       Object {
-        "options": Object {
-          "content": "oie.okta_verify.push.sent.respond_to_continue",
-        },
-        "type": "Description",
-      },
-      Object {
         "noMargin": true,
         "options": Object {
           "content": "oie.custom_app.push.warning",
         },
         "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "contentType": "footer",
@@ -132,17 +132,17 @@ Object {
         "type": "Title",
       },
       Object {
-        "options": Object {
-          "content": "oie.okta_verify.push.sent.respond_to_continue",
-        },
-        "type": "Description",
-      },
-      Object {
         "noMargin": true,
         "options": Object {
           "content": "oie.custom_app.push.warning",
         },
         "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "contentType": "footer",
@@ -231,6 +231,12 @@ Object {
   "uischema": Object {
     "elements": Array [
       Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent",
+        },
+        "type": "Title",
+      },
+      Object {
         "noMargin": true,
         "options": Object {
           "actionParams": Object {
@@ -243,12 +249,6 @@ Object {
           "step": "resend",
         },
         "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.okta_verify.push.sent",
-        },
-        "type": "Title",
       },
       Object {
         "contentType": "subtitle",
@@ -300,6 +300,12 @@ Object {
   "uischema": Object {
     "elements": Array [
       Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent",
+        },
+        "type": "Title",
+      },
+      Object {
         "noMargin": true,
         "options": Object {
           "actionParams": Object {
@@ -312,12 +318,6 @@ Object {
           "step": "resend",
         },
         "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.okta_verify.push.sent",
-        },
-        "type": "Title",
       },
       Object {
         "contentType": "subtitle",
@@ -384,17 +384,17 @@ Object {
         "type": "Title",
       },
       Object {
-        "options": Object {
-          "content": "oie.okta_verify.push.sent.respond_to_continue",
-        },
-        "type": "Description",
-      },
-      Object {
         "noMargin": true,
         "options": Object {
           "content": "oktaverify.warning",
         },
         "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "contentType": "footer",
@@ -434,17 +434,17 @@ Object {
         "type": "Title",
       },
       Object {
-        "options": Object {
-          "content": "oie.okta_verify.push.sent.respond_to_continue",
-        },
-        "type": "Description",
-      },
-      Object {
         "noMargin": true,
         "options": Object {
           "content": "oktaverify.warning",
         },
         "type": "Reminder",
+      },
+      Object {
+        "options": Object {
+          "content": "oie.okta_verify.push.sent.respond_to_continue",
+        },
+        "type": "Description",
       },
       Object {
         "contentType": "footer",

--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
@@ -1225,6 +1225,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.email.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1235,13 +1242,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 0,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.email.title",
-                },
-                "type": "Title",
                 "viewIndex": 0,
               },
               Object {
@@ -1283,6 +1283,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.email.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1293,13 +1300,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 1,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.email.title",
-                },
-                "type": "Title",
                 "viewIndex": 1,
               },
               Object {
@@ -1327,6 +1327,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.email.title",
+                },
+                "type": "Title",
+                "viewIndex": 2,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1337,13 +1344,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 2,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.email.title",
-                },
-                "type": "Title",
                 "viewIndex": 2,
               },
               Object {
@@ -1371,6 +1371,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.email.title",
+                },
+                "type": "Title",
+                "viewIndex": 3,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1381,13 +1388,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 3,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.email.title",
-                },
-                "type": "Title",
                 "viewIndex": 3,
               },
               Object {
@@ -1427,6 +1427,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.email.title",
+                },
+                "type": "Title",
+                "viewIndex": 4,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1437,13 +1444,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 4,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.email.title",
-                },
-                "type": "Title",
                 "viewIndex": 4,
               },
               Object {
@@ -1524,6 +1524,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.sms.title",
+                },
+                "type": "Title",
+                "viewIndex": 0,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1534,13 +1541,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 0,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.sms.title",
-                },
-                "type": "Title",
                 "viewIndex": 0,
               },
               Object {
@@ -1582,6 +1582,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.sms.title",
+                },
+                "type": "Title",
+                "viewIndex": 1,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1592,13 +1599,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 1,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.sms.title",
-                },
-                "type": "Title",
                 "viewIndex": 1,
               },
               Object {
@@ -1626,6 +1626,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.sms.title",
+                },
+                "type": "Title",
+                "viewIndex": 2,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1636,13 +1643,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 2,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.sms.title",
-                },
-                "type": "Title",
                 "viewIndex": 2,
               },
               Object {
@@ -1670,6 +1670,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.sms.title",
+                },
+                "type": "Title",
+                "viewIndex": 3,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1680,13 +1687,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 3,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.sms.title",
-                },
-                "type": "Title",
                 "viewIndex": 3,
               },
               Object {
@@ -1726,6 +1726,13 @@ Object {
             "elements": Array [
               Object {
                 "options": Object {
+                  "content": "oie.enroll.okta_verify.setup.sms.title",
+                },
+                "type": "Title",
+                "viewIndex": 4,
+              },
+              Object {
+                "options": Object {
                   "actionParams": Object {
                     "resend": true,
                   },
@@ -1736,13 +1743,6 @@ Object {
                   "step": "resend",
                 },
                 "type": "Reminder",
-                "viewIndex": 4,
-              },
-              Object {
-                "options": Object {
-                  "content": "oie.enroll.okta_verify.setup.sms.title",
-                },
-                "type": "Title",
                 "viewIndex": 4,
               },
               Object {

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.test.ts
@@ -89,10 +89,10 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
       .toBe('oie.okta_verify.push.sent');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe('oie.okta_verify.push.sent.respond_to_continue');
-    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
       .toBe('oktaverify.warning');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('goback');
   });
@@ -116,10 +116,10 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
       .toBe('oie.custom_app.push.sent');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe('oie.okta_verify.push.sent.respond_to_continue');
-    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
       .toBe('oie.custom_app.push.warning');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('goback');
   });
@@ -136,10 +136,10 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
       .toBe('oie.okta_verify.push.sent');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe('oie.okta_verify.push.sent.respond_to_continue');
-    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
       .toBe('oktaverify.warning');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('oie.verification.switch.authenticator');
     expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)
@@ -171,14 +171,14 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     });
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.content)
-      .toBe('oie.numberchallenge.warning');
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.isActionStep)
-      .toBe(true);
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.step)
-      .toBe('resend');
-    expect((updatedFormBag.uischema.elements[1] as TitleElement).options.content)
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
       .toBe('oie.okta_verify.push.sent');
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
+      .toBe('oie.numberchallenge.warning');
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.step)
+      .toBe('resend');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
       .toBe('oie.numberchallenge.instruction');
     expect((updatedFormBag.uischema.elements[3] as ImageWithTextElement).type)
@@ -216,14 +216,14 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(6);
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.content)
-      .toBe('oie.numberchallenge.warning');
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.isActionStep)
-      .toBe(true);
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.step)
-      .toBe('resend');
-    expect((updatedFormBag.uischema.elements[1] as TitleElement).options.content)
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
       .toBe('oie.okta_verify.push.sent');
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
+      .toBe('oie.numberchallenge.warning');
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.step)
+      .toBe('resend');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
       .toBe('oie.numberchallenge.instruction');
     expect((updatedFormBag.uischema.elements[3] as ImageWithTextElement).type)
@@ -353,10 +353,10 @@ describe('Transform Custom App Challenge Poll Tests', () => {
     expect(updatedFormBag.uischema.elements.length).toBe(4);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
       .toBe('oie.custom_app.push.sent');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe('oie.okta_verify.push.sent.respond_to_continue');
-    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
       .toBe('oie.custom_app.push.warning');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('goback');
   });
@@ -373,10 +373,10 @@ describe('Transform Custom App Challenge Poll Tests', () => {
     expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
       .toBe('oie.custom_app.push.sent');
-    expect((updatedFormBag.uischema.elements[1] as DescriptionElement).options.content)
-      .toBe('oie.okta_verify.push.sent.respond_to_continue');
-    expect((updatedFormBag.uischema.elements[2] as ReminderElement).options.content)
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
       .toBe('oie.custom_app.push.warning');
+    expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)
+      .toBe('oie.okta_verify.push.sent.respond_to_continue');
     expect((updatedFormBag.uischema.elements[3] as LinkElement).options.label)
       .toBe('oie.verification.switch.authenticator');
     expect((updatedFormBag.uischema.elements[4] as LinkElement).options.label)

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyCustomAppChallengePoll.ts
@@ -54,11 +54,6 @@ export const transformOktaVerifyCustomAppChallengePoll: IdxStepTransformer = (op
     const correctAnswer = relatesTo?.value?.contextualData?.correctAnswer;
 
     if (correctAnswer) {
-      uischema.elements.unshift({
-        type: 'Title',
-        options: { content: loc('oie.okta_verify.push.sent', 'login') },
-      } as TitleElement);
-
       const resendStep = availableSteps?.find(({ name }) => name?.endsWith('resend'));
       if (resendStep) {
         const { name } = resendStep;
@@ -80,6 +75,11 @@ export const transformOktaVerifyCustomAppChallengePoll: IdxStepTransformer = (op
           },
         } as ReminderElement);
       }
+
+      uischema.elements.unshift({
+        type: 'Title',
+        options: { content: loc('oie.okta_verify.push.sent', 'login') },
+      } as TitleElement);
 
       const phoneIconImage: ImageWithTextElement = {
         type: 'ImageWithText',
@@ -111,6 +111,12 @@ export const transformOktaVerifyCustomAppChallengePoll: IdxStepTransformer = (op
     } else {
       const isOV = getAuthenticatorKey(transaction) === AUTHENTICATOR_KEY.OV;
       uischema.elements.unshift({
+        type: 'Description',
+        options: {
+          content: loc('oie.okta_verify.push.sent.respond_to_continue', 'login'),
+        },
+      } as DescriptionElement);
+      uischema.elements.unshift({
         type: 'Reminder',
         noMargin: true,
         options: {
@@ -119,12 +125,6 @@ export const transformOktaVerifyCustomAppChallengePoll: IdxStepTransformer = (op
             : loc('oie.custom_app.push.warning', 'login', [getDisplayName(transaction)]),
         },
       } as ReminderElement);
-      uischema.elements.unshift({
-        type: 'Description',
-        options: {
-          content: loc('oie.okta_verify.push.sent.respond_to_continue', 'login'),
-        },
-      } as DescriptionElement);
       uischema.elements.unshift({
         type: 'Title',
         options: {

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
@@ -71,18 +71,18 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
     const [layoutOne, layoutTwo, layoutThree] = (stepperLayout as StepperLayout).elements;
 
     expect(layoutOne.elements.length).toBe(5);
-    expect((layoutOne.elements[0] as ReminderElement).options.content)
-      .toBe('oie.enroll.okta_verify.sms.notReceived');
-    expect((layoutOne.elements[0] as ReminderElement).options.contentClassname)
-      .toBe('resend-link');
-    expect((layoutOne.elements[0] as ReminderElement).options.contentHasHtml)
-      .toBe(true);
-    expect((layoutOne.elements[0] as ReminderElement).options.isActionStep)
-      .toBe(true);
-    expect((layoutOne.elements[0] as ReminderElement).options.step)
-      .toBe('resend');
-    expect((layoutOne.elements[1] as TitleElement).options.content)
+    expect((layoutOne.elements[0] as TitleElement).options.content)
       .toBe('oie.enroll.okta_verify.setup.sms.title');
+    expect((layoutOne.elements[1] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.sms.notReceived');
+    expect((layoutOne.elements[1] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutOne.elements[1] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutOne.elements[1] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutOne.elements[1] as ReminderElement).options.step)
+      .toBe('resend');
     expect(layoutOne.elements[2].type)
       .toBe('List');
     expect((layoutOne.elements[2] as ListElement).options.type)
@@ -106,18 +106,18 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
       .toBe('select-enrollment-channel');
 
     expect(layoutTwo.elements.length).toBe(4);
-    expect((layoutTwo.elements[0] as ReminderElement).options.content)
-      .toBe('oie.enroll.okta_verify.sms.notReceived');
-    expect((layoutTwo.elements[0] as ReminderElement).options.contentClassname)
-      .toBe('resend-link');
-    expect((layoutTwo.elements[0] as ReminderElement).options.contentHasHtml)
-      .toBe(true);
-    expect((layoutTwo.elements[0] as ReminderElement).options.isActionStep)
-      .toBe(true);
-    expect((layoutTwo.elements[0] as ReminderElement).options.step)
-      .toBe('resend');
-    expect((layoutTwo.elements[1] as TitleElement).options.content)
+    expect((layoutTwo.elements[0] as TitleElement).options.content)
       .toBe('oie.enroll.okta_verify.setup.sms.title');
+    expect((layoutTwo.elements[1] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.sms.notReceived');
+    expect((layoutTwo.elements[1] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutTwo.elements[1] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutTwo.elements[1] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutTwo.elements[1] as ReminderElement).options.step)
+      .toBe('resend');
     expect((layoutTwo.elements[2] as DescriptionElement).options.content)
       .toBe('oie.enroll.okta_verify.email.info.updated');
     expect(layoutTwo.elements[3].type).toBe('TextWithActionLink');
@@ -131,18 +131,18 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
       .toBe('select-enrollment-channel');
 
     expect(layoutThree.elements.length).toBe(4);
-    expect((layoutThree.elements[0] as ReminderElement).options.content)
-      .toBe('oie.enroll.okta_verify.sms.notReceived');
-    expect((layoutThree.elements[0] as ReminderElement).options.contentClassname)
-      .toBe('resend-link');
-    expect((layoutThree.elements[0] as ReminderElement).options.contentHasHtml)
-      .toBe(true);
-    expect((layoutThree.elements[0] as ReminderElement).options.isActionStep)
-      .toBe(true);
-    expect((layoutThree.elements[0] as ReminderElement).options.step)
-      .toBe('resend');
-    expect((layoutThree.elements[1] as TitleElement).options.content)
+    expect((layoutThree.elements[0] as TitleElement).options.content)
       .toBe('oie.enroll.okta_verify.setup.sms.title');
+    expect((layoutThree.elements[1] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.sms.notReceived');
+    expect((layoutThree.elements[1] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutThree.elements[1] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutThree.elements[1] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutThree.elements[1] as ReminderElement).options.step)
+      .toBe('resend');
     expect((layoutThree.elements[2] as DescriptionElement).options.content)
       .toBe('oie.enroll.okta_verify.sms.info.updated');
     expect(layoutThree.elements[3].type).toBe('TextWithActionLink');
@@ -182,18 +182,18 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
     const [layoutOne, layoutTwo, layoutThree] = (stepperLayout as StepperLayout).elements;
 
     expect(layoutOne.elements.length).toBe(5);
-    expect((layoutOne.elements[0] as ReminderElement).options.content)
-      .toBe('oie.enroll.okta_verify.email.notReceived');
-    expect((layoutOne.elements[0] as ReminderElement).options.contentClassname)
-      .toBe('resend-link');
-    expect((layoutOne.elements[0] as ReminderElement).options.contentHasHtml)
-      .toBe(true);
-    expect((layoutOne.elements[0] as ReminderElement).options.isActionStep)
-      .toBe(true);
-    expect((layoutOne.elements[0] as ReminderElement).options.step)
-      .toBe('resend');
-    expect((layoutOne.elements[1] as TitleElement).options.content)
+    expect((layoutOne.elements[0] as TitleElement).options.content)
       .toBe('oie.enroll.okta_verify.setup.email.title');
+    expect((layoutOne.elements[1] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.email.notReceived');
+    expect((layoutOne.elements[1] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutOne.elements[1] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutOne.elements[1] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutOne.elements[1] as ReminderElement).options.step)
+      .toBe('resend');
     expect(layoutOne.elements[2].type)
       .toBe('List');
     expect((layoutOne.elements[2] as ListElement).options.type)
@@ -217,18 +217,18 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
       .toBe('select-enrollment-channel');
 
     expect(layoutTwo.elements.length).toBe(4);
-    expect((layoutTwo.elements[0] as ReminderElement).options.content)
-      .toBe('oie.enroll.okta_verify.email.notReceived');
-    expect((layoutTwo.elements[0] as ReminderElement).options.contentClassname)
-      .toBe('resend-link');
-    expect((layoutTwo.elements[0] as ReminderElement).options.contentHasHtml)
-      .toBe(true);
-    expect((layoutTwo.elements[0] as ReminderElement).options.isActionStep)
-      .toBe(true);
-    expect((layoutTwo.elements[0] as ReminderElement).options.step)
-      .toBe('resend');
-    expect((layoutTwo.elements[1] as TitleElement).options.content)
+    expect((layoutTwo.elements[0] as TitleElement).options.content)
       .toBe('oie.enroll.okta_verify.setup.email.title');
+    expect((layoutTwo.elements[1] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.email.notReceived');
+    expect((layoutTwo.elements[1] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutTwo.elements[1] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutTwo.elements[1] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutTwo.elements[1] as ReminderElement).options.step)
+      .toBe('resend');
     expect((layoutTwo.elements[2] as DescriptionElement).options.content)
       .toBe('oie.enroll.okta_verify.email.info.updated');
     expect(layoutTwo.elements[3].type).toBe('TextWithActionLink');
@@ -242,18 +242,18 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
       .toBe('select-enrollment-channel');
 
     expect(layoutThree.elements.length).toBe(4);
-    expect((layoutThree.elements[0] as ReminderElement).options.content)
-      .toBe('oie.enroll.okta_verify.email.notReceived');
-    expect((layoutThree.elements[0] as ReminderElement).options.contentClassname)
-      .toBe('resend-link');
-    expect((layoutThree.elements[0] as ReminderElement).options.contentHasHtml)
-      .toBe(true);
-    expect((layoutThree.elements[0] as ReminderElement).options.isActionStep)
-      .toBe(true);
-    expect((layoutThree.elements[0] as ReminderElement).options.step)
-      .toBe('resend');
-    expect((layoutThree.elements[1] as TitleElement).options.content)
+    expect((layoutThree.elements[0] as TitleElement).options.content)
       .toBe('oie.enroll.okta_verify.setup.email.title');
+    expect((layoutThree.elements[1] as ReminderElement).options.content)
+      .toBe('oie.enroll.okta_verify.email.notReceived');
+    expect((layoutThree.elements[1] as ReminderElement).options.contentClassname)
+      .toBe('resend-link');
+    expect((layoutThree.elements[1] as ReminderElement).options.contentHasHtml)
+      .toBe(true);
+    expect((layoutThree.elements[1] as ReminderElement).options.isActionStep)
+      .toBe(true);
+    expect((layoutThree.elements[1] as ReminderElement).options.step)
+      .toBe('resend');
     expect((layoutThree.elements[2] as DescriptionElement).options.content)
       .toBe('oie.enroll.okta_verify.sms.info.updated');
     expect(layoutThree.elements[3].type).toBe('TextWithActionLink');

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
@@ -451,8 +451,8 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
       {
         type: UISchemaLayoutType.VERTICAL,
         elements: [
-          ...(reminder ? [reminder] : []),
           title,
+          ...(reminder ? [reminder] : []),
           {
             type: 'List',
             noMargin: true,
@@ -469,8 +469,8 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
       {
         type: UISchemaLayoutType.VERTICAL,
         elements: [
-          ...(reminder ? [reminder] : []),
           title,
+          ...(reminder ? [reminder] : []),
           {
             type: 'Description',
             contentType: 'subtitle',
@@ -485,8 +485,8 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
       {
         type: UISchemaLayoutType.VERTICAL,
         elements: [
-          ...(reminder ? [reminder] : []),
           title,
+          ...(reminder ? [reminder] : []),
           {
             type: 'Description',
             contentType: 'subtitle',
@@ -501,8 +501,8 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
       {
         type: UISchemaLayoutType.VERTICAL,
         elements: [
-          ...(reminder ? [reminder] : []),
           title,
+          ...(reminder ? [reminder] : []),
           {
             type: 'Description',
             contentType: 'subtitle',
@@ -527,8 +527,8 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
       {
         type: UISchemaLayoutType.VERTICAL,
         elements: [
-          ...(reminder ? [reminder] : []),
           title,
+          ...(reminder ? [reminder] : []),
           {
             type: 'Description',
             contentType: 'subtitle',

--- a/src/v3/src/transformer/phone/__snapshots__/phoneChallengeTransformer.test.ts.snap
+++ b/src/v3/src/transformer/phone/__snapshots__/phoneChallengeTransformer.test.ts.snap
@@ -163,6 +163,12 @@ Object {
     "elements": Array [
       Object {
         "options": Object {
+          "content": "oie.phone.verify.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "options": Object {
           "actionParams": Object {
             "resend": true,
           },
@@ -172,12 +178,6 @@ Object {
           "step": "resend",
         },
         "type": "Reminder",
-      },
-      Object {
-        "options": Object {
-          "content": "oie.phone.verify.title",
-        },
-        "type": "Title",
       },
       Object {
         "contentType": "subtitle",

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.test.ts
@@ -55,10 +55,10 @@ describe('PhoneChallengeTransformer Tests', () => {
 
     expect(updatedFormBag).toMatchSnapshot();
     expect(updatedFormBag.uischema.elements.length).toBe(5);
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options.content)
-      .toBe('oie.phone.verify.sms.resendText');
-    expect((updatedFormBag.uischema.elements[1] as TitleElement).options.content)
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
       .toBe('oie.phone.verify.title');
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options.content)
+      .toBe('oie.phone.verify.sms.resendText');
     const subtitleKey = 'oie.phone.verify.sms.codeSentText.with.phone.without.nickname';
     expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options.content)

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
@@ -85,10 +85,10 @@ export const transformPhoneChallenge: IdxStepTransformer = ({ transaction, formB
       ),
     );
   }
-  uischema.elements.unshift(titleElement);
   if (reminderElement) {
     uischema.elements.unshift(reminderElement);
   }
+  uischema.elements.unshift(titleElement);
 
   return formBag;
 };

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -90,11 +90,11 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, 
   // 1. Title 2. Description ... Button is last element
   uischema.elements.unshift(carrierChargeDisclaimerText);
   uischema.elements.unshift(informationalTextElement);
-  uischema.elements.unshift(titleElement);
-  uischema.elements.push(submitButton);
   if (reminderElement) {
     uischema.elements.unshift(reminderElement);
   }
+  uischema.elements.unshift(titleElement);
+  uischema.elements.push(submitButton);
 
   return formBag;
 };

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -121,15 +121,12 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                   </div>
                   <div
                     class="MuiBox-root emotion-11"
-                  />
-                  <div
-                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <h2
-                        class="MuiTypography-root MuiTypography-h4 emotion-20"
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
                         data-se="o-form-head"
                         tabindex="-1"
                       >
@@ -139,9 +136,12 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                   </div>
                   <div
                     class="MuiBox-root emotion-11"
+                  />
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-23"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -124,15 +124,12 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                   >
                     <div
                       class="MuiBox-root emotion-11"
-                    />
-                    <div
-                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-19"
                       >
                         <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-21"
+                          class="MuiTypography-root MuiTypography-h4 emotion-20"
                           data-se="o-form-head"
                           tabindex="-1"
                         >
@@ -142,9 +139,12 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                     </div>
                     <div
                       class="MuiBox-root emotion-11"
+                    />
+                    <div
+                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-19"
                       >
                         <p
                           class="MuiTypography-root MuiTypography-body1 emotion-24"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -762,15 +762,12 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   </div>
                   <div
                     class="MuiBox-root emotion-11"
-                  />
-                  <div
-                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <h2
-                        class="MuiTypography-root MuiTypography-h4 emotion-20"
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
                         data-se="o-form-head"
                         tabindex="-1"
                       >
@@ -780,9 +777,12 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   </div>
                   <div
                     class="MuiBox-root emotion-11"
+                  />
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-23"
@@ -797,7 +797,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-23"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -131,15 +131,12 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   </div>
                   <div
                     class="MuiBox-root emotion-11"
-                  />
-                  <div
-                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <h2
-                        class="MuiTypography-root MuiTypography-h4 emotion-20"
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
                         data-se="o-form-head"
                         tabindex="-1"
                       >
@@ -149,9 +146,12 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   </div>
                   <div
                     class="MuiBox-root emotion-11"
+                  />
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-23"
@@ -166,7 +166,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-23"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -121,15 +121,12 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                   </div>
                   <div
                     class="MuiBox-root emotion-11"
-                  />
-                  <div
-                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <h2
-                        class="MuiTypography-root MuiTypography-h4 emotion-20"
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
                         data-se="o-form-head"
                         tabindex="-1"
                       >
@@ -139,9 +136,12 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                   </div>
                   <div
                     class="MuiBox-root emotion-11"
+                  />
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-23"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -124,15 +124,12 @@ exports[`Email authenticator verification when email magic link = undefined rend
                   >
                     <div
                       class="MuiBox-root emotion-11"
-                    />
-                    <div
-                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-19"
                       >
                         <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-21"
+                          class="MuiTypography-root MuiTypography-h4 emotion-20"
                           data-se="o-form-head"
                           tabindex="-1"
                         >
@@ -142,9 +139,12 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     </div>
                     <div
                       class="MuiBox-root emotion-11"
+                    />
+                    <div
+                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-19"
                       >
                         <p
                           class="MuiTypography-root MuiTypography-body1 emotion-24"
@@ -322,18 +322,33 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-11"
                     >
                       <div
+                        class="MuiBox-root emotion-19"
+                      >
+                        <h2
+                          class="MuiTypography-root MuiTypography-h4 emotion-20"
+                          data-se="o-form-head"
+                          tabindex="-1"
+                        >
+                          Verify with your email
+                        </h2>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-11"
+                    >
+                      <div
                         class="MuiBox-root emotion-11"
                       >
                         <div
-                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutWarning MuiAlert-callout emotion-20"
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutWarning MuiAlert-callout emotion-23"
                           role="alert"
                         >
                           <div
-                            class="MuiAlert-icon emotion-21"
+                            class="MuiAlert-icon emotion-24"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-22"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-25"
                               fill="none"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -348,10 +363,10 @@ exports[`Email authenticator verification when email magic link = undefined rend
                             </svg>
                           </div>
                           <div
-                            class="MuiAlert-message emotion-23"
+                            class="MuiAlert-message emotion-26"
                           >
                             <span
-                              class="MuiBox-root emotion-24"
+                              class="MuiBox-root emotion-27"
                               translate="no"
                             >
                               warning
@@ -360,12 +375,12 @@ exports[`Email authenticator verification when email magic link = undefined rend
                               class="MuiBox-root emotion-1"
                             >
                               <div
-                                class="MuiBox-root emotion-26"
+                                class="MuiBox-root emotion-29"
                               >
                                 Haven't received an email?
                               </div>
                               <a
-                                class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-27"
+                                class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-30"
                                 href="#"
                               >
                                 Send again
@@ -379,22 +394,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-29"
-                      >
-                        <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-30"
-                          data-se="o-form-head"
-                          tabindex="-1"
-                        >
-                          Verify with your email
-                        </h2>
-                      </div>
-                    </div>
-                    <div
-                      class="MuiBox-root emotion-11"
-                    >
-                      <div
-                        class="MuiBox-root emotion-29"
+                        class="MuiBox-root emotion-19"
                       >
                         <p
                           class="MuiTypography-root MuiTypography-body1 emotion-33"
@@ -570,15 +570,12 @@ exports[`Email authenticator verification when email magic link = undefined rend
                   >
                     <div
                       class="MuiBox-root emotion-11"
-                    />
-                    <div
-                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-19"
                       >
                         <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-21"
+                          class="MuiTypography-root MuiTypography-h4 emotion-20"
                           data-se="o-form-head"
                           tabindex="-1"
                         >
@@ -588,9 +585,12 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     </div>
                     <div
                       class="MuiBox-root emotion-11"
+                    />
+                    <div
+                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-19"
                       >
                         <p
                           class="MuiTypography-root MuiTypography-body1 emotion-24"
@@ -845,15 +845,12 @@ exports[`Email authenticator verification when email magic link = undefined rend
                   >
                     <div
                       class="MuiBox-root emotion-18"
-                    />
-                    <div
-                      class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiBox-root emotion-27"
+                        class="MuiBox-root emotion-26"
                       >
                         <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-28"
+                          class="MuiTypography-root MuiTypography-h4 emotion-27"
                           data-se="o-form-head"
                           tabindex="-1"
                         >
@@ -863,9 +860,12 @@ exports[`Email authenticator verification when email magic link = undefined rend
                     </div>
                     <div
                       class="MuiBox-root emotion-18"
+                    />
+                    <div
+                      class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiBox-root emotion-27"
+                        class="MuiBox-root emotion-26"
                       >
                         <p
                           class="MuiTypography-root MuiTypography-body1 emotion-31"
@@ -1151,14 +1151,29 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-18"
                     >
                       <div
+                        class="MuiBox-root emotion-26"
+                      >
+                        <h2
+                          class="MuiTypography-root MuiTypography-h4 emotion-27"
+                          data-se="o-form-head"
+                          tabindex="-1"
+                        >
+                          Verify with your email
+                        </h2>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <div
                         class="MuiBox-root emotion-18"
                       >
                         <div
-                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutWarning MuiAlert-callout emotion-27"
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutWarning MuiAlert-callout emotion-30"
                           role="alert"
                         >
                           <div
-                            class="MuiAlert-icon emotion-28"
+                            class="MuiAlert-icon emotion-31"
                           >
                             <svg
                               aria-hidden="true"
@@ -1189,12 +1204,12 @@ exports[`Email authenticator verification when email magic link = undefined rend
                               class="MuiBox-root emotion-1"
                             >
                               <div
-                                class="MuiBox-root emotion-33"
+                                class="MuiBox-root emotion-36"
                               >
                                 Haven't received an email?
                               </div>
                               <a
-                                class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-34"
+                                class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-37"
                                 href="#"
                               >
                                 Send again
@@ -1208,22 +1223,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-18"
                     >
                       <div
-                        class="MuiBox-root emotion-36"
-                      >
-                        <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-37"
-                          data-se="o-form-head"
-                          tabindex="-1"
-                        >
-                          Verify with your email
-                        </h2>
-                      </div>
-                    </div>
-                    <div
-                      class="MuiBox-root emotion-18"
-                    >
-                      <div
-                        class="MuiBox-root emotion-36"
+                        class="MuiBox-root emotion-26"
                       >
                         <p
                           class="MuiTypography-root MuiTypography-body1 emotion-40"
@@ -1580,15 +1580,12 @@ exports[`Email authenticator verification when email magic link = undefined shou
                   >
                     <div
                       class="MuiBox-root emotion-11"
-                    />
-                    <div
-                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-19"
                       >
                         <h2
-                          class="MuiTypography-root MuiTypography-h4 emotion-21"
+                          class="MuiTypography-root MuiTypography-h4 emotion-20"
                           data-se="o-form-head"
                           tabindex="-1"
                         >
@@ -1598,9 +1595,12 @@ exports[`Email authenticator verification when email magic link = undefined shou
                     </div>
                     <div
                       class="MuiBox-root emotion-11"
+                    />
+                    <div
+                      class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiBox-root emotion-20"
+                        class="MuiBox-root emotion-19"
                       >
                         <p
                           class="MuiTypography-root MuiTypography-body1 emotion-24"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -116,21 +116,36 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                     </div>
                   </div>
                   <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
+                        data-se="o-form-head"
+                        tabindex="-1"
+                      >
+                        Push notification sent
+                      </h2>
+                    </div>
+                  </div>
+                  <div
                     class="MuiBox-root emotion-1"
                   >
                     <div
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutWarning MuiAlert-callout emotion-19"
+                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-calloutWarning MuiAlert-callout emotion-22"
                         role="alert"
                       >
                         <div
-                          class="MuiAlert-icon emotion-20"
+                          class="MuiAlert-icon emotion-23"
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-21"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-24"
                             fill="none"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -145,10 +160,10 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                           </svg>
                         </div>
                         <div
-                          class="MuiAlert-message emotion-22"
+                          class="MuiAlert-message emotion-25"
                         >
                           <span
-                            class="MuiBox-root emotion-23"
+                            class="MuiBox-root emotion-26"
                             translate="no"
                           >
                             warning
@@ -161,7 +176,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                             >
                               Haven't received a push notification yet? Try opening the Okta Verify app on your device, or 
                               <a
-                                class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways resend-number-challenge emotion-26"
+                                class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways resend-number-challenge emotion-29"
                                 href="#"
                               >
                                 resend the push notification
@@ -171,21 +186,6 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-11"
-                  >
-                    <div
-                      class="MuiBox-root emotion-28"
-                    >
-                      <h2
-                        class="MuiTypography-root MuiTypography-h4 emotion-29"
-                        data-se="o-form-head"
-                        tabindex="-1"
-                      >
-                        Push notification sent
-                      </h2>
                     </div>
                   </div>
                   <div
@@ -234,7 +234,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-28"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-37"
@@ -455,16 +455,13 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-1"
-                  />
-                  <div
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <h2
-                        class="MuiTypography-root MuiTypography-h4 emotion-20"
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
                         data-se="o-form-head"
                         tabindex="-1"
                       >
@@ -472,6 +469,9 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                       </h2>
                     </div>
                   </div>
+                  <div
+                    class="MuiBox-root emotion-1"
+                  />
                   <div
                     class="MuiBox-root emotion-11"
                   >
@@ -518,7 +518,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-28"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -131,13 +131,16 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                     </div>
                   </div>
                   <div
+                    class="MuiBox-root emotion-1"
+                  />
+                  <div
                     class="MuiBox-root emotion-11"
                   >
                     <div
                       class="MuiBox-root emotion-18"
                     >
                       <p
-                        class="MuiTypography-root MuiTypography-body1 emotion-22"
+                        class="MuiTypography-root MuiTypography-body1 emotion-23"
                         data-se="o-form-explain"
                         tabindex="-1"
                       >
@@ -145,9 +148,6 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                       </p>
                     </div>
                   </div>
-                  <div
-                    class="MuiBox-root emotion-1"
-                  />
                   <div
                     class="MuiBox-root emotion-11"
                   >
@@ -182,7 +182,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                             />
                           </span>
                           <span
-                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-22"
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
                           >
                             Send push automatically
                           </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -131,15 +131,12 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   </div>
                   <div
                     class="MuiBox-root emotion-11"
-                  />
-                  <div
-                    class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <h2
-                        class="MuiTypography-root MuiTypography-h4 emotion-20"
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
                         data-se="o-form-head"
                         tabindex="-1"
                       >
@@ -148,10 +145,13 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     </div>
                   </div>
                   <div
+                    class="MuiBox-root emotion-11"
+                  />
+                  <div
                     class="MuiBox-root emotion-1"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-23"
@@ -172,7 +172,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-11"
                   >
                     <div
-                      class="MuiBox-root emotion-19"
+                      class="MuiBox-root emotion-18"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body1 emotion-23"


### PR DESCRIPTION
## Description:

**Before:** 
On most pages the reminder prompt is rendered before title. On page `Push notification sent` (`transformOktaVerifyCustomAppChallengePoll`) the reminder prompt is rendered after title and description.

**After:** 
On all pages the reminder prompt is rendered right after title.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-871675](https://oktainc.atlassian.net/browse/OKTA-871675)

### Reviewers:

### Screenshot/Video:

Before:

<img width="463" alt="Screenshot 2025-03-27 at 19 28 27" src="https://github.com/user-attachments/assets/53f6351b-b454-401f-b266-aead144222eb" />
<img width="452" alt="Screenshot 2025-03-27 at 18 53 46 ----- old" src="https://github.com/user-attachments/assets/c0fed31d-45df-47de-ba8a-11420fa5c40c" />

After:

<img width="443" alt="Screenshot 2025-03-27 at 18 50 44" src="https://github.com/user-attachments/assets/dc55d5bb-82c0-4835-86a9-b30895c9842f" />
<img width="457" alt="Screenshot 2025-03-27 at 18 50 52" src="https://github.com/user-attachments/assets/2a449842-4453-4190-a1d0-f2c363596c13" />
<img width="473" alt="Screenshot 2025-03-27 at 18 57 03" src="https://github.com/user-attachments/assets/45e4fc83-4755-4ed3-928c-8193f56a5374" />
<img width="485" alt="Screenshot 2025-03-27 at 18 59 03" src="https://github.com/user-attachments/assets/3c05c047-914d-4d17-a601-9389e761ea71" />
<img width="467" alt="Screenshot 2025-03-27 at 19 00 43" src="https://github.com/user-attachments/assets/44646d8d-98c7-4953-86f6-0955fa9ed801" />
<img width="469" alt="Screenshot 2025-03-27 at 19 01 04" src="https://github.com/user-attachments/assets/65860935-314b-4d06-ac50-6afebfe3d226" />
<img width="472" alt="Screenshot 2025-03-27 at 19 05 18" src="https://github.com/user-attachments/assets/928cfefb-1e73-4583-8f68-8bb2e870ae7c" />
<img width="466" alt="Screenshot 2025-03-27 at 19 05 35" src="https://github.com/user-attachments/assets/9e0e7fe1-e927-4694-b0ce-3b22ca558a7d" />



### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&author=denys.oblohin%40okta.com&branch=d16t-okta-signin-widget-b705444&page=1&pageSize=6&tab=main


