### PR TITLE
fix(oie): Empty custom i18n value fix

### DIFF
--- a/src/v2/ion/i18nUtils.js
+++ b/src/v2/ion/i18nUtils.js
@@ -393,7 +393,7 @@ const isCustomizedI18nKey = (i18nKey, settings) => {
   
   // Lower case the language codes when searching for i18n key so it is case insensitive
   return Object.entries(i18n).some(
-    ([customizedLangCode, customizedI18nKeys]) => customizedLangCode.toLowerCase() === widgetLanguageLowerCase && customizedI18nKeys[i18nKey] !== undefined
+    ([customizedLangCode, customizedI18nKeys]) => customizedLangCode.toLowerCase() === widgetLanguageLowerCase && !!customizedI18nKeys[i18nKey]
   );
 };
 

--- a/src/v3/src/transformer/i18n/isCustomizedI18nKey.test.ts
+++ b/src/v3/src/transformer/i18n/isCustomizedI18nKey.test.ts
@@ -46,6 +46,18 @@ describe('isCustomizedI18nKey', () => {
     expect(isCustomizedI18nKey('primaryauth.username.tooltip', widgetProps)).toEqual(true);
   });
 
+  it('should return false when value is empty string', () => {
+    widgetProps = {
+      i18n: {
+        en: {
+          'primaryauth.username.tooltip': '',
+        },
+      },
+    };
+
+    expect(isCustomizedI18nKey('primaryauth.username.tooltip', widgetProps)).toEqual(false);
+  });
+
   it('should return false when there are no languages with custom i18n keys', () => {
     widgetProps = {
       i18n: {},

--- a/src/v3/src/transformer/i18n/isCustomizedI18nKey.ts
+++ b/src/v3/src/transformer/i18n/isCustomizedI18nKey.ts
@@ -24,5 +24,5 @@ export const isCustomizedI18nKey = (i18nKey: string, widgetProps: WidgetProps): 
   // Lower case the language codes when searching for i18n key so it is case insensitive
   // eslint-disable-next-line max-len
   return Object.entries(i18n).some(([customizedLangCode, customizedI18nKeys]) => customizedLangCode.toLowerCase() === widgetLanguageLowerCase
-        && customizedI18nKeys[i18nKey] !== undefined);
+        && !!customizedI18nKeys[i18nKey]);
 };


### PR DESCRIPTION
## Description:

This PR fixes an issue where an L10N_ERROR translation error is shown when overriding an i18n key with an empty string.  

**Before:**

<img width="714" height="644" alt="Screenshot 2025-07-31 at 3 35 59 PM" src="https://github.com/user-attachments/assets/f0b7e677-2852-4da0-8218-a8ac6b69d145" />


**After:**

<img width="761" height="655" alt="Screenshot 2025-07-31 at 3 34 55 PM" src="https://github.com/user-attachments/assets/ad8a6ff6-0d96-4826-a906-415ab32bb3bb" />



## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-986305](https://oktainc.atlassian.net/browse/OKTA-986305)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



