### PR TITLE
fix: Set `mode: 'cors'` when loading translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- START GITHUB ONLY -->
+
 [<img src="https://aws1.discourse-cdn.com/standard14/uploads/oktadev/original/1X/0c6402653dfb70edc661d4976a43a46f33e5e919.png" align="right" width="256px"/>](https://devforum.okta.com/)
 [![Support](https://img.shields.io/badge/support-developer%20forum-blue.svg)](https://devforum.okta.com)
 [![Build Status](https://travis-ci.org/okta/okta-signin-widget.svg?branch=master)](https://travis-ci.org/okta/okta-signin-widget)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <!-- START GITHUB ONLY -->
-
 [<img src="https://aws1.discourse-cdn.com/standard14/uploads/oktadev/original/1X/0c6402653dfb70edc661d4976a43a46f33e5e919.png" align="right" width="256px"/>](https://devforum.okta.com/)
 [![Support](https://img.shields.io/badge/support-developer%20forum-blue.svg)](https://devforum.okta.com)
 [![Build Status](https://travis-ci.org/okta/okta-signin-widget.svg?branch=master)](https://travis-ci.org/okta/okta-signin-widget)

--- a/src/util/Bundles.ts
+++ b/src/util/Bundles.ts
@@ -151,10 +151,24 @@ function fetchJson(bundle, language, assets) {
 
   const headers = {
     Accept: 'application/json',
-    'Content-Type': 'text/plain',
   };
 
-  const mode = 'no-cors';
+  // Specify `mode: 'cors'` explicitly.
+  //
+  // Browsers allow specific types of requests to considered "simple" requests,
+  // even if we set `mode: 'no-cors'` and event if the request header `Content-Type` is
+  // set to `'text/plain'` for a GET request. This allows the normally opaque response
+  // to be readable when it would otherwise not be able to _as long as_ the server sends
+  // `Access-Control-Allow-Origin: *` (or a list that includes the origin of the document).
+  //
+  // On localhost, special browser security rules seem to disallow reading the response
+  // even under the above conditions when 'mode: 'no-cors'` is set. This means that we need
+  // to explicitly set the `mode` to `cors` in order to get a readable response.
+  //
+  // We are always actually making a CORS request anyways, so explicitly setting the mode
+  // to `cors` should not have any negative impact and is actually just a more accurate
+  // representation of what is happening.
+  const mode = 'cors';
 
   return fetch(assets.baseUrl + path, {
     method: 'GET',

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -347,7 +347,6 @@ fn.isJsonAssetRequest = function(args, expected) {
   expect(args.requestHeaders).toEqual(
     jasmine.objectContaining({
       accept: 'application/json',
-      'content-type': 'text/plain',
     })
   );
 };


### PR DESCRIPTION
## Description:

We were using `no-cors` mode for the fetch call to avoid triggering CORS handling by the browser and relying on the implicit allowance of what is actually a CORS request after the response came back since the resource server does return `Access-Control-Allow-Headers: *`, so then we're able to read the response without issue. However, there won't be any difference in behavior if we explicitly set `cors` mode since it actually _is_ a CORS request and since it's a `GET` request without any special headers, it won't trigger the CORS "pre-flight" `OPTIONS` call anyways, and the rest of the request will be the same as it was before.

Meanwhile, in `localhost` development, some browsers seem to handle the above scenario differently (perhaps for security reasons) and still prevent the response from being read (so it is treated as "opaque" and the body cannot be read by the script). This change makes explicit what we already were implicitly doing and also allows for CORS requests to be satisfied correctly in local development.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-920948](https://oktainc.atlassian.net/browse/OKTA-920948)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



