### PR TITLE
fix(gen3): auth header a11y issue

### DIFF
--- a/src/v3/src/components/AuthHeader/AuthHeader.tsx
+++ b/src/v3/src/components/AuthHeader/AuthHeader.tsx
@@ -78,7 +78,7 @@ const AuthHeader: FunctionComponent<AuthHeaderProps> = ({
         },
       }}
     >
-      <Typography variant="h1" role="presentation">
+      <Typography variant="h1" role="presentation" tabIndex={-1}>
         { logo && (
           <Image
             alt={logoText || brandName || loc('logo.default.alt.text', 'login')}

--- a/src/v3/src/components/AuthHeader/AuthHeader.tsx
+++ b/src/v3/src/components/AuthHeader/AuthHeader.tsx
@@ -78,7 +78,11 @@ const AuthHeader: FunctionComponent<AuthHeaderProps> = ({
         },
       }}
     >
-      <Typography variant="h1" role="presentation" tabIndex={-1}>
+      <Typography
+        variant="h1"
+        role="presentation"
+        tabIndex={-1}
+      >
         { logo && (
           <Image
             alt={logoText || brandName || loc('logo.default.alt.text', 'login')}

--- a/src/v3/src/components/AuthHeader/AuthHeader.tsx
+++ b/src/v3/src/components/AuthHeader/AuthHeader.tsx
@@ -10,8 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box } from '@mui/material';
-import { Typography, useOdysseyDesignTokens } from '@okta/odyssey-react-mui';
+import { Box, Typography } from '@mui/material';
+import { useOdysseyDesignTokens } from '@okta/odyssey-react-mui';
 import { FunctionComponent, h } from 'preact';
 import { AuthCoinProps } from 'src/types';
 
@@ -78,7 +78,7 @@ const AuthHeader: FunctionComponent<AuthHeaderProps> = ({
         },
       }}
     >
-      <Typography variant="h1">
+      <Typography variant="h1" role="presentation">
         { logo && (
           <Image
             alt={logoText || brandName || loc('logo.default.alt.text', 'login')}

--- a/src/v3/test/integration/__snapshots__/admin-consent-without-logo.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/admin-consent-without-logo.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`admin-consent-without-logo should render form without logo 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/admin-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/admin-consent.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`admin-consent should render form with logo 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -259,6 +260,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -489,6 +491,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -1601,6 +1602,7 @@ exports[`authenticator-enroll-data-phone should render form without an autoFocus
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -3173,6 +3175,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -293,6 +294,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -548,6 +550,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -798,6 +801,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -660,6 +661,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -431,6 +432,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -946,6 +948,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -1461,6 +1464,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -431,6 +432,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -773,6 +775,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -1228,6 +1231,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -712,6 +713,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-expired-password should present field level error message
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -700,6 +701,7 @@ exports[`authenticator-expired-password should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -849,6 +850,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -383,6 +384,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -737,6 +739,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -1091,6 +1094,7 @@ exports[`authenticator-piv-cac-verification should render PIV/CAC view when clic
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-reset-password should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -606,6 +607,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-custom-otp.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-custom-otp should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-with-email.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-data-with-email should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -225,6 +226,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -475,6 +477,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -707,6 +710,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -1011,6 +1015,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -1369,6 +1374,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -1485,6 +1491,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -368,6 +369,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp-only-ov.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-okta-verify-totp-only-ov should render form 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-okta-verify-totp should have autocomplete at
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -241,6 +242,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-resend-push-notification.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-ov-resend-push-notification renders form 1`]
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-ov-totp-biometrics-error.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-ov-totp-biometrics-error should render form 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-unlock-success.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-unlock-success should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -419,6 +420,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -791,6 +793,7 @@ exports[`authenticator-verification-webauthn should render form with required us
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/byol.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`byol loading custom language should load custom language with "language
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -1601,6 +1602,7 @@ exports[`byol loading custom language should load custom language with assets.ba
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -3173,6 +3175,7 @@ exports[`byol loading default language should not load custom language when the 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -4745,6 +4748,7 @@ exports[`byol loading default language should not load custom language with "lan
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/device-code-activate.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/device-code-activate.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`device-code-activate should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`email-challenge-consent should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enduser-consent-without-logo should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enduser-consent should render form with logo 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new-additional-fields.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enroll-profile-new-additional-fields fails client side validation with 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -1918,6 +1919,7 @@ exports[`enroll-profile-new-additional-fields should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enroll-profile-new should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-registration-callbacks.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enroll-profile-with-password should add new field to view and remove it
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -334,6 +335,7 @@ exports[`enroll-profile-with-password should show custom error message and preve
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -666,6 +668,7 @@ exports[`enroll-profile-with-password should show custom field level error messa
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -998,6 +1001,7 @@ exports[`enroll-profile-with-password should show generic error message and prev
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -1313,6 +1317,7 @@ exports[`enroll-profile-with-password should show validation error messages on a
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-optional-fields.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enroll-profile-update-optional-fields should render form with one requi
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update-required-field.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enroll-profile-update-required-field fails client side validation with 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -362,6 +363,7 @@ exports[`enroll-profile-update-required-field should render form with one requir
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-update.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enroll-profile-update fails client side validation with empty required 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -313,6 +314,7 @@ exports[`enroll-profile-update should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enroll-profile-with-password should display field level error when pass
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -777,6 +778,7 @@ exports[`enroll-profile-with-password should display field level error when pass
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -1520,6 +1522,7 @@ exports[`enroll-profile-with-password should display field level error when pass
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -2273,6 +2276,7 @@ exports[`enroll-profile-with-password should display field level error when pass
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -3016,6 +3020,7 @@ exports[`enroll-profile-with-password should display field level error when pass
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -3750,6 +3755,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-400-unauthorized-client should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-account-creation should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/error-activation-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-activation-token-invalid.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-activation-token-invalid should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-feature-not-enabled should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-recovery-token-invalid should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-session-expired should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/flow-verify-with-piv-as-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-verify-with-piv-as-authenticator.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`flow-verify-with-piv-as-authenticator should render select authenticato
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/granular-consent-without-logo.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/granular-consent-without-logo.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`granular-consent-without-logo should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`granular-consent should render form with logo 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`identify-recovery renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -411,6 +412,7 @@ exports[`identify-with-password Client-side field change validation tests should
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -793,6 +795,7 @@ exports[`identify-with-password Client-side field change validation tests should
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -1175,6 +1178,7 @@ exports[`identify-with-password renders form with focus 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -1480,6 +1484,7 @@ exports[`identify-with-password renders form without focus 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>
@@ -1785,6 +1790,7 @@ exports[`identify-with-password renders the loading state first 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-applink.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`oda-enrollment-android-applink should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -201,6 +202,7 @@ exports[`oda-enrollment-android-applink should render view when "No, I don’t h
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -451,6 +453,7 @@ exports[`oda-enrollment-android-applink should render view when "Yes, I already 
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-android-loopback.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`oda-enrollment-android-loopback should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/oda-enrollment-ios.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`oda-enrollment-ios should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -1539,6 +1540,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form witho
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/request-activation-email.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`request-activation-email renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`terminal-return-email-error should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`terminal-return-email renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -29,6 +29,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/trigger-email-verify-callback.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/trigger-email-verify-callback.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`triggerEmailVerifyCallback with otp flow should create proxy server res
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`unlock-account-success renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`user-unlock-account renders form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
             </div>

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`webauthn-enroll should render form 1`] = `
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -249,6 +250,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div
@@ -487,6 +489,7 @@ exports[`webauthn-enroll should render form with user verification and edge brow
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
                 tabindex="-1"
               />
               <div


### PR DESCRIPTION
## Description:

Manually verfiied with MacOS voice over


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-874282](https://oktainc.atlassian.net/browse/OKTA-874282)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



