### PR TITLE
fix(gen3): Change Authenticator button h3 tag to p

### DIFF
--- a/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
+++ b/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
@@ -243,7 +243,7 @@ const AuthenticatorButton: UISchemaElementComponent<{
         }}
       >
         <Typography
-          component="h2"
+          component="p"
           variant="h3"
           id={`${iconName}-label`}
           sx={{

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -212,14 +212,14 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="google_otp_0-label"
                               translate="no"
                             >
                               Google Authenticator
-                            </h2>
+                            </p>
                             <p
                               aria-label="Enter a temporary code generated from the Google Authenticator app."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -313,14 +313,14 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="okta_verify_1-label"
                               translate="no"
                             >
                               Okta Verify
-                            </h2>
+                            </p>
                             <p
                               aria-label="Okta Verify is an authenticator app, installed on your phone or computer, used to prove your identity."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -428,14 +428,14 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="phone_number_2-label"
                               translate="no"
                             >
                               Phone
-                            </h2>
+                            </p>
                             <p
                               aria-label="Verify with a code sent to your phone."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -553,14 +553,14 @@ exports[`authenticator-enroll-phone-sms Send correct payload when back to authen
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="webauthn_3-label"
                               translate="no"
                             >
                               Security Key or Biometric Authenticator
-                            </h2>
+                            </p>
                             <p
                               aria-label="Use a security key or a biometric authenticator to sign in."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -192,14 +192,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="okta_password_0-label"
                               translate="no"
                             >
                               Password
-                            </h2>
+                            </p>
                             <p
                               aria-label="Choose a password for your account."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -307,14 +307,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="phone_number_1-label"
                               translate="no"
                             >
                               Phone
-                            </h2>
+                            </p>
                             <p
                               aria-label="Verify with a code sent to your phone."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -432,14 +432,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="webauthn_2-label"
                               translate="no"
                             >
                               Security Key or Biometric Authenticator
-                            </h2>
+                            </p>
                             <p
                               aria-label="Use a security key or a biometric authenticator to sign in."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -192,14 +192,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="okta_password_0-label"
                               translate="no"
                             >
                               Password
-                            </h2>
+                            </p>
                             <p
                               aria-label="Choose a password for your account."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -307,14 +307,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="phone_number_1-label"
                               translate="no"
                             >
                               Phone
-                            </h2>
+                            </p>
                             <p
                               aria-label="Verify with a code sent to your phone."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -432,14 +432,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="webauthn_2-label"
                               translate="no"
                             >
                               Security Key or Biometric Authenticator
-                            </h2>
+                            </p>
                             <p
                               aria-label="Use a security key or a biometric authenticator to sign in."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -537,14 +537,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="security_question_3-label"
                               translate="no"
                             >
                               Security Question
-                            </h2>
+                            </p>
                             <p
                               aria-label="Choose a security question and answer that will be used for signing in."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -638,14 +638,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="okta_verify_4-label"
                               translate="no"
                             >
                               Okta Verify
-                            </h2>
+                            </p>
                             <p
                               aria-label="Okta Verify is an authenticator app, installed on your phone or computer, used to prove your identity."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -763,14 +763,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="google_otp_5-label"
                               translate="no"
                             >
                               Google Authenticator
-                            </h2>
+                            </p>
                             <p
                               aria-label="Enter a temporary code generated from the Google Authenticator app."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -868,14 +868,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="onprem_mfa_6-label"
                               translate="no"
                             >
                               Atko Custom On-prem
-                            </h2>
+                            </p>
                             <p
                               aria-label="Verify by entering a code generated by Atko Custom On-prem."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -967,14 +967,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="rsa_token_7-label"
                               translate="no"
                             >
                               RSA SecurID
-                            </h2>
+                            </p>
                             <p
                               aria-label="Verify by entering a code generated by RSA SecurID."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -1068,14 +1068,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="duo_8-label"
                               translate="no"
                             >
                               Duo Security
-                            </h2>
+                            </p>
                             <p
                               aria-label="Verify your identity using Duo Security."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -1178,14 +1178,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="external_idp_9-label"
                               translate="no"
                             >
                               IDP Authenticator
-                            </h2>
+                            </p>
                             <p
                               aria-label="Redirect to verify with IDP Authenticator."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -1288,14 +1288,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="custom_otp_10-label"
                               translate="no"
                             >
                               Atko Custom OTP Authenticator
-                            </h2>
+                            </p>
                             <p
                               aria-label="Enter a temporary code generated from an authenticator device."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -1395,14 +1395,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="symantec_vip_11-label"
                               translate="no"
                             >
                               Symantec VIP
-                            </h2>
+                            </p>
                             <p
                               aria-label="Verify by entering a temporary code from the Symantec VIP app."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"
@@ -1502,14 +1502,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-31"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-32"
                               data-se="authenticator-button-label"
                               id="yubikey_token_12-label"
                               translate="no"
                             >
                               YubiKey Authenticator
-                            </h2>
+                            </p>
                             <p
                               aria-label="Verify your identity using YubiKey."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-33"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-with-device-known.test.tsx.snap
@@ -200,14 +200,14 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                             class="MuiBox-root emotion-29"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-30"
                               data-se="authenticator-button-label"
                               id="okta_verify_2-label"
                               translate="no"
                             >
                               Okta Verify
-                            </h2>
+                            </p>
                             <p
                               aria-label="Use Okta FastPass."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-31"
@@ -294,14 +294,14 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                             class="MuiBox-root emotion-29"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-30"
                               data-se="authenticator-button-label"
                               id="okta_verify_0-label"
                               translate="no"
                             >
                               Okta Verify
-                            </h2>
+                            </p>
                             <p
                               aria-label="Get a push notification."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-31"
@@ -388,14 +388,14 @@ exports[`authenticator-verification-data-ov-only-with-device-known should render
                             class="MuiBox-root emotion-29"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-30"
                               data-se="authenticator-button-label"
                               id="okta_verify_1-label"
                               translate="no"
                             >
                               Okta Verify
-                            </h2>
+                            </p>
                             <p
                               aria-label="Enter a code."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-31"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-ov-only-without-device-known.test.tsx.snap
@@ -200,14 +200,14 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                             class="MuiBox-root emotion-29"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-30"
                               data-se="authenticator-button-label"
                               id="okta_verify_0-label"
                               translate="no"
                             >
                               Okta Verify
-                            </h2>
+                            </p>
                             <p
                               aria-label="Get a push notification."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-31"
@@ -294,14 +294,14 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                             class="MuiBox-root emotion-29"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-30"
                               data-se="authenticator-button-label"
                               id="okta_verify_1-label"
                               translate="no"
                             >
                               Okta Verify
-                            </h2>
+                            </p>
                             <p
                               aria-label="Enter a code."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-31"
@@ -388,14 +388,14 @@ exports[`authenticator-verification-data-ov-only-without-device-known should ren
                             class="MuiBox-root emotion-29"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-30"
                               data-se="authenticator-button-label"
                               id="okta_verify_2-label"
                               translate="no"
                             >
                               Okta Verify
-                            </h2>
+                            </p>
                             <p
                               aria-label="Use Okta FastPass."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-31"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -177,14 +177,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="okta_password_0-label"
                               translate="no"
                             >
                               Password
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -287,14 +287,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="webauthn_1-label"
                               translate="no"
                             >
                               Security Key or Biometric Authenticator
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -377,14 +377,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="okta_email_2-label"
                               translate="no"
                             >
                               Email
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -477,14 +477,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="phone_number_3-label"
                               translate="no"
                             >
                               Phone
-                            </h2>
+                            </p>
                             <p
                               aria-label="+1 XXX-XXX-5309."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-57"
@@ -587,14 +587,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="phone_number_4-label"
                               translate="no"
                             >
                               Phone
-                            </h2>
+                            </p>
                             <p
                               aria-label="+1 XXX-XXX-5310."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-57"
@@ -687,14 +687,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="security_question_5-label"
                               translate="no"
                             >
                               Security Question
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -773,14 +773,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="okta_verify_6-label"
                               translate="no"
                             >
                               Okta Verify
-                            </h2>
+                            </p>
                             <p
                               aria-label="Use Okta FastPass."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-57"
@@ -891,14 +891,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="google_otp_7-label"
                               translate="no"
                             >
                               Google Authenticator
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -981,14 +981,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="onprem_mfa_8-label"
                               translate="no"
                             >
                               Atko Custom On-prem
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -1065,14 +1065,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="rsa_token_9-label"
                               translate="no"
                             >
                               RSA SecurID
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -1151,14 +1151,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="duo_10-label"
                               translate="no"
                             >
                               Duo Security
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -1246,14 +1246,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="external_idp_11-label"
                               translate="no"
                             >
                               IDP Authenticator
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -1341,14 +1341,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="custom_otp_12-label"
                               translate="no"
                             >
                               Atko Custom OTP Authenticator
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -1433,14 +1433,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="symantec_vip_13-label"
                               translate="no"
                             >
                               Symantec VIP
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -1525,14 +1525,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="yubikey_token_14-label"
                               translate="no"
                             >
                               YubiKey Authenticator
-                            </h2>
+                            </p>
                           </div>
                           <div
                             class="MuiBox-root emotion-30"
@@ -1596,14 +1596,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                             class="MuiBox-root emotion-28"
                             data-se="authenticator-button-content"
                           >
-                            <h2
+                            <p
                               class="MuiTypography-root MuiTypography-h3 emotion-29"
                               data-se="authenticator-button-label"
                               id="custom_app_15-label"
                               translate="no"
                             >
                               Custom Push App
-                            </h2>
+                            </p>
                             <p
                               aria-label="Get a push notification."
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-57"

--- a/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
@@ -3,7 +3,9 @@ import { within } from '@testing-library/testcafe';
 import BasePageObject from './BasePageObject';
 
 const factorListRowSelector = userVariables.gen3 ? '[data-se="authenticator-button"]' : '.authenticator-list .authenticator-row';
-const factorLabelSelector = `${factorListRowSelector} .authenticator-label`;
+const factorLabelSelector = userVariables.gen3 
+  ? `${factorListRowSelector} [data-se="authenticator-button-content"] p[data-se="authenticator-button-label"]` 
+  : `${factorListRowSelector} .authenticator-label`;
 const factorDescriptionSelector = userVariables.gen3
   ? `${factorListRowSelector} [data-se="authenticator-button-description"]`
   : `${factorListRowSelector} .authenticator-description .authenticator-description--text`;
@@ -64,7 +66,8 @@ export default class SelectFactorPageObject extends BasePageObject {
   getFactorLabelByIndex(index) {
     if (userVariables.gen3) {
       const factorButton = this.getFactorButtons().nth(index);
-      return within(factorButton).findByRole('heading', { level: 2 }).textContent;
+      // return within(factorButton).findByRole('heading', { level: 2 }).textContent;
+      return within(factorButton).find(factorLabelSelector).textContent;
     }
     return this.form.getElement(factorLabelSelector).nth(index).textContent;
   }

--- a/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
@@ -66,7 +66,6 @@ export default class SelectFactorPageObject extends BasePageObject {
   getFactorLabelByIndex(index) {
     if (userVariables.gen3) {
       const factorButton = this.getFactorButtons().nth(index);
-      // return within(factorButton).findByRole('heading', { level: 2 }).textContent;
       return within(factorButton).find(factorLabelSelector).textContent;
     }
     return this.form.getElement(factorLabelSelector).nth(index).textContent;


### PR DESCRIPTION
## Description:

The gen 3 Authenticator button label text uses an `h3` tag to match parity with the gen 2 widget, but it is not appropriate from an accessibility perspective for that label to use h3 tag since the label is integrated within the button.  The tag is changed to `p` instead but does not make any visual changes.

Bacon downstream test again okta-core: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=OKTA-974299-test&page=1&pageSize=6&tab=main

**HeadingsMap Before:**

<img width="1227" height="821" alt="Screenshot 2025-07-31 at 3 06 09 PM" src="https://github.com/user-attachments/assets/761c4147-ee82-4f39-9990-1924823df51a" />


**HeadingsMap After:**

<img width="1251" height="824" alt="Screenshot 2025-07-31 at 3 05 51 PM" src="https://github.com/user-attachments/assets/42e90d20-066b-4d82-a46f-74b1dd68d31a" />


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-974299](https://oktainc.atlassian.net/browse/OKTA-974299)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



