### PR TITLE
OKTA-897996: Adds inline validation for empty input on OTP verify

### DIFF
--- a/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorVerify.test.ts.snap
+++ b/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorVerify.test.ts.snap
@@ -4,6 +4,9 @@ exports[`Google Authenticator Verify Transformer Tests should add UI elements 1`
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorVerify.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorVerify.ts
@@ -15,8 +15,10 @@ import {
   ButtonType,
   DescriptionElement,
   FieldElement,
+  FormBag,
   IdxStepTransformer,
   TitleElement,
+  WidgetMessage,
 } from '../../../types';
 import { loc } from '../../../util';
 import { getUIElementWithName } from '../../utils';
@@ -25,7 +27,7 @@ export const transformGoogleAuthenticatorVerify: IdxStepTransformer = ({
   formBag,
   transaction,
 }) => {
-  const { uischema } = formBag;
+  const { uischema, dataSchema } = formBag;
 
   const titleElement: TitleElement = {
     type: 'Title',
@@ -59,6 +61,22 @@ export const transformGoogleAuthenticatorVerify: IdxStepTransformer = ({
     passcodeElement,
     submitButtonElement,
   ];
+
+  // Controls form submission validation
+  dataSchema['credentials.passcode'] = {
+    validate: (data: FormBag['data']) => {
+      const phoneCode = data['credentials.passcode'] as string;
+      const errorMessages: WidgetMessage[] = [];
+      if (phoneCode.trim() === '') {
+        errorMessages.push({
+          class: 'ERROR',
+          message: loc('model.validation.field.blank', 'login'),
+          i18n: { key: 'model.validation.field.blank' },
+        });
+      }
+      return errorMessages.length > 0 ? errorMessages : undefined;
+    },
+  };
 
   return formBag;
 };

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorVerify.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorVerify.ts
@@ -65,9 +65,9 @@ export const transformGoogleAuthenticatorVerify: IdxStepTransformer = ({
   // Controls form submission validation
   dataSchema['credentials.passcode'] = {
     validate: (data: FormBag['data']) => {
-      const phoneCode = data['credentials.passcode'] as string;
+      const authenticatorCode = data['credentials.passcode'] as string;
       const errorMessages: WidgetMessage[] = [];
-      if (phoneCode.trim() === '') {
+      if (authenticatorCode.trim() === '') {
         errorMessages.push({
           class: 'ERROR',
           message: loc('model.validation.field.blank', 'login'),

--- a/src/v3/src/transformer/phone/__snapshots__/phoneChallengeTransformer.test.ts.snap
+++ b/src/v3/src/transformer/phone/__snapshots__/phoneChallengeTransformer.test.ts.snap
@@ -4,6 +4,9 @@ exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
@@ -53,6 +56,9 @@ exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
@@ -102,6 +108,9 @@ exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
@@ -151,6 +160,9 @@ exports[`PhoneChallengeTransformer Tests should create SMS challenge UI elements
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
@@ -212,6 +224,9 @@ exports[`PhoneChallengeTransformer Tests should create voice challenge UI elemen
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
@@ -261,6 +276,9 @@ exports[`PhoneChallengeTransformer Tests should create voice challenge UI elemen
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],
@@ -310,6 +328,9 @@ exports[`PhoneChallengeTransformer Tests should create voice challenge UI elemen
 Object {
   "data": Object {},
   "dataSchema": Object {
+    "credentials.passcode": Object {
+      "validate": [Function],
+    },
     "fieldsToExclude": [Function],
     "fieldsToTrim": Array [],
     "fieldsToValidate": Array [],


### PR DESCRIPTION
## Description:
Currently in the SIW gen3, if a user enters only whitespace in a OTP field (e.g., Phone code, Google Authenticator code) the widget strips the input and submits this an empty string value to the `/idp/idx/challenge/answer` endpoint. The backend idx pipeline performs a generic null/empty check and incorrectly returns a hardcoded error message: `Password requirements were not met. User password cannot be empty`. While the ideal long-term solution involves fixing the backend API to return contextually appropriate error messages, adding this client-side check provides an immediate UX improvement and effectively 'hides' the customer issue.

This PR modifies only the Phone Authenticator and Google Authenticator verify views in the SIW to override the default inline validation. Instead of only checking if the input field is empty, it now trims any whitespace from the input and checks if the resulting value is empty. If the result is empty, then we prevent the submission to the `/idp/idx/challenge/answer` endpoint.

## PR Checklist
- [X] Have you verified the basic functionality for this change?
- [X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-897996](https://oktainc.atlassian.net/browse/OKTA-897996)

### Reviewers:

### Screenshot/Video:
Before
https://github.com/user-attachments/assets/1be2af4e-5962-4d12-8a94-4613dbffcc77

After:
https://github.com/user-attachments/assets/d2e31d9b-cab3-471d-9eb6-8464f83a8a20

### Downstream Monolith Build:



