### PR TITLE
fix: addresses issue with AbortError on iOS

### DIFF
--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -399,6 +399,14 @@ describe('v2/view-builder/views/IdentifierView', function() {
         expectErrorSuppressed: true
       },
       {
+        description: 'should suppress error when navigator.credentials.get throws AbortError (e.g., when modal passkey flow cancels autofill)',
+        errorMessage: 'The operation was aborted.',
+        errorName: 'AbortError',
+        errorCode: 20,
+        isRelyingPartyIdMismatch: false,
+        expectErrorSuppressed: true
+      },
+      {
         description: 'should show error when navigator.credentials.get throws non-Relying Party ID mismatch error',
         errorMessage: 'Unsuppressed WebAuthn error',
         errorName: 'UnsuppressedError',
@@ -428,6 +436,46 @@ describe('v2/view-builder/views/IdentifierView', function() {
         // Check that an error message IS displayed in the UI (error was not suppressed)
         expect(testContext.view.$el.find('.infobox-error p').text()).toContain(errorMessage);
       }
+    });
+  });
+
+  describe('WebAuthn Autofill conditional invocation in postRender', function() {
+    let getCredentialsAndInvokeActionSpy;
+
+    beforeEach(function() {
+      getCredentialsAndInvokeActionSpy = jest.spyOn(
+        IdentifierView.prototype.Body.prototype,
+        'getCredentialsAndInvokeAction'
+      ).mockResolvedValue(undefined);
+    });
+
+    afterEach(function() {
+      getCredentialsAndInvokeActionSpy.mockRestore();
+    });
+
+    it('should invoke getCredentialsAndInvokeAction when Autofill UI remediation is present', function() {
+      jest.spyOn(AppState.prototype, 'hasRemediationObject').mockImplementation(remediation => {
+        return remediation === FORMS.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR;
+      });
+      jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
+      jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(true);
+
+      testContext.init(XHRIdentifyWithWebAuthnAutofill.remediation.value);
+
+      expect(getCredentialsAndInvokeActionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT invoke getCredentialsAndInvokeAction when Autofill UI remediation is NOT present', function() {
+      jest.spyOn(AppState.prototype, 'hasRemediationObject').mockImplementation(remediation => {
+        // Only return true for non-autofill remediations
+        return remediation === FORMS.LAUNCH_PASSKEYS_AUTHENTICATOR;
+      });
+      jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
+      jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(true);
+
+      testContext.init(XHRIdentifyWithPasskeys.remediation.value);
+
+      expect(getCredentialsAndInvokeActionSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Description:

Adds a conditional around invoking the WebAuthn API in order to only do it if Autofill UI is enabled.
Also adds an error suppression in the case of both Autofill UI and Sign in with a passkey button are enabled.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1095131](https://oktainc.atlassian.net/browse/OKTA-1095131)

### Reviewers:

### Screenshot/Video:

Sign in with a passkey button only:

https://github.com/user-attachments/assets/b3f49ac5-c1e0-4636-95d2-cde12bd37e8d


Both Autofill UI and Sign in with a passkey button:

https://github.com/user-attachments/assets/27e52b60-3772-4858-8775-48b3ab651538


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=b7d94d2b070734b2f7cdce6a9c1350a1b8a5df8d&tab=main


