### PR TITLE
Okta 1145765 uber bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "webpack-dev-server": "^4.15.2"
   },
   "dependencies": {
-    "@okta/okta-auth-js": "7.14.0",
+    "@okta/okta-auth-js": "7.14.2",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "@types/backbone": "^1.4.15",
     "@types/eslint-scope": "^3.7.3",

--- a/playground/mocks/data/idp/idx/authenticator-enroll-webauthn-custom.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-webauthn-custom.json
@@ -97,6 +97,7 @@
           "authenticatorSelection": {
             "userVerification": "discouraged"
           },
+          "hints": ["security-key"],
           "u2fParams": {
             "appid": "http://idx.okta1.com:1802"
           }

--- a/playground/mocks/data/idp/idx/authenticator-enroll-webauthn-passkeys.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-webauthn-passkeys.json
@@ -96,6 +96,7 @@
           "authenticatorSelection": {
             "userVerification": "discouraged"
           },
+          "hints": ["client-device"],
           "u2fParams": {
             "appid": "http://idx.okta1.com:1802"
           }

--- a/playground/mocks/data/idp/idx/authenticator-enroll-webauthn.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-webauthn.json
@@ -213,6 +213,7 @@
           "authenticatorSelection": {
             "userVerification": "discouraged"
           },
+          "hints": ["security-key"],
           "u2fParams": {
             "appid": "http://idx.okta1.com:1802"
           }

--- a/playground/mocks/data/idp/idx/authenticator-verification-webauthn-custom.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-webauthn-custom.json
@@ -63,6 +63,7 @@
         "challengeData": {
           "challenge": "qjUCU0xoVe5QZ3-etDCD",
           "userVerification": "discouraged",
+          "hints": ["security-key"],
           "extensions": {
             "appid": "https://localhost:3000"
           }

--- a/playground/mocks/data/idp/idx/authenticator-verification-webauthn-passkeys.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-webauthn-passkeys.json
@@ -63,6 +63,7 @@
         "challengeData": {
           "challenge": "qjUCU0xoVe5QZ3-etDCD",
           "userVerification": "discouraged",
+          "hints": ["client-device"],
           "extensions": {
             "appid": "https://localhost:3000"
           }

--- a/playground/mocks/data/idp/idx/authenticator-verification-webauthn.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-webauthn.json
@@ -189,6 +189,7 @@
         "challengeData": {
           "challenge": "qjUCU0xoVe5QZ3-etDCD",
           "userVerification": "required",
+          "hints": ["security-key"],
           "extensions": {
             "appid": "https://localhost:3000"
           }
@@ -297,7 +298,8 @@
         "key": "webauthn",
         "id": "autwa6eD9o02iBbtv0g2",
         "authenticatorId": "aidtheidkwh282hv8g3",
-        "credentialId": "hpxQXbu5R5Y2JMqpvtE9Oo9FdwO6z2kMR-ZQkAb6p6GSguXQ57oVXKvpVHT2fyCR_m2EL1vIgszxi00kyFIX6w"
+        "credentialId": "hpxQXbu5R5Y2JMqpvtE9Oo9FdwO6z2kMR-ZQkAb6p6GSguXQ57oVXKvpVHT2fyCR_m2EL1vIgszxi00kyFIX6w",
+        "transports": ["usb", "nfc"]
       },
       {
         "displayName": "MacBook Touch ID",
@@ -305,7 +307,8 @@
         "key": "webauthn",
         "id": "autwa6eD9o02iBbtv0g2",
         "authenticatorId": "fwftheidkwh282hv8g3",
-        "credentialId": "7Ag2iWUqfz0SanWDj-ZZ2fpDsgiEDt_08O1VSSRZHpgkUS1zhLSyWYDrxXXB5VE_w1iiqSvPaRgXcmG5rPwB-w"
+        "credentialId": "7Ag2iWUqfz0SanWDj-ZZ2fpDsgiEDt_08O1VSSRZHpgkUS1zhLSyWYDrxXXB5VE_w1iiqSvPaRgXcmG5rPwB-w",
+        "transports": ["internal"]
       },
       {
         "displayName": "Okta Email",

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -370,6 +370,12 @@ const Body = BaseForm.extend({
       .then((assertion) => {
         this.remediateWithAssertion(assertion, RemediationForms.LAUNCH_PASSKEYS_AUTHENTICATOR);
       }, (error) => {
+        if (webauthn.isRelyingPartyIdMismatchError(error)) {
+          const rpId = this.options.appState.get('webauthnAutofillUIChallenge')?.challengeData?.rpId;
+          const errorSummary = loc('signin.passkeys.error.rpIdMismatch', 'login', [rpId]);
+          this.model.trigger('error', this.model, this._generateErrorObject(errorSummary));
+          return;
+        }
         this._handleWebAuthnError(error);
       })
       .finally(() => {

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -88,8 +88,9 @@ const Body = BaseForm.extend({
           type: 'public-key',
           id: CryptoUtil.strToBin(enrollement.credentialId),
         };
-        if (Array.isArray(enrollement.transports)) {
-          credential.transports = enrollement.transports;
+        const transports = enrollement.transports ?? enrollement.profile?.transports;
+        if (Array.isArray(transports)) {
+          credential.transports = transports;
         }
         allowCredentials.push(credential);
       }

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -84,10 +84,14 @@ const Body = BaseForm.extend({
     const authenticatorEnrollments = this.options.appState.get('authenticatorEnrollments')?.value || [];
     authenticatorEnrollments.forEach((enrollement) => {
       if (enrollement.key === 'webauthn') {
-        allowCredentials.push({
+        const credential = {
           type: 'public-key',
           id: CryptoUtil.strToBin(enrollement.credentialId),
-        });
+        };
+        if (Array.isArray(enrollement.transports)) {
+          credential.transports = enrollement.transports;
+        }
+        allowCredentials.push(credential);
       }
     });
     const challengeData = authenticatorData.contextualData.challengeData;

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -123,6 +123,21 @@ const Body = BaseForm.extend({
       });
       this.saveForm(this.model);
     }, (error) => {
+      // Override the default browser RP ID mismatch error in order to provide
+      // a more user friendly error and have it localized
+      if (webauthn.isRelyingPartyIdMismatchError(error)) {
+        this.model.trigger('error', this.model, {
+          responseJSON: {
+            errorSummary: loc(
+              'signin.passkeys.error.rpIdMismatch',
+              'login',
+              [authenticatorData.contextualData.challengeData.rpId]
+            )
+          }
+        });
+        return;
+      }
+
       // Do not display if it is abort error triggered by code when switching.
       // this.webauthnAbortController would be null if abort was triggered by code.
       if (this.webauthnAbortController) {

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
@@ -12,10 +12,15 @@ function getExcludeCredentials(authenticatorEnrollments = []) {
   const credentials = [];
   authenticatorEnrollments.forEach((enrollement) => {
     if (enrollement.key === 'webauthn') {
-      credentials.push({
+      const credential = {
         type: 'public-key',
         id: CryptoUtil.strToBin(enrollement.credentialId),
-      });
+      };
+      const transports = enrollement.transports ?? enrollement.profile?.transports;
+      if (Array.isArray(transports)) {
+        credential.transports = transports;
+      }
+      credentials.push(credential);
     }
   });
   return credentials;
@@ -86,12 +91,14 @@ const Body = BaseForm.extend({
         publicKey: options,
         signal: this.webauthnAbortController && this.webauthnAbortController.signal
       }).then((newCredential) => {
+        // example data: ["nfc", "usb"]
+        const transports =
+          webauthn.processWebAuthnResponse(newCredential.response.getTransports, newCredential.response);
         this.model.set({
           credentials : {
             clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),
             attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
-            // example data: ["nfc", "usb"]
-            transports: webauthn.processWebAuthnResponse(newCredential.response.getTransports, newCredential.response),
+            ...(transports !== null && { transports }),
             // example data: {"credProps":{"rk":true}}
             clientExtensions: webauthn.processWebAuthnResponse(newCredential.getClientExtensionResults, newCredential)
           }

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
@@ -106,6 +106,16 @@ const Body = BaseForm.extend({
         this.saveForm(this.model);
       })
         .catch((error) => {
+          // Override the default browser RP ID mismatch error in order to provide
+          // a more user friendly error and have it localized
+          if (webauthn.isRelyingPartyIdMismatchError(error)) {
+            this.model.trigger('error', this.model, {
+              responseJSON: {
+                errorSummary: loc('signin.passkeys.error.SecurityError', 'login')
+              }
+            });
+            return;
+          }
           this.model.trigger('error', this.model, {responseJSON: {errorSummary: getMessageFromBrowserError(error)}});
         }).finally(() => {
           this.webauthnAbortController = null;

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -54,7 +54,7 @@
     "@mui/material": "^5.8.5",
     "@okta/odyssey-design-tokens": "1.44.0",
     "@okta/odyssey-react-mui": "1.44.0",
-    "@okta/okta-auth-js": "7.14.0",
+    "@okta/okta-auth-js": "7.14.2",
     "altcha": "^1.4.2",
     "chroma-js": "^2.4.2",
     "cross-fetch": "^3.1.5",

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -191,6 +191,11 @@ export type WebAuthNEnrollmentPayload = {
      * for a newly-created key pair.
      */
     attestation: string;
+    /**
+     * JSON-serialized array of transport types supported by the authenticator.
+     * Omitted if getTransports() is not supported by the browser.
+     */
+    transports?: string;
   }
 };
 

--- a/src/v3/src/util/webauthnUtils.test.ts
+++ b/src/v3/src/util/webauthnUtils.test.ts
@@ -53,7 +53,11 @@ describe('WebAuthN Util Tests', () => {
           signatureData: 'ghi',
         } as WebauthnVerificationValues),
       ),
-      getAttestation: jest.fn(),
+      getAttestation: jest.fn().mockReturnValue({
+        id: 'test-id',
+        clientData: 'mock-client-data',
+        attestation: 'mock-attestation',
+      }),
     };
     OktaAuth.webauthn = mockedWebauthn;
   });
@@ -77,10 +81,37 @@ describe('WebAuthN Util Tests', () => {
     } as RawIdxResponse;
     const { credentials } = await webAuthNEnrollmentHandler(transaction);
 
-    expect(credentials.clientData).not.toBeUndefined();
-    expect(credentials.attestation).not.toBeUndefined();
+    expect(credentials.clientData).toBe('mock-client-data');
+    expect(credentials.attestation).toBe('mock-attestation');
+    expect(credentials.transports).toBeUndefined();
     expect(mockedWebauthn.buildCredentialCreationOptions).toHaveBeenCalled();
+    expect(mockedWebauthn.getAttestation).toHaveBeenCalled();
     expect(mockCredentialsContainer.create).toHaveBeenCalled();
+  });
+
+  it('should return transports when getAttestation includes them', async () => {
+    mockedWebauthn.getAttestation = jest.fn().mockReturnValue({
+      id: 'test-id',
+      clientData: 'mock-client-data',
+      attestation: 'mock-attestation',
+      transports: '["usb","nfc"]',
+    });
+
+    transaction.nextStep = {
+      name: 'mock-step',
+      relatesTo: {
+        value: {
+          contextualData: { activationData: 'abc123' },
+        } as unknown as IdxAuthenticator,
+      },
+    };
+    transaction.rawIdxState = {
+      ...transaction.rawIdxState,
+      authenticatorEnrollments: { value: [{ credentialId: '123456' }] },
+    } as RawIdxResponse;
+    const { credentials } = await webAuthNEnrollmentHandler(transaction);
+
+    expect(credentials.transports).toEqual('["usb","nfc"]');
   });
 
   it('should throw an error when browser credentials prompt is interrupted while enrolling with webauthn', async () => {

--- a/src/v3/src/util/webauthnUtils.test.ts
+++ b/src/v3/src/util/webauthnUtils.test.ts
@@ -20,7 +20,38 @@ import {
 } from '@okta/okta-auth-js';
 import { getMockCreateCredentialsResponse, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
 
-import { webAuthNAuthenticationHandler, webAuthNEnrollmentHandler } from '.';
+import { isRelyingPartyIdMismatchError, webAuthNAuthenticationHandler, webAuthNEnrollmentHandler } from '.';
+
+jest.mock('./locUtil', () => ({
+  loc: jest.fn().mockImplementation((key: string, _bundle: string, params?: unknown[]) => {
+    if (params?.length) {
+      return `${key}:${params.join(',')}`;
+    }
+    return key;
+  }),
+}));
+
+describe('isRelyingPartyIdMismatchError', () => {
+  it('should return true for a DOMException with name SecurityError and code 18', () => {
+    const error = new DOMException('RP ID mismatch', 'SecurityError');
+    expect(isRelyingPartyIdMismatchError(error)).toBe(true);
+  });
+
+  it('should return false for a regular Error', () => {
+    expect(isRelyingPartyIdMismatchError(new Error('SecurityError'))).toBe(false);
+  });
+
+  it('should return false for a DOMException with a different name', () => {
+    const error = new DOMException('not allowed', 'NotAllowedError');
+    expect(isRelyingPartyIdMismatchError(error)).toBe(false);
+  });
+
+  it('should return false for non-error values', () => {
+    expect(isRelyingPartyIdMismatchError(null)).toBe(false);
+    expect(isRelyingPartyIdMismatchError(undefined)).toBe(false);
+    expect(isRelyingPartyIdMismatchError('string')).toBe(false);
+  });
+});
 
 describe('WebAuthN Util Tests', () => {
   const transaction = getStubTransactionWithNextStep();
@@ -122,6 +153,15 @@ describe('WebAuthN Util Tests', () => {
     await expect(webAuthNEnrollmentHandler(transaction)).rejects.toThrow('NotAllowed');
   });
 
+  it('should throw localized SecurityError when credentials.create rejects with RP ID mismatch', async () => {
+    mockCredentialsContainer.create = jest.fn().mockRejectedValueOnce(
+      new DOMException('RP ID mismatch', 'SecurityError'),
+    );
+
+    await expect(webAuthNEnrollmentHandler(transaction))
+      .rejects.toThrow('signin.passkeys.error.SecurityError');
+  });
+
   it('should create clientData, authenticatorData, & signatureData parameters when authenticating with webauthn',
     async () => {
       transaction.nextStep = {
@@ -154,5 +194,29 @@ describe('WebAuthN Util Tests', () => {
     );
 
     await expect(webAuthNAuthenticationHandler(transaction)).rejects.toThrow('NotAllowed');
+  });
+
+  it('should throw localized rpIdMismatch error with rpId when credentials.get rejects with RP ID mismatch', async () => {
+    mockCredentialsContainer.get = jest.fn().mockRejectedValueOnce(
+      new DOMException('RP ID mismatch', 'SecurityError'),
+    );
+
+    transaction.nextStep = {
+      name: 'mock-step',
+      relatesTo: {
+        value: {
+          contextualData: {
+            challengeData: { rpId: 'example.okta.com' } as ChallengeData,
+          },
+        } as IdxAuthenticator,
+      },
+    };
+    transaction.rawIdxState = {
+      ...transaction.rawIdxState,
+      authenticatorEnrollments: { value: [{ credentialId: '123456' }] },
+    } as RawIdxResponse;
+
+    await expect(webAuthNAuthenticationHandler(transaction))
+      .rejects.toThrow('signin.passkeys.error.rpIdMismatch:example.okta.com');
   });
 });

--- a/src/v3/src/util/webauthnUtils.ts
+++ b/src/v3/src/util/webauthnUtils.ts
@@ -85,15 +85,13 @@ export const webAuthNEnrollmentHandler: WebAuthNEnrollmentHandler = async (trans
   // enroll in this flow. Generates a Object that contains ClientData (origin, challenge)
   // and attestation (arraybuffer containing authenticator data)
   const result = await navigator.credentials.create(options);
-  const attestationResponse = (
-    (result as PublicKeyCredential).response as AuthenticatorAttestationResponse
+
+  // Extracts clientData, attestation, and transports from the credential response
+  const { id, ...credentials } = OktaAuth.webauthn.getAttestation(
+    result as PublicKeyCredential,
   );
 
-  // converts they arrayBuffer into a string to pass to Idx
-  const clientData = binToStr(attestationResponse.clientDataJSON);
-  const attestation = binToStr(attestationResponse.attestationObject);
-
-  return { credentials: { clientData, attestation } };
+  return { credentials };
 };
 
 /**

--- a/src/v3/src/util/webauthnUtils.ts
+++ b/src/v3/src/util/webauthnUtils.ts
@@ -103,7 +103,7 @@ export const webAuthNEnrollmentHandler: WebAuthNEnrollmentHandler = async (trans
   }
 
   // Extracts clientData, attestation, and transports from the credential response
-  const { id, ...credentials } = OktaAuth.webauthn.getAttestation(
+  const { id: _id, ...credentials } = OktaAuth.webauthn.getAttestation(
     result as PublicKeyCredential,
   );
 

--- a/src/v3/src/util/webauthnUtils.ts
+++ b/src/v3/src/util/webauthnUtils.ts
@@ -19,6 +19,7 @@ import {
   WebAuthNChallengeDataWithUserVerification,
   WebAuthNEnrollmentHandler,
 } from '../types';
+import { loc } from './locUtil';
 
 export const binToStr = (bin: ArrayBuffer): string => btoa(
   new Uint8Array(bin).reduce((s, byte) => s + String.fromCharCode(byte), ''),
@@ -55,6 +56,13 @@ export const isPasskeyAutofillAvailable = async () => {
 };
 
 export const isGetPasskeyAvailable = () => isCredentialsGetApiAvailable() && typeof PublicKeyCredential !== 'undefined';
+
+export const isRelyingPartyIdMismatchError = (
+  error: unknown,
+): boolean => error instanceof DOMException
+  && error.name === 'SecurityError'
+  && error.code === 18;
+
 /**
  * Uses the Web Authentication API to generate credentials for enrolling
  * a user into the WebAuthN flow
@@ -81,10 +89,18 @@ export const webAuthNEnrollmentHandler: WebAuthNEnrollmentHandler = async (trans
     authenticatorEnrollments.value,
   );
 
-  // Causes a browser prompt enabling the user to select the desired device to
-  // enroll in this flow. Generates a Object that contains ClientData (origin, challenge)
-  // and attestation (arraybuffer containing authenticator data)
-  const result = await navigator.credentials.create(options);
+  let result: Credential | null;
+  try {
+    // Causes a browser prompt enabling the user to select the desired device to
+    // enroll in this flow. Generates a Object that contains ClientData (origin, challenge)
+    // and attestation (arraybuffer containing authenticator data)
+    result = await navigator.credentials.create(options);
+  } catch (error) {
+    if (isRelyingPartyIdMismatchError(error)) {
+      throw new Error(loc('signin.passkeys.error.SecurityError', 'login'));
+    }
+    throw error;
+  }
 
   // Extracts clientData, attestation, and transports from the credential response
   const { id, ...credentials } = OktaAuth.webauthn.getAttestation(
@@ -119,9 +135,17 @@ export const webAuthNAuthenticationHandler: WebAuthNAuthenticationHandler = asyn
     authenticatorEnrollments.value,
   );
 
-  // Triggers a browser prompt allowing the user to provide consent based on the options
-  // passed to this method to collect their credentials.
-  const credentials = await navigator.credentials.get(options) as PublicKeyCredential;
+  let credentials: PublicKeyCredential;
+  try {
+    // Triggers a browser prompt allowing the user to provide consent based on the options
+    // passed to this method to collect their credentials.
+    credentials = await navigator.credentials.get(options) as PublicKeyCredential;
+  } catch (error) {
+    if (isRelyingPartyIdMismatchError(error)) {
+      throw new Error(loc('signin.passkeys.error.rpIdMismatch', 'login', [challengeData?.rpId]));
+    }
+    throw error;
+  }
 
   // Extracts the key properties from the credentials object and returns.
   // for some reason generic remediator does not allow/expect id field and fails when passed

--- a/src/v3/src/util/webauthnUtils.ts
+++ b/src/v3/src/util/webauthnUtils.ts
@@ -57,9 +57,10 @@ export const isPasskeyAutofillAvailable = async () => {
 
 export const isGetPasskeyAvailable = () => isCredentialsGetApiAvailable() && typeof PublicKeyCredential !== 'undefined';
 
-export const isRelyingPartyIdMismatchError = (error: unknown): boolean =>
-  (error as DOMException)?.name === 'SecurityError' &&
-  (error as DOMException)?.code === 18;
+export const isRelyingPartyIdMismatchError = (error: unknown): boolean => (
+  (error as DOMException)?.name === 'SecurityError'
+  && (error as DOMException)?.code === 18
+);
 
 /**
  * Uses the Web Authentication API to generate credentials for enrolling

--- a/src/v3/src/util/webauthnUtils.ts
+++ b/src/v3/src/util/webauthnUtils.ts
@@ -57,11 +57,9 @@ export const isPasskeyAutofillAvailable = async () => {
 
 export const isGetPasskeyAvailable = () => isCredentialsGetApiAvailable() && typeof PublicKeyCredential !== 'undefined';
 
-export const isRelyingPartyIdMismatchError = (
-  error: unknown,
-): boolean => error instanceof DOMException
-  && error.name === 'SecurityError'
-  && error.code === 18;
+export const isRelyingPartyIdMismatchError = (error: unknown): boolean =>
+  (error as DOMException)?.name === 'SecurityError' &&
+  (error as DOMException)?.code === 18;
 
 /**
  * Uses the Web Authentication API to generate credentials for enrolling

--- a/src/v3/src/util/webauthnUtils.ts
+++ b/src/v3/src/util/webauthnUtils.ts
@@ -103,7 +103,8 @@ export const webAuthNEnrollmentHandler: WebAuthNEnrollmentHandler = async (trans
   }
 
   // Extracts clientData, attestation, and transports from the credential response
-  const { id: _id, ...credentials } = OktaAuth.webauthn.getAttestation(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id, ...credentials } = OktaAuth.webauthn.getAttestation(
     result as PublicKeyCredential,
   );
 

--- a/src/v3/test/integration/webauthn-enroll.test.tsx
+++ b/src/v3/test/integration/webauthn-enroll.test.tsx
@@ -98,10 +98,10 @@ describe('webauthn-enroll', () => {
 
   it('should include transports in payload when getTransports is supported', async () => {
     const mockTransports = ['usb', 'nfc'];
-    const mockResponse_create = getMockCredentialsResponse();
-    (mockResponse_create.response as AuthenticatorAttestationResponse).getTransports =
-      () => mockTransports;
-    mockCredentialsContainer!.create = jest.fn().mockResolvedValueOnce(mockResponse_create);
+    const mockCreateResponse = getMockCredentialsResponse();
+    (mockCreateResponse.response as AuthenticatorAttestationResponse).getTransports
+      = () => mockTransports;
+    mockCredentialsContainer!.create = jest.fn().mockResolvedValueOnce(mockCreateResponse);
 
     const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
     navigatorCredentials.mockReturnValue(

--- a/src/v3/test/integration/webauthn-enroll.test.tsx
+++ b/src/v3/test/integration/webauthn-enroll.test.tsx
@@ -95,4 +95,38 @@ describe('webauthn-enroll', () => {
       }),
     );
   });
+
+  it('should include transports in payload when getTransports is supported', async () => {
+    const mockTransports = ['usb', 'nfc'];
+    const mockResponse_create = getMockCredentialsResponse();
+    (mockResponse_create.response as AuthenticatorAttestationResponse).getTransports =
+      () => mockTransports;
+    mockCredentialsContainer!.create = jest.fn().mockResolvedValueOnce(mockResponse_create);
+
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { credentials: mockCredentialsContainer, userAgent: '' } as unknown as Navigator,
+    );
+
+    const {
+      authClient,
+      user,
+      findByText,
+      findByTestId,
+    } = await setup({ mockResponse });
+
+    await findByText(/Set up security key or biometric authenticator/);
+    const submitButton = await findByTestId('button');
+
+    await user.click(submitButton);
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
+        credentials: {
+          clientData: 'AAAAAAAAAAAAAA==',
+          attestation: 'AAAAAAAAAAAAAA==',
+          transports: '["usb","nfc"]',
+        },
+      }),
+    );
+  });
 });

--- a/src/v3/test/integration/webauthn-enroll.test.tsx
+++ b/src/v3/test/integration/webauthn-enroll.test.tsx
@@ -99,8 +99,8 @@ describe('webauthn-enroll', () => {
   it('should include transports in payload when getTransports is supported', async () => {
     const mockTransports = ['usb', 'nfc'];
     const mockCreateResponse = getMockCredentialsResponse();
-    (mockCreateResponse.response as AuthenticatorAttestationResponse).getTransports
-      = () => mockTransports;
+    (mockCreateResponse.response as AuthenticatorAttestationResponse)
+      .getTransports = () => mockTransports;
     mockCredentialsContainer!.create = jest.fn().mockResolvedValueOnce(mockCreateResponse);
 
     const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -165,17 +165,20 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
               id: CryptoUtil.strToBin(
                 'hpxQXbu5R5Y2JMqpvtE9Oo9FdwO6z2kMR-ZQkAb6p6GSguXQ57oVXKvpVHT2fyCR_m2EL1vIgszxi00kyFIX6w'
               ),
+              transports: ['usb', 'nfc'],
             },
             {
               type: 'public-key',
               id: CryptoUtil.strToBin(
                 '7Ag2iWUqfz0SanWDj-ZZ2fpDsgiEDt_08O1VSSRZHpgkUS1zhLSyWYDrxXXB5VE_w1iiqSvPaRgXcmG5rPwB-w'
               ),
+              transports: ['internal'],
             },
           ],
           extensions: {
             appid: 'https://localhost:3000',
           },
+          hints: ['security-key'],
           userVerification: 'required',
           challenge: CryptoUtil.strToBin(
             ChallengeWebauthnResponse.currentAuthenticator.value.contextualData.challengeData.challenge
@@ -190,6 +193,51 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
       });
       expect(testContext.view.form.saveForm).toHaveBeenCalledWith(testContext.view.form.model);
       expect(testContext.view.form.webauthnAbortController).toBe(null);
+      done();
+    })
+      .catch(done.fail);
+  });
+
+  it('does not include transports in allowCredentials when enrollments lack transports', function(done) {
+    const assertion = {
+      response: {
+        clientDataJSON: 123,
+        authenticatorData: 234,
+        signature: 'magizh',
+      },
+    };
+    jest.spyOn(BaseForm.prototype, 'saveForm');
+    jest.spyOn(navigator.credentials, 'get').mockReturnValue(Promise.resolve(assertion));
+
+    const enrollmentsWithoutTransports = {
+      value: [
+        {
+          displayName: 'yubikey',
+          type: 'security_key',
+          key: 'webauthn',
+          id: 'autwa6eD9o02iBbtv0g2',
+          authenticatorId: 'aidtheidkwh282hv8g3',
+          credentialId: 'hpxQXbu5R5Y2JMqpvtE9Oo9FdwO6z2kMR-ZQkAb6p6GSguXQ57oVXKvpVHT2fyCR_m2EL1vIgszxi00kyFIX6w',
+        },
+      ],
+    };
+
+    testContext.init(
+      ChallengeWebauthnResponse.currentAuthenticator.value,
+      enrollmentsWithoutTransports
+    );
+    Expect.wait(() => {
+      return BaseForm.prototype.saveForm.mock.calls.length > 0;
+    }).then(() => {
+      const calledWith = navigator.credentials.get.mock.calls[0][0];
+      expect(calledWith.publicKey.allowCredentials).toEqual([
+        {
+          type: 'public-key',
+          id: CryptoUtil.strToBin(
+            'hpxQXbu5R5Y2JMqpvtE9Oo9FdwO6z2kMR-ZQkAb6p6GSguXQ57oVXKvpVHT2fyCR_m2EL1vIgszxi00kyFIX6w'
+          ),
+        },
+      ]);
       done();
     })
       .catch(done.fail);
@@ -320,6 +368,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
           extensions: {
             appid: 'https://localhost:3000',
           },
+          hints: ['security-key'],
           userVerification: 'required',
           challenge: CryptoUtil.strToBin(
             ChallengeWebauthnResponse.currentAuthenticator.value.contextualData.challengeData.challenge

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -274,6 +274,36 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
       .catch(done.fail);
   });
 
+  it('RP ID mismatch SecurityError shows localized rpIdMismatch error when credentials.get fails', function(done) {
+    jest.spyOn(navigator.credentials, 'get').mockReturnValue(Promise.reject({
+      message: 'RP ID mismatch',
+      name: 'SecurityError',
+      code: 18,
+    }));
+
+    const currentAuthenticatorWithRpId = {
+      ...ChallengeWebauthnResponse.currentAuthenticator.value,
+      contextualData: {
+        ...ChallengeWebauthnResponse.currentAuthenticator.value.contextualData,
+        challengeData: {
+          ...ChallengeWebauthnResponse.currentAuthenticator.value.contextualData.challengeData,
+          rpId: 'example.okta.com',
+        },
+      },
+    };
+
+    testContext.init(currentAuthenticatorWithRpId);
+
+    Expect.waitForCss('.infobox-error')
+      .then(() => {
+        expect(testContext.view.$('.infobox-error')[0].textContent.trim())
+          .toBe('Could not sign in with a passkey. The RP ID example.okta.com is invalid for this domain.');
+        expect(testContext.view.form.webauthnAbortController).toBe(null);
+        done();
+      })
+      .catch(done.fail);
+  });
+
   it('shows correct text when Can\'t verify? is clicked', function() {
     testContext.init();
     expect(testContext.view.$('.idx-webauthn-verify-text').text()).toMatchInlineSnapshot(

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -431,6 +431,53 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
       .catch(done.fail);
   });
 
+  it('includes transports from profile fallback in allowCredentials', function(done) {
+    const assertion = {
+      response: {
+        clientDataJSON: 123,
+        authenticatorData: 234,
+        signature: 'magizh',
+      },
+    };
+    jest.spyOn(BaseForm.prototype, 'saveForm');
+    jest.spyOn(navigator.credentials, 'get').mockReturnValue(Promise.resolve(assertion));
+
+    const enrollmentsWithProfileTransports = {
+      value: [
+        {
+          displayName: 'Touch ID',
+          type: 'security_key',
+          key: 'webauthn',
+          id: 'autwa6eD9o02iBbtv0g3',
+          authenticatorId: 'fwftheidkwh282hv8g3',
+          credentialId: '7Ag2iWUqfz0SanWDj-ZZ2fpDsgiEDt_08O1VSSRZHpgkUS1zhLSyWYDrxXXB5VE_w1iiqSvPaRgXcmG5rPwB-w',
+          profile: { transports: ['internal'] },
+        },
+      ],
+    };
+
+    testContext.init(
+      ChallengeWebauthnResponse.currentAuthenticator.value,
+      enrollmentsWithProfileTransports,
+    );
+    Expect.wait(() => {
+      return BaseForm.prototype.saveForm.mock.calls.length > 0;
+    }).then(() => {
+      const calledWith = navigator.credentials.get.mock.calls[0][0];
+      expect(calledWith.publicKey.allowCredentials).toEqual([
+        {
+          type: 'public-key',
+          id: CryptoUtil.strToBin(
+            '7Ag2iWUqfz0SanWDj-ZZ2fpDsgiEDt_08O1VSSRZHpgkUS1zhLSyWYDrxXXB5VE_w1iiqSvPaRgXcmG5rPwB-w'
+          ),
+          transports: ['internal'],
+        },
+      ]);
+      done();
+    })
+      .catch(done.fail);
+  });
+
   describe('WebAuthn displayName variations', function() {
     it('shows DEFAULT title', function() {
       testContext.init(ChallengeWebauthnResponse.currentAuthenticator.value);

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -157,6 +157,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
             u2fParams: {
               appid: 'http://idx.okta1.com:1802',
             },
+            hints: ['security-key'],
             excludeCredentials: [
               {
                 type: 'public-key',
@@ -234,6 +235,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
             u2fParams: {
               appid: 'http://idx.okta1.com:1802',
             },
+            hints: ['security-key'],
             excludeCredentials: [
               {
                 type: 'public-key',
@@ -318,6 +320,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
             u2fParams: {
               appid: 'http://idx.okta1.com:1802',
             },
+            hints: ['security-key'],
             excludeCredentials: [
               {
                 type: 'public-key',
@@ -445,6 +448,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
             u2fParams: {
               appid: 'http://idx.okta1.com:1802',
             },
+            hints: ['security-key'],
             excludeCredentials: [],
           },
           signal: jasmine.any(Object),

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -257,7 +257,6 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
         expect(testContext.view.form.model.get('credentials')).toEqual({
           clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),
           attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
-          transports: null,
           clientExtensions: null
         });
         expect(testContext.view.form.saveForm).toHaveBeenCalledWith(testContext.view.form.model);
@@ -343,14 +342,13 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
           clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),
           attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
           clientExtensions: null,
-          transports: null
         };
 
         if (mockGetClientExtensions) {
           responseData.clientExtensions = JSON.stringify(newCredential.getClientExtensionResults());
         }
 
-        if(mockGetTransports){
+        if (mockGetTransports) {
           responseData.transports = JSON.stringify(newCredential.response.getTransports());
         }
 
@@ -392,6 +390,100 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
       .then(() => {
         expect(testContext.view.$('.infobox-error')[0].textContent.trim()).toBe('The operation either timed out or was not allowed.');
         expect(testContext.view.form.webauthnAbortController).toBe(null);
+        done();
+      })
+      .catch(done.fail);
+  });
+
+  it('excludeCredentials includes transports from authenticatorEnrollments when available', function(done) {
+    const newCredential = {
+      response: {
+        clientDataJSON: 123,
+        attestationObject: 234,
+        getTransports: function() { return ['usb', 'nfc']; },
+      },
+      getClientExtensionResults: function() { return {}; },
+    };
+    spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
+    spyOn(navigator.credentials, 'create').and.returnValue(Promise.resolve(newCredential));
+    spyOn(BaseForm.prototype, 'saveForm');
+
+    const enrollmentsWithTransports = {
+      value: [
+        {
+          displayName: 'yubikey',
+          type: 'security_key',
+          key: 'webauthn',
+          id: 'autwa6eD9o02iBbtv0g2',
+          authenticatorId: 'aidtheidkwh282hv8g3',
+          credentialId: 'hpxQXbu5R5Y2JMqpvtE9Oo9FdwO6z2kMR-ZQkAb6p6GSguXQ57oVXKvpVHT2fyCR_m2EL1vIgszxi00kyFIX6w',
+          transports: ['usb', 'nfc'],
+        },
+      ],
+    };
+
+    testContext.init(EnrollWebauthnResponse.currentAuthenticator.value, enrollmentsWithTransports);
+    testContext.view.$('.webauthn-setup').click();
+
+    Expect.waitForSpyCall(testContext.view.form.saveForm)
+      .then(() => {
+        const calledWith = navigator.credentials.create.calls.mostRecent().args[0];
+        expect(calledWith.publicKey.excludeCredentials).toEqual([
+          {
+            type: 'public-key',
+            id: CryptoUtil.strToBin(
+              'hpxQXbu5R5Y2JMqpvtE9Oo9FdwO6z2kMR-ZQkAb6p6GSguXQ57oVXKvpVHT2fyCR_m2EL1vIgszxi00kyFIX6w'
+            ),
+            transports: ['usb', 'nfc'],
+          },
+        ]);
+        done();
+      })
+      .catch(done.fail);
+  });
+
+  it('excludeCredentials includes transports from profile fallback in authenticatorEnrollments', function(done) {
+    const newCredential = {
+      response: {
+        clientDataJSON: 123,
+        attestationObject: 234,
+        getTransports: function() { return ['internal']; },
+      },
+      getClientExtensionResults: function() { return {}; },
+    };
+    spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
+    spyOn(navigator.credentials, 'create').and.returnValue(Promise.resolve(newCredential));
+    spyOn(BaseForm.prototype, 'saveForm');
+
+    const enrollmentsWithProfileTransports = {
+      value: [
+        {
+          displayName: 'Touch ID',
+          type: 'security_key',
+          key: 'webauthn',
+          id: 'autwa6eD9o02iBbtv0g3',
+          authenticatorId: 'fwftheidkwh282hv8g3',
+          credentialId: '7Ag2iWUqfz0SanWDj-ZZ2fpDsgiEDt_08O1VSSRZHpgkUS1zhLSyWYDrxXXB5VE_w1iiqSvPaRgXcmG5rPwB-w',
+          profile: { transports: ['internal'] },
+        },
+      ],
+    };
+
+    testContext.init(EnrollWebauthnResponse.currentAuthenticator.value, enrollmentsWithProfileTransports);
+    testContext.view.$('.webauthn-setup').click();
+
+    Expect.waitForSpyCall(testContext.view.form.saveForm)
+      .then(() => {
+        const calledWith = navigator.credentials.create.calls.mostRecent().args[0];
+        expect(calledWith.publicKey.excludeCredentials).toEqual([
+          {
+            type: 'public-key',
+            id: CryptoUtil.strToBin(
+              '7Ag2iWUqfz0SanWDj-ZZ2fpDsgiEDt_08O1VSSRZHpgkUS1zhLSyWYDrxXXB5VE_w1iiqSvPaRgXcmG5rPwB-w'
+            ),
+            transports: ['internal'],
+          },
+        ]);
         done();
       })
       .catch(done.fail);

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -395,6 +395,29 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
       .catch(done.fail);
   });
 
+  it('RP ID mismatch SecurityError shows localized error when credentials.create fails', function(done) {
+    spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
+    spyOn(navigator.credentials, 'create').and.returnValue(Promise.reject({
+      message: 'RP ID mismatch',
+      name: 'SecurityError',
+      code: 18,
+    }));
+
+    testContext.init();
+    testContext.view.$('.webauthn-setup').click();
+
+    Expect.waitForCss('.infobox-error')
+      .then(() => {
+        expect(testContext.view.$('.infobox-error')[0].textContent.trim()).toBe(
+          'The relying party ID is not a registrable domain suffix of, nor equal to the current domain.'
+          + ' Subsequently, an attempt to fetch the .well-known/webauthn resource of the claimed RP ID failed.'
+        );
+        expect(testContext.view.form.webauthnAbortController).toBe(null);
+        done();
+      })
+      .catch(done.fail);
+  });
+
   it('excludeCredentials includes transports from authenticatorEnrollments when available', function(done) {
     const newCredential = {
       response: {

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -51,6 +51,9 @@ describe('v2/view-builder/views/IdentifierView', function() {
   });
   afterEach(function() {
     jest.resetAllMocks();
+    // Some tests overwrite Bundles['login_en'] with only custom keys, wiping out the real bundle.
+    // Restore it after each test so subsequent tests can resolve i18n keys from the actual properties file.
+    Bundles['login_en'] = originalLoginEnBundle;
   });
 
   it('view renders forgot password link correctly with mutiple IDPs', function() {
@@ -469,7 +472,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
       jest.spyOn(AppState.prototype, 'get').mockImplementation((key) => {
         const mockData = {
           'idx': { neededToProceed: [] },
-          'webauthnAutofillUIChallenge': { challengeData: { challenge: 'test-challenge' } },
+          'webauthnAutofillUIChallenge': { challengeData: { challenge: 'test-challenge', rpId: 'example.okta.com' } },
           'neededToProceed': [],
           'remediations': [],
           'currentAuthenticator': { profile: {} },
@@ -516,11 +519,12 @@ describe('v2/view-builder/views/IdentifierView', function() {
         expectFriendlyError: true
       },
       {
-        description: 'should NOT suppress Relying Party ID mismatch error (unlike autofill UI, this is user-initiated)',
+        description: 'should show localized RP ID mismatch error for SecurityError (unlike autofill UI, this is user-initiated)',
         errorMessage: 'Relying Party ID mismatch',
         errorName: 'SecurityError',
         errorCode: 18,
-        expectErrorSuppressed: false
+        expectErrorSuppressed: false,
+        expectRpIdMismatchError: true
       },
       {
         description: 'should show error for unknown errors',
@@ -529,7 +533,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
         errorCode: undefined,
         expectErrorSuppressed: false
       }
-    ])('$description', async function({ errorMessage, errorName, errorCode, isAbortReasonCleanup, expectErrorSuppressed, expectFriendlyError }) {
+    ])('$description', async function({ errorMessage, errorName, errorCode, isAbortReasonCleanup, expectErrorSuppressed, expectFriendlyError, expectRpIdMismatchError }) {
       let rejection;
       if (isAbortReasonCleanup) {
         rejection = 'WebAuthNAutofill component cleanup';
@@ -553,6 +557,9 @@ describe('v2/view-builder/views/IdentifierView', function() {
         expect(testContext.view.$el.find('.infobox-error p').length).toBe(0);
       } else if (expectFriendlyError) {
         expect(testContext.view.$el.find('.infobox-error p').length).toBe(1);
+      } else if (expectRpIdMismatchError) {
+        expect(testContext.view.$el.find('.infobox-error p').text())
+          .toContain('Could not sign in with a passkey. The RP ID example.okta.com is invalid for this domain.');
       } else {
         expect(testContext.view.$el.find('.infobox-error p').text()).toContain(errorMessage);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4759,6 +4759,27 @@
     webcrypto-shim "^0.1.5"
     xhr2 "0.1.3"
 
+"@okta/okta-auth-js@7.14.2":
+  version "7.14.2"
+  resolved "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-7.14.2.tgz#1da3ecf1168259f843f7e6d04afae732deccd7bb"
+  integrity sha512-1RH+53jF7NvH6DrTxWFk+vD1yvb4tfQp5yX+Jp51nyTVePcGtG+Q3yzvgDty/EEEJt02cxWuQAlKwwg6mKwygg==
+  dependencies:
+    "@babel/runtime" "^7.27.0"
+    "@peculiar/webcrypto" "^1.4.0"
+    Base64 "1.1.0"
+    atob "^2.1.2"
+    broadcast-channel "~5.3.0"
+    btoa "^1.2.1"
+    core-js "^3.39.0"
+    cross-fetch "^3.1.5"
+    fast-text-encoding "^1.0.6"
+    js-cookie "^3.0.1"
+    node-cache "^5.1.2"
+    p-cancelable "^2.0.0"
+    tiny-emitter "1.1.0"
+    webcrypto-shim "^0.1.5"
+    xhr2 "0.1.3"
+
 "@okta/okta-sdk-nodejs@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-7.1.0.tgz#28d506351b400d840660b1400541b6b11bc39b16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4738,27 +4738,6 @@
     react-window "^1.8.10"
     word-wrap "^1.2.5"
 
-"@okta/okta-auth-js@7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.14.0.tgz#ffecf48ccd6fca1a737b8e8ac2759e2ed6e6b6eb"
-  integrity sha512-LCqJhhT1oXC/I7XaM7G3EHzHB5aubNMRHqAsmv0wiNdoC1zEeXJo5SwY9ZmS9LmLbfMOj+YmbydRIxRF8CpBNQ==
-  dependencies:
-    "@babel/runtime" "^7.27.0"
-    "@peculiar/webcrypto" "^1.4.0"
-    Base64 "1.1.0"
-    atob "^2.1.2"
-    broadcast-channel "~5.3.0"
-    btoa "^1.2.1"
-    core-js "^3.39.0"
-    cross-fetch "^3.1.5"
-    fast-text-encoding "^1.0.6"
-    js-cookie "^3.0.1"
-    node-cache "^5.1.2"
-    p-cancelable "^2.0.0"
-    tiny-emitter "1.1.0"
-    webcrypto-shim "^0.1.5"
-    xhr2 "0.1.3"
-
 "@okta/okta-auth-js@7.14.2":
   version "7.14.2"
   resolved "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-7.14.2.tgz#1da3ecf1168259f843f7e6d04afae732deccd7bb"
@@ -18100,7 +18079,7 @@ react-async-script@^1.2.0:
     hoist-non-react-statics "^3.3.0"
     prop-types "^15.5.0"
 
-"react-dom@npm:@preact/compat", "react@npm:@preact/compat":
+"react-dom@npm:@preact/compat":
   version "17.1.2"
   resolved "https://registry.yarnpkg.com/@preact/compat/-/compat-17.1.2.tgz#928756713b07af6faf7812f6a56840d8ce6fed37"
   integrity sha512-7pOZN9lMDDRQ+6aWvjwTp483KR8/zOpfS83wmOo3zfuLKdngS8/5RLbsFWzFZMGdYlotAhX980hJ75bjOHTwWg==
@@ -18170,6 +18149,11 @@ react-window@^1.8.10:
   dependencies:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
+
+"react@npm:@preact/compat":
+  version "17.1.2"
+  resolved "https://registry.yarnpkg.com/@preact/compat/-/compat-17.1.2.tgz#928756713b07af6faf7812f6a56840d8ce6fed37"
+  integrity sha512-7pOZN9lMDDRQ+6aWvjwTp483KR8/zOpfS83wmOo3zfuLKdngS8/5RLbsFWzFZMGdYlotAhX980hJ75bjOHTwWg==
 
 read-file-relative@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18079,7 +18079,7 @@ react-async-script@^1.2.0:
     hoist-non-react-statics "^3.3.0"
     prop-types "^15.5.0"
 
-"react-dom@npm:@preact/compat":
+"react-dom@npm:@preact/compat", "react@npm:@preact/compat":
   version "17.1.2"
   resolved "https://registry.yarnpkg.com/@preact/compat/-/compat-17.1.2.tgz#928756713b07af6faf7812f6a56840d8ce6fed37"
   integrity sha512-7pOZN9lMDDRQ+6aWvjwTp483KR8/zOpfS83wmOo3zfuLKdngS8/5RLbsFWzFZMGdYlotAhX980hJ75bjOHTwWg==
@@ -18149,11 +18149,6 @@ react-window@^1.8.10:
   dependencies:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
-
-"react@npm:@preact/compat":
-  version "17.1.2"
-  resolved "https://registry.yarnpkg.com/@preact/compat/-/compat-17.1.2.tgz#928756713b07af6faf7812f6a56840d8ce6fed37"
-  integrity sha512-7pOZN9lMDDRQ+6aWvjwTp483KR8/zOpfS83wmOo3zfuLKdngS8/5RLbsFWzFZMGdYlotAhX980hJ75bjOHTwWg==
 
 read-file-relative@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Description:

### Problem

WebAuthn credential creation and verification did not pass `transports` or `hints` to the browser, limiting its ability to guide users toward the correct authenticator (e.g., security key vs. biometric). This resulted in a generic browser prompt regardless of what was used during enrollment.

Additionally, when a WebAuthn operation failed due to a Relying Party (RP) ID mismatch — a `SecurityError` DOMException with code 18 — users saw a raw, untranslated browser error message that varied by browser and was never localized.

### Solution

**WebAuthn operations now include `transports` and `hints`** when building credential request/creation options. This lets browsers present more relevant authenticator prompts based on what was used during enrollment, improving the user experience during both verification and enrollment flows.

**RP ID mismatch errors are now caught and shown as localized, user-friendly messages** across all WebAuthn flows in both v2 and v3:

- **Challenge/verify flow** — displays a message that includes the invalid RP ID so the user (or admin) can identify the misconfiguration
- **Enrollment flow** — displays a localized security error explaining the domain mismatch
- **Identifier page "Sign in with a passkey" button** — catches the error at the caller level (distinct from the autofill flow, which silently suppresses it since it's not user-initiated)

### Testing

- Tests for transport/hint passthrough in credential building (v2)
- Integration test for WebAuthn enrollment error handling (v3)
- Unit tests for `isRelyingPartyIdMismatchError` utility (v3)
- Unit tests for RP ID mismatch error handling in both enrollment and authentication handlers (v3)
- Unit tests for RP ID mismatch in `EnrollWebauthnView`, `ChallengeWebauthnView`, and `IdentifierView` modal passkey flow (v2)
- Fixed a pre-existing test isolation issue where i18n bundle overrides leaked between tests in `IdentifierView_spec.js`

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1145765](https://oktainc.atlassian.net/browse/OKTA-1145765)

### Reviewers:

### Screenshot/Video:

#### Hints & transports:

https://github.com/user-attachments/assets/ffed90e2-ef89-45f4-b5c1-70ff1eeb2eb5
https://github.com/user-attachments/assets/535cafc6-cdbf-44e2-8e30-c529d6f41257
https://github.com/user-attachments/assets/42179e36-de81-43a1-8408-b9b2e1ed7633
https://github.com/user-attachments/assets/29499964-5619-4866-b469-b21285b6b366

#### Error handling:

<img width="1572" height="1367" alt="Screenshot 2026-04-22 at 5 35 38 PM" src="https://github.com/user-attachments/assets/dd7756f4-f729-442c-b44c-90968d0844ee" />
<img width="560" height="702" alt="Screenshot 2026-04-23 at 3 14 01 PM" src="https://github.com/user-attachments/assets/46f8b8f0-d002-45a8-a159-f757ac5ed4c5" />
<img width="1569" height="1367" alt="Screenshot 2026-04-23 at 3 14 13 PM" src="https://github.com/user-attachments/assets/eba630c8-bcc6-4048-ab07-c9d226d1fb65" />
<img width="1573" height="1368" alt="Screenshot 2026-04-23 at 3 14 40 PM" src="https://github.com/user-attachments/assets/0ac6f319-5a3a-4d62-b2fc-ebdbb1883f9d" />
<img width="2736" height="1367" alt="Screenshot 2026-04-23 at 3 15 34 PM" src="https://github.com/user-attachments/assets/4e6ba482-a859-4d0a-97ff-80be4550d79a" />
<img width="2747" height="1369" alt="Screenshot 2026-04-23 at 3 18 01 PM" src="https://github.com/user-attachments/assets/14d4a543-4e8e-4f8c-97d3-a7e3139e6d26" />
<img width="1146" height="1369" alt="Screenshot 2026-04-23 at 3 18 07 PM" src="https://github.com/user-attachments/assets/eb072d2e-b3af-473f-9206-b56ba8d82c0f" />
<img width="1150" height="1368" alt="Screenshot 2026-04-23 at 3 25 59 PM" src="https://github.com/user-attachments/assets/2093ebde-8cb7-43eb-b307-ff377e039a2c" />
<img width="502" height="702" alt="Screenshot 2026-04-23 at 12 28 25 PM" src="https://github.com/user-attachments/assets/a5fde29a-98de-4d5e-9cd4-c54b3af09e82" />

### Downstream Monolith Build:


https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=287da2df2150354ba34c2beba0a62201c9f82cef&tab=main
