### PR TITLE
(fix): Gen 3 input label overlap footer

### DIFF
--- a/src/v3/src/components/Widget/style.scss
+++ b/src/v3/src/components/Widget/style.scss
@@ -101,6 +101,7 @@
   p {
     margin-block: map.get($ods-tokens, 'spacing', '3');
   }
+  z-index: 1;
 }
 .auth .footer .footer-container {
   padding-inline: map.get($ods-tokens, spacing, '8');


### PR DESCRIPTION
## Description:

This PR fixes an issue in gen 3 where input labels would overlap the footer.


**Before:**

<img width="1773" height="284" alt="image" src="https://github.com/user-attachments/assets/f4971d54-78f2-4f88-bc96-a467d3756239" />


**After:**

<img width="1774" height="289" alt="image" src="https://github.com/user-attachments/assets/da9120fc-8ebb-44a3-a766-883a921397b5" />


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1016934](https://oktainc.atlassian.net/browse/OKTA-1016934)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



