### PR TITLE
OKTA-1151436 fix stale stateHandle in ALTCHA captcha's altchaCustomFetch

### DIFF
--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -170,7 +170,7 @@ export default View.extend({
       // Check if the state handle is one of the fields that should be passed in the body
       if (value?.find((field) => field?.name === 'stateHandle')) {
         newInit.body = JSON.stringify({ 
-          stateHandle: this.options.appState.settings.options.stateToken
+          stateHandle: this.options.appState.get('idx').context.stateHandle
         });
       }
 

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -54,6 +54,7 @@ describe('v2/view-builder/views/CaptchaView', function() {
       const appState = new AppState({
         captcha
       }, { settings });
+      appState.set('idx', { context: { stateHandle: 'test-state-handle' } });
       testContext.view = new CaptchaView({
         appState,
         settings,
@@ -323,7 +324,7 @@ describe('v2/view-builder/views/CaptchaView', function() {
       await altchaWidget.customfetch(testUrl, {});
       
       expect(window.fetch).toHaveBeenCalledWith(testUrl, expect.objectContaining({
-        body: JSON.stringify({ stateHandle: 'test-state-token' })
+        body: JSON.stringify({ stateHandle: 'test-state-handle' })
       }));
       window.fetch = originalFetch;
     });


### PR DESCRIPTION
## Description:
Read `stateHandle` from `appState.get('idx').context.stateHandle` instead of the immutable `settings.options.stateToken`, which becomes stale after the IDX flow progresses. If a user solves `ALTCHA` and the state handle changes later on in  the flow (ex. after `/cancel`), we will be able to retrieve a challenge with the new state token instead of the old stale token.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1151436](https://oktainc.atlassian.net/browse/OKTA-1151436)

### Reviewers:
@lesterchoi-okta, @shuowu

### Screenshot/Video:
https://github.com/user-attachments/assets/afb6a20f-56cc-4282-b8d2-0ca6ab821569

### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&author=ahmed.alkoasmh%40okta.com&branch=d16t-okta-signin-widget-10ef432-69dfd3f1&page=1&pageSize=6&tab=main