### PR TITLE
fix(v1): password validation in registration flow

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -1186,5 +1186,5 @@ const temporaryAccessCode = {
 };
 
 module.exports = {
-  mocks: selfServiceRegistration
+  mocks: idx
 };

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -1075,6 +1075,7 @@ const selfServiceRegistration = {
   ],
   '/api/v1/registration/form': [
     'form',
+    // 'form-with-additional-validation',
   ],
   '/api/v1/registration/:id/register': [
     'register',
@@ -1185,5 +1186,5 @@ const temporaryAccessCode = {
 };
 
 module.exports = {
-  mocks: idx
+  mocks: selfServiceRegistration
 };

--- a/playground/mocks/data/api/v1/registration/form-with-additional-validation.json
+++ b/playground/mocks/data/api/v1/registration/form-with-additional-validation.json
@@ -1,0 +1,67 @@
+{
+  "policyId": "regyb5XILfdDeLzm10g3",
+  "lastUpdate": 1634687026000,
+  "profileSchema": {
+    "properties": {
+      "firstName": {
+        "type": "string",
+        "title": "First name",
+        "minLength": 1,
+        "maxLength": 50,
+        "default": "string"
+      },
+      "lastName": {
+        "type": "string",
+        "title": "Last name",
+        "minLength": 1,
+        "maxLength": 50,
+        "default": "string"
+      },
+      "password": {
+        "type": "string",
+        "title": "Password",
+        "allOf": [
+          {
+            "description": "At least 12 character(s)",
+            "minLength": 12
+          },
+          {
+            "description": "Does not contain part of username",
+            "format": "/^[#/userName]/"
+          },
+          {
+            "description": "Does not contain 'First name'",
+            "format": "/^[#/firstName]/"
+          },
+          {
+            "description": "Does not contain 'Last name'",
+            "format": "/^[#/lastName]/"
+          }
+        ],
+        "default": "Password"
+      },
+      "email": {
+        "type": "email",
+        "title": "Email",
+        "format": "email",
+        "default": "Email"
+      },
+      "custom_bool": {
+        "type": "boolean",
+        "title": "Custom bool"
+      }
+    },
+    "required": [
+      "email",
+      "password",
+      "firstName",
+      "lastName"
+    ],
+    "fieldOrder": [
+      "email",
+      "password",
+      "firstName",
+      "lastName"
+    ]
+  }
+}

--- a/src/v1/util/RegistrationFormFactory.js
+++ b/src/v1/util/RegistrationFormFactory.js
@@ -62,7 +62,7 @@ const checkSubSchema = function(subSchema, value, model) {
   const minLength = subSchema.get('minLength');
   const maxLength = subSchema.get('maxLength');
   const regex = subSchema.get('format');
-  
+
   if (_.isNumber(minLength)) {
     if (value.length < minLength) {
       return false;

--- a/src/v1/util/RegistrationFormFactory.js
+++ b/src/v1/util/RegistrationFormFactory.js
@@ -62,7 +62,7 @@ const checkSubSchema = function(subSchema, value, model) {
   const minLength = subSchema.get('minLength');
   const maxLength = subSchema.get('maxLength');
   const regex = subSchema.get('format');
-
+  
   if (_.isNumber(minLength)) {
     if (value.length < minLength) {
       return false;
@@ -86,8 +86,10 @@ const checkSubSchema = function(subSchema, value, model) {
         // with email as login enabled, we only have email populated
         // Therefore we fallback and run validation with email attribute.
         fieldValue = model.has('userName') ? model.get('userName') : model.get('email');
+        return !passwordContainsFormField(fieldValue, password);
+      } else {
+        return !fieldValue || password.indexOf(fieldValue) === -1;
       }
-      return !passwordContainsFormField(fieldValue, password);
     } else {
       if (!new RegExp(regex).test(value)) {
         return false;
@@ -221,4 +223,5 @@ export default {
   createInputOptions: fnCreateInputOptions,
   getUsernameParts: getParts,
   passwordContainsFormField: passwordContainsFormField,
+  checkSubSchema: checkSubSchema,
 };


### PR DESCRIPTION
## Description:


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-986532](https://oktainc.atlassian.net/browse/OKTA-986532)

### Reviewers:

### Screenshot/Video:

**test password: test1234**

<img width="820" height="899" alt="Screenshot 2025-09-19 at 9 45 26 AM" src="https://github.com/user-attachments/assets/297073f7-4e91-458e-973b-745f3f846f30" />


test password: passwordabcd

<img width="687" height="824" alt="Screenshot 2025-09-19 at 9 46 29 AM" src="https://github.com/user-attachments/assets/9ed0a76b-46d7-4beb-8377-5215b2704121" />


### Downstream Monolith Build:



