### PR TITLE
Revert "OKTA-948792: enable verify registry install bacon task (#3857)"

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -143,14 +143,15 @@ test_suites:
     script_name: detect-english-leaks-v3
     criteria: MERGE
     queue_name: small
-  - name: verify-registry-install
-    prereq_test_suite_name: publish
-    script_path: /root/okta/okta-signin-widget/scripts
-    sort_order: '19'
-    timeout: '20'
-    script_name: verify-registry-install
-    criteria: MERGE
-    queue_name: small
+  # Re-enablement tracking jira: https://oktainc.atlassian.net/browse/OKTA-948779
+  # - name: verify-registry-install
+  #   prereq_test_suite_name: publish
+  #   script_path: /root/okta/okta-signin-widget/scripts
+  #   sort_order: '19'
+  #   timeout: '20'
+  #   script_name: verify-registry-install
+  #   criteria: MERGE
+  #   queue_name: small
   - name: find-internal-packages
     script_path: /root/okta/okta-signin-widget/scripts
     sort_order: '20'

--- a/scripts/verify-registry-install.sh
+++ b/scripts/verify-registry-install.sh
@@ -8,7 +8,7 @@ export PUBLIC_REGISTRY="https://registry.yarnpkg.com"
 cd ${OKTA_HOME}/${REPO}
 
 # Install required node version
-setup_service node v16.19.1
+setup_service node v14.18.2
 setup_service yarn 1.22.19
 
 # Install required dependencies


### PR DESCRIPTION
This reverts commit 1a317c06dfea46f4bb5b4378aec690b77e58a578.

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



