### PR TITLE
OKTA-1068483 Pin Altcha to v2.3.0 and add SRI verification

### DIFF
--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -20,7 +20,8 @@ const OktaSignInWidgetOnCaptchaLoadedCallback = 'OktaSignInWidgetOnCaptchaLoaded
 const OktaSignInWidgetOnCaptchaSolvedCallback = 'OktaSignInWidgetOnCaptchaSolved';
 
 const HCAPTCHA_URL = 'https://hcaptcha.com/1/api.js';
-const ALTCHA_URL = 'https://cdn.jsdelivr.net/gh/altcha-org/altcha/dist/altcha.min.js';
+const ALTCHA_URL = 'https://cdn.jsdelivr.net/gh/altcha-org/altcha@2.3.0/dist/altcha.min.js';
+const ALTCHA_SRI_HASH = 'sha384-lxB6k+TvdhSBKnLm6JqwAnW7QxKXj88yK1kq9g3MevDXlG9HdWtnShLgJzuYCUIw';
 const RECAPTCHAV2_URL = 'https://www.google.com/recaptcha/api.js';
 
 const ALTCHA_CHALLENGE_PATH = '/api/v1/altcha';
@@ -271,6 +272,10 @@ export default View.extend({
 
     if (url.indexOf('altcha') !== -1) {
       scriptTag.type = 'module';
+      if (this.captchaConfig?.sriEnabled) {
+        scriptTag.integrity = ALTCHA_SRI_HASH;
+        scriptTag.crossOrigin = 'anonymous';
+      }
       scriptTag.onload = window[OktaSignInWidgetOnCaptchaLoadedCallback];
     }
 

--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -20,6 +20,11 @@ const OktaSignInWidgetOnCaptchaLoadedCallback = 'OktaSignInWidgetOnCaptchaLoaded
 const OktaSignInWidgetOnCaptchaSolvedCallback = 'OktaSignInWidgetOnCaptchaSolved';
 
 const HCAPTCHA_URL = 'https://hcaptcha.com/1/api.js';
+// ALTCHA_URL and ALTCHA_SRI_HASH must be updated together — changing one
+// without the other will silently break CAPTCHA.
+//
+// To regenerate the SRI hash after a version bump:
+//   echo "sha384-$(curl -s <new-url> | openssl dgst -sha384 -binary | openssl base64 -A)"
 const ALTCHA_URL = 'https://cdn.jsdelivr.net/gh/altcha-org/altcha@2.3.0/dist/altcha.min.js';
 const ALTCHA_SRI_HASH = 'sha384-lxB6k+TvdhSBKnLm6JqwAnW7QxKXj88yK1kq9g3MevDXlG9HdWtnShLgJzuYCUIw';
 const RECAPTCHAV2_URL = 'https://www.google.com/recaptcha/api.js';

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -18,6 +18,19 @@ const captchaAltchaObject = {
   }
 };
 
+const captchaAltchaWithSri = {
+  captcha: {
+    type: 'object',
+    value: {
+      id: 'altcha',
+      name: 'altcha',
+      siteKey: 'altcha-site-key',
+      type: 'ALTCHA',
+      sriEnabled: true
+    }
+  }
+};
+
 const captchaAltchaWithChallengeUrl = {
   captcha: {
     type: 'object',
@@ -201,7 +214,7 @@ describe('v2/view-builder/views/CaptchaView', function() {
     it('ALTCHA Captcha gets loaded with correct URL', function() {
       const spy = jest.spyOn(CaptchaView.prototype, '_loadCaptchaLib');
       testContext.init(captchaAltchaObject.captcha.value);
-      expect(spy).toHaveBeenCalledWith('https://cdn.jsdelivr.net/gh/altcha-org/altcha/dist/altcha.min.js');
+      expect(spy).toHaveBeenCalledWith('https://cdn.jsdelivr.net/gh/altcha-org/altcha@2.3.0/dist/altcha.min.js');
     });
 
     it('ALTCHA uses altcha-captcha class in template', function() {
@@ -407,6 +420,34 @@ describe('v2/view-builder/views/CaptchaView', function() {
       const scriptTag = appendChildSpy.mock.calls[0][0];
       expect(scriptTag.type).toBe('module');
       expect(scriptTag.src).toContain('altcha');
+    });
+
+    it('ALTCHA script tag includes SRI integrity and crossorigin attributes when sriEnabled is true', function() {
+      const appendChildSpy = jest.fn();
+      jest.spyOn(window.document, 'getElementById').mockReturnValue({
+        appendChild: appendChildSpy
+      });
+
+      testContext.init(captchaAltchaWithSri.captcha.value);
+
+      expect(appendChildSpy).toHaveBeenCalled();
+      const scriptTag = appendChildSpy.mock.calls[0][0];
+      expect(scriptTag.integrity).toBe('sha384-lxB6k+TvdhSBKnLm6JqwAnW7QxKXj88yK1kq9g3MevDXlG9HdWtnShLgJzuYCUIw');
+      expect(scriptTag.crossOrigin).toBe('anonymous');
+    });
+
+    it('ALTCHA script tag does not include SRI attributes when sriEnabled is absent', function() {
+      const appendChildSpy = jest.fn();
+      jest.spyOn(window.document, 'getElementById').mockReturnValue({
+        appendChild: appendChildSpy
+      });
+
+      testContext.init(captchaAltchaObject.captcha.value);
+
+      expect(appendChildSpy).toHaveBeenCalled();
+      const scriptTag = appendChildSpy.mock.calls[0][0];
+      expect(scriptTag.integrity).toBe('');
+      expect(scriptTag.crossOrigin).toBe('');
     });
   });
 });

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -446,8 +446,8 @@ describe('v2/view-builder/views/CaptchaView', function() {
 
       expect(appendChildSpy).toHaveBeenCalled();
       const scriptTag = appendChildSpy.mock.calls[0][0];
-      expect(scriptTag.integrity).toBe('');
-      expect(scriptTag.crossOrigin).toBeNull();
+      expect(scriptTag.integrity).toBeFalsy();
+      expect(scriptTag.crossOrigin).toBeFalsy();
     });
   });
 });

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -447,7 +447,7 @@ describe('v2/view-builder/views/CaptchaView', function() {
       expect(appendChildSpy).toHaveBeenCalled();
       const scriptTag = appendChildSpy.mock.calls[0][0];
       expect(scriptTag.integrity).toBe('');
-      expect(scriptTag.crossOrigin).toBe('');
+      expect(scriptTag.crossOrigin).toBeNull();
     });
   });
 });

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -446,8 +446,8 @@ describe('v2/view-builder/views/CaptchaView', function() {
 
       expect(appendChildSpy).toHaveBeenCalled();
       const scriptTag = appendChildSpy.mock.calls[0][0];
-      expect(scriptTag.integrity).toBeUndefined();
-      expect(scriptTag.crossOrigin).toBeUndefined();
+      expect(scriptTag.getAttribute('integrity')).toBeNull();
+      expect(scriptTag.getAttribute('crossorigin')).toBeNull();
     });
   });
 });

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -446,8 +446,8 @@ describe('v2/view-builder/views/CaptchaView', function() {
 
       expect(appendChildSpy).toHaveBeenCalled();
       const scriptTag = appendChildSpy.mock.calls[0][0];
-      expect(scriptTag.integrity).toBeFalsy();
-      expect(scriptTag.crossOrigin).toBeFalsy();
+      expect(scriptTag.integrity).toBeUndefined();
+      expect(scriptTag.crossOrigin).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Description

Pins the Altcha CAPTCHA library to v2.3.0 and adds Subresource Integrity (SRI) verification for the CDN-loaded script. When the server sends `sriEnabled: true` in the captcha config, the widget sets `integrity` (SHA-384) and `crossOrigin="anonymous"` on the script tag, ensuring the browser blocks any tampered or modified script.

**Associated FF(s)**: `sriEnabled` flag sent from server captcha config
**Associated CCS**: N/A
**Rollout plan**: Merge to master, ships with next widget release
**Rollback plan**: Revert PR
**Test coverage**: Unit tests for SRI attributes (enabled and absent). Existing URL test updated for pinned version.
**Risk assessment**: Low — additive security hardening. If CDN serves a modified script, the browser blocks it (fail-closed). No functional change when hash matches.

## Changes

- Pin Altcha CDN URL to `@2.3.0` (was unpinned `altcha-org/altcha/dist/...`)
- Add `integrity` (SHA-384) and `crossOrigin="anonymous"` attributes when `sriEnabled` is true
- Add `captchaAltchaWithSri` test fixture
- Add unit tests for SRI-enabled and SRI-absent scenarios
- Update existing URL test to match pinned version