### PR TITLE
update node version in verify-install

### DIFF
--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -159,7 +159,7 @@ if [ -n "${TEST_SUITE_ID}" ]; then
   set +e
   # Verify minimum supported version of node
   export PATH=$ORIGINAL_PATH
-  setup_service node v14.18.2
+  setup_service node v16.19.1
 
   # Verify minimum supported version of yarn
   setup_service yarn 1.22.19


### PR DESCRIPTION
## Description:

This PR fixes error in verify-install suite due to incorrect node version:

https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=master&page=1&pageSize=6&sha=d4c1497555d4c28ffe67664c61771ece9a9712bd&tab=tests&testSuite=okta-signin-widget-verify-package

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1047076](https://oktainc.atlassian.net/browse/OKTA-1047076)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



