### PR TITLE
Revert "fix: addresses issue with AbortError on iOS (#3944)"

### DIFF
--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -149,11 +149,7 @@ const Body = BaseForm.extend({
     // When a user enters invalid credentials, /introspect returns an error,
     // along with a user object containing the identifier entered by the user.
     this.$el.find('.identifier-container').remove();
-
-    // there is no need to invoke the webauthn API unless we have Autofill UI enabled
-    if (this._hasAutofillUIChallenge()) {
-      this.getCredentialsAndInvokeAction();
-    }
+    this.getCredentialsAndInvokeAction();
   },
 
   /**
@@ -179,8 +175,10 @@ const Body = BaseForm.extend({
           };
         }
 
+        const isAutoFillUIChallenge =
+          this.options.appState.hasRemediationObject(RemediationForms.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR);
         // Setting the autocomplete value to 'webauthn' allows the browser to list passkeys alongside usernames
-        const autoCompleteDefaultValue = this._hasAutofillUIChallenge() && webauthn.isConditionalMediationAvailable()
+        const autoCompleteDefaultValue = isAutoFillUIChallenge && webauthn.isConditionalMediationAvailable()
           ? 'username webauthn'
           : 'username';
         // We enable the browser's autocomplete for the identifier input
@@ -309,13 +307,6 @@ const Body = BaseForm.extend({
           return;
         }
 
-        // If one navigator.credentials call is canceled in order to invoke another one
-        // (eg. when we have both Autofill UI and Sign in with a passkey button)
-        // we want to suppress the error and let the user continue with authentication.
-        if (webauthn.isAbortError(error)) {
-          return;
-        }
-
         // Suppress the error shown to the enduser in case of the relying party id mismatch.
         // The error message shown was:
         // "The relying party ID is not a registrable domain suffix of, nor equal to the current domain.
@@ -413,10 +404,6 @@ const Body = BaseForm.extend({
     if (cookieUsername) {
       this.model.set('identifier', cookieUsername);
     }
-  },
-
-  _hasAutofillUIChallenge() {
-    return this.options.appState.hasRemediationObject(RemediationForms.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR);
   }
 });
 

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -399,14 +399,6 @@ describe('v2/view-builder/views/IdentifierView', function() {
         expectErrorSuppressed: true
       },
       {
-        description: 'should suppress error when navigator.credentials.get throws AbortError (e.g., when modal passkey flow cancels autofill)',
-        errorMessage: 'The operation was aborted.',
-        errorName: 'AbortError',
-        errorCode: 20,
-        isRelyingPartyIdMismatch: false,
-        expectErrorSuppressed: true
-      },
-      {
         description: 'should show error when navigator.credentials.get throws non-Relying Party ID mismatch error',
         errorMessage: 'Unsuppressed WebAuthn error',
         errorName: 'UnsuppressedError',
@@ -436,46 +428,6 @@ describe('v2/view-builder/views/IdentifierView', function() {
         // Check that an error message IS displayed in the UI (error was not suppressed)
         expect(testContext.view.$el.find('.infobox-error p').text()).toContain(errorMessage);
       }
-    });
-  });
-
-  describe('WebAuthn Autofill conditional invocation in postRender', function() {
-    let getCredentialsAndInvokeActionSpy;
-
-    beforeEach(function() {
-      getCredentialsAndInvokeActionSpy = jest.spyOn(
-        IdentifierView.prototype.Body.prototype,
-        'getCredentialsAndInvokeAction'
-      ).mockResolvedValue(undefined);
-    });
-
-    afterEach(function() {
-      getCredentialsAndInvokeActionSpy.mockRestore();
-    });
-
-    it('should invoke getCredentialsAndInvokeAction when Autofill UI remediation is present', function() {
-      jest.spyOn(AppState.prototype, 'hasRemediationObject').mockImplementation(remediation => {
-        return remediation === FORMS.CHALLENGE_WEBAUTHN_AUTOFILLUI_AUTHENTICATOR;
-      });
-      jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
-      jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(true);
-
-      testContext.init(XHRIdentifyWithWebAuthnAutofill.remediation.value);
-
-      expect(getCredentialsAndInvokeActionSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('should NOT invoke getCredentialsAndInvokeAction when Autofill UI remediation is NOT present', function() {
-      jest.spyOn(AppState.prototype, 'hasRemediationObject').mockImplementation(remediation => {
-        // Only return true for non-autofill remediations
-        return remediation === FORMS.LAUNCH_PASSKEYS_AUTHENTICATOR;
-      });
-      jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
-      jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(true);
-
-      testContext.init(XHRIdentifyWithPasskeys.remediation.value);
-
-      expect(getCredentialsAndInvokeActionSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Description:
This reverts commit c3a942ee27f9d64c2ee0f8de508cef153793e526 as this change needs to target the next SIW release 7.40.1

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- OKTA-1103576

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



