### PR TITLE
Make Chrome LNA strings browser-agnostic

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1693,12 +1693,12 @@ api.policy.okta.account.management.insufficient.authenticators.unable.to.sign.in
 
 # Chrome Local Network Access
 chrome.lna.fastpass.requires.permission.title = Okta FastPass requires network permission
-chrome.lna.prompt.title = Allow the upcoming Chrome prompt
+chrome.lna.prompt.title = Allow the upcoming prompt
 chrome.lna.prompt.description.part1 = If you don't allow this network permission, Okta FastPass may not work properly, and you might not be able to sign in.
 chrome.lna.prompt.description.part2 = This process is secure and only communicates with the device where Okta Verify is installed; Okta will not look for or connect to any other device on your local network.
-chrome.lna.prompt.description.learn.more = Learn more about <$1>Chrome Local Network Access</$1>
-chrome.lna.open.prompt.label = Open Chrome prompt
+chrome.lna.prompt.description.learn.more = Learn more about <$1>Local Network Access</$1>
+chrome.lna.open.prompt.label = Open prompt
 chrome.lna.error.title = Unable to sign in
 chrome.lna.error.description.part1 = The browser is blocking communication with Okta Verify.
 chrome.lna.error.description.part2 = To sign in, go to your browser's site settings, find "Local network access", and change the permission from "Block" to "Allow." Then, reload this page.
-chrome.lna.error.description.more.information = For more information, follow the instructions on the <$1>Chrome Local Network Access</$1> page or contact your administrator for help.
+chrome.lna.error.description.more.information = For more information, follow the instructions on the <$1>Local Network Access</$1> page or contact your administrator for help.


### PR DESCRIPTION
## Description:
- Feedback from Tech Talks demo to make Chrome LNA strings browser-agnostic


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1002404](https://oktainc.atlassian.net/browse/OKTA-1002404)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



