### PR TITLE
Integrate altcha with V2 & V3

### DIFF
--- a/scripts/buildtools/terser/config.js
+++ b/scripts/buildtools/terser/config.js
@@ -2,8 +2,8 @@
 module.exports = {
   compress: {
     // Drop all console.* statements
-    drop_console: true,
-    drop_debugger: true,
+    drop_console: false,
+    drop_debugger: false,
     pure_funcs: [
       // don't drop 'Logger.*' statements
     ],

--- a/src/v2/view-builder/internals/BaseForm.ts
+++ b/src/v2/view-builder/internals/BaseForm.ts
@@ -70,7 +70,7 @@ export default Form.extend({
     this.$el.find('.o-form-error-container').empty();
 
     // Execute Captcha if enabled for this form.
-    if (this.captchaObject) {
+    if (this.captchaObject && (this.captchaObject.tagName || '').toUpperCase() !== 'ALTCHA-WIDGET') {
       this.captchaObject.execute();
     } else {
       this.options.appState.trigger('saveForm', model);

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -55,6 +55,7 @@
     "@okta/odyssey-design-tokens": "1.13.0",
     "@okta/odyssey-react-mui": "1.13.0",
     "@okta/okta-auth-js": "7.14.0",
+    "altcha": "^1.4.2",
     "chroma-js": "^2.4.2",
     "cross-fetch": "^3.1.5",
     "dompurify": "^2.5.8",

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -23,6 +23,8 @@ import {
   UISchemaElementComponent,
 } from '../../types';
 
+import 'altcha';
+
 declare global {
   interface Window {
     recaptchaOptions?: {
@@ -37,6 +39,7 @@ declare global {
 const CaptchaContainer: UISchemaElementComponent<{
   uischema: CaptchaContainerElement
 }> = ({ uischema }) => {
+ 
   const {
     options: {
       siteKey,
@@ -54,8 +57,8 @@ const CaptchaContainer: UISchemaElementComponent<{
   const isHcaptchaInstance = (captchaObj: HCaptcha | ReCAPTCHA)
   : captchaObj is HCaptcha => captchaObj instanceof HCaptcha;
 
-  // Customizig reCAPTCHA script URI can be done with global `recaptchaOptions` object:
-  // https://github.com/dozoisch/react-google-recaptcha#advanced-usage
+  // // Customizig reCAPTCHA script URI can be done with global `recaptchaOptions` object:
+  // // https://github.com/dozoisch/react-google-recaptcha#advanced-usage
   if (captchaType === 'RECAPTCHA_V2' && recaptchaOptions?.scriptSource && !window.recaptchaOptions) {
     const useRecaptchaNet = recaptchaOptions.scriptSource?.includes('recaptcha.net');
     window.recaptchaOptions = {
@@ -133,6 +136,37 @@ const CaptchaContainer: UISchemaElementComponent<{
     resetCaptchaContainer();
   };
 
+  const onAltchaVerify = (ev: CustomEvent) => {
+    const payload = ev.detail.payload;
+
+    const {
+      submit: {
+        actionParams: params,
+        step,
+        includeImmutableData,
+      },
+    } = dataSchema;
+
+    const captchaSubmitParams = {
+      captchaVerify: {
+        captchaToken: payload,
+        captchaId: "altcha",
+      },
+    };
+
+    onSubmitHandler({
+      includeData: true,
+      includeImmutableData,
+      params: captchaSubmitParams,
+      step,
+    });
+
+  };
+
+  if (captchaType === 'ALTCHA') {
+    return (<altcha-widget debug floating hidefooter hidelogo onverified={onAltchaVerify} challengeurl="/api/v1/altcha"></altcha-widget>);
+  }
+
   if (captchaType === 'RECAPTCHA_V2') {
     return (
       // set z-index to 1 for ReCaptcha so the badge does not get covered by the footer
@@ -151,6 +185,7 @@ const CaptchaContainer: UISchemaElementComponent<{
       </Box>
     );
   }
+
   return (
     <HCaptcha
       // Params like `apihost` will be passed to hCaptcha loader.

--- a/src/v3/src/transformer/captcha/transformCaptcha.ts
+++ b/src/v3/src/transformer/captcha/transformCaptcha.ts
@@ -20,6 +20,8 @@ import { isCaptchaEnabled, loc } from '../../util';
 export const transformCaptcha: TransformStepFnWithOptions = ({ transaction }) => (
   formbag,
 ) => {
+  console.log("transform");
+  console.log({transaction});
   if (!isCaptchaEnabled(transaction)) {
     return formbag;
   }
@@ -37,7 +39,9 @@ export const transformCaptcha: TransformStepFnWithOptions = ({ transaction }) =>
     },
   } = transaction;
 
-  if (!['HCAPTCHA', 'RECAPTCHA_V2'].includes(captchaType)) {
+  console.log({captchaType});
+
+  if (!['HCAPTCHA', 'RECAPTCHA_V2', 'ALTCHA'].includes(captchaType)) {
     return formbag;
   }
 

--- a/src/v3/src/transformer/main.ts
+++ b/src/v3/src/transformer/main.ts
@@ -38,6 +38,7 @@ const logger: TransformStepFn = (formbag) => {
 };
 
 export const transformIdxTransaction = (options: TransformationOptions): FormBag => {
+  console.log("transforming Captcha");
   const transformationStepFns: TransformStepFn[] = [
     transformTransactionData(options),
     transformFields(options),

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -719,7 +719,7 @@ export interface CaptchaContainerElement extends UISchemaElement {
   options: {
     captchaId: string;
     siteKey: string;
-    type: 'HCAPTCHA' | 'RECAPTCHA_V2';
+    type: 'HCAPTCHA' | 'RECAPTCHA_V2' | 'ALTCHA';
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,11 @@
     ciecam02 "^0.4.6"
     hsluv "^0.1.0"
 
+"@altcha/crypto@^0.0.1":
+  version "0.0.1"
+  resolved "https://artifacts.aue1e.internal/artifactory/api/npm/npm-okta-master/@altcha/crypto/-/crypto-0.0.1.tgz#0e2f254559fb350c80ff56d29b8e3ab2e6bbea95"
+  integrity sha512-qZMdnoD3lAyvfSUMNtC2adRi666Pxdcw9zqfMU5qBOaJWqpN9K+eqQGWqeiKDMqL0SF+EytNG4kR/Pr/99GJ6g==
+
 "@ampproject/remapping@^2.1.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.1.2.tgz#4edca94973ded9630d20101cd8559cedb8d8bd34"
@@ -4926,6 +4931,11 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@rollup/rollup-linux-x64-gnu@4.18.0":
+  version "4.18.0"
+  resolved "https://artifacts.aue1e.internal/artifactory/api/npm/npm-okta-master/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz#1a7481137a54740bee1ded4ae5752450f155d942"
+  integrity sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==
+
 "@sideway/address@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
@@ -6688,6 +6698,15 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.8.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
+
+altcha@^1.4.2:
+  version "1.4.2"
+  resolved "https://artifacts.aue1e.internal/artifactory/api/npm/npm-okta-master/altcha/-/altcha-1.4.2.tgz#a7feb7a7e7eec35d1496e5980a57f304224f0c39"
+  integrity sha512-7UcWh4tHWqP5YHo+jC8vmm+sThYUi1R9qXsiiXtmdoOiimfA0LCLccSKqYSoDmYvqq+CBV79WpQVWafKQCKHmw==
+  dependencies:
+    "@altcha/crypto" "^0.0.1"
+  optionalDependencies:
+    "@rollup/rollup-linux-x64-gnu" "4.18.0"
 
 amdefine@>=0.0.4:
   version "1.0.1"


### PR DESCRIPTION
## Description:
Add integration for the new ALTCHA library into the sign-in widget repo.

The ALTCHA widget is treated as a CAPTCHA and follows the same flow as other CAPTCHAs to load into the page.

Putting out this PR on behalf of Lijo Daniel and retrieving it from his forked repo since he is still working on getting access.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-954339](https://oktainc.atlassian.net/browse/OKTA-954339)]

### Reviewers:

### Screenshot/Video:
**Working on getting this from Lijo's set up**

### Downstream Monolith Build:
**Working on getting this from Lijo's set up**