### PR TITLE
Add altcha license

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -10,6 +10,32 @@ of a given package.
 
 Third Party Notices
 
+Altcha
+Version (if any): 1.4.2
+Brief Description: A spam and bot protection library that provides proof-of-work based verification for websites, APIs, and online services without relying on third-party tracking services.
+License: MIT License
+
+Copyright (c) 2023 Daniel Regeci, BAU Software s.r.o.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 Almond
 Version (if any):	0.3.1
 Brief Description:	A replacement AMD loader for RequireJS. It provides a 


### PR DESCRIPTION
## Description:
Add MIT license for Altcha plugin used for bot protection

Kill switch | n/a
-- | --
FF | n/a
Description | As above
Test Coverage | n/a
Risk assessment | Very low
Rollout plan | Weekly
Rollback plan | Revert branch
Metrics/Monitoring (if applicable) | n/a

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1095853](https://oktainc.atlassian.net/browse/OKTA-1095853)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



