### PR TITLE
fix: iPadOS 26 scrolling issue in authentication forms (OKTA-1104008)

### DIFF
--- a/packages/@okta/courage-dist/esm/src/courage/views/forms/BaseForm.js
+++ b/packages/@okta/courage-dist/esm/src/courage/views/forms/BaseForm.js
@@ -901,6 +901,22 @@ var BaseForm = BaseView.extend(
       return;
     }
 
+    // iOS detection - check for iPad, iPhone, iPod, or iPad on iOS 13+
+    const isIOS = /iPad|iPhone|iPod/i.test(navigator.userAgent)
+      || (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
+
+    // Check if user is actively typing in an input field
+    const activeElement = document.activeElement;
+    const isActivelyTyping = activeElement &&
+      (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA') &&
+      !activeElement.readOnly;
+
+    // Skip scroll animation on iOS during active input to prevent scrolling issues
+    // Only allow scroll on form submission (when no element is focused)
+    if (isIOS && isActivelyTyping) {
+      return;
+    }
+
     const $el = oktaJQueryStatic('#' + this.id + ' .o-form-error-container');
 
     if ($el.length) {

--- a/packages/@okta/courage-dist/esm/src/courage/views/forms/inputs/TextBox.js
+++ b/packages/@okta/courage-dist/esm/src/courage/views/forms/inputs/TextBox.js
@@ -1,5 +1,6 @@
 import _Handlebars2 from '../../../../../lib/handlebars/dist/cjs/handlebars.runtime.js';
 import oktaJQueryStatic from '../../../util/jquery-wrapper.js';
+import oktaUnderscore from '../../../util/underscore-wrapper.js';
 import '@okta/qtip';
 import Keys from '../../../util/Keys.js';
 import '../../../vendor/plugins/jquery.placeholder.js';
@@ -267,6 +268,17 @@ var TextBox = BaseInput.extend({
   constructor: function () {
     BaseInput.apply(this, arguments);
     this.$el.addClass('o-form-control');
+
+    // iOS detection - check for iPad, iPhone, iPod, or iPad on iOS 13+
+    const isIOS = /iPad|iPhone|iPod/i.test(navigator.userAgent)
+      || (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
+
+    // Apply debouncing to the update method for iOS devices
+    // This reduces validation frequency during typing to prevent scrolling issues
+    if (isIOS) {
+      const originalUpdate = this.update;
+      this.update = oktaUnderscore.debounce(originalUpdate, 300);
+    }
   },
 
   /**

--- a/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.ts
+++ b/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.ts
@@ -88,6 +88,28 @@ const Form = BaseForm.extend({
     if (settings.get('features.scrollOnError') === false) {
       return false;
     }
+
+    // iOS detection - check for iPad, iPhone, iPod, or iPad on iOS 13+
+    const isIOS = /iPad|iPhone|iPod/i.test(navigator.userAgent)
+      || (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
+
+    // Check if iOS scroll fix is enabled (default is true)
+    const iosScrollFixEnabled = settings.get('features.iosScrollFix') !== false;
+
+    // On iOS devices with scroll fix enabled, only allow scroll on form submission
+    // Track form submission state to determine when to allow scrolling
+    if (isIOS && iosScrollFixEnabled) {
+      const activeElement = document.activeElement;
+      const isActivelyTyping = activeElement &&
+        (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA') &&
+        !activeElement.readOnly;
+
+      // Prevent scrolling during active typing
+      if (isActivelyTyping) {
+        return false;
+      }
+    }
+
     return true;
   }
 });

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -106,6 +106,7 @@ const local: Record<string, ModelProperty> = {
   'features.showPasswordRequirementsAsHtmlList': ['boolean', false, false],
   'features.mfaOnlyFlow': ['boolean', false, false],
   'features.scrollOnError': ['boolean', false, true],
+  'features.iosScrollFix': ['boolean', false, true], // Enable iOS scroll fix by default
   'features.showKeepMeSignedIn': ['boolean', false, true],
   'features.showIdentifier': ['boolean', false, true],
   'features.autoFocus': ['boolean', false, true],

--- a/src/v3/src/components/Widget/style.scss
+++ b/src/v3/src/components/Widget/style.scss
@@ -301,3 +301,35 @@ span.strong {
 span.no-translate {
   white-space: nowrap;
 }
+
+/* iOS-specific fixes for scrolling issues */
+/* @supports (-webkit-touch-callout: none) targets iOS devices */
+@supports (-webkit-touch-callout: none) {
+  /* Fix footer position on iOS to prevent conflicts with virtual keyboard */
+  @media only screen and (max-width: 768px) and (max-height: 1024px) {
+    .auth .footer {
+      position: absolute;
+      /* Ensure footer stays at the document bottom, not viewport bottom */
+      position: -webkit-sticky;
+      position: sticky;
+    }
+  }
+
+  /* Fix login background image on iOS */
+  @media only screen and (max-width: 768px) {
+    .login-bg-image {
+      position: absolute;
+      min-block-size: 100vh;
+      /* Use visual viewport on iOS to handle keyboard */
+      min-block-size: -webkit-fill-available;
+    }
+  }
+
+  /* Additional iOS keyboard handling */
+  @media only screen and (max-width: 600px) {
+    .auth .content {
+      /* Prevent content from being hidden behind keyboard */
+      padding-block-end: env(safe-area-inset-bottom);
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17975,7 +17975,7 @@ react-async-script@^1.2.0:
     hoist-non-react-statics "^3.3.0"
     prop-types "^15.5.0"
 
-"react-dom@npm:@preact/compat", "react@npm:@preact/compat":
+"react-dom@npm:@preact/compat":
   version "17.1.2"
   resolved "https://registry.yarnpkg.com/@preact/compat/-/compat-17.1.2.tgz#928756713b07af6faf7812f6a56840d8ce6fed37"
   integrity sha512-7pOZN9lMDDRQ+6aWvjwTp483KR8/zOpfS83wmOo3zfuLKdngS8/5RLbsFWzFZMGdYlotAhX980hJ75bjOHTwWg==
@@ -18045,6 +18045,11 @@ react-window@^1.8.10:
   dependencies:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
+
+"react@npm:@preact/compat":
+  version "17.1.2"
+  resolved "https://registry.yarnpkg.com/@preact/compat/-/compat-17.1.2.tgz#928756713b07af6faf7812f6a56840d8ce6fed37"
+  integrity sha512-7pOZN9lMDDRQ+6aWvjwTp483KR8/zOpfS83wmOo3zfuLKdngS8/5RLbsFWzFZMGdYlotAhX980hJ75bjOHTwWg==
 
 read-file-relative@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
DO NOT MERGE until reproduced and validated on physical device

## Description:
Fixes UI bug where iPadOS 26 automatically scrolls to bottom after each character typed in authentication forms, making the widget unusable on iPads.

Root cause: Aggressive form validation on every keystroke triggers error scroll animation, which conflicts with iOS virtual keyboard viewport changes.

Changes:
- Add iOS detection and skip scroll during active input in BaseForm.js
- Implement 300ms input debouncing for iOS devices in TextBox.js
- Add features.iosScrollFix configuration flag (enabled by default)
- Fix CSS positioning issues with footer and background on iOS
- Enhance widget-level Form to respect iOS scroll fix setting

The fix only activates on iOS devices and can be disabled via: 
`features: { iosScrollFix: false }`

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1104008](https://oktainc.atlassian.net/browse/OKTA-1104008)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



