### PR TITLE
wip: disable stylis plugin prefixer that breaks checkbox on hover

### DIFF
--- a/src/v3/stylis-logical-plugin/src/plugin.ts
+++ b/src/v3/stylis-logical-plugin/src/plugin.ts
@@ -39,7 +39,8 @@ const createPlugin: (opts: PluginOptions) => Middleware = function pluginFactory
   const safelyPrefix = (value: string, prefix: 'ltr' | 'rtl'): string => {
     let resolvedValue = value;
     const prefixes = {
-      ltr: `${rootDirElement}:not(${RTL_ATTR_SELECTOR})`,
+      // ltr: `${rootDirElement}:not(${RTL_ATTR_SELECTOR})`, // FIXME this breaks checkbox
+      ltr: '',
       rtl: RTL_ATTR_SELECTOR,
     };
 


### PR DESCRIPTION
## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-104788](https://oktainc.atlassian.net/browse/OKTA-104788)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



