### PR TITLE
Okta 1105231 update altcha submission

### DIFF
--- a/src/v2/view-builder/internals/BaseForm.ts
+++ b/src/v2/view-builder/internals/BaseForm.ts
@@ -41,7 +41,7 @@ export default Form.extend({
 
     // When ALTCHA captcha is solved, trigger the form's save flow
     // This ensures IdentifierView.saveForm() runs (for deviceFingerprint, etc.)
-    this.listenTo(this.options.appState, 'onAltchaSolved', () => {
+    this.listenTo(this.options.appState, 'altchaSolved', () => {
       this.trigger('save', this.model);
     });
 

--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -117,7 +117,7 @@ export default View.extend({
       // Calls saveForm on the parent view (ex. IdentifierView) to trigger the form submission flow.
       // This ensures ParentView.saveForm() runs (for deviceFingerprint, etc. if applicable)
       // and the parent view triggers BaseForm.saveForm().
-      this.options.appState.trigger('onAltchaSolved');
+      this.options.appState.trigger('altchaSolved');
     };
 
     const setUpTempToken = () => {

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -383,7 +383,7 @@ describe('v2/view-builder/views/CaptchaView', function() {
       
       expect(window.altcha.reset).toHaveBeenCalledWith('altcha');
       expect(testContext.view.model.get('captchaVerify.captchaToken')).toEqual('altcha-test-token');
-      expect(spy).toHaveBeenCalledWith('onAltchaSolved');
+      expect(spy).toHaveBeenCalledWith('altchaSolved');
     });
 
     it('ALTCHA _getCaptchaObject returns window.altcha', function() {


### PR DESCRIPTION
## Description:
When ALTCHA captcha was solved, it was directly triggering the form submission, bypassing the parent form's save method which is responsible for generating the device fingerprint. Unlike HCAPTCHA/reCAPTCHA where the captcha is executed after the form save flow starts, ALTCHA is a floating overlay widget that users interact with directly before form submission.

This fix introduces a new event that ALTCHA triggers when verification completes, which the base form listens for and properly routes through the form's save flow. This ensures the device fingerprint is generated before the form is submitted to the server. The existing HCAPTCHA and reCAPTCHA flows remain unchanged. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1105231](https://oktainc.atlassian.net/browse/OKTA-1105231)

### Reviewers:
@alexchen-okta

### Screenshot/Video:
https://github.com/user-attachments/assets/c4b5ea1a-2a1d-4638-b283-f00a0411caec


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=98439d5bdb6ebb5fa3f080dfa121018e4565b119&tab=main


