### PR TITLE
chore: add chrome dtc antivirus enabled remediation string

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1657,6 +1657,7 @@ idx.error.code.access_denied.device_assurance.remediation.device.must.be.managed
 idx.error.code.access_denied.device_assurance.remediation.additional_help_default = For more information, follow the instructions on <$1>the help page</$1> or contact your administrator for help
 idx.error.code.access_denied.device_assurance.remediation.additional_help_custom = For more information, follow the instructions on <$1>your organization's help page</$1> or contact your administrator for help
 # end user remediation for Chrome DTC signals
+idx.error.code.access_denied.device_assurance.remediation.chrome.antivirus = Enable antivirus software
 idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted = Turn on disk encryption
 idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = Turn on your device's firewall
 idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured = Turn on automatic screen saver and screen locking when idle

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -1251,6 +1251,7 @@ idx.error.code.access_denied.device_assurance.remediation.windows.use_biometric_
 idx.error.code.access_denied.device_assurance.remediation.device.must.be.managed = 》Ûšé å ðéṽîçé ɱåñåĝéð ƀý ýöûŕ öŕĝåñîžåţîöñ €홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 idx.error.code.access_denied.device_assurance.remediation.additional_help_default = 》Ƒöŕ ɱöŕé îñƒöŕɱåţîöñ، ƒöļļöŵ ţĥé îñšţŕûçţîöñš öñ <$1>ţĥé ĥéļþ þåĝé</$1> öŕ çöñţåçţ ýöûŕ åðɱîñîšţŕåţöŕ ƒöŕ ĥéļþ ฐโ⾼ئ䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 idx.error.code.access_denied.device_assurance.remediation.additional_help_custom = 》Ƒöŕ ɱöŕé îñƒöŕɱåţîöñ، ƒöļļöŵ ţĥé îñšţŕûçţîöñš öñ <$1>ýöûŕ öŕĝåñîžåţîöñ´š ĥéļþ þåĝé</$1> öŕ çöñţåçţ ýöûŕ åðɱîñîšţŕåţöŕ ƒöŕ ĥéļþ 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+idx.error.code.access_denied.device_assurance.remediation.chrome.antivirus = 》Éñåƀļé åñţîṽîŕûš šöƒţŵåŕé 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted = 》Ţûŕñ öñ ðîšķ éñçŕýþţîöñ 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = 》Ţûŕñ öñ ýöûŕ ðéṽîçé´š ƒîŕéŵåļļ 䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured = 》Ţûŕñ öñ åûţöɱåţîç šçŕééñ šåṽéŕ åñð šçŕééñ ļöçķîñĝ ŵĥéñ îðļé 䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《

--- a/packages/@okta/i18n/src/properties/login_ok_SK.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_SK.properties
@@ -1251,6 +1251,7 @@ idx.error.code.access_denied.device_assurance.remediation.windows.use_biometric_
 idx.error.code.access_denied.device_assurance.remediation.device.must.be.managed = [[okta-signin-widget:login: idx.error.code.access_denied.device_assurance.remediation.device.must.be.managed]]
 idx.error.code.access_denied.device_assurance.remediation.additional_help_default = [[okta-signin-widget:login: idx.error.code.access_denied.device_assurance.remediation.additional_help_default]]
 idx.error.code.access_denied.device_assurance.remediation.additional_help_custom = [[okta-signin-widget:login: idx.error.code.access_denied.device_assurance.remediation.additional_help_custom]]
+idx.error.code.access_denied.device_assurance.remediation.chrome.antivirus = [[okta-signin-widget:login: idx.error.code.access_denied.device_assurance.remediation.chrome.antivirus]]
 idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted = [[okta-signin-widget:login: idx.error.code.access_denied.device_assurance.remediation.chrome.disk_encrypted]]
 idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall = [[okta-signin-widget:login: idx.error.code.access_denied.device_assurance.remediation.chrome.os_firewall]]
 idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured = [[okta-signin-widget:login: idx.error.code.access_denied.device_assurance.remediation.chrome.screen_lock_secured]]


### PR DESCRIPTION
## Description:
- Needed to support new remediation message for failing Chrome DTC antivirus enabled condition


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1033950](https://oktainc.atlassian.net/browse/OKTA-1033950)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



