### PR TITLE
fix(gen3): security question verification i18n error

### DIFF
--- a/src/v3/src/mocks/response/idp/idx/identify/securityquestion-verify-no-profile.json
+++ b/src/v3/src/mocks/response/idp/idx/identify/securityquestion-verify-no-profile.json
@@ -1,0 +1,195 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02lzgq6CgaXplODrsJStwY-46AKYyqUsEexTQJGZSD",
+  "expiresAt": "2022-04-21T19:59:23.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "challenge-authenticator",
+        "relatesTo": [
+          "$.currentAuthenticatorEnrollment"
+        ],
+        "href": "http://localhost:3000/idp/idx/challenge/answer",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "questionKey",
+                  "label": "What is the food you least liked as a child?",
+                  "required": true,
+                  "value": "disliked_food",
+                  "visible": false,
+                  "mutable": false
+                },
+                {
+                  "name": "answer",
+                  "label": "Answer",
+                  "required": true,
+                  "secret": true
+                }
+              ]
+            },
+            "required": true
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02lzgq6CgaXplODrsJStwY-46AKYyqUsEexTQJGZSD",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut41wnl0kSazUCZ05d7",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "security_question",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02lzgq6CgaXplODrsJStwY-46AKYyqUsEexTQJGZSD",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "currentAuthenticatorEnrollment": {
+    "type": "object",
+    "value": {
+      "contextualData": {
+        "enrolledQuestion": {
+          "questionKey": "disliked_food",
+          "question": "What is the food you least liked as a child?"
+        }
+      },
+      "type": "security_question",
+      "key": "security_question",
+      "id": "qae4ks1ygweGSuDPk5d7",
+      "displayName": "Security Question",
+      "methods": [
+        {
+          "type": "security_question"
+        }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "security_question",
+        "key": "security_question",
+        "id": "aut41wnl0kSazUCZ05d7",
+        "displayName": "Security Question",
+        "methods": [
+          {
+            "type": "security_question"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "type": "security_question",
+        "key": "security_question",
+        "id": "qae4ks1ygweGSuDPk5d7",
+        "displayName": "Security Question",
+        "methods": [
+          {
+            "type": "security_question"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u41xf0kyDTLXsGT5d7",
+      "identifier": "tester@okta1.com",
+      "profile": {
+        "firstName": "Tester",
+        "lastName": "McTesterson",
+        "timeZone": "America/Los_Angeles",
+        "locale": "en_US"
+      }
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02lzgq6CgaXplODrsJStwY-46AKYyqUsEexTQJGZSD",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "okta_enduser",
+      "label": "Okta Dashboard",
+      "id": "0oa41wbvuxdjMeta75d7"
+    }
+  }
+}

--- a/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionVerify.test.ts.snap
+++ b/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionVerify.test.ts.snap
@@ -102,7 +102,58 @@ Object {
 }
 `;
 
-exports[`SecurityQuestionVerify Tests should create security question verify UI elements from remediation inputs 1`] = `
+exports[`SecurityQuestionVerify Tests should create security question verify UI elements from remediation inputs when question is custom 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.security.question.challenge.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "noTranslate": true,
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.answer",
+            "secret": true,
+          },
+        },
+        "translations": Array [
+          Object {
+            "i18nKey": "",
+            "name": "label",
+            "value": "What is the answer to this custom question?",
+          },
+        ],
+        "type": "Field",
+      },
+      Object {
+        "label": "oform.verify",
+        "options": Object {
+          "step": "mock-step",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;
+
+exports[`SecurityQuestionVerify Tests should create security question verify UI elements from remediation inputs when question key should be localized 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {

--- a/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionVerify.test.ts.snap
+++ b/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionVerify.test.ts.snap
@@ -101,3 +101,54 @@ Object {
   },
 }
 `;
+
+exports[`SecurityQuestionVerify Tests should create security question verify UI elements from remediation inputs 1`] = `
+Object {
+  "data": Object {},
+  "dataSchema": Object {
+    "fieldsToExclude": [Function],
+    "fieldsToTrim": Array [],
+    "fieldsToValidate": Array [],
+    "submit": Object {
+      "step": "challenge-authenticator",
+    },
+  },
+  "schema": Object {},
+  "uischema": Object {
+    "elements": Array [
+      Object {
+        "options": Object {
+          "content": "oie.security.question.challenge.title",
+        },
+        "type": "Title",
+      },
+      Object {
+        "noTranslate": true,
+        "options": Object {
+          "inputMeta": Object {
+            "name": "credentials.answer",
+            "secret": true,
+          },
+        },
+        "translations": Array [
+          Object {
+            "i18nKey": "",
+            "name": "label",
+            "value": "security.disliked_food",
+          },
+        ],
+        "type": "Field",
+      },
+      Object {
+        "label": "oform.verify",
+        "options": Object {
+          "step": "mock-step",
+          "type": "submit",
+        },
+        "type": "Button",
+      },
+    ],
+    "type": "VerticalLayout",
+  },
+}
+`;

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
@@ -119,7 +119,7 @@ describe('SecurityQuestionVerify Tests', () => {
       name: 'mock-step',
       relatesTo: {
         value: {
-          profile: {} // no questionKey in profile
+          profile: {}, // no questionKey in profile
         } as unknown as IdxAuthenticator,
       },
       inputs: [
@@ -135,10 +135,10 @@ describe('SecurityQuestionVerify Tests', () => {
             {
               name: 'answer',
               label: 'Answer',
-            }
-          ]
-        }
-      ]
+            },
+          ],
+        },
+      ],
     };
     const updatedFormBag = transformSecurityQuestionVerify({ transaction, formBag, widgetProps });
 
@@ -175,43 +175,43 @@ describe('SecurityQuestionVerify Tests', () => {
       'input[0].value is undefined',
       [
         {
-          value: undefined
-        }
-      ]
+          value: undefined,
+        },
+      ],
     ],
     [
       'input[0].value is empty array',
       [
         {
-          value: []
-        }
-      ]
+          value: [],
+        },
+      ],
     ],
     [
       'input[0].value does not have questionKey name',
       [
         {
-          value: [{name: 'answer'}]
-        }
-      ]
+          value: [{ name: 'answer' }],
+        },
+      ],
     ],
     [
       'input[0].value does not have questionKey value',
       [
         {
-          value: [{name: 'questionKey'}]
-        }
-      ]
+          value: [{ name: 'questionKey' }],
+        },
+      ],
     ],
-  ])('can not find the security question from remediation inputs when %s', function(_, inputs) {
+  ])('can not find the security question from remediation inputs when %s', (_, inputs) => {
     transaction.nextStep = {
       name: 'mock-step',
       relatesTo: {
         value: {
-          profile: {} // no questionKey in profile
+          profile: {}, // no questionKey in profile
         } as unknown as IdxAuthenticator,
       },
-      inputs: inputs as Input[]
+      inputs: inputs as Input[],
     };
     const updatedFormBag = transformSecurityQuestionVerify({ transaction, formBag, widgetProps });
     expect(updatedFormBag.uischema.elements.length).toBe(3);

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
@@ -114,7 +114,38 @@ describe('SecurityQuestionVerify Tests', () => {
       .toBe(ButtonType.SUBMIT);
   });
 
-  it('should create security question verify UI elements from remediation inputs', () => {
+  it.each([
+    [
+      'question key should be localized',
+      [
+        {
+          name: 'questionKey',
+          label: 'What is the food you least liked as a child (locale=en)?',
+          value: 'disliked_food',
+        },
+        {
+          name: 'answer',
+          label: 'Answer',
+        },
+      ],
+      'security.disliked_food',
+    ],
+    [
+      'question is custom',
+      [
+        {
+          name: 'questionKey',
+          label: 'What is the answer to this custom question?',
+          value: 'custom',
+        },
+        {
+          name: 'answer',
+          label: 'Answer',
+        },
+      ],
+      'What is the answer to this custom question?',
+    ],
+  ])('should create security question verify UI elements from remediation inputs when %s', (_, inputsValue, expected) => {
     transaction.nextStep = {
       name: 'mock-step',
       relatesTo: {
@@ -126,17 +157,7 @@ describe('SecurityQuestionVerify Tests', () => {
         {
           name: 'credentials',
           type: 'object',
-          value: [
-            {
-              name: 'questionKey',
-              label: 'What is the food you least liked as a child (locale=en)?',
-              value: 'disliked_food',
-            },
-            {
-              name: 'answer',
-              label: 'Answer',
-            },
-          ],
+          value: inputsValue,
         },
       ],
     };
@@ -158,7 +179,7 @@ describe('SecurityQuestionVerify Tests', () => {
       .toEqual({
         i18nKey: '',
         name: 'label',
-        value: 'security.disliked_food',
+        value: expected,
       });
 
     // submit button

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.test.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxAuthenticator } from '@okta/okta-auth-js';
+import { IdxAuthenticator, Input } from '@okta/okta-auth-js';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 import {
   ButtonElement,
@@ -112,5 +112,114 @@ describe('SecurityQuestionVerify Tests', () => {
     expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.verify');
     expect((updatedFormBag.uischema.elements[2] as ButtonElement).options?.type)
       .toBe(ButtonType.SUBMIT);
+  });
+
+  it('should create security question verify UI elements from remediation inputs', () => {
+    transaction.nextStep = {
+      name: 'mock-step',
+      relatesTo: {
+        value: {
+          profile: {} // no questionKey in profile
+        } as unknown as IdxAuthenticator,
+      },
+      inputs: [
+        {
+          name: 'credentials',
+          type: 'object',
+          value: [
+            {
+              name: 'questionKey',
+              label: 'What is the food you least liked as a child (locale=en)?',
+              value: 'disliked_food',
+            },
+            {
+              name: 'answer',
+              label: 'Answer',
+            }
+          ]
+        }
+      ]
+    };
+    const updatedFormBag = transformSecurityQuestionVerify({ transaction, formBag, widgetProps });
+
+    expect(updatedFormBag).toMatchSnapshot();
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content)
+      .toBe('oie.security.question.challenge.title');
+
+    // answer element
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.name)
+      .toBe('credentials.answer');
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).options?.inputMeta.secret)
+      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).noTranslate)
+      .toBe(true);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).translations?.[0])
+      .toEqual({
+        i18nKey: '',
+        name: 'label',
+        value: 'security.disliked_food',
+      });
+
+    // submit button
+    expect(updatedFormBag.uischema.elements[2].type).toBe('Button');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).label).toBe('oform.verify');
+    expect((updatedFormBag.uischema.elements[2] as ButtonElement).options?.type)
+      .toBe(ButtonType.SUBMIT);
+  });
+
+  it.each([
+    ['input is undefined', undefined],
+    ['input is empty array', []],
+    [
+      'input[0].value is undefined',
+      [
+        {
+          value: undefined
+        }
+      ]
+    ],
+    [
+      'input[0].value is empty array',
+      [
+        {
+          value: []
+        }
+      ]
+    ],
+    [
+      'input[0].value does not have questionKey name',
+      [
+        {
+          value: [{name: 'answer'}]
+        }
+      ]
+    ],
+    [
+      'input[0].value does not have questionKey value',
+      [
+        {
+          value: [{name: 'questionKey'}]
+        }
+      ]
+    ],
+  ])('can not find the security question from remediation inputs when %s', function(_, inputs) {
+    transaction.nextStep = {
+      name: 'mock-step',
+      relatesTo: {
+        value: {
+          profile: {} // no questionKey in profile
+        } as unknown as IdxAuthenticator,
+      },
+      inputs: inputs as Input[]
+    };
+    const updatedFormBag = transformSecurityQuestionVerify({ transaction, formBag, widgetProps });
+    expect(updatedFormBag.uischema.elements.length).toBe(3);
+    expect((updatedFormBag.uischema.elements[1] as FieldElement).translations?.[0])
+      .toEqual({
+        i18nKey: '',
+        name: 'label',
+        value: new Error('Invalid i18n key: security.undefined'),
+      });
   });
 });

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
@@ -50,8 +50,11 @@ export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transactio
   } else {
     // get the security question from inputs and i18n
     Logger.warn('Security question key missing from profile, getting from inputs');
-    const securityQuestionKey = (inputs?.[0]?.value as Input[])?.find(({ name }) => name === 'questionKey')?.value;
-    securityQuestion = loc(`security.${securityQuestionKey}`, 'login');
+    const sequrityQuestionInput = (inputs?.[0]?.value as Input[])?.find(({ name }) => name === 'questionKey');
+    const securityQuestionKey = sequrityQuestionInput?.value;
+    securityQuestion = securityQuestionKey === 'custom' ?
+      sequrityQuestionInput?.label as string :
+      loc(`security.${securityQuestionKey}`, 'login');
   }
   answerElement.translations = [{
     name: 'label',

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
@@ -52,9 +52,9 @@ export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transactio
     Logger.warn('Security question key missing from profile, getting from inputs');
     const sequrityQuestionInput = (inputs?.[0]?.value as Input[])?.find(({ name }) => name === 'questionKey');
     const securityQuestionKey = sequrityQuestionInput?.value;
-    securityQuestion = securityQuestionKey === 'custom' ?
-      sequrityQuestionInput?.label as string :
-      loc(`security.${securityQuestionKey}`, 'login');
+    securityQuestion = securityQuestionKey === 'custom'
+      ? sequrityQuestionInput?.label as string
+      : loc(`security.${securityQuestionKey}`, 'login');
   }
   answerElement.translations = [{
     name: 'label',

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { NextStep } from '@okta/okta-auth-js';
+import { Input, NextStep } from '@okta/okta-auth-js';
 
 import {
   ButtonElement,
@@ -22,9 +22,10 @@ import {
 } from '../../../types';
 import { loc } from '../../../util';
 import { getUIElementWithName } from '../../utils';
+import Logger from '../../../../../util/Logger';
 
 export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transaction, formBag }) => {
-  const { nextStep: { relatesTo } = {} as NextStep } = transaction;
+  const { nextStep: { relatesTo, inputs } = {} as NextStep } = transaction;
   const { uischema } = formBag;
 
   const titleElement: TitleElement = {
@@ -38,12 +39,17 @@ export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transactio
     'credentials.answer',
     uischema.elements as UISchemaElement[],
   ) as FieldElement;
+  let securityQuestionKey = relatesTo?.value?.profile?.questionKey;
+  if (!securityQuestionKey) {
+    Logger.warn('Security question key is missing from profile, getting from inputs');
+    securityQuestionKey = (inputs?.[0].value as Input[]).find(({ name }) => name === 'questionKey')?.value;
+  }
   answerElement.translations = [{
     name: 'label',
     i18nKey: '',
-    value: relatesTo?.value?.profile?.questionKey === 'custom'
+    value: securityQuestionKey === 'custom'
       ? relatesTo?.value?.profile?.question as string
-      : loc(`security.${relatesTo?.value?.profile?.questionKey}`, 'login'),
+      : loc(`security.${securityQuestionKey}`, 'login'),
   }];
 
   // TODO: this should be cleaned up once backend API was fixed.

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
@@ -12,6 +12,7 @@
 
 import { Input, NextStep } from '@okta/okta-auth-js';
 
+import Logger from '../../../../../util/Logger';
 import {
   ButtonElement,
   ButtonType,
@@ -22,7 +23,6 @@ import {
 } from '../../../types';
 import { loc } from '../../../util';
 import { getUIElementWithName } from '../../utils';
-import Logger from '../../../../../util/Logger';
 
 export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transaction, formBag }) => {
   const { nextStep: { relatesTo, inputs } = {} as NextStep } = transaction;
@@ -40,13 +40,13 @@ export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transactio
     uischema.elements as UISchemaElement[],
   ) as FieldElement;
   const securityQuestionProfileKey = relatesTo?.value?.profile?.questionKey;
-  let securityQuestion = ''
+  let securityQuestion = '';
   if (securityQuestionProfileKey === 'custom') {
     // get the custom security question from profile
     securityQuestion = relatesTo?.value?.profile?.question as string;
-  } else if (!!securityQuestionProfileKey) {
+  } else if (securityQuestionProfileKey) {
     // get the security question from i18n with valid key
-    securityQuestion = loc(`security.${securityQuestionProfileKey}`, 'login')
+    securityQuestion = loc(`security.${securityQuestionProfileKey}`, 'login');
   } else {
     // get the security question from inputs and i18n
     Logger.warn('Security question key missing from profile, getting from inputs');

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
@@ -39,17 +39,24 @@ export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transactio
     'credentials.answer',
     uischema.elements as UISchemaElement[],
   ) as FieldElement;
-  let securityQuestionKey = relatesTo?.value?.profile?.questionKey;
-  if (!securityQuestionKey) {
-    Logger.warn('Security question key is missing from profile, getting from inputs');
-    securityQuestionKey = (inputs?.[0].value as Input[]).find(({ name }) => name === 'questionKey')?.value;
+  const securityQuestionProfileKey = relatesTo?.value?.profile?.questionKey;
+  let securityQuestion = ''
+  if (securityQuestionProfileKey === 'custom') {
+    // get the custom security question from profile
+    securityQuestion = relatesTo?.value?.profile?.question as string;
+  } else if (!!securityQuestionProfileKey) {
+    // get the security question from i18n with valid key
+    securityQuestion = loc(`security.${securityQuestionProfileKey}`, 'login')
+  } else {
+    // get the security question from inputs and i18n
+    Logger.warn('Security question key missing from profile, getting from inputs');
+    const securityQuestionKey = (inputs?.[0]?.value as Input[])?.find(({ name }) => name === 'questionKey')?.value;
+    securityQuestion = loc(`security.${securityQuestionKey}`, 'login');
   }
   answerElement.translations = [{
     name: 'label',
     i18nKey: '',
-    value: securityQuestionKey === 'custom'
-      ? relatesTo?.value?.profile?.question as string
-      : loc(`security.${securityQuestionKey}`, 'login'),
+    value: securityQuestion,
   }];
 
   // TODO: this should be cleaned up once backend API was fixed.

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -233,3 +233,237 @@ exports[`authenticator-verification-security-question renders form 1`] = `
   </div>
 </div>
 `;
+
+exports[`authenticator-verification-security-question renders form when idx response does not have profile in currentAuthenticatorEnrollment 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <main
+      class="MuiBox-root emotion-1"
+      data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+      data-se="auth-container main-container"
+      data-version="0.0.0"
+      dir="ltr"
+      id="okta-sign-in"
+      lang="en"
+    >
+      <div
+        class="MuiScopedCssBaseline-root emotion-2"
+      >
+        <div
+          class="MuiBox-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="MuiBox-root emotion-5"
+              data-se="okta-sign-in-header auth-header authCoinSpacing"
+            >
+              <h1
+                class="MuiTypography-root MuiTypography-h1 emotion-6"
+                role="presentation"
+                tabindex="-1"
+              />
+              <div
+                aria-hidden="true"
+                class="MuiBox-root emotion-7"
+                data-se="factor-beacon mfa-okta-security-question "
+              >
+                <svg
+                  aria-labelledby="mfa-okta-security-question"
+                  fill="none"
+                  height="2.85714286rem"
+                  role="img"
+                  viewBox="0 0 48 48"
+                  width="2.85714286rem"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <title
+                    id="mfa-okta-security-question"
+                  >
+                    Security Question
+                  </title>
+                  <path
+                    class="siwFillSecondary"
+                    d="m24.25 39.123-4.615-3.433a21.799 21.799 0 0 1-8.827-16.259l-.329-5.738 12.84-4.534a2.818 2.818 0 0 1 1.862 0l12.84 4.534-.329 5.738a21.8 21.8 0 0 1-8.827 16.259l-4.615 3.433ZM11.521 14.387l.285 4.987a20.811 20.811 0 0 0 8.425 15.514l4.019 2.989 4.019-2.989a20.81 20.81 0 0 0 8.425-15.514l.285-4.987L24.848 10.1a1.792 1.792 0 0 0-1.2 0l-12.127 4.287Z"
+                    fill="#A7B5EC"
+                  />
+                  <path
+                    class="siwFillPrimaryDark"
+                    d="M29.44 19.729a5.007 5.007 0 0 0-8.846-2.356 4.484 4.484 0 0 0-.827 4.385l.929-.367A3.48 3.48 0 0 1 21.369 18a4.027 4.027 0 1 1 5.244 5.972C25 25 23.5 26.252 23.5 28.528h1c0-1.691 1.058-2.7 2.646-3.707a5.067 5.067 0 0 0 2.294-5.092Zm-5.454 12.246a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+                    fill="#00297A"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-8"
+            >
+              <form
+                aria-live="polite"
+                class="o-form MuiBox-root emotion-9"
+                data-se="o-form"
+                novalidate=""
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-12"
+                      data-se="identifier-container"
+                      title="tester@okta1.com"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault emotion-13"
+                        data-se="identifier"
+                        translate="no"
+                      >
+                        <div
+                          class="MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault MuiBox-root emotion-14"
+                        >
+                          <svg
+                            aria-label="User"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                            fill="none"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M15.5 6.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Zm2 0a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0ZM5 23c0-2.357.694-4.363 1.886-5.762C8.064 15.856 9.782 15 12 15c2.215 0 3.934.862 5.113 2.25C18.307 18.652 19 20.66 19 23h2c0-2.722-.807-5.216-2.363-7.046C17.067 14.107 14.785 13 12 13c-2.782 0-5.064 1.097-6.636 2.941C3.806 17.77 3 20.263 3 23h2Z"
+                              fill="currentColor"
+                              fill-rule="evenodd"
+                            />
+                            <title>
+                              User
+                            </title>
+                          </svg>
+                        </div>
+                        <span
+                          class="MuiChip-label MuiChip-labelMedium emotion-16"
+                        >
+                          tester@okta1.com
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <h1
+                        class="MuiTypography-root MuiTypography-h4 emotion-19"
+                        data-se="o-form-head"
+                        tabindex="-1"
+                      >
+                        Verify with your Security Question
+                      </h1>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-21"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-22"
+                        data-shrink="false"
+                        for="credentials.answer"
+                        id="credentials.answer-label"
+                      >
+                        <span>
+                          What is the food you least liked as a child?
+                        </span>
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-23"
+                        required="true"
+                        translate="no"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-labelledby="credentials.answer-label"
+                          autocomplete="off"
+                          class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-24"
+                          data-se="credentials.answer"
+                          id="credentials.answer"
+                          name="credentials.answer"
+                          required=""
+                          role="textbox"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-25"
+                        >
+                          <button
+                            aria-controls="credentials.answer"
+                            aria-label="Show password"
+                            aria-pressed="false"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-26"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-27"
+                              fill="none"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M3.43 12.813A12.814 12.814 0 0 1 3.069 12a14.153 14.153 0 0 1 1.966-3.38C6.506 6.762 8.746 5 12 5s5.494 1.761 6.966 3.62A14.152 14.152 0 0 1 20.932 12a14.151 14.151 0 0 1-1.966 3.38C17.494 17.238 15.254 19 12 19s-5.494-1.761-6.966-3.62a14.152 14.152 0 0 1-1.603-2.567Zm19.518-1.13L22 12c.949.316.949.317.948.317v.004l-.003.007-.008.024a7.012 7.012 0 0 1-.137.362 16.147 16.147 0 0 1-2.266 3.906C18.84 18.762 16.08 21 12 21c-4.08 0-6.84-2.239-8.534-4.38A16.15 16.15 0 0 1 1.2 12.715a10.039 10.039 0 0 1-.137-.362l-.008-.024-.002-.007-.001-.003c0-.001 0-.002.948-.318a91.698 91.698 0 0 1-.948-.317v-.004l.003-.007.008-.024.029-.08c.025-.067.06-.163.108-.282A16.15 16.15 0 0 1 3.466 7.38C5.16 5.24 7.92 3 12 3c4.08 0 6.84 2.239 8.534 4.38a16.147 16.147 0 0 1 2.266 3.906 10.026 10.026 0 0 1 .137.362l.008.024.002.007.001.003ZM2 12l-.949.316L.946 12l.105-.316L2 12Zm20 0 .949-.316.105.316-.105.316L22 12ZM9 12a3 3 0 1 1 6 0 3 3 0 0 1-6 0Zm3-5a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth emotion-29"
+                      data-se="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-31"
+                      data-se="cancel"
+                      role="link"
+                      type="button"
+                    >
+                      Back to sign in
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;

--- a/src/v3/test/integration/authenticator-verification-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-security-question.test.tsx
@@ -14,10 +14,17 @@ import { waitFor } from '@testing-library/preact';
 import { createAuthJsPayloadArgs, setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/securityquestion-verify.json';
+import mockResponseNoProfile from '../../src/mocks/response/idp/idx/identify/securityquestion-verify-no-profile.json';
 
 describe('authenticator-verification-security-question', () => {
   it('renders form', async () => {
     const { container, findByText } = await setup({ mockResponse });
+    await findByText(/Verify with your Security Question/);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders form when idx response does not have profile in currentAuthenticatorEnrollment', async () => {
+    const { container, findByText } = await setup({ mockResponse: mockResponseNoProfile });
     await findByText(/Verify with your Security Question/);
     expect(container).toMatchSnapshot();
   });


### PR DESCRIPTION
fix the i18n error when configured security question as verification authenticator

Resolves: OKTA-998463

## Description:
The error happens when the idx response doesn't have the `profile` property in the `/idp/idx/challenge` response, e.g [this one](https://github.com/okta/okta-signin-widget/blob/928d0ba9b178339037947f2aba285233871ac7d0/src/v3/src/mocks/response/idp/idx/identify/securityquestion-verify.json#L106-L109), also can refer to the `har` file in the ticket

It works in Gen2 but not in Gen3 because Gen2 and Gen3 are implemented differently.
 
#### Gen2

This is the high-level workflow of security question as verification authenticator in Gen2
* call [uiSchemaTransformer.js](https://github.com/okta/okta-signin-widget/blob/928d0ba9b178339037947f2aba285233871ac7d0/src/v2/ion/uiSchemaTransformer.js#L38) first, it will get uiSchema from the [remediation form values here](https://github.com/okta/okta-signin-widget/blob/928d0ba9b178339037947f2aba285233871ac7d0/src/v3/src/mocks/response/idp/idx/identify/securityquestion-verify.json#L24-L41)
<img width="614" height="472" alt="Screenshot 2025-08-27 at 4 25 34 PM" src="https://github.com/user-attachments/assets/0f91cefe-5186-40d3-8769-c334c6c8f454" />

* call [i18nTransformer.js](https://github.com/okta/okta-signin-widget/blob/928d0ba9b178339037947f2aba285233871ac7d0/src/v2/ion/i18nTransformer.js#L72), but now the data will be in uiSchema, so the translation is correct, see in the screenshot below, the `disliked_food` key is obtained
<img width="660" height="352" alt="Screenshot 2025-08-27 at 3 41 38 PM" src="https://github.com/user-attachments/assets/ac9f1a6c-78c0-4c03-b077-9d9288f540ae" />

#### Gen3
Gen3 the [securityQuestionVerify.ts](https://github.com/okta/okta-signin-widget/blob/928d0ba9b178339037947f2aba285233871ac7d0/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts#L41-L47) transform happens on the layout layer, which is before [uiSchema and i18n](https://github.com/okta/okta-signin-widget/blob/928d0ba9b178339037947f2aba285233871ac7d0/src/v3/src/transformer/main.ts#L42-L51), to be secure, we should not change the transform order, so the fix would be still in the layout layer

When profile is missing, the key would be `security.undefined`
<img width="545" height="200" alt="Screenshot 2025-08-28 at 3 42 20 PM" src="https://github.com/user-attachments/assets/903a4589-2d43-45d1-a67e-87b7a9d24e45" />

To fix it, we need to access the remediation form data, and we had similar implementation in [securityQuestionEnroll.ts](https://github.com/okta/okta-signin-widget/blob/928d0ba9b178339037947f2aba285233871ac7d0/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.ts#L50-L51)

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-998463](https://oktainc.atlassian.net/browse/OKTA-998463)

### Reviewers:

### Screenshot/Video:

#### Before fix
Gen2:

https://github.com/user-attachments/assets/be01b5c9-c197-4f09-baf2-c32fcaf40a75

Gen3:

https://github.com/user-attachments/assets/7358fffb-849a-4b7b-9fe5-f3b200af01f1

#### After fix
Gen2: works same
Gen3:

https://github.com/user-attachments/assets/97059f41-4387-4c16-8237-6a93d8a5b9d0

### Downstream Monolith Build:



