### PR TITLE
OKTA-954339 - Add ALTCHA Integration into signin widget

### DIFF
--- a/assets/sass/okta-sign-in.scss
+++ b/assets/sass/okta-sign-in.scss
@@ -34,6 +34,7 @@
   @import 'common/enduser/reset';
   @import 'widgets/mega-drop-down';
   @import 'widgets/chosen';
+  @import 'widgets/altcha';
   @import 'common/shared/o-forms/o-form';
   @import 'common/admin/modules/infobox/infobox';
   @import 'base';

--- a/assets/sass/widgets/_altcha.scss
+++ b/assets/sass/widgets/_altcha.scss
@@ -1,15 +1,13 @@
-div {
-    .altcha {
-        background: #fff;
-        border: 1px solid #a0a0a0;
-    }
+.altcha {
+    background: #fff;
+    border: 1px solid #a0a0a0;
+}
 
-    .altcha-main {
-        padding: 12px;
-    }
+.altcha-main {
+    padding: 12px;
+}
 
-    .altcha-anchor-arrow {
-        border: 6px solid transparent;
-        border-bottom-color: #a0a0a0;
-    }
+.altcha-anchor-arrow {
+    border: 6px solid transparent;
+    border-bottom-color: #a0a0a0;
 }

--- a/assets/sass/widgets/_altcha.scss
+++ b/assets/sass/widgets/_altcha.scss
@@ -1,0 +1,15 @@
+div {
+    .altcha {
+        background: #fff;
+        border: 1px solid #a0a0a0;
+    }
+
+    .altcha-main {
+        padding: 12px;
+    }
+
+    .altcha-anchor-arrow {
+        border: 6px solid transparent;
+        border-bottom-color: #a0a0a0;
+    }
+}

--- a/src/v2/view-builder/internals/BaseForm.ts
+++ b/src/v2/view-builder/internals/BaseForm.ts
@@ -70,7 +70,7 @@ export default Form.extend({
     this.$el.find('.o-form-error-container').empty();
 
     // Execute Captcha if enabled for this form.
-    if (this.captchaObject) {
+    if (this.captchaObject && (this.captchaObject.tagName || '').toUpperCase() !== 'ALTCHA-WIDGET') {
       this.captchaObject.execute();
     } else {
       this.options.appState.trigger('saveForm', model);

--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -196,9 +196,9 @@ export default View.extend({
     scriptTag.src = url;
     scriptTag.async = true;
     scriptTag.defer = true;
-    scriptTag.crossOrigin = 'anonymous';
 
     if (url.indexOf('altcha') !== -1) {
+      scriptTag.crossOrigin = 'anonymous';
       scriptTag.type = 'module';
       scriptTag.onload = window[OktaSignInWidgetOnCaptchaLoadedCallback];
     }

--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -20,6 +20,7 @@ const OktaSignInWidgetOnCaptchaLoadedCallback = 'OktaSignInWidgetOnCaptchaLoaded
 const OktaSignInWidgetOnCaptchaSolvedCallback = 'OktaSignInWidgetOnCaptchaSolved';
 
 const HCAPTCHA_URL = 'https://hcaptcha.com/1/api.js';
+const ALTCHA_URL = 'https://cdn.jsdelivr.net/gh/altcha-org/altcha/dist/altcha.min.js';
 const RECAPTCHAV2_URL = 'https://www.google.com/recaptcha/api.js';
 
 export default View.extend({
@@ -38,7 +39,16 @@ export default View.extend({
 
   getTemplateData: function() {
     if (this.captchaConfig) {
-      const className = this.captchaConfig.type === 'HCAPTCHA' ? 'h-captcha' : 'g-recaptcha';
+      let className;
+
+      if (this.captchaConfig.type === 'ALTCHA') {
+        className = 'altcha';
+      } else if (this.captchaConfig.type === 'HCAPTCHA') {
+        className = 'h-captcha';
+      } else {
+        className = 'g-recaptcha';
+      }
+
       return { 
         siteKey: this.captchaConfig.siteKey,
         isCaptchaConfigured: true,
@@ -106,6 +116,12 @@ export default View.extend({
       // dummy value. We then overwrite this with the proper token in the onCaptchaSolved callback.
       this.model.set(this.options.name, 'tempToken');
 
+      // ALTCHA is a web-component: render the <altcha-widget> into the container and wire its event.
+      if (this.captchaConfig.type === 'ALTCHA') {
+        initializeAltchaWidget();
+        return;
+      }
+
       const captchaId = captchaObject.render('captcha-container', {
         sitekey: this.captchaConfig.siteKey,
         callback: onCaptchaSolved
@@ -130,11 +146,37 @@ export default View.extend({
     // the 'data-callback' attribute which the Captcha library uses to invoke the callback.
     window[OktaSignInWidgetOnCaptchaSolvedCallback] = onCaptchaSolved;
 
-    
+
     if (this.captchaConfig.type === 'HCAPTCHA') {
       this._loadCaptchaLib(this._getCaptchaUrl(HCAPTCHA_URL, 'hcaptcha'));
     } else if (this.captchaConfig.type === 'RECAPTCHA_V2') {
       this._loadCaptchaLib(this._getCaptchaUrl(RECAPTCHAV2_URL, 'recaptcha'));
+    } if (this.captchaConfig.type === 'ALTCHA') {
+      console.log('loading altcha');
+      this._loadCaptchaLib(this._getCaptchaUrl(ALTCHA_URL, 'altcha'));
+    }
+
+    const initializeAltchaWidget = () => {
+      const $container = this.$el.find('#captcha-container');
+      const altEl = document.createElement('altcha-widget');
+      Object.entries({
+        debug: '',
+        floating: '',
+        hidefooter: '',
+        hidelogo: '',
+        challengeurl: '/api/v1/altcha',
+      }).forEach(([k, v]) => altEl.setAttribute(k, v));
+      altEl.addEventListener && altEl.addEventListener('verified', (e) => {
+        const token = (e && e.detail && e.detail.payload) || e;
+        onCaptchaSolved(token);
+      });
+
+      window.altcha = altEl;
+      $container.empty().append(altEl);
+      // mark as bound
+      $container.attr('data-captcha-id', 'altcha');
+      // notify Baseform
+      this.options.appState.trigger('onCaptchaLoaded', altEl);
     }
   },
   
@@ -147,6 +189,29 @@ export default View.extend({
     scriptTag.src = url;
     scriptTag.async = true;
     scriptTag.defer = true;
+    scriptTag.crossOrigin = 'anonymous';
+    if (url.indexOf('altcha') !== -1) {
+      scriptTag.type = 'module';
+    }
+
+    // fallback: call global onload callback when the script loads
+    scriptTag.onload = () => {
+      try {
+        const cb = window[OktaSignInWidgetOnCaptchaLoadedCallback];
+        if (typeof cb === 'function') {
+          cb();
+        } else {
+          console.log('captcha lib loaded but no global onload callback found');
+        }
+      } catch (e) {
+        console.error('Error invoking captcha onload callback', e);
+      }
+    };
+
+    scriptTag.onerror = (evt) => {
+      console.error('Failed to load captcha script:', url, evt);
+    };
+
     document.getElementById(Enums.WIDGET_CONTAINER_ID).appendChild(scriptTag);
   },
 
@@ -170,8 +235,18 @@ export default View.extend({
   },
 
   _getCaptchaOject() {
-    const captchaObject = this.captchaConfig.type === 'HCAPTCHA' ? window.hcaptcha : window.grecaptcha;
-    return captchaObject;
+    // Return the appropriate global captcha object for the configured type.
+    if (this.captchaConfig.type === 'HCAPTCHA') {
+      return window.hcaptcha;
+    }
+    if (this.captchaConfig.type === 'RECAPTCHA_V2') {
+      return window.grecaptcha;
+    }
+    if (this.captchaConfig.type === 'ALTCHA') {
+      // Altcha may expose different globals or be used as a web component.
+      return window.altcha || null;
+    }
+    return null;
   },
 
   /**
@@ -187,6 +262,12 @@ export default View.extend({
     const scriptParams = this.options.settings.get(`${settingsKey}.scriptParams`);
 
     const baseUrl = scriptSource || defaultBaseUrl;
+
+    // Altcha is a web component / module; don't append reCAPTCHA/hCaptcha-specific query params.
+    if (settingsKey === 'altcha') {
+      return baseUrl;
+    }
+
     const params = {
       ...scriptParams,
       onload: OktaSignInWidgetOnCaptchaLoadedCallback,

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -55,6 +55,7 @@
     "@okta/odyssey-design-tokens": "1.13.0",
     "@okta/odyssey-react-mui": "1.13.0",
     "@okta/okta-auth-js": "7.14.0",
+    "altcha": "^1.4.2",
     "chroma-js": "^2.4.2",
     "cross-fetch": "^3.1.5",
     "dompurify": "^2.5.8",

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -23,6 +23,8 @@ import {
   UISchemaElementComponent,
 } from '../../types';
 
+import 'altcha';
+
 declare global {
   interface Window {
     recaptchaOptions?: {
@@ -133,6 +135,37 @@ const CaptchaContainer: UISchemaElementComponent<{
     resetCaptchaContainer();
   };
 
+  const onAltchaVerify = (ev: CustomEvent) => {
+    const payload = ev.detail.payload;
+
+    const {
+      submit: {
+        actionParams: params,
+        step,
+        includeImmutableData,
+      },
+    } = dataSchema;
+
+    const captchaSubmitParams = {
+      captchaVerify: {
+        captchaToken: payload,
+        captchaId: "altcha",
+      },
+    };
+
+    onSubmitHandler({
+      includeData: true,
+      includeImmutableData,
+      params: captchaSubmitParams,
+      step,
+    });
+
+  };
+
+  if (captchaType === 'ALTCHA') {
+    return (<altcha-widget debug floating hidefooter hidelogo onverified={onAltchaVerify} challengeurl="/api/v1/altcha"></altcha-widget>);
+  }
+
   if (captchaType === 'RECAPTCHA_V2') {
     return (
       // set z-index to 1 for ReCaptcha so the badge does not get covered by the footer
@@ -151,6 +184,7 @@ const CaptchaContainer: UISchemaElementComponent<{
       </Box>
     );
   }
+
   return (
     <HCaptcha
       // Params like `apihost` will be passed to hCaptcha loader.

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -10,6 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import 'altcha';
+
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Box } from '@mui/material';
 import { useEffect, useRef } from 'preact/hooks';
@@ -22,8 +24,6 @@ import {
   CaptchaContainerElement,
   UISchemaElementComponent,
 } from '../../types';
-
-import 'altcha';
 
 declare global {
   interface Window {
@@ -136,7 +136,7 @@ const CaptchaContainer: UISchemaElementComponent<{
   };
 
   const onAltchaVerify = (ev: CustomEvent) => {
-    const payload = ev.detail.payload;
+    const { payload } = ev.detail;
 
     const {
       submit: {
@@ -148,7 +148,7 @@ const CaptchaContainer: UISchemaElementComponent<{
     const captchaSubmitParams = {
       captchaVerify: {
         captchaToken: payload,
-        captchaId: "altcha",
+        captchaId: 'altcha',
       },
     };
 
@@ -158,11 +158,19 @@ const CaptchaContainer: UISchemaElementComponent<{
       params: captchaSubmitParams,
       step,
     });
-
   };
 
   if (captchaType === 'ALTCHA') {
-    return (<altcha-widget debug floating hidefooter hidelogo onverified={onAltchaVerify} challengeurl="/api/v1/altcha"></altcha-widget>);
+    return (
+      <altcha-widget
+        debug
+        floating
+        hidefooter
+        hidelogo
+        onverified={onAltchaVerify}
+        challengeurl="/api/v1/altcha"
+      />
+    );
   }
 
   if (captchaType === 'RECAPTCHA_V2') {

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -140,7 +140,6 @@ const CaptchaContainer: UISchemaElementComponent<{
 
     const {
       submit: {
-        actionParams: params,
         step,
         includeImmutableData,
       },

--- a/src/v3/src/transformer/captcha/transformCaptcha.ts
+++ b/src/v3/src/transformer/captcha/transformCaptcha.ts
@@ -37,7 +37,7 @@ export const transformCaptcha: TransformStepFnWithOptions = ({ transaction }) =>
     },
   } = transaction;
 
-  if (!['HCAPTCHA', 'RECAPTCHA_V2'].includes(captchaType)) {
+  if (!['HCAPTCHA', 'RECAPTCHA_V2', 'ALTCHA'].includes(captchaType)) {
     return formbag;
   }
 

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -719,7 +719,7 @@ export interface CaptchaContainerElement extends UISchemaElement {
   options: {
     captchaId: string;
     siteKey: string;
-    type: 'HCAPTCHA' | 'RECAPTCHA_V2';
+    type: 'HCAPTCHA' | 'RECAPTCHA_V2' | 'ALTCHA';
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,11 @@
     ciecam02 "^0.4.6"
     hsluv "^0.1.0"
 
+"@altcha/crypto@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@altcha/crypto/-/crypto-0.0.1.tgz#0e2f254559fb350c80ff56d29b8e3ab2e6bbea95"
+  integrity sha512-qZMdnoD3lAyvfSUMNtC2adRi666Pxdcw9zqfMU5qBOaJWqpN9K+eqQGWqeiKDMqL0SF+EytNG4kR/Pr/99GJ6g==
+
 "@ampproject/remapping@^2.1.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.1.2.tgz#4edca94973ded9630d20101cd8559cedb8d8bd34"
@@ -4926,6 +4931,11 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@rollup/rollup-linux-x64-gnu@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz#1a7481137a54740bee1ded4ae5752450f155d942"
+  integrity sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==
+
 "@sideway/address@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
@@ -6688,6 +6698,15 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.8.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
+
+altcha@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/altcha/-/altcha-1.4.2.tgz#a7feb7a7e7eec35d1496e5980a57f304224f0c39"
+  integrity sha512-7UcWh4tHWqP5YHo+jC8vmm+sThYUi1R9qXsiiXtmdoOiimfA0LCLccSKqYSoDmYvqq+CBV79WpQVWafKQCKHmw==
+  dependencies:
+    "@altcha/crypto" "^0.0.1"
+  optionalDependencies:
+    "@rollup/rollup-linux-x64-gnu" "4.18.0"
 
 amdefine@>=0.0.4:
   version "1.0.1"


### PR DESCRIPTION
## Description:
Putting out this PR on behalf of Lijo Daniel and retrieving it from [his forked repo](https://github.com/lijodaniel-okta/okta-signin-widget-altcha/tree/cherry-from-local) since he is still working on getting access.

This PR adds integration for the new ALTCHA library into the sign-in widget repo.

The ALTCHA widget is treated as a CAPTCHA and follows the same flow as other CAPTCHAs to load into the page.

It is meant to work on both v2 and v3 versions of the widget.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-954339](https://oktainc.atlassian.net/browse/OKTA-954339)

### Reviewers:

### Screenshot/Video:
https://github.com/user-attachments/assets/6e2926d4-f336-444b-9837-e18169f91cf6

RECAPTCHA working with changes:

https://github.com/user-attachments/assets/40d0c397-b536-4d18-a8d1-d4d6b816646a

HCAPTCHA working with changes:

https://github.com/user-attachments/assets/3cfa19be-4ab9-439c-92b3-c4f8fc17e129


### Downstream Monolith Build:
Build and CAPTCHA tests passing: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&author=ahmed.alkoasmh%40okta.com&branch=d16t-okta-signin-widget-1a75565-68d30816&page=1&pageSize=6&tab=main