### PR TITLE
fix: suppresses webauthn relying party id mismatch error

### DIFF
--- a/src/util/webauthn.js
+++ b/src/util/webauthn.js
@@ -93,5 +93,8 @@ export default {
       isAvailable = await PublicKeyCredential.isConditionalMediationAvailable();
     }
     return isAvailable;
-  }
+  },
+  isRelyingPartyIdMismatchError: function(error) {
+    return error?.name === 'SecurityError' && error?.code === 18;
+  },
 };

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -251,6 +251,16 @@ const Body = BaseForm.extend({
         { credentials }
       );
     }, (error) => {
+      // Suppress the error shown to the enduser in case of the relying party id mismatch.
+      // The error message shown was:
+      // "The relying party ID is not a registrable domain suffix of, nor equal to the current domain.
+      // Subsequently, an attempt to fetch the .well-known/webauthn resource of the claimed RP ID failed."
+      // There is no need to show this error, as it was not triggered by a user action,
+      // nor is it stopping the user from proceeding.
+      if (webauthn.isRelyingPartyIdMismatchError(error)) {
+        return;
+      }
+
       // Do not display if it is abort error triggered by code when switching.
       // this.webauthnAbortController would be null if abort was triggered by code.
       if (this.webauthnAbortController) {


### PR DESCRIPTION
## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



