### PR TITLE
Chrome LNA translations

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1690,3 +1690,15 @@ oie.enrollment.policy.grace.period.required.in.one.day = Required in 1 day
 
 # OAMP Strings
 api.policy.okta.account.management.insufficient.authenticators.unable.to.sign.in = Unable to sign in. Contact support for assistance.
+
+# Chrome Local Network Access
+chrome.lna.fast.pass.requires.permission.title = Okta FastPass requires network permission
+chrome.lna.prompt.title = Allow the upcoming Chrome prompt
+chrome.lna.prompt.description.part1 = If you don't allow this network permission, Okta FastPass may not work properly, and you might not be able to sign in.
+chrome.lna.prompt.description.part2 = This is a secure and necessary step that allows the Okta sign-in page to communicate with the Okta Verify app on your device. Okta Verify does not access any other devices on your network.
+chrome.lna.prompt.description.learn.more = Learn more about <$1>Chrome Local Network Access</$1>
+chrome.lna.open.prompt.label = Open Chrome prompt
+chrome.lna.error.title = Unable to sign in
+chrome.lna.error.description.part1 = The browser is blocking communication with Okta Verify.
+chrome.lna.error.description.part2 = To sign in, go to your browser's site settings, find "Local network access", and change the permission from "Block" to "Allow." Then, reload this page.
+chrome.lna.error.description.more.information = For more information, follow the instructions on the <$1>Chrome Local Network Access</$1> page or contact your administrator for help.

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1692,7 +1692,7 @@ oie.enrollment.policy.grace.period.required.in.one.day = Required in 1 day
 api.policy.okta.account.management.insufficient.authenticators.unable.to.sign.in = Unable to sign in. Contact support for assistance.
 
 # Chrome Local Network Access
-chrome.lna.fast.pass.requires.permission.title = Okta FastPass requires network permission
+chrome.lna.fastpass.requires.permission.title = Okta FastPass requires network permission
 chrome.lna.prompt.title = Allow the upcoming Chrome prompt
 chrome.lna.prompt.description.part1 = If you don't allow this network permission, Okta FastPass may not work properly, and you might not be able to sign in.
 chrome.lna.prompt.description.part2 = This is a secure and necessary step that allows the Okta sign-in page to communicate with the Okta Verify app on your device. Okta Verify does not access any other devices on your network.


### PR DESCRIPTION
## Description:
- Adds translations for the Chrome Local Network Access prompt (PR with source code changes to follow next week)


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1000438](https://oktainc.atlassian.net/browse/OKTA-1000438)

### Reviewers:

### Screenshot/Video:
### Hypothetical gen3 usage of strings (subject to change)
<img width="473" height="764" alt="Screenshot 2025-08-19 at 6 57 29 PM" src="https://github.com/user-attachments/assets/e899ded7-0df9-48b3-8661-94307c686525" />

<img width="473" height="852" alt="Screenshot 2025-08-19 at 6 57 24 PM" src="https://github.com/user-attachments/assets/cd2e5b6e-41e9-42da-a38f-026e76ff7336" />

### Downstream Monolith Build:



