### PR TITLE
fix(gen3): Prevent translation plugins from modifying DOM

### DIFF
--- a/src/v3/src/OktaSignIn/index.test.ts
+++ b/src/v3/src/OktaSignIn/index.test.ts
@@ -12,23 +12,19 @@
 
 import { h, render } from 'preact';
 
+import type { RenderResult } from '../../../types';
+import type { WidgetProps } from '../types';
 import OktaSignIn from '.';
 
-import type { FunctionComponent } from 'preact';
-import type { WidgetProps } from '../types';
-import type { RenderResult } from '../../../types';
-
 let onSuccessWrapper: (res: RenderResult) => void;
-jest.mock('preact', () => {
-  return {
-    ...jest.requireActual<typeof import('preact')>('preact'),
-    render: jest.fn(),
-    h: jest.fn().mockImplementation((component: FunctionComponent<WidgetProps>, props: WidgetProps) => {
-      // Extract the passsed globalSuccessFn prop so we can call it later to resolve the render promise
-      onSuccessWrapper = props.globalSuccessFn ?? onSuccessWrapper;
-    }),
-  };
-});
+jest.mock('preact', () => ({
+  ...jest.requireActual<typeof import('preact')>('preact'),
+  render: jest.fn(),
+  h: jest.fn().mockImplementation((_, props: WidgetProps) => {
+    // Extract the passsed globalSuccessFn prop so we can call it later to resolve the render promise
+    onSuccessWrapper = props.globalSuccessFn ?? onSuccessWrapper;
+  }),
+}));
 
 describe('OktaSignIn', () => {
   let container: HTMLElement;
@@ -77,7 +73,7 @@ describe('OktaSignIn', () => {
 
     const widget = new OktaSignIn(options);
 
-    expect(widget.renderEl({
+    await expect(widget.renderEl({
       el: '#non-existent',
       clientId: options.clientId,
       redirectUri: options.redirectUri,

--- a/src/v3/src/OktaSignIn/index.test.ts
+++ b/src/v3/src/OktaSignIn/index.test.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { h, render } from 'preact';
+import { render } from 'preact';
 
 import type { RenderResult } from '../../../types';
 import type { WidgetProps } from '../types';

--- a/src/v3/src/OktaSignIn/index.test.ts
+++ b/src/v3/src/OktaSignIn/index.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { h, render } from 'preact';
+
+import OktaSignIn from '.';
+
+import type { FunctionComponent } from 'preact';
+import type { WidgetProps } from '../types';
+import type { RenderResult } from '../../../types';
+
+let onSuccessWrapper: (res: RenderResult) => void;
+jest.mock('preact', () => {
+  return {
+    ...jest.requireActual<typeof import('preact')>('preact'),
+    render: jest.fn(),
+    h: jest.fn().mockImplementation((component: FunctionComponent<WidgetProps>, props: WidgetProps) => {
+      // Extract the passsed globalSuccessFn prop so we can call it later to resolve the render promise
+      onSuccessWrapper = props.globalSuccessFn ?? onSuccessWrapper;
+    }),
+  };
+});
+
+describe('OktaSignIn', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.setAttribute('id', 'test-container');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    jest.clearAllMocks();
+  });
+
+  it('should add translate="no" to the target element when renderEl is called', async () => {
+    const options = {
+      el: '#test-container',
+      baseUrl: 'https://example.com',
+      clientId: 'test-client-id',
+      redirectUri: 'https://example.com/redirect',
+    };
+
+    const widget = new OktaSignIn(options);
+
+    const renderResult: Promise<RenderResult> = widget.renderEl({
+      el: '#test-container',
+      clientId: 'test-client-id',
+      redirectUri: 'https://example.com/redirect',
+    });
+    // Normally called by the Widget component but the component is mocked
+    onSuccessWrapper({ status: 'SUCCESS' });
+
+    await renderResult;
+
+    expect(container.getAttribute('translate')).toBe('no');
+    expect(render).toHaveBeenCalled();
+  });
+
+  it('should throw an error if the target element is not found', async () => {
+    const options = {
+      baseUrl: 'https://example.com',
+      clientId: 'test-client-id',
+      redirectUri: 'https://example.com/redirect',
+    };
+
+    const widget = new OktaSignIn(options);
+
+    expect(widget.renderEl({
+      el: '#non-existent',
+      clientId: options.clientId,
+      redirectUri: options.redirectUri,
+    })).rejects.toThrow('could not find element #non-existent');
+    expect(render).not.toHaveBeenCalled();
+  });
+});

--- a/src/v3/src/OktaSignIn/index.ts
+++ b/src/v3/src/OktaSignIn/index.ts
@@ -171,6 +171,13 @@ export default class OktaSignIn implements OktaSignInAPI {
           : this.el;
 
         if (target) {
+          // OKTA-901691 Translation plugins break React/Preact since they directly maniuplate the DOM
+          // and React/Preact does not know about it so the next conditional render will fail.
+          // Setting this attribute will prevent translation plugins from affecting the Gen3 widget.
+          // This is a workaround until we can find a better solution.
+          // @see https://github.com/preactjs/preact/issues/948
+          target.setAttribute('translate', 'no');
+
           // @ts-ignore OKTA-508744
           render(h(Widget, {
             ...this.options,

--- a/src/v3/src/OktaSignIn/index.ts
+++ b/src/v3/src/OktaSignIn/index.ts
@@ -171,7 +171,7 @@ export default class OktaSignIn implements OktaSignInAPI {
           : this.el;
 
         if (target) {
-          // OKTA-901691 Translation plugins break React/Preact since they directly maniuplate the DOM
+          // OKTA-901691 Translation plugins break React/Preact since they directly manipulate the DOM
           // and React/Preact does not know about it so the next conditional render will fail.
           // Setting this attribute will prevent translation plugins from affecting the Gen3 widget.
           // This is a workaround until we can find a better solution.

--- a/src/v3/src/OktaSignIn/index.ts
+++ b/src/v3/src/OktaSignIn/index.ts
@@ -200,7 +200,6 @@ export default class OktaSignIn implements OktaSignInAPI {
   }
 
   showSignInToGetTokens(options = {}): Promise<Tokens> {
-    // @ts-expect-error isAuthorizationCodeFlow does not exist on type OktaAuth
     if (this.authClient.isAuthorizationCodeFlow() && this.authClient.isPKCE()) {
       throw new Error('"showSignInToGetTokens()" should not be used for authorization_code flow. Use "showSignInAndRedirect()" instead');
     }


### PR DESCRIPTION
## Description:

Google Translate (and other translation plugins) manipulate the DOM in a way that Preact/React cannot handle due to the assumption that React/Preact make about the ownership of the nodes within it's container.

Setting `translate="no"` prevents translation plugins from affecting the container node and child nodes. Preventing translation of the widget isn't limiting in any way from the current behavior since the widget does not work at all if a translation plugin is applied to it.

There _may_ be workarounds but they require us to write our JSX in a particular way to avoid the issue. There is a [lint plugin](https://github.com/getcouped/eslint-plugin-react-google-translate) that might also be able to help. Any pursuit of a workaround would be a greater scope of work so we are not currently pursuing that.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-901691](https://oktainc.atlassian.net/browse/OKTA-901691)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



