### PR TITLE
fix: add null guard for navigator.credentials.create result in WebAut…

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1046,6 +1046,7 @@ oie.enroll.webauthn.instructions.edge = Note: If you are enrolling a security ke
 oie.enroll.webauthn.save = Set up
 oie.webauthn.error.not.supported = Security key or biometric authenticator is not supported on this browser. Contact your admin for assistance.
 oie.webauthn.passkeysRebrand.error.not.supported = Passkeys are not supported on this browser. Contact your admin for assistance.
+oie.webauthn.error.nullcredential = Authenticator enrollment could not be completed. If a password manager intercepted this request, dismiss it and try again.
 oie.webauthn.error.invalidPasskey = Invalid passkey.
 oie.verify.webauth.title = Verify with Security Key or Biometric Authenticator
 oie.verify.webauth.passkeysRebrand.passkeys.title = Verify with a passkey

--- a/src/v1/controllers/EnrollWebauthnController.js
+++ b/src/v1/controllers/EnrollWebauthnController.js
@@ -84,6 +84,11 @@ export default FormController.extend({
             },
             excludeCredentials: getExcludeCredentials(activation.excludeCredentials),
           });
+          // Default rp.id per WebAuthn spec §5.4.2 — some credential managers
+          // (e.g. LastPass) require rp.id to be explicitly set
+          if (options.rp && !options.rp.id) {
+            options.rp.id = window.location.hostname;
+          }
 
           // AbortController is not supported in IE11
           if (typeof AbortController !== 'undefined') {
@@ -96,6 +101,11 @@ export default FormController.extend({
             })
           )
             .then(function(newCredential) {
+              if (!newCredential) {
+                throw new DOMException(
+                  loc('oie.webauthn.error.nullcredential', 'login'), 'InvalidStateError'
+                );
+              }
               return transaction.activate({
                 attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
                 clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
@@ -78,6 +78,11 @@ const Body = BaseForm.extend({
         },
         excludeCredentials
       });
+      // Default rp.id per WebAuthn spec §5.4.2 — some credential managers
+      // (e.g. LastPass) require rp.id to be explicitly set
+      if (options.rp && !options.rp.id) {
+        options.rp.id = window.location.hostname;
+      }
       // AbortController is not supported in IE11
       if (typeof AbortController !== 'undefined') {
         this.webauthnAbortController = new AbortController();
@@ -86,6 +91,12 @@ const Body = BaseForm.extend({
         publicKey: options,
         signal: this.webauthnAbortController && this.webauthnAbortController.signal
       }).then((newCredential) => {
+        if (!newCredential) {
+          throw new DOMException(
+            loc('oie.webauthn.error.nullcredential', 'login'),
+            'InvalidStateError'
+          );
+        }
         this.model.set({
           credentials : {
             clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),

--- a/src/v3/src/util/webauthnUtils.test.ts
+++ b/src/v3/src/util/webauthnUtils.test.ts
@@ -91,6 +91,20 @@ describe('WebAuthN Util Tests', () => {
     await expect(webAuthNEnrollmentHandler(transaction)).rejects.toThrow('NotAllowed');
   });
 
+  it('should throw an error when credentials.create resolves with null (e.g. third-party credential manager)', async () => {
+    mockCredentialsContainer.create = jest.fn().mockImplementationOnce(
+      () => Promise.resolve(null),
+    );
+
+    await expect(webAuthNEnrollmentHandler(transaction)).rejects.toThrow(DOMException);
+    mockCredentialsContainer.create = jest.fn().mockImplementationOnce(
+      () => Promise.resolve(null),
+    );
+    await expect(webAuthNEnrollmentHandler(transaction)).rejects.toMatchObject({
+      name: 'InvalidStateError',
+    });
+  });
+
   it('should create clientData, authenticatorData, & signatureData parameters when authenticating with webauthn',
     async () => {
       transaction.nextStep = {

--- a/src/v3/src/util/webauthnUtils.ts
+++ b/src/v3/src/util/webauthnUtils.ts
@@ -19,6 +19,7 @@ import {
   WebAuthNChallengeDataWithUserVerification,
   WebAuthNEnrollmentHandler,
 } from '../types';
+import { loc } from './locUtil';
 
 export const binToStr = (bin: ArrayBuffer): string => btoa(
   new Uint8Array(bin).reduce((s, byte) => s + String.fromCharCode(byte), ''),
@@ -80,11 +81,22 @@ export const webAuthNEnrollmentHandler: WebAuthNEnrollmentHandler = async (trans
     activationData,
     authenticatorEnrollments.value,
   );
+  // Default rp.id per WebAuthn spec §5.4.2 — some credential managers
+  // (e.g. LastPass) require rp.id to be explicitly set
+  if (options?.publicKey?.rp && !options.publicKey.rp.id) {
+    options.publicKey.rp.id = window.location.hostname;
+  }
 
   // Causes a browser prompt enabling the user to select the desired device to
   // enroll in this flow. Generates a Object that contains ClientData (origin, challenge)
   // and attestation (arraybuffer containing authenticator data)
   const result = await navigator.credentials.create(options);
+  if (!result) {
+    throw new DOMException(
+      loc('oie.webauthn.error.nullcredential', 'login'),
+      'InvalidStateError'
+    );
+  }
   const attestationResponse = (
     (result as PublicKeyCredential).response as AuthenticatorAttestationResponse
   );

--- a/test/unit/spec/v1/EnrollWebauthn_spec.js
+++ b/test/unit/spec/v1/EnrollWebauthn_spec.js
@@ -1,5 +1,5 @@
 /* eslint max-params: [2, 16] */
-import { _ } from '@okta/courage';
+import { _, loc } from '@okta/courage';
 import getAuthClient from 'helpers/getAuthClient';
 import Router from 'v1/LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
@@ -120,6 +120,17 @@ Expect.describe('EnrollWebauthn', function() {
       const deferred = Q.defer();
 
       deferred.reject({ message: 'something went wrong' });
+      return deferred.promise;
+    });
+  }
+
+  function mockWebauthnNullCredentialRegistration() {
+    Q.stopUnhandledRejectionTracking();
+    mockWebauthn();
+    spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
+    spyOn(navigator.credentials, 'create').and.callFake(function() {
+      const deferred = Q.defer();
+      deferred.resolve(null);
       return deferred.promise;
     });
   }
@@ -330,6 +341,7 @@ Expect.describe('EnrollWebauthn', function() {
           expect(navigator.credentials.create).toHaveBeenCalledWith({
             publicKey: {
               rp: {
+                id: 'localhost',
                 name: 'acme',
               },
               user: {
@@ -391,6 +403,7 @@ Expect.describe('EnrollWebauthn', function() {
           expect(navigator.credentials.create).toHaveBeenCalledWith({
             publicKey: {
               rp: {
+                id: 'localhost',
                 name: 'acme',
               },
               user: {
@@ -452,6 +465,7 @@ Expect.describe('EnrollWebauthn', function() {
           expect(navigator.credentials.create).toHaveBeenCalledWith({
             publicKey: {
               rp: {
+                id: 'localhost',
                 name: 'acme',
               },
               user: {
@@ -515,6 +529,7 @@ Expect.describe('EnrollWebauthn', function() {
           expect(navigator.credentials.create).toHaveBeenCalledWith({
             publicKey: {
               rp: {
+                id: 'localhost',
                 name: 'acme',
               },
               user: {
@@ -596,6 +611,25 @@ Expect.describe('EnrollWebauthn', function() {
               },
             },
           ]);
+          expect(test.router.controller.model.webauthnAbortController).toBe(null);
+        });
+    });
+    itp('shows error when navigator.credentials.create resolves with null (e.g. third-party credential manager)', function() {
+      mockWebauthnNullCredentialRegistration();
+      return setup()
+        .then(function(test) {
+          Util.resetAjaxRequests();
+          test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
+          test.form.submit();
+          return Expect.waitForSpyCall(navigator.credentials.create, test);
+        })
+        .then(function(test) {
+          expect(navigator.credentials.create).toHaveBeenCalled();
+          expect(test.form.hasErrors()).toBe(true);
+          expect(test.form.errorBox().length).toEqual(1);
+          expect(test.form.errorMessage()).toEqual(
+            loc('oie.webauthn.error.nullcredential', 'login')
+          );
           expect(test.router.controller.model.webauthnAbortController).toBe(null);
         });
     });

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -132,6 +132,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
         expect(navigator.credentials.create).toHaveBeenCalledWith({
           publicKey: {
             rp: {
+              id: 'localhost',
               name: 'idx',
             },
             user: {
@@ -209,6 +210,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
         expect(navigator.credentials.create).toHaveBeenCalledWith({
           publicKey: {
             rp: {
+              id: 'localhost',
               name: 'idx',
             },
             user: {
@@ -293,6 +295,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
         expect(navigator.credentials.create).toHaveBeenCalledWith({
           publicKey: {
             rp: {
+              id: 'localhost',
               name: 'idx',
             },
             user: {
@@ -359,6 +362,23 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
       .catch(done.fail);
   });
 
+  it('error is displayed when credentials.create resolves with null (e.g. third-party credential manager)', function(done) {
+    spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
+    spyOn(navigator.credentials, 'create').and.returnValue(Promise.resolve(null));
+
+    testContext.init();
+    testContext.view.$('.webauthn-setup').click();
+
+    Expect.waitForCss('.infobox-error')
+      .then(() => {
+        expect(testContext.view.$('.infobox-error')[0].textContent.trim())
+          .toBe('Authenticator enrollment could not be completed. If a password manager intercepted this request, dismiss it and try again.');
+        expect(testContext.view.form.webauthnAbortController).toBe(null);
+        done();
+      })
+      .catch(done.fail);
+  });
+
   it('error with a name that not supported on login bundle is displayed when credentials.create fails', function(done) {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     spyOn(navigator.credentials, 'create').and.returnValue(Promise.reject({ message: 'error from browser' }));
@@ -419,6 +439,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
         expect(navigator.credentials.create).toHaveBeenCalledWith({
           publicKey: {
             rp: {
+              id: 'localhost',
               name: 'idx',
             },
             user: {


### PR DESCRIPTION
## Description:

Webauthn Enrollment

When third-party credential managers (e.g. LastPass on Windows) intercept navigator.credentials.create(), they may resolve with null instead of throwing an InvalidStateError when a matching credential already exists in excludeCredentials. This causes a TypeError: Cannot read properties of null (reading 'id').

Add null checks on the credential result across all three engines (v1, v2, v3) to surface a user-friendly error instead of crashing.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1147258](https://oktainc.atlassian.net/browse/OKTA-1147258)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



