### PR TITLE
fix: hide beacon on safari + idp verify auto redirect

### DIFF
--- a/src/v2/view-builder/views/idp/BaseIdpAuthenticator.js
+++ b/src/v2/view-builder/views/idp/BaseIdpAuthenticator.js
@@ -1,6 +1,9 @@
+import { $ } from '@okta/courage';
 import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from 'v2/view-builder/components/BaseAuthenticatorView';
 import { FORMS as REMEDIATION_FORMS } from 'v2/ion/RemediationConstants';
+import BrowserFeatures from 'util/BrowserFeatures';
+import Enums from 'util/Enums';
 
 export const BaseIdPAuthenticatorBody =  BaseForm.extend({
   initialize() {
@@ -22,6 +25,19 @@ export const BaseIdpAuthenticatorView = BaseAuthenticatorView.extend({
       !Array.isArray(messages.value) &&
       this.model.get('formName') !== REMEDIATION_FORMS.REDIRECT_IDVERIFY
     ) { 
+      const appState = this.options.appState;
+      const authenticatorKey = appState.get('authenticatorKey');
+      const currentAuth = appState.get('currentAuthenticator') || appState.get('currentAuthenticatorEnrollment');
+    
+      if (
+        BrowserFeatures.isSafari() &&
+        authenticatorKey === 'external_idp' &&
+        currentAuth?.logoUri
+      ) {
+        const mainContentContainer = $(`#${Enums.WIDGET_CONTAINER_ID}`);
+        mainContentContainer.addClass('no-beacon');
+        this.$('.beacon-container').hide();
+      }
       this.$('.o-form-button-bar').hide();
       this.$('.okta-waiting-spinner').show();
       this.form.trigger('save', this.model);


### PR DESCRIPTION
## Description:

This fixed the issue with **Gen2** where the custom logo (loaded from a CDN) does not appear while the redirection is in progress. ie when we display a temporary “redirecting” page during the transition.

Rootcause - Safari terminates all the inflight request ( logo fetch) as soon as redirection is triggered

Solution - remove the custom logo only for Safari + auto redirect enabled+ external_idp. Got it approved from [UX](https://okta.slack.com/archives/CAZH2MWEL/p1769616000363419?thread_ts=1769451069.791829&cid=CAZH2MWEL) as well.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=4e7f98172e3792b3a80f5aa8cd36fd13066ce70e&tab=main
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1107955](https://oktainc.atlassian.net/browse/OKTA-1107955)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:

#### Safari - Hide custom logo

https://github.com/user-attachments/assets/04597a59-3677-4bf7-b125-2d8db43963cc

#### Chrome - shows custom logo

https://github.com/user-attachments/assets/f831a581-4ea4-42bc-a178-43a369111b08





