### PR TITLE
Remove `deviceChallenge.enhancedPollingEnabled` check to be default behavior

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-2.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-2.json
@@ -135,7 +135,6 @@
             "challengeMethod": "LOOPBACK",
             "challengeRequest": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5c",
             "domain": "http://localhost",
-            "enhancedPollingEnabled": true,
             "ports": [
               "2000",
               "6511",

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-second-challenge.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-second-challenge.json
@@ -135,7 +135,6 @@
             "challengeMethod": "LOOPBACK",
             "challengeRequest": "123",
             "domain": "http://localhost",
-            "enhancedPollingEnabled": false,
             "ports": [
               "2000",
               "6511",

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback.json
@@ -135,7 +135,6 @@
             "challengeMethod": "LOOPBACK",
             "challengeRequest": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5c",
             "domain": "http://localhost",
-            "enhancedPollingEnabled": false,
             "ports": [
               "2000",
               "6511",

--- a/playground/mocks/data/idp/idx/identify-with-device-probing-https-loopback.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-probing-https-loopback.json
@@ -64,7 +64,6 @@
             "challengeRequest": "eyJraWQiOiI1aTZaQW5TTlZ4RHlNYlNLS0NDcUhpUDdaNG92Q1Fab0thYlFYVE4zVnFjIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJhdWQiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJleHAiOjE1NzUxNDY0NDEsImlhdCI6MTU3NTE0NjE0MSwibm9uY2UiOiJzYW1wbGVOb25jZSIsInNpZ25hbHMiOlsic2NyZWVuTG9jayIsInJvb3RQcml2aWxlZ2VzIiwiZnVsbERpc2tFbmNyeXB0aW9uIiwiaWQiLCJwbGF0Zm9ybSIsIm9zVmVyc2lvbiIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwiZGV2aWNlQXR0ZXN0YXRpb24iXSwidXNlclZlcmlmaWNhdGlvblJlcXVpcmVtZW50IjpmYWxzZSwidmVyaWZpY2F0aW9uVXJpIjoiaHR0cHM6Ly9yYWluLm9rdGExLmNvbS8vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dGhlbnRpY2F0b3JJZC90cmFuc2FjdGlvbnMvdHJhbnNhY3Rpb25JZC92ZXJpZnkiLCJ2ZXIiOjB9.JEXKJAQE95ANX5u1CEPA7HtH1n4YcHquhee4nd5fCRtD6rvu49OSZhJo7mpd9UjF1UNLBxkektTetpvmq7IXaf0WQ-a0EqMHELbdqmpsLl9jQd7lmVpXN6nrjI-YjxZzgTNqj5GEw_Of_3eMkHo_SM4Em4YYxf8XdQHmtPJUima9gHoGbShZ-XjD1K0feEl1ybCFyflxHXa6qvhqSbhxB0wD81Khb7T-T9-GUmfDGh9FlrypIhexjDghC52puY6N-m9kuJI5IllxeW_ggFD0cB6lx8VImFrbn5CETlFCwvDqZzhbAYWh0v-Nt59w-W-DlyPp-ap0meU4pdyfcGqisQ",
             "domain": "http://localhost",
             "httpsDomain": "https://randomOrgId.authenticatorlocaldev.com",
-            "enhancedPollingEnabled": false,
             "ports": [ "2000", "6511", "6512", "6513" ],
             "probeTimeoutMillis": 3000,
             "cancel": {

--- a/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-2.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-2.json
@@ -63,7 +63,6 @@
             "challengeMethod": "LOOPBACK",
             "challengeRequest": "eyJraWQiOiI1aTZaQW5TTlZ4RHlNYlNLS0NDcUhpUDdaNG92Q1Fab0thYlFYVE4zVnFjIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJhdWQiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJleHAiOjE1NzUxNDY0NDEsImlhdCI6MTU3NTE0NjE0MSwibm9uY2UiOiJzYW1wbGVOb25jZSIsInNpZ25hbHMiOlsic2NyZWVuTG9jayIsInJvb3RQcml2aWxlZ2VzIiwiZnVsbERpc2tFbmNyeXB0aW9uIiwiaWQiLCJwbGF0Zm9ybSIsIm9zVmVyc2lvbiIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwiZGV2aWNlQXR0ZXN0YXRpb24iXSwidXNlclZlcmlmaWNhdGlvblJlcXVpcmVtZW50IjpmYWxzZSwidmVyaWZpY2F0aW9uVXJpIjoiaHR0cHM6Ly9yYWluLm9rdGExLmNvbS8vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dGhlbnRpY2F0b3JJZC90cmFuc2FjdGlvbnMvdHJhbnNhY3Rpb25JZC92ZXJpZnkiLCJ2ZXIiOjB9.JEXKJAQE95ANX5u1CEPA7HtH1n4YcHquhee4nd5fCRtD6rvu49OSZhJo7mpd9UjF1UNLBxkektTetpvmq7IXaf0WQ-a0EqMHELbdqmpsLl9jQd7lmVpXN6nrjI-YjxZzgTNqj5GEw_Of_3eMkHo_SM4Em4YYxf8XdQHmtPJUima9gHoGbShZ-XjD1K0feEl1ybCFyflxHXa6qvhqSbhxB0wD81Khb7T-T9-GUmfDGh9FlrypIhexjDghC52puY6N-m9kuJI5IllxeW_ggFD0cB6lx8VImFrbn5CETlFCwvDqZzhbAYWh0v-Nt59w-W-DlyPp-ap0meU4pdyfcGqisa",
             "domain": "http://localhost",
-            "enhancedPollingEnabled": false,
             "ports": [ "2000", "6511", "6512", "6513" ],
             "cancel": {
                 "rel": [

--- a/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-3.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-3.json
@@ -63,7 +63,6 @@
             "challengeMethod": "LOOPBACK",
             "challengeRequest": "eyJraWQiOiI1aTZaQW5TTlZ4RHlNYlNLS0NDcUhpUDdaNG92Q1Fab0thYlFYVE4zVnFjIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJhdWQiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJleHAiOjE1NzUxNDY0NDEsImlhdCI6MTU3NTE0NjE0MSwibm9uY2UiOiJzYW1wbGVOb25jZSIsInNpZ25hbHMiOlsic2NyZWVuTG9jayIsInJvb3RQcml2aWxlZ2VzIiwiZnVsbERpc2tFbmNyeXB0aW9uIiwiaWQiLCJwbGF0Zm9ybSIsIm9zVmVyc2lvbiIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwiZGV2aWNlQXR0ZXN0YXRpb24iXSwidXNlclZlcmlmaWNhdGlvblJlcXVpcmVtZW50IjpmYWxzZSwidmVyaWZpY2F0aW9uVXJpIjoiaHR0cHM6Ly9yYWluLm9rdGExLmNvbS8vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dGhlbnRpY2F0b3JJZC90cmFuc2FjdGlvbnMvdHJhbnNhY3Rpb25JZC92ZXJpZnkiLCJ2ZXIiOjB9.JEXKJAQE95ANX5u1CEPA7HtH1n4YcHquhee4nd5fCRtD6rvu49OSZhJo7mpd9UjF1UNLBxkektTetpvmq7IXaf0WQ-a0EqMHELbdqmpsLl9jQd7lmVpXN6nrjI-YjxZzgTNqj5GEw_Of_3eMkHo_SM4Em4YYxf8XdQHmtPJUima9gHoGbShZ-XjD1K0feEl1ybCFyflxHXa6qvhqSbhxB0wD81Khb7T-T9-GUmfDGh9FlrypIhexjDghC52puY6N-m9kuJI5IllxeW_ggFD0cB6lx8VImFrbn5CETlFCwvDqZzhbAYWh0v-Nt59w-W-DlyPp-ap0meU4pdyfcGqisb",
             "domain": "http://localhost",
-            "enhancedPollingEnabled": false,
             "ports": [ "2000", "6511", "6512", "6513" ],
             "cancel": {
                 "rel": [

--- a/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-4.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-4.json
@@ -63,7 +63,6 @@
             "challengeMethod": "LOOPBACK",
             "challengeRequest": "eyJraWQiOiI1aTZaQW5TTlZ4RHlNYlNLS0NDcUhpUDdaNG92Q1Fab0thYlFYVE4zVnFjIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJhdWQiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJleHAiOjE1NzUxNDY0NDEsImlhdCI6MTU3NTE0NjE0MSwibm9uY2UiOiJzYW1wbGVOb25jZSIsInNpZ25hbHMiOlsic2NyZWVuTG9jayIsInJvb3RQcml2aWxlZ2VzIiwiZnVsbERpc2tFbmNyeXB0aW9uIiwiaWQiLCJwbGF0Zm9ybSIsIm9zVmVyc2lvbiIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwiZGV2aWNlQXR0ZXN0YXRpb24iXSwidXNlclZlcmlmaWNhdGlvblJlcXVpcmVtZW50IjpmYWxzZSwidmVyaWZpY2F0aW9uVXJpIjoiaHR0cHM6Ly9yYWluLm9rdGExLmNvbS8vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dGhlbnRpY2F0b3JJZC90cmFuc2FjdGlvbnMvdHJhbnNhY3Rpb25JZC92ZXJpZnkiLCJ2ZXIiOjB9.JEXKJAQE95ANX5u1CEPA7HtH1n4YcHquhee4nd5fCRtD6rvu49OSZhJo7mpd9UjF1UNLBxkektTetpvmq7IXaf0WQ-a0EqMHELbdqmpsLl9jQd7lmVpXN6nrjI-YjxZzgTNqj5GEw_Of_3eMkHo_SM4Em4YYxf8XdQHmtPJUima9gHoGbShZ-XjD1K0feEl1ybCFyflxHXa6qvhqSbhxB0wD81Khb7T-T9-GUmfDGh9FlrypIhexjDghC52puY6N-m9kuJI5IllxeW_ggFD0cB6lx8VImFrbn5CETlFCwvDqZzhbAYWh0v-Nt59w-W-DlyPp-ap0meU4pdyfcGqisQ",
             "domain": "http://localhost",
-            "enhancedPollingEnabled": false,
             "ports": [ "3000", "6511", "6512", "6513" ],
             "cancel": {
                 "rel": [

--- a/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-chrome-lna.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-probing-loopback-chrome-lna.json
@@ -63,7 +63,6 @@
             "challengeMethod": "LOOPBACK",
             "challengeRequest": "eyJraWQiOiI1aTZaQW5TTlZ4RHlNYlNLS0NDcUhpUDdaNG92Q1Fab0thYlFYVE4zVnFjIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJhdWQiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJleHAiOjE1NzUxNDY0NDEsImlhdCI6MTU3NTE0NjE0MSwibm9uY2UiOiJzYW1wbGVOb25jZSIsInNpZ25hbHMiOlsic2NyZWVuTG9jayIsInJvb3RQcml2aWxlZ2VzIiwiZnVsbERpc2tFbmNyeXB0aW9uIiwiaWQiLCJwbGF0Zm9ybSIsIm9zVmVyc2lvbiIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwiZGV2aWNlQXR0ZXN0YXRpb24iXSwidXNlclZlcmlmaWNhdGlvblJlcXVpcmVtZW50IjpmYWxzZSwidmVyaWZpY2F0aW9uVXJpIjoiaHR0cHM6Ly9yYWluLm9rdGExLmNvbS8vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dGhlbnRpY2F0b3JJZC90cmFuc2FjdGlvbnMvdHJhbnNhY3Rpb25JZC92ZXJpZnkiLCJ2ZXIiOjB9.JEXKJAQE95ANX5u1CEPA7HtH1n4YcHquhee4nd5fCRtD6rvu49OSZhJo7mpd9UjF1UNLBxkektTetpvmq7IXaf0WQ-a0EqMHELbdqmpsLl9jQd7lmVpXN6nrjI-YjxZzgTNqj5GEw_Of_3eMkHo_SM4Em4YYxf8XdQHmtPJUima9gHoGbShZ-XjD1K0feEl1ybCFyflxHXa6qvhqSbhxB0wD81Khb7T-T9-GUmfDGh9FlrypIhexjDghC52puY6N-m9kuJI5IllxeW_ggFD0cB6lx8VImFrbn5CETlFCwvDqZzhbAYWh0v-Nt59w-W-DlyPp-ap0meU4pdyfcGqisQ",
             "domain": "http://localhost",
-            "enhancedPollingEnabled": false,
             "ports": [ "2000", "6511", "6512", "6513" ],
             "chromeLocalNetworkAccessDetails": {
                 "chromeLNAHelpLink": "https://okta.com"

--- a/playground/mocks/data/idp/idx/identify-with-device-probing-loopback.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-probing-loopback.json
@@ -63,7 +63,6 @@
             "challengeMethod": "LOOPBACK",
             "challengeRequest": "eyJraWQiOiI1aTZaQW5TTlZ4RHlNYlNLS0NDcUhpUDdaNG92Q1Fab0thYlFYVE4zVnFjIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJhdWQiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJleHAiOjE1NzUxNDY0NDEsImlhdCI6MTU3NTE0NjE0MSwibm9uY2UiOiJzYW1wbGVOb25jZSIsInNpZ25hbHMiOlsic2NyZWVuTG9jayIsInJvb3RQcml2aWxlZ2VzIiwiZnVsbERpc2tFbmNyeXB0aW9uIiwiaWQiLCJwbGF0Zm9ybSIsIm9zVmVyc2lvbiIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwiZGV2aWNlQXR0ZXN0YXRpb24iXSwidXNlclZlcmlmaWNhdGlvblJlcXVpcmVtZW50IjpmYWxzZSwidmVyaWZpY2F0aW9uVXJpIjoiaHR0cHM6Ly9yYWluLm9rdGExLmNvbS8vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dGhlbnRpY2F0b3JJZC90cmFuc2FjdGlvbnMvdHJhbnNhY3Rpb25JZC92ZXJpZnkiLCJ2ZXIiOjB9.JEXKJAQE95ANX5u1CEPA7HtH1n4YcHquhee4nd5fCRtD6rvu49OSZhJo7mpd9UjF1UNLBxkektTetpvmq7IXaf0WQ-a0EqMHELbdqmpsLl9jQd7lmVpXN6nrjI-YjxZzgTNqj5GEw_Of_3eMkHo_SM4Em4YYxf8XdQHmtPJUima9gHoGbShZ-XjD1K0feEl1ybCFyflxHXa6qvhqSbhxB0wD81Khb7T-T9-GUmfDGh9FlrypIhexjDghC52puY6N-m9kuJI5IllxeW_ggFD0cB6lx8VImFrbn5CETlFCwvDqZzhbAYWh0v-Nt59w-W-DlyPp-ap0meU4pdyfcGqisQ",
             "domain": "http://localhost",
-            "enhancedPollingEnabled": false,
             "ports": [ "2000", "6511", "6512", "6513" ],
             "cancel": {
                 "rel": [

--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -8,7 +8,7 @@ import {
   CHALLENGE_TIMEOUT,
 } from '../utils/Constants';
 import BrowserFeatures from 'util/BrowserFeatures';
-import { 
+import {
   doChallenge,
   cancelPollingWithParams,
   createInvisibleIFrame,
@@ -118,27 +118,20 @@ const Body = BaseFormWithPolling.extend({
           return onPortFound(getAuthenticatorUrl('challenge', domainUrl))
             .then(() => {
               foundPort = true;
-              if (deviceChallenge.enhancedPollingEnabled !== false) {
-                // this way we can gurantee that
-                // 1. the polling is triggered right away (1ms interval)
-                // 2. Only one polling queue
-                // 3. follwoing polling will continue with refresh interval from previous polling response
-                // NOTE: technically, there could still be concurrency issue where when we called stopPolling,
-                // there is already a polling triggered and hasn't completed yet
-                // but the possibility would be much smaller than previous concurrency issue
-                // this is a best effort change
-                this.stopPolling();
-                this.startPolling(1);
-                return;
-              }
-              // once the OV challenge succeeds,
-              // triggers another polling right away without waiting for the next ongoing polling to be triggered
-              // to make the authentication flow goes faster 
-              return this.trigger('save', this.model);
+              // this way we can gurantee that
+              // 1. the polling is triggered right away (1ms interval)
+              // 2. Only one polling queue
+              // 3. follwoing polling will continue with refresh interval from previous polling response
+              // NOTE: technically, there could still be concurrency issue where when we called stopPolling,
+              // there is already a polling triggered and hasn't completed yet
+              // but the possibility would be much smaller than previous concurrency issue
+              // this is a best effort change
+              this.stopPolling();
+              this.startPolling(1);
             })
             .catch((xhr) => {
               countFailedPorts++;
-              // Windows and MacOS return status code 503 when 
+              // Windows and MacOS return status code 503 when
               // there are multiple profiles on the device and
               // the wrong OS profile responds to the challenge request
               if (xhr.status !== 503) {

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -6,8 +6,8 @@ import BasePageObject from '../framework/page-objects/BasePageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import identify from '../../../playground/mocks/data/idp/idx/identify';
 import identifyWithUserVerificationLoopback from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback';
+import identifyWithUserVerificationLoopback2 from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-2';
 import identifyWithUserVerificationLoopbackSecondChallenge from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-second-challenge';
-import identifyWithUserVerificationLoopbackWithEnhancedPolling from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-with-enhanced-polling';
 import identifyWithUserVerificationBiometricsErrorMobile from '../../../playground/mocks/data/idp/idx/error-400-okta-verify-uv-fastpass-verify-enable-biometrics-mobile.json';
 import identifyWithUserVerificationBiometricsErrorDesktop from '../../../playground/mocks/data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-desktop.json';
 import identifyWithUserVerificationCustomURI from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-custom-uri';
@@ -26,8 +26,7 @@ import { renderWidget } from '../framework/shared';
 const BEACON_CLASS = 'mfa-okta-verify';
 
 const pollCounters = {
-  loopbackRedundantPolling: userVariables.gen3 ? -1 : 0,
-  loopbackEnhancedPolling: userVariables.gen3 ? -1 : 0,
+  loopbackPolling: userVariables.gen3 ? -1 : 0,
   loopbackFallback: userVariables.gen3 ? -1 : 0,
 };
 
@@ -73,52 +72,6 @@ const loopbackSuccessMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
   .respond(identifyWithDeviceLaunchAuthenticator);
 
-const loopbackRedundantPollingLogger = RequestLogger(/introspect|probe|challenge|poll/, { logRequestBody: true, stringifyRequestBody: true });
-const loopbackRedundantPollingMock = RequestMock()
-  .onRequestTo(/\/idp\/idx\/introspect/)
-  .respond(identifyWithUserVerificationLoopback)
-  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
-  .respond(async (req, res) => {
-    res.headers['content-type'] = 'application/json';
-    switch (pollCounters.loopbackRedundantPolling++) {
-    case -1:
-      res.statusCode = '200';
-      res.setBody(identifyWithUserVerificationLoopback);
-      break;
-    case 0:
-      // specifically make the first poll call takes more time to complete
-      // so that we can verify if there will be a redundant poll call after it
-      await new Promise((r) => setTimeout(r, 5000));
-      res.statusCode = '200';
-      res.setBody(identify);
-      break;
-    default:
-      res.statusCode = '400';
-      res.setBody(badRequestError);
-    }
-  })
-  .onRequestTo({ url: /2000|6511\/probe/, method: 'OPTIONS' })
-  .respond(null, 200, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
-  })
-  .onRequestTo({ url: /2000|6511\/probe/, method: 'GET' })
-  .respond(null, 500, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
-  })
-  .onRequestTo(/6512\/probe/)
-  .respond(null, 200, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
-  })
-  .onRequestTo(/6512\/challenge/)
-  .respond(null, 200, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
-    'access-control-allow-methods': 'POST, OPTIONS'
-  });
-
 const loopbackRedundantPollingForPollCancelMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/introspect/)
   .respond(identifyWithUserVerificationLoopback)
@@ -143,17 +96,17 @@ const loopbackRedundantPollingForPollCancelMock = RequestMock()
     'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
   });
 
-const loopbackEnhancedPollingLogger = RequestLogger(/introspect|probe|challenge|poll/, { logRequestBody: true, stringifyRequestBody: true });
-const loopbackEnhancedPollingMock = RequestMock()
+const loopbackPollingLogger = RequestLogger(/introspect|probe|challenge|poll/, { logRequestBody: true, stringifyRequestBody: true });
+const loopbackPollingMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/introspect/)
-  .respond(identifyWithUserVerificationLoopbackWithEnhancedPolling)
+  .respond(identifyWithUserVerificationLoopback2)
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond(async (req, res) => {
     res.headers['content-type'] = 'application/json';
-    switch (pollCounters.loopbackEnhancedPolling++) {
+    switch (pollCounters.loopbackPolling++) {
     case -1:
       res.statusCode = '200';
-      res.setBody(identifyWithUserVerificationLoopbackWithEnhancedPolling);
+      res.setBody(identifyWithUserVerificationLoopback2);
       break;
     case 0:
       // give more time for the waiting time
@@ -409,32 +362,7 @@ async function setupLoopbackFallback(t, widgetOptions, mockKey) {
 }
 
 test
-  .meta('gen3', false) // Gen3 does not have the same redundant polling issue as Gen2 and does not need to implement enhancedPollingEnabled, so skip this test
-  .requestHooks(loopbackRedundantPollingLogger, loopbackRedundantPollingMock)('in loopback server, redundant polling exists if server returns enhancedPollingEnabled as false', async t => {
-    const deviceChallengePollPageObject = await setup(t, 'loopbackRedundantPolling');
-    await checkA11y(t);
-    await t.expect(deviceChallengePollPageObject.getBeaconSelector()).contains(BEACON_CLASS);
-    await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
-    await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
-    await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().innerText).eql('Verify with something else');
-    await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
-    await t.expect(loopbackRedundantPollingLogger.count(
-      record => record.response.statusCode === 200 &&
-        record.request.url.match(/challenge/) &&
-        record.request.body.match(/challengeRequest":"02vQULJDA20fnlkloDn2/)
-    )).eql(1);
-
-    // If there is redundant polling, SIW will show bad request error
-    await t.expect(deviceChallengePollPageObject.form.getErrorBoxText()).contains('Bad request');
-    await t.expect(deviceChallengePollPageObject.hasErrorBox()).eql(true);
-
-    const identityPage = new IdentityPageObject(t);
-    await identityPage.fillIdentifierField('Test Identifier');
-    await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
-  });
-
-test
-  .meta('gen3', false) // Gen3 does not have the same redundant polling issue as Gen2 and does not need to implement enhancedPollingEnabled, so skip this test
+  .meta('gen3', false) // skip this test since Gen3 does not have the same redundant polling issue as Gen2
   .requestHooks(loopbackRedundantPollingForPollCancelMock)('in loopback server, no more polling when cancel polling has been called', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await checkA11y(t);
@@ -454,8 +382,8 @@ test
   });
 
 test
-  .requestHooks(loopbackEnhancedPollingLogger, loopbackEnhancedPollingMock)('in loopback server, no redundant polling if server returns enhancedPollingEnabled as true', async t => {
-    const deviceChallengePollPageObject = await setup(t, 'loopbackEnhancedPolling');
+  .requestHooks(loopbackPollingLogger, loopbackPollingMock)('in loopback server, no redundant polling', async t => {
+    const deviceChallengePollPageObject = await setup(t, 'loopbackPolling');
     await checkA11y(t);
     await t.expect(deviceChallengePollPageObject.getBeaconSelector()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getFormTitle()).eql('Verifying your identity');
@@ -465,7 +393,7 @@ test
     }
     await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().innerText).eql('Verify with something else');
     await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
-    await t.expect(loopbackEnhancedPollingLogger.count(
+    await t.expect(loopbackPollingLogger.count(
       record => record.response.statusCode === 200 &&
         record.request.url.match(/challenge/) &&
         record.request.body.match(/challengeRequest":"02vQULJDA20fnlkloDn2/)


### PR DESCRIPTION
## Description:
- We [removed](https://github.com/atko-eng/okta-core/pull/115355) the property from monolith (merged in `2025.08.4` weekly CF). 
- No issues or regressions have been reported, so we can safely remove the corresponding [SIW check](https://github.com/okta/okta-signin-widget/blob/master/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js#L121).
    -  As [recommended by Shaw](https://oktawiki.atlassian.net/wiki/spaces/~988051222/pages/2779389341/SIW+Polling+400+errors+enhancement?focusedCommentId=2781779613), the [SIW check](https://github.com/okta/okta-signin-widget/blob/master/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js#L121) handles pinned SIW versions to prevent regressions.
    ```
    // Enter if-statement when deviceChallenge.enhancedPollingEnabled is true or undefined
    // Therefore, SIW behavior is unchanged when the true-by-default property is removed
    if (deviceChallenge.enhancedPollingEnabled !== false) {
        ...
    }
    ```
- These json files are very similar but the `refresh` property differs:
    - `authenticator-verification-okta-verify-signed-nonce-loopback.json` [[L20](https://github.com/okta/okta-signin-widget/blob/master/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback.json#L20)]
    - `authenticator-verification-okta-verify-signed-nonce-loopback-with-enhanced-polling.json` [[L20](https://github.com/okta/okta-signin-widget/blob/master/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback-with-enhanced-polling.json#L20)]
- This [test](https://github.com/okta/okta-signin-widget/blob/master/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js#L511-L512) fails consistently on my local server, but it passes on bacon 🤔
    
<img width="1168" height="427" alt="Screenshot 2026-01-01 at 6 03 52 AM" src="https://github.com/user-attachments/assets/6a1ca53f-d95e-4457-a5a7-72c8319f0d32" />

```
yarn start
yarn test -t testcafe chrome test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
```

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-999700](https://oktainc.atlassian.net/browse/OKTA-999700)

### Reviewers:

### Screenshot/Video:

### Downstream Monolith Build:

