### PR TITLE
OKTA-1146579 : Remove stale underscore and handlebars entries from .retireignore.json

### DIFF
--- a/.retireignore.json
+++ b/.retireignore.json
@@ -5,11 +5,6 @@
     "justification": "CVE issues (CVE-2019-11358, CVE-2020-11023) have been mitigated with a patched version of jQuery (packages/@okta/courage-dist/esm/src/courage/vendor/lib/jquery-1.12.4.js)"
   },
   {
-    "component": "underscore.js",
-    "version": "1.13.1",
-    "justification": "CVE-2026-27601: _.flatten and _.isEqual DoS via unbounded recursion. Mitigated - the widget does not pass untrusted external input to these functions. Upstream fix requires rebuilding courage-dist with underscore 1.13.8."
-  },
-  {
     "component": "dompurify",
     "version": "2.5.8",
     "justification": "CVE-2025-26791 has been patched locally within patches/dompurify+2.5.8.patch compared fix (https://github.com/cure53/DOMPurify/commit/d18ffcb554e0001748865da03ac75dd7829f0f02#diff-8e647ca2a1d9380f03114f7df5e6a70563c9cb40b03dca353a43ce84b974c2cdR6)"
@@ -18,15 +13,5 @@
     "component": "DOMPurify",
     "version": "2.5.8",
     "justification": "CVE-2025-26791 has been patched locally within patches/dompurify+2.5.8.patch compared fix (https://github.com/cure53/DOMPurify/commit/d18ffcb554e0001748865da03ac75dd7829f0f02#diff-8e647ca2a1d9380f03114f7df5e6a70563c9cb40b03dca353a43ce84b974c2cdR6)"
-  },
-  {
-    "component": "handlebars",
-    "version": "4.7.7",
-    "justification": "CVE-2026-33937 (critical, NumberLiteral AST injection RCE): Not exploitable — the widget never passes user-supplied objects to Handlebars.compile(); templates are precompiled at build time via babel-plugin-handlebars-inline-precompile. CVE-2026-33916 (medium, prototype pollution via partial resolution XSS): Low risk — requires a separate prototype pollution vulnerability as prerequisite; the widget does not expose prototype pollution vectors. CVE-2026-33941 (medium, CLI precompiler argument injection): Not exploitable — the widget does not use the Handlebars CLI; precompilation is done via Babel plugin at build time. CVE-2026-33939 (medium, __lookupSetter__ blocklist omission): Not exploitable — the widget does not set allowProtoMethodsByDefault:true. Upgrade to handlebars 4.7.9 tracked in OKTA-1145322."
-  },
-  {
-    "component": "handlebars.js",
-    "version": "4.7.7",
-    "justification": "Same as handlebars 4.7.7 entry above. RetireJS may detect under alternate component name. Upgrade tracked in OKTA-1145322."
   }
 ]

--- a/package.json
+++ b/package.json
@@ -258,7 +258,7 @@
     "chokidar": "^3.5.1",
     "clipboard": "^1.5.16",
     "cross-fetch": "^3.1.5",
-    "handlebars": "^4.7.7",
+    "handlebars": "^4.7.9",
     "jquery": "^3.6.0",
     "parse-ms": "^2.0.0",
     "q": "1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12355,13 +12355,13 @@ handlebars-loader@^1.7.3:
     loader-utils "1.4.x"
     object-assign "^4.1.0"
 
-handlebars@^4.7.7:
-  version "4.7.7"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
-  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+handlebars@^4.7.9:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
-    neo-async "^2.6.0"
+    neo-async "^2.6.2"
     source-map "^0.6.1"
     wordwrap "^1.0.0"
   optionalDependencies:
@@ -15730,7 +15730,7 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-neo-async@^2.6.0, neo-async@^2.6.2:
+neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==


### PR DESCRIPTION
## Description:

Underscore 1.13.1→1.13.8 and handlebars 4.7.7→4.7.9 were already upgraded in OKTA-1145322. Remove the now-unnecessary retireignore suppressions and bump the handlebars dependency spec so yarn.lock resolves to 4.7.9.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1146579](https://oktainc.atlassian.net/browse/OKTA-1146579)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



