### PR TITLE
Update custom RP ID error message for SIW v3 to match v2

### DIFF
--- a/src/v3/src/components/LaunchPasskeysAuthenticatorButton/LaunchPasskeysAuthenticatorButton.test.tsx
+++ b/src/v3/src/components/LaunchPasskeysAuthenticatorButton/LaunchPasskeysAuthenticatorButton.test.tsx
@@ -123,4 +123,66 @@ describe('LaunchPasskeysAuthenticatorButton', () => {
       });
     });
   });
+
+  it('shows NotSupportedError message when getCredentials throws a NotSupportedError', async () => {
+    const setMessage = jest.fn();
+
+    (jest.requireMock('src/contexts') as any).useWidgetContext = () => ({
+      setLoading,
+      setMessage,
+      abortController: {
+        abort: jest.fn(),
+        signal: { aborted: false },
+      },
+      widgetProps: { eventEmitter: { emit } },
+      sharedHcaptchaRef: mockHcaptchaRef,
+    });
+
+    const notSupportedError = new DOMException('Not supported', 'NotSupportedError');
+    getCredentials.mockRejectedValue(notSupportedError);
+
+    renderWithContext();
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(getCredentials).toHaveBeenCalled();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+      expect(setMessage).toHaveBeenCalledWith({
+        class: 'ERROR',
+        i18n: { key: 'signin.passkeys.error.NotSupportedError' },
+        message: 'signin.passkeys.error.NotSupportedError',
+      });
+    });
+  });
+
+  it('shows SecurityError message when getCredentials throws a SecurityError with code 18', async () => {
+    const setMessage = jest.fn();
+
+    (jest.requireMock('src/contexts') as any).useWidgetContext = () => ({
+      setLoading,
+      setMessage,
+      abortController: {
+        abort: jest.fn(),
+        signal: { aborted: false },
+      },
+      widgetProps: { eventEmitter: { emit } },
+      sharedHcaptchaRef: mockHcaptchaRef,
+    });
+
+    const securityError = new DOMException('Security error', 'SecurityError');
+    getCredentials.mockRejectedValue(securityError);
+
+    renderWithContext();
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(getCredentials).toHaveBeenCalled();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+      expect(setMessage).toHaveBeenCalledWith({
+        class: 'ERROR',
+        i18n: { key: 'signin.passkeys.error.SecurityError' },
+        message: 'signin.passkeys.error.SecurityError',
+      });
+    });
+  });
 });

--- a/src/v3/src/components/LaunchPasskeysAuthenticatorButton/LaunchPasskeysAuthenticatorButton.tsx
+++ b/src/v3/src/components/LaunchPasskeysAuthenticatorButton/LaunchPasskeysAuthenticatorButton.tsx
@@ -65,6 +65,10 @@ const LaunchPasskeysAuthenticatorButton: UISchemaElementComponent<{
           case 'NotSupportedError':
             key = `signin.passkeys.error.${err.name}`;
             break;
+          case 'SecurityError':
+            if (err.code !== 18) { break; }
+            key = `signin.passkeys.error.${err.name}`;
+            break;
           default:
             break;
         }


### PR DESCRIPTION
## Description:

- Show custom RP ID error rather than generic "Could not sign in with a passkey" error

Before:
<img width="444" height="650" alt="Screenshot 2026-02-25 at 12 34 31 PM" src="https://github.com/user-attachments/assets/8ca8bc22-b909-45f5-86e1-970d7dbf8510" />

After:
<img width="441" height="715" alt="Screenshot 2026-02-25 at 12 35 58 PM" src="https://github.com/user-attachments/assets/cb2555f8-231c-478f-a3ca-d2c5133d44fe" />

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1095810](https://oktainc.atlassian.net/browse/OKTA-1095810)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



