### PR TITLE
fix(Gen2): Fix warning icon height on Callout

### DIFF
--- a/assets/sass/v2/_callout.scss
+++ b/assets/sass/v2/_callout.scss
@@ -3,7 +3,7 @@
   .clearfix:after {
     visibility: visible;
     content: '';
-    height: 102%;
+    height: calc(100% + 2px);
   }
   .infobox {
     a {


### PR DESCRIPTION
## Description:
Fixes the height of the warning icon that caused the lower part of the Callout to be misaligned.

## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:
![image](https://github.com/user-attachments/assets/782bb1ca-d46e-4dad-a93b-f9a911412412)
![image](https://github.com/user-attachments/assets/3c8726a1-9ae5-46a5-84b6-97d110a290e8)

### Downstream Monolith Build:



