### PR TITLE
OKTA-925206 : SIW gen 3: Enable multiple OV loopback challenges

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-second-challenge.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-second-challenge.json
@@ -1,0 +1,240 @@
+{
+  "stateHandle": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+  "version": "1.0.0",
+  "expiresAt": "2020-01-13T21:14:37.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "name": "challenge-poll",
+        "href": "http://localhost:3000/idp/idx/authenticators/poll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "refresh": 4000,
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Verify",
+                "relatesTo": "$.authenticatorEnrollments.value[0]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttheidkwh282hv8g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "signed_nonce",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              },
+              {
+                "label": "Okta Password",
+                "relatesTo": "$.authenticatorEnrollments.value[1]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttmbseAWnMPtLe20g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "password",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "displayName":"Okta Verify",
+      "type": "app",
+      "key": "okta_verify",
+      "id": "aen1mz5J4cuNoaR3l0g4",
+      "methods":[
+        {
+          "type":"signed_nonce"
+        }
+      ],
+      "cancel": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "cancel-polling",
+        "href": "http://localhost:3000/idp/idx/authenticators/poll/cancel",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "123",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      "contextualData": {
+        "challenge": {
+          "type": "object",
+          "value": {
+            "challengeMethod": "LOOPBACK",
+            "challengeRequest": "123",
+            "domain": "http://localhost",
+            "enhancedPollingEnabled": false,
+            "ports": [
+              "2000",
+              "6511",
+              "6512",
+              "6513"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "authenticators":{
+    "type":"array",
+    "value":[
+      {
+        "type":"app",
+        "key": "okta_verify",
+        "id":"autmho3zRhIfiSzOy0g4",
+        "displayName":"Okta Verify",
+        "methods":[
+          {
+            "type":"signed_nonce"
+          }
+        ]
+      },
+      {
+        "type":"password",
+        "key": "okta_password",
+        "id":"autmhm5s2gQhWbPfu0g4",
+        "displayName":"Password",
+        "methods":[
+          {
+            "type":"password"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments":{
+    "type":"array",
+    "value":[
+      {
+        "profile":{
+          "deviceName":"DESKTOP-9AD225Q"
+        },
+        "type":"app",
+        "key": "okta_verify",
+        "id":"pfdtxkyRQrmwfWdIE0g4",
+        "displayName":"Okta Verify",
+        "methods":[
+          {
+            "type":"signed_nonce"
+          }
+        ]
+      },
+      {
+        "type":"password",
+        "key": "okta_password",
+        "id":"lae3obwhjXZOu3dfz0g4",
+        "displayName":"Password",
+        "methods":[
+          {
+            "type":"password"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00utjm1GstPjCF9Ad0g3",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Native client",
+      "id": "0oa2lpzzzJHJy0E6q0g4"
+    }
+  }
+}

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -155,7 +155,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
 
     doLoopback();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [challengeRequest]);
   /* eslint-enable no-await-in-loop, no-continue */
 
   return null;

--- a/src/v3/src/util/getCurrentAuthenticator.ts
+++ b/src/v3/src/util/getCurrentAuthenticator.ts
@@ -18,7 +18,7 @@ export const getCurrentAuthenticator = (
   if (typeof transaction === 'undefined') {
     return undefined;
   }
-  
+
   // currentAuthenticator is from enrollment flows and currentAuthenticatorEnrollment is from verify flows
   const { rawIdxState: { currentAuthenticator, currentAuthenticatorEnrollment } } = transaction;
 

--- a/src/v3/src/util/getCurrentAuthenticator.ts
+++ b/src/v3/src/util/getCurrentAuthenticator.ts
@@ -13,8 +13,12 @@
 import { IdxTransaction, RawIdxResponse } from '@okta/okta-auth-js';
 
 export const getCurrentAuthenticator = (
-  transaction: IdxTransaction,
+  transaction?: IdxTransaction,
 ): RawIdxResponse['currentAuthenticator'] | undefined => {
+  if (typeof transaction === 'undefined') {
+    return undefined;
+  }
+  
   // currentAuthenticator is from enrollment flows and currentAuthenticatorEnrollment is from verify flows
   const { rawIdxState: { currentAuthenticator, currentAuthenticatorEnrollment } } = transaction;
 

--- a/src/v3/src/util/idxUtils.test.ts
+++ b/src/v3/src/util/idxUtils.test.ts
@@ -421,7 +421,7 @@ describe('IdxUtils Tests', () => {
     });
   });
 
-  it('transactions should not be considered equal when another loopback challenge is received and challenge ids are not the same', () => {
+  it('transactions should not be considered equal when auth ids are the same but challenge ids are not the same', () => {
     const transaction1 = {
       ...transaction,
       rawIdxState: {
@@ -429,11 +429,11 @@ describe('IdxUtils Tests', () => {
         stateHandle: '',
         currentAuthenticator: {
           value: {
+            id: 'authenticator_id',
             contextualData: {
               challenge: {
                 value: {
                   challengeRequest: 'challenge_request_1',
-                  challengeMethod: 'LOOPBACK',
                 },
               },
             },
@@ -449,11 +449,11 @@ describe('IdxUtils Tests', () => {
         stateHandle: '',
         currentAuthenticator: {
           value: {
+            id: 'authenticator_id',
             contextualData: {
               challenge: {
                 value: {
                   challengeRequest: 'challenge_request_2',
-                  challengeMethod: 'LOOPBACK',
                 },
               },
             },

--- a/src/v3/src/util/idxUtils.test.ts
+++ b/src/v3/src/util/idxUtils.test.ts
@@ -16,6 +16,7 @@ import { getStubTransaction } from 'src/mocks/utils/utils';
 
 import { RegistrationElementSchema, WidgetProps } from '../types';
 import {
+  areTransactionsEqual,
   buildAuthCoinProps,
   convertIdxInputsToRegistrationSchema,
   convertRegistrationSchemaToIdxInputs,
@@ -418,6 +419,50 @@ describe('IdxUtils Tests', () => {
       i18n: { key: '' },
       message: 'oform.errorbanner.title',
     });
+  });
+
+  it('transactions should not be considered equal when another loopback challenge is received and challenge ids are not the same', () => {
+    const transaction1 = {
+      ...transaction,
+      rawIdxState: {
+        version: '',
+        stateHandle: '',
+        currentAuthenticator: {
+          value: {
+            contextualData: {
+              challenge: {
+                value: {
+                  challengeRequest: 'challenge_request_1',
+                  challengeMethod: 'LOOPBACK',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const transaction2 = {
+      ...transaction,
+      rawIdxState: {
+        version: '',
+        stateHandle: '',
+        currentAuthenticator: {
+          value: {
+            contextualData: {
+              challenge: {
+                value: {
+                  challengeRequest: 'challenge_request_2',
+                  challengeMethod: 'LOOPBACK',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(areTransactionsEqual(transaction1, transaction2)).toBe(false);
   });
 
   describe('triggerEmailVerifyCallback Tests', () => {

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -224,35 +224,19 @@ export const areTransactionsEqual = (
     return false;
   }
 
-  const tx1AuthId = typeof tx1 !== 'undefined'
-    ? getCurrentAuthenticator(tx1)?.value?.id
-    : undefined;
-  const tx2AuthId = typeof tx2 !== 'undefined'
-    ? getCurrentAuthenticator(tx2)?.value?.id
-    : undefined;
+  const tx1AuthId = getCurrentAuthenticator(tx1)?.value?.id;
+  const tx2AuthId = getCurrentAuthenticator(tx2)?.value?.id;
+  
   if (tx1AuthId !== tx2AuthId) {
     return false;
   }
 
-  const challengeMethod1 = typeof tx1 !== 'undefined'
-    ? getCurrentAuthenticator(tx1)?.value?.contextualData?.challenge?.value?.challengeMethod
-    : undefined;
-  const challengeMethod2 = typeof tx2 !== 'undefined'
-    ? getCurrentAuthenticator(tx2)?.value?.contextualData?.challenge?.value?.challengeMethod
-    : undefined;
+  // case where another challenge from the same authenticator is received
+  const tx1ChallengeId = getCurrentAuthenticator(tx1)?.value?.contextualData?.challenge?.value?.challengeRequest;
+  const tx2ChallengeId = getCurrentAuthenticator(tx2)?.value?.contextualData?.challenge?.value?.challengeRequest;
 
-  // case where a second loopback challenge is received, we should allow the LoopBackProbe component to probe again
-  if (challengeMethod1 === CHALLENGE_METHOD.LOOPBACK
-        && challengeMethod2 === CHALLENGE_METHOD.LOOPBACK) {
-    const tx1ChallengeId = typeof tx1 !== 'undefined'
-      ? getCurrentAuthenticator(tx1)?.value?.contextualData?.challenge?.value?.challengeRequest
-      : undefined;
-    const tx2ChallengeId = typeof tx2 !== 'undefined'
-      ? getCurrentAuthenticator(tx2)?.value?.contextualData?.challenge?.value?.challengeRequest
-      : undefined;
-    if (tx1ChallengeId !== tx2ChallengeId) {
-      return false;
-    }
+  if (tx1ChallengeId !== tx2ChallengeId) {
+    return false;
   }
 
   // on the safe mode poll remediation (IDX_STEP.POLL) we _always_

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -242,7 +242,7 @@ export const areTransactionsEqual = (
     : undefined;
 
   // case where a second loopback challenge is received, we should allow the LoopBackProbe component to probe again
-  if (challengeMethod1 === CHALLENGE_METHOD.LOOPBACK 
+  if (challengeMethod1 === CHALLENGE_METHOD.LOOPBACK
         && challengeMethod2 === CHALLENGE_METHOD.LOOPBACK) {
     const tx1ChallengeId = typeof tx1 !== 'undefined'
       ? getCurrentAuthenticator(tx1)?.value?.contextualData?.challenge?.value?.challengeRequest

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -28,7 +28,6 @@ import { StateUpdater } from 'preact/hooks';
 import { getMessage } from '../../../v2/ion/i18nUtils';
 import {
   AUTHENTICATOR_KEY,
-  CHALLENGE_METHOD,
   CONSENT_HEADER_STEPS,
   DEVICE_ENROLLMENT_TYPE,
   EMAIL_AUTHENTICATOR_TERMINAL_KEYS,
@@ -226,14 +225,16 @@ export const areTransactionsEqual = (
 
   const tx1AuthId = getCurrentAuthenticator(tx1)?.value?.id;
   const tx2AuthId = getCurrentAuthenticator(tx2)?.value?.id;
-  
+
   if (tx1AuthId !== tx2AuthId) {
     return false;
   }
 
   // case where another challenge from the same authenticator is received
-  const tx1ChallengeId = getCurrentAuthenticator(tx1)?.value?.contextualData?.challenge?.value?.challengeRequest;
-  const tx2ChallengeId = getCurrentAuthenticator(tx2)?.value?.contextualData?.challenge?.value?.challengeRequest;
+  const tx1ChallengeId = getCurrentAuthenticator(tx1)
+    ?.value?.contextualData?.challenge?.value?.challengeRequest;
+  const tx2ChallengeId = getCurrentAuthenticator(tx2)
+    ?.value?.contextualData?.challenge?.value?.challengeRequest;
 
   if (tx1ChallengeId !== tx2ChallengeId) {
     return false;

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -242,7 +242,8 @@ export const areTransactionsEqual = (
     : undefined;
 
   // case where a second loopback challenge is received, we should allow the LoopBackProbe component to probe again
-  if (challengeMethod1 === CHALLENGE_METHOD.LOOPBACK && challengeMethod2 === CHALLENGE_METHOD.LOOPBACK) {
+  if (challengeMethod1 === CHALLENGE_METHOD.LOOPBACK 
+        && challengeMethod2 === CHALLENGE_METHOD.LOOPBACK) {
     const tx1ChallengeId = typeof tx1 !== 'undefined'
       ? getCurrentAuthenticator(tx1)?.value?.contextualData?.challenge?.value?.challengeRequest
       : undefined;

--- a/src/v3/src/util/idxUtils.ts
+++ b/src/v3/src/util/idxUtils.ts
@@ -28,6 +28,7 @@ import { StateUpdater } from 'preact/hooks';
 import { getMessage } from '../../../v2/ion/i18nUtils';
 import {
   AUTHENTICATOR_KEY,
+  CHALLENGE_METHOD,
   CONSENT_HEADER_STEPS,
   DEVICE_ENROLLMENT_TYPE,
   EMAIL_AUTHENTICATOR_TERMINAL_KEYS,
@@ -231,6 +232,26 @@ export const areTransactionsEqual = (
     : undefined;
   if (tx1AuthId !== tx2AuthId) {
     return false;
+  }
+
+  const challengeMethod1 = typeof tx1 !== 'undefined'
+    ? getCurrentAuthenticator(tx1)?.value?.contextualData?.challenge?.value?.challengeMethod
+    : undefined;
+  const challengeMethod2 = typeof tx2 !== 'undefined'
+    ? getCurrentAuthenticator(tx2)?.value?.contextualData?.challenge?.value?.challengeMethod
+    : undefined;
+
+  // case where a second loopback challenge is received, we should allow the LoopBackProbe component to probe again
+  if (challengeMethod1 === CHALLENGE_METHOD.LOOPBACK && challengeMethod2 === CHALLENGE_METHOD.LOOPBACK) {
+    const tx1ChallengeId = typeof tx1 !== 'undefined'
+      ? getCurrentAuthenticator(tx1)?.value?.contextualData?.challenge?.value?.challengeRequest
+      : undefined;
+    const tx2ChallengeId = typeof tx2 !== 'undefined'
+      ? getCurrentAuthenticator(tx2)?.value?.contextualData?.challenge?.value?.challengeRequest
+      : undefined;
+    if (tx1ChallengeId !== tx2ChallengeId) {
+      return false;
+    }
   }
 
   // on the safe mode poll remediation (IDX_STEP.POLL) we _always_

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -566,7 +566,7 @@ test
     const identityPage = new IdentityPageObject(t);
     await identityPage.fillIdentifierField('Test Identifier');
     await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
-});
+  });
 
 test
   .requestHooks(loopbackBiometricsNoResponseErrorLogger, loopbackBiometricsNoResponseErrorMock)('in loopback server, when user does not respond to biometrics request, cancel the polling', async t => {

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -6,6 +6,7 @@ import BasePageObject from '../framework/page-objects/BasePageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import identify from '../../../playground/mocks/data/idp/idx/identify';
 import identifyWithUserVerificationLoopback from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback';
+import identifyWithUserVerificationLoopbackSecondChallenge from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-second-challenge';
 import identifyWithUserVerificationLoopbackWithEnhancedPolling from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-with-enhanced-polling';
 import identifyWithUserVerificationBiometricsErrorMobile from '../../../playground/mocks/data/idp/idx/error-400-okta-verify-uv-fastpass-verify-enable-biometrics-mobile.json';
 import identifyWithUserVerificationBiometricsErrorDesktop from '../../../playground/mocks/data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-desktop.json';
@@ -40,6 +41,9 @@ const loopbackSuccessInitialPollMock = RequestMock()
 const loopbackSuccessAfterProbePollMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond(identify);
+const loopbackSecondLoopbackChallengeAfterProbePollMock = RequestMock()
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(identifyWithUserVerificationLoopbackSecondChallenge);
 const loopbackSuccessMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/introspect/)
   .respond(identifyWithUserVerificationLoopback)
@@ -503,6 +507,66 @@ test
     await identityPage.fillIdentifierField('Test Identifier');
     await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
   });
+
+test
+  .requestHooks(loopbackSuccessLogger, loopbackSuccessMock, loopbackSuccessInitialPollMock)('in loopback server approach, probing and polling requests are sent and responded multiple challenge requests', async t => {
+    const deviceChallengePollPageObject = await setup(t);
+    await checkA11y(t);
+    await t.expect(deviceChallengePollPageObject.getBeaconSelector()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
+    // in v3 all cancel buttons are the same so skip this assertion
+    if (!userVariables.gen3) {
+      await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
+    }
+    await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().innerText).eql('Verify with something else');
+    await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
+
+    // 1st challenge
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.method !== 'options' &&
+        record.request.url.match(/introspect|6512/)
+    )).eql(3);
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/challenge/) &&
+        record.request.body.match(/challengeRequest":"02vQULJDA20fnlkloDn2/)
+    )).eql(1);
+    // Check if pre-flight HTTP requests were sent
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.method === 'options' &&
+        record.request.url.match(/2000|6511/)
+    )).eql(2);
+
+    // need wait times to prevent first mock poll from overriding second mock poll
+    await t.wait(4000);
+    await t.removeRequestHooks(loopbackSuccessInitialPollMock);
+    await t.addRequestHooks(loopbackSecondLoopbackChallengeAfterProbePollMock);
+    await t.wait(4000);
+
+    // 2nd challenge
+    // expect challenge with new challengeRequest
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/challenge/) &&
+        record.request.body.match(/challengeRequest":"123/)
+    )).eql(1);
+    // pre-flight HTTP requests sent should be double after second challenge
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.method === 'options' &&
+        record.request.url.match(/2000|6511/)
+    )).eql(4);
+
+    await t.removeRequestHooks(loopbackSecondLoopbackChallengeAfterProbePollMock);
+    await t.addRequestHooks(loopbackSuccessAfterProbePollMock);
+
+    await t.expect(loopbackSuccessLogger.contains(record => record.request.url.match(/6513/))).eql(false);
+    const identityPage = new IdentityPageObject(t);
+    await identityPage.fillIdentifierField('Test Identifier');
+    await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+});
 
 test
   .requestHooks(loopbackBiometricsNoResponseErrorLogger, loopbackBiometricsNoResponseErrorMock)('in loopback server, when user does not respond to biometrics request, cancel the polling', async t => {


### PR DESCRIPTION
## Description:

This PR enables SIW gen 3 to re-prompt for auth when multiple loopback challenges are received while polling.  This is to match behavior with gen 2.


**Before:**

https://github.com/user-attachments/assets/b35913f7-3bc3-4a4f-895e-949fa8e17279

**After:**

https://github.com/user-attachments/assets/61da92cf-9b26-466a-942b-654bf2ddbc53




## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-925206](https://oktainc.atlassian.net/browse/OKTA-925206)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



