### PR TITLE
add identifier to fieldsToTrim

### DIFF
--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -170,7 +170,8 @@ export const transformStepInputs = (
         };
         acc.dataSchema.fieldsToValidate.push(name);
         // Of the required fields, trim appropriately
-        if (uischema.options.attributes?.inputmode === 'numeric') {
+        if (uischema.options.attributes?.inputmode === 'numeric'
+          || uischema.key === 'identifier' ) {
           acc.dataSchema.fieldsToTrim.push(name);
         }
       }


### PR DESCRIPTION
Resolves: OKTA-948846

## Description:
Unlike gen2, gen3 username doesn't trim, so add the `identifier` to `fieldsToTrim`
passcode input is NOT trimmed

One nuance is
In Gen2, the trim happens in the courage model level, the UI still preserve the space
![Screenshot 2025-06-17 at 1 47 29 PM](https://github.com/user-attachments/assets/76225703-7645-4b39-8206-99426777db92)

In Gen3, after we add the `identifier` to `fieldsToTrim`, it will also reflect in the UI, video below:

https://github.com/user-attachments/assets/8a4cd496-57a1-4f0d-a7f9-3d3e4f0045f4


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-948846](https://oktainc.atlassian.net/browse/OKTA-948846)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



