### PR TITLE
Use supportedLocales list in window.okta object

### DIFF
--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -232,7 +232,10 @@ const derived: Record<string, ModelProperty>  = {
       // By default, the language be automatically detected from the browser
       // Developers can specify the language. It will be added to the supportedLanguages list.
       // Developers can also provide a list of languages with hosted assets, these replace the default list
-      const supportedLanguages = hostedLanguages || config.supportedLanguages;
+      const oktaSupportedLocales = window.okta?.supportedLocales;
+      // Use hostedLanguages if provided, otherwise use non-empty window.okta.supportedLocales list.
+      // If neither are present, fall back to config.supportedLanguages.
+      const supportedLanguages = hostedLanguages || (!_.isEmpty(oktaSupportedLocales) ? oktaSupportedLocales : config.supportedLanguages);
       return _.union(
         supportedLanguages,
         _.keys(i18n),

--- a/src/util/loc.ts
+++ b/src/util/loc.ts
@@ -35,6 +35,7 @@ interface L10nErrorDetail {
 declare global {
   interface Window {
     okta?: {
+      supportedLocales?: string[];
       locale?: string
     }
   }

--- a/src/v3/src/util/settingsUtils.ts
+++ b/src/v3/src/util/settingsUtils.ts
@@ -48,10 +48,12 @@ import { loc } from './locUtil';
  *       the config (fallback for when `widgetProps.assets.languages` is not provided)
  * 3. `widgetProps.i18n` - Custom language overrides defined in the i18n configuration
  * 4. `widgetProps.language` - The language specified by the widget properties
+ * 5. `window.okta.supportedLocales` - the locales supported by Okta
  */
 export const getSupportedLanguages = (widgetProps: WidgetProps): string[] => {
   const { i18n, language, assets: { languages } = {} } = widgetProps;
-  const supportedLanguages = languages || config.supportedLanguages;
+  const oktaSupportedLocales = window.okta?.supportedLocales;
+  const supportedLanguages = languages || (Array.isArray(oktaSupportedLocales) && oktaSupportedLocales.length > 0 ? oktaSupportedLocales : config.supportedLanguages);
   const customLanguages = Object.keys(i18n || {});
 
   return union(


### PR DESCRIPTION
## Description:

- Currently, the `supportedLanguages` is calculated based on the value of `hostedLanguages` and supportedLanguages from config file (generated during the build time). 
- We are enabling `window.okta.supportedLocales` by default, so the SIW can use supportedLocales list.


Testing:
- Turn on supported locales list, command: `ok mono jmx property set locale.interceptor.add.supported.locales true`

<img width="584" height="360" alt="image" src="https://github.com/user-attachments/assets/7275526c-2854-48ec-9b82-4c53efe3a361" />

The supported locales from `window.okta` object

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1002485](https://oktainc.atlassian.net/browse/OKTA-1002485)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



