### PR TITLE
Okta-1156653: svg accessibility alt text

### DIFF
--- a/src/v3/src/components/PasswordRequirements/Icon.tsx
+++ b/src/v3/src/components/PasswordRequirements/Icon.tsx
@@ -16,6 +16,7 @@ import { CheckCircleFilledIcon, CloseIcon, InformationCircleIcon } from '@okta/o
 import { FunctionComponent, h } from 'preact';
 
 import { PasswordRequirementStatus } from '../../types';
+import { loc } from '../../util';
 
 type PasswordRequirementIconProps = {
   status: PasswordRequirementStatus;
@@ -27,9 +28,21 @@ const Icon: FunctionComponent<PasswordRequirementIconProps> = (
   const { status } = props;
   const tokens = useOdysseyDesignTokens();
   const statusToIcon = {
-    incomplete: { component: CloseIcon, color: tokens.PaletteNeutralMain },
-    complete: { component: CheckCircleFilledIcon, color: tokens.PaletteSuccessMain },
-    info: { component: InformationCircleIcon, color: tokens.PalettePrimaryMain },
+    incomplete: {
+      component: CloseIcon,
+      color: tokens.PaletteNeutralMain,
+      ariaLabelKey: 'password.complexity.status.notMet',
+    },
+    complete: {
+      component: CheckCircleFilledIcon,
+      color: tokens.PaletteSuccessMain,
+      ariaLabelKey: 'password.complexity.status.met',
+    },
+    info: {
+      component: InformationCircleIcon,
+      color: tokens.PalettePrimaryMain,
+      ariaLabelKey: 'password.complexity.status.info',
+    },
   };
   const OdyIcon = statusToIcon[status].component;
 
@@ -41,7 +54,8 @@ const Icon: FunctionComponent<PasswordRequirementIconProps> = (
         // This is to force the icon align with the top of the text
         marginBlockStart: '2px',
       }}
-      aria-hidden
+      role="img"
+      aria-label={loc(statusToIcon[status].ariaLabelKey, 'login')}
     >
       <OdyIcon
         sx={{

--- a/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordMatches.tsx
@@ -68,7 +68,6 @@ const PasswordMatches: UISchemaElementComponent<{
           marginBlockStart: '0',
           marginBlockEnd: `-${tokens.Spacing3}`,
         }}
-        aria-hidden
       >
         <PasswordRequirementListItem
           status={isMatching ? 'complete' : 'incomplete'}

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirements.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirements.tsx
@@ -110,7 +110,7 @@ const PasswordRequirements: UISchemaElementComponent<{
     if (unmetRequirements.length === 0) {
       return loc('password.complexity.status.allMet', 'login');
     }
-    return loc('password.complexity.status.notMetPrefix', 'login', [unmetRequirements.join(', ')]);
+    return loc('password.complexity.status.notMetPrefix', 'login', [unmetRequirements.length, unmetRequirements.join(', ')]);
   }, [passwordValidations, requirements]);
 
   return requirements?.length > 0 ? (

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirements.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirements.tsx
@@ -17,6 +17,7 @@ import { Fragment, h } from 'preact';
 import {
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from 'preact/hooks';
 
@@ -98,19 +99,19 @@ const PasswordRequirements: UISchemaElementComponent<{
     userProvidedUserInfo.profile?.lastName,
   ]);
 
-  const hasValidations = Object.keys(passwordValidations).length > 0;
-  const unmetRequirements = hasValidations
-    ? requirements
+  const liveText = useMemo(() => {
+    const hasValidations = Object.keys(passwordValidations).length > 0;
+    if (!hasValidations) {
+      return '';
+    }
+    const unmetRequirements = requirements
       .filter(({ ruleKey }) => getPasswordStatus(ruleKey, passwordValidations) === 'incomplete')
-      .map(({ label }) => label)
-    : [];
-
-  let liveText = '';
-  if (hasValidations && unmetRequirements.length === 0) {
-    liveText = loc('password.complexity.status.allMet', 'login');
-  } else if (hasValidations) {
-    liveText = loc('password.complexity.status.notMetPrefix', 'login', [unmetRequirements.join(', ')]);
-  }
+      .map(({ label }) => label);
+    if (unmetRequirements.length === 0) {
+      return loc('password.complexity.status.allMet', 'login');
+    }
+    return loc('password.complexity.status.notMetPrefix', 'login', [unmetRequirements.join(', ')]);
+  }, [passwordValidations, requirements]);
 
   return requirements?.length > 0 ? (
     // Fragment wraps the figure and the live region so aria-describedby

--- a/src/v3/src/components/PasswordRequirements/PasswordRequirements.tsx
+++ b/src/v3/src/components/PasswordRequirements/PasswordRequirements.tsx
@@ -13,7 +13,7 @@
 import { Box } from '@mui/material';
 import { useOdysseyDesignTokens } from '@okta/odyssey-react-mui';
 import debounce from 'lodash/debounce';
-import { h } from 'preact';
+import { Fragment, h } from 'preact';
 import {
   useCallback,
   useEffect,
@@ -28,7 +28,7 @@ import {
   UISchemaElementComponent,
   UserInfo,
 } from '../../types';
-import { getUserProvidedUserInfo, validatePassword } from '../../util';
+import { getUserProvidedUserInfo, loc, validatePassword } from '../../util';
 import PasswordRequirementListItem from './PasswordRequirementListItem';
 
 const PasswordRequirements: UISchemaElementComponent<{
@@ -98,33 +98,67 @@ const PasswordRequirements: UISchemaElementComponent<{
     userProvidedUserInfo.profile?.lastName,
   ]);
 
+  const hasValidations = Object.keys(passwordValidations).length > 0;
+  const unmetRequirements = hasValidations
+    ? requirements
+      .filter(({ ruleKey }) => getPasswordStatus(ruleKey, passwordValidations) === 'incomplete')
+      .map(({ label }) => label)
+    : [];
+
+  let liveText = '';
+  if (hasValidations && unmetRequirements.length === 0) {
+    liveText = loc('password.complexity.status.allMet', 'login');
+  } else if (hasValidations) {
+    liveText = loc('password.complexity.status.notMetPrefix', 'login', [unmetRequirements.join(', ')]);
+  }
+
   return requirements?.length > 0 ? (
-    <Box
-      component="figure"
-      sx={{ marginBlock: 0, marginInline: 0 }}
-      data-se="password-authenticator--rules"
-      id={uischema.id}
-    >
+    // Fragment wraps the figure and the live region so aria-describedby
+    // (which targets the figure by id) does not include the live region.
+    <Fragment>
       <Box
-        component="figcaption"
-        data-se="password-authenticator--heading"
+        component="figure"
+        sx={{ marginBlock: 0, marginInline: 0 }}
+        data-se="password-authenticator--rules"
+        id={uischema.id}
       >
-        {header}
+        <Box
+          component="figcaption"
+          data-se="password-authenticator--heading"
+        >
+          {header}
+        </Box>
+        <Box
+          component="ul"
+          id={listId}
+          sx={{ listStyle: 'none', padding: '0', marginBlockStart: tokens.Spacing3 }}
+        >
+          {requirements.map(({ ruleKey, label }) => (
+            <PasswordRequirementListItem
+              key={label}
+              status={getPasswordStatus(ruleKey, passwordValidations)}
+              label={label}
+            />
+          ))}
+        </Box>
       </Box>
       <Box
-        component="ul"
-        id={listId}
-        sx={{ listStyle: 'none', padding: '0', marginBlockStart: tokens.Spacing3 }}
+        role="status"
+        sx={{
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          padding: 0,
+          margin: '-1px',
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+          borderWidth: 0,
+        }}
       >
-        {requirements.map(({ ruleKey, label }) => (
-          <PasswordRequirementListItem
-            key={label}
-            status={getPasswordStatus(ruleKey, passwordValidations)}
-            label={label}
-          />
-        ))}
+        {liveText}
       </Box>
-    </Box>
+    </Fragment>
   ) : null;
 };
 

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -203,7 +203,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -243,7 +243,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -283,7 +283,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -323,7 +323,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -363,7 +363,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -403,7 +403,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -617,7 +617,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -163,9 +163,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -202,9 +203,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -241,9 +243,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -280,9 +283,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -319,9 +323,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -358,9 +363,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -397,9 +403,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -431,12 +438,18 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-67"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-68"
+                        class="MuiBox-root emotion-69"
                         id="username"
                         name="username"
                         type="text"
@@ -446,10 +459,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-70"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-71"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-71"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-72"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -459,7 +472,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-72"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-73"
                           required="true"
                         >
                           <input
@@ -468,7 +481,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             aria-invalid="true"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-73"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             name="credentials.passcode"
@@ -477,19 +490,19 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-74"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-75"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-75"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-76"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-76"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -506,11 +519,11 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-77"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-78"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-78"
+                            class="MuiBox-root emotion-79"
                           >
                             Error:
                           </span>
@@ -526,10 +539,10 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-70"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-71"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-71"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-72"
                           data-shrink="false"
                           for="confirmPassword"
                           id="confirmPassword-label"
@@ -539,7 +552,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-72"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-73"
                           required="true"
                         >
                           <input
@@ -547,7 +560,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="confirmPassword-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-73"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
                             data-se="confirmPassword"
                             id="confirmPassword"
                             name="confirmPassword"
@@ -556,19 +569,19 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-74"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-75"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-75"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-76"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-76"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -594,8 +607,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-90"
+                          class="MuiBox-root emotion-91"
                           id="credentials.newPassword-list"
                         >
                           <li
@@ -605,13 +617,14 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-94"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-95"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -644,7 +657,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-98"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-99"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -656,7 +669,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -668,7 +681,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-100"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-101"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -292,7 +292,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                               class="MuiBox-root emotion-43"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-44"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -282,7 +282,6 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
                           class="MuiBox-root emotion-41"
                           id="generated"
                         >
@@ -293,9 +292,10 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                               class="MuiBox-root emotion-43"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-44"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -246,7 +246,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -286,7 +286,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -326,7 +326,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -366,7 +366,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -615,7 +615,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"
@@ -862,7 +862,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -902,7 +902,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -942,7 +942,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -982,7 +982,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1022,7 +1022,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1220,7 +1220,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -206,9 +206,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -245,9 +246,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -284,9 +286,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -323,9 +326,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -362,9 +366,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -396,12 +401,18 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-62"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-63"
+                        class="MuiBox-root emotion-64"
                         id="username"
                         name="username"
                         type="text"
@@ -411,10 +422,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-66"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-67"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -424,7 +435,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-68"
                           required="true"
                         >
                           <input
@@ -433,7 +444,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                             aria-invalid="true"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-69"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             name="credentials.passcode"
@@ -442,13 +453,13 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-70"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-71"
                               tabindex="0"
                               type="button"
                             >
@@ -471,11 +482,11 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-72"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-73"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-73"
+                            class="MuiBox-root emotion-74"
                           >
                             Error:
                           </span>
@@ -484,20 +495,20 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-75"
+                              class="MuiList-root MuiList-dense emotion-76"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-76"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-77"
                               >
                                 At least 8 characters
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-76"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-77"
                               >
                                 An uppercase letter
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-76"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-77"
                               >
                                 A number
                               </li>
@@ -510,10 +521,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-66"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-67"
                           data-shrink="false"
                           for="confirmPassword"
                           id="confirmPassword-label"
@@ -523,7 +534,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-68"
                           required="true"
                         >
                           <input
@@ -532,7 +543,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                             aria-invalid="true"
                             aria-labelledby="confirmPassword-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-69"
                             data-se="confirmPassword"
                             id="confirmPassword"
                             name="confirmPassword"
@@ -541,13 +552,13 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-70"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-71"
                               tabindex="0"
                               type="button"
                             >
@@ -570,11 +581,11 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-72"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-73"
                           id="confirmPassword-error"
                         >
                           <span
-                            class="MuiBox-root emotion-73"
+                            class="MuiBox-root emotion-74"
                           >
                             Error:
                           </span>
@@ -594,8 +605,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-92"
+                          class="MuiBox-root emotion-93"
                           id="credentials.newPassword-list"
                         >
                           <li
@@ -605,13 +615,14 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-96"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-97"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -644,7 +655,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-100"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-101"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -656,7 +667,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-102"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-103"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -668,7 +679,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-102"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-103"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -851,9 +862,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -890,9 +902,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -929,9 +942,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -968,9 +982,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1007,9 +1022,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1041,12 +1057,18 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-55"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-56"
+                        class="MuiBox-root emotion-57"
                         id="generated"
                         name="username"
                         type="text"
@@ -1056,10 +1078,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="generated"
@@ -1069,7 +1091,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-60"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
                           required="true"
                         >
                           <input
@@ -1077,7 +1099,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                             data-se="credentials.passcode"
                             id="generated"
                             name="credentials.passcode"
@@ -1086,19 +1108,19 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-62"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-63"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-64"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1120,10 +1142,10 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
                           data-shrink="false"
                           for="confirmPassword"
                           id="generated"
@@ -1133,7 +1155,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-60"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
                           required="true"
                         >
                           <input
@@ -1141,7 +1163,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                             data-se="confirmPassword"
                             id="generated"
                             name="confirmPassword"
@@ -1150,19 +1172,19 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-62"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-63"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-64"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1188,8 +1210,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-75"
+                          class="MuiBox-root emotion-76"
                           id="generated"
                         >
                           <li
@@ -1199,13 +1220,14 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-79"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-80"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -1238,7 +1260,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-83"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-84"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1250,7 +1272,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-86"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -1262,7 +1284,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-86"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -246,7 +246,7 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -286,7 +286,7 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -326,7 +326,7 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -366,7 +366,7 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -615,7 +615,7 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"
@@ -850,7 +850,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -890,7 +890,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -930,7 +930,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -970,7 +970,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1010,7 +1010,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1208,7 +1208,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -206,9 +206,10 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -245,9 +246,10 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -284,9 +286,10 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -323,9 +326,10 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -362,9 +366,10 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -396,12 +401,18 @@ exports[`authenticator-expired-password should present field level error message
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-62"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-63"
+                        class="MuiBox-root emotion-64"
                         id="username"
                         name="username"
                         type="text"
@@ -411,10 +422,10 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-66"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-67"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -424,7 +435,7 @@ exports[`authenticator-expired-password should present field level error message
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-68"
                           required="true"
                         >
                           <input
@@ -433,7 +444,7 @@ exports[`authenticator-expired-password should present field level error message
                             aria-invalid="true"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-69"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             name="credentials.passcode"
@@ -442,13 +453,13 @@ exports[`authenticator-expired-password should present field level error message
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-70"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-71"
                               tabindex="0"
                               type="button"
                             >
@@ -471,11 +482,11 @@ exports[`authenticator-expired-password should present field level error message
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-72"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-73"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-73"
+                            class="MuiBox-root emotion-74"
                           >
                             Error:
                           </span>
@@ -484,20 +495,20 @@ exports[`authenticator-expired-password should present field level error message
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-75"
+                              class="MuiList-root MuiList-dense emotion-76"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-76"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-77"
                               >
                                 At least 8 characters
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-76"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-77"
                               >
                                 An uppercase letter
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-76"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-77"
                               >
                                 A number
                               </li>
@@ -510,10 +521,10 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-66"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-67"
                           data-shrink="false"
                           for="confirmPassword"
                           id="confirmPassword-label"
@@ -523,7 +534,7 @@ exports[`authenticator-expired-password should present field level error message
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-68"
                           required="true"
                         >
                           <input
@@ -532,7 +543,7 @@ exports[`authenticator-expired-password should present field level error message
                             aria-invalid="true"
                             aria-labelledby="confirmPassword-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-69"
                             data-se="confirmPassword"
                             id="confirmPassword"
                             name="confirmPassword"
@@ -541,13 +552,13 @@ exports[`authenticator-expired-password should present field level error message
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-70"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-71"
                               tabindex="0"
                               type="button"
                             >
@@ -570,11 +581,11 @@ exports[`authenticator-expired-password should present field level error message
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-72"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-73"
                           id="confirmPassword-error"
                         >
                           <span
-                            class="MuiBox-root emotion-73"
+                            class="MuiBox-root emotion-74"
                           >
                             Error:
                           </span>
@@ -594,8 +605,7 @@ exports[`authenticator-expired-password should present field level error message
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-92"
+                          class="MuiBox-root emotion-93"
                           id="credentials.newPassword-list"
                         >
                           <li
@@ -605,13 +615,14 @@ exports[`authenticator-expired-password should present field level error message
                               class="MuiBox-root emotion-33"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-34"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-96"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-97"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -644,7 +655,7 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-100"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-101"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -656,7 +667,7 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-102"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-103"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -839,9 +850,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -878,9 +890,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -917,9 +930,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -956,9 +970,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -995,9 +1010,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1029,12 +1045,18 @@ exports[`authenticator-expired-password should render form 1`] = `
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-55"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-56"
+                        class="MuiBox-root emotion-57"
                         id="generated"
                         name="username"
                         type="text"
@@ -1044,10 +1066,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="generated"
@@ -1057,7 +1079,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-60"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
                           required="true"
                         >
                           <input
@@ -1065,7 +1087,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                             data-se="credentials.passcode"
                             id="generated"
                             name="credentials.passcode"
@@ -1074,19 +1096,19 @@ exports[`authenticator-expired-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-62"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-63"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-64"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1108,10 +1130,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
                           data-shrink="false"
                           for="confirmPassword"
                           id="generated"
@@ -1121,7 +1143,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-60"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
                           required="true"
                         >
                           <input
@@ -1129,7 +1151,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                             data-se="confirmPassword"
                             id="generated"
                             name="confirmPassword"
@@ -1138,19 +1160,19 @@ exports[`authenticator-expired-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-62"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-63"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-64"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1176,8 +1198,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-75"
+                          class="MuiBox-root emotion-76"
                           id="generated"
                         >
                           <li
@@ -1187,13 +1208,14 @@ exports[`authenticator-expired-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-79"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-80"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -1226,7 +1248,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-83"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-84"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1238,7 +1260,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-86"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -221,9 +221,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -260,9 +261,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -299,9 +301,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -338,9 +341,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -377,9 +381,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -416,9 +421,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -455,9 +461,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -494,9 +501,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -528,12 +536,18 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-83"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-84"
+                        class="MuiBox-root emotion-85"
                         id="username"
                         name="username"
                         type="text"
@@ -543,10 +557,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-86"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-87"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-87"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-88"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -556,7 +570,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-88"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-89"
                           required="true"
                         >
                           <input
@@ -565,7 +579,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                             aria-invalid="true"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-89"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-90"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             name="credentials.passcode"
@@ -574,13 +588,13 @@ exports[`authenticator-expiry-warning-password should present field level error 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-90"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-91"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-91"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-92"
                               tabindex="0"
                               type="button"
                             >
@@ -603,11 +617,11 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-93"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-94"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-94"
+                            class="MuiBox-root emotion-95"
                           >
                             Error:
                           </span>
@@ -616,25 +630,25 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-96"
+                              class="MuiList-root MuiList-dense emotion-97"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-97"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
                               >
                                 At least 8 characters
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-97"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
                               >
                                 An uppercase letter
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-97"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
                               >
                                 A number
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-97"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
                               >
                                 A symbol
                               </li>
@@ -647,10 +661,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-86"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-87"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-87"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-88"
                           data-shrink="false"
                           for="confirmPassword"
                           id="confirmPassword-label"
@@ -660,7 +674,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-88"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-89"
                           required="true"
                         >
                           <input
@@ -669,7 +683,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                             aria-invalid="true"
                             aria-labelledby="confirmPassword-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-89"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-90"
                             data-se="confirmPassword"
                             id="confirmPassword"
                             name="confirmPassword"
@@ -678,13 +692,13 @@ exports[`authenticator-expiry-warning-password should present field level error 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-90"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-91"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-91"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-92"
                               tabindex="0"
                               type="button"
                             >
@@ -707,11 +721,11 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-93"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-94"
                           id="confirmPassword-error"
                         >
                           <span
-                            class="MuiBox-root emotion-94"
+                            class="MuiBox-root emotion-95"
                           >
                             Error:
                           </span>
@@ -731,8 +745,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-114"
+                          class="MuiBox-root emotion-115"
                           id="credentials.newPassword-list"
                         >
                           <li
@@ -742,13 +755,14 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-118"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-119"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -781,7 +795,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-122"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-123"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -793,7 +807,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-124"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-125"
                         data-se="skip"
                         role="link"
                         type="button"
@@ -805,7 +819,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-124"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-125"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -1003,9 +1017,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1042,9 +1057,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1081,9 +1097,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1120,9 +1137,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1159,9 +1177,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1198,9 +1217,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1237,9 +1257,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1276,9 +1297,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1310,12 +1332,18 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-76"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-77"
+                        class="MuiBox-root emotion-78"
                         id="generated"
                         name="username"
                         type="text"
@@ -1325,10 +1353,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-79"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-80"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-80"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-81"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="generated"
@@ -1338,7 +1366,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-81"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-82"
                           required="true"
                         >
                           <input
@@ -1346,7 +1374,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-82"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-83"
                             data-se="credentials.passcode"
                             id="generated"
                             name="credentials.passcode"
@@ -1355,19 +1383,19 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-83"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-84"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-84"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-85"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-85"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-86"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1389,10 +1417,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-79"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-80"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-80"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-81"
                           data-shrink="false"
                           for="confirmPassword"
                           id="generated"
@@ -1402,7 +1430,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-81"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-82"
                           required="true"
                         >
                           <input
@@ -1410,7 +1438,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-82"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-83"
                             data-se="confirmPassword"
                             id="generated"
                             name="confirmPassword"
@@ -1419,19 +1447,19 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-83"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-84"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-84"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-85"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-85"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-86"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1457,8 +1485,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-96"
+                          class="MuiBox-root emotion-97"
                           id="generated"
                         >
                           <li
@@ -1468,13 +1495,14 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-100"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-101"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -1507,7 +1535,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-104"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-105"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1519,7 +1547,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-106"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
                         data-se="skip"
                         role="link"
                         type="button"
@@ -1531,7 +1559,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-106"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -261,7 +261,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -301,7 +301,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -341,7 +341,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -381,7 +381,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -421,7 +421,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -461,7 +461,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -501,7 +501,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -755,7 +755,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               class="MuiBox-root emotion-36"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-37"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"
@@ -1017,7 +1017,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1057,7 +1057,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1097,7 +1097,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1137,7 +1137,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1177,7 +1177,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1217,7 +1217,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1257,7 +1257,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1297,7 +1297,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1495,7 +1495,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               class="MuiBox-root emotion-29"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-30"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -203,7 +203,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -243,7 +243,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -283,7 +283,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -323,7 +323,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -363,7 +363,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -403,7 +403,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -601,7 +601,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -163,9 +163,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -202,9 +203,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -241,9 +243,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -280,9 +283,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -319,9 +323,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -358,9 +363,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -397,9 +403,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -431,12 +438,18 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-67"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-68"
+                        class="MuiBox-root emotion-69"
                         id="username"
                         name="username"
                         type="text"
@@ -446,10 +459,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-70"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-71"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-71"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-72"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -459,7 +472,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-72"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-73"
                           required="true"
                         >
                           <input
@@ -467,7 +480,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-73"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             name="credentials.passcode"
@@ -476,19 +489,19 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-74"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-75"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-75"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-76"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-76"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -510,10 +523,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-70"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-71"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-71"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-72"
                           data-shrink="false"
                           for="confirmPassword"
                           id="confirmPassword-label"
@@ -523,7 +536,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-72"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-73"
                           required="true"
                         >
                           <input
@@ -531,7 +544,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="confirmPassword-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-73"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
                             data-se="confirmPassword"
                             id="confirmPassword"
                             name="confirmPassword"
@@ -540,19 +553,19 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-74"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-75"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-75"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-76"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-76"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -578,8 +591,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-87"
+                          class="MuiBox-root emotion-88"
                           id="credentials.newPassword-list"
                         >
                           <li
@@ -589,13 +601,14 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-91"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-92"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -628,10 +641,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <fieldset
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-95"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-96"
                       >
                         <legend
-                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-96"
+                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-97"
                           id="credentials.revokeSessions-label"
                         >
                           
@@ -640,19 +653,19 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         </legend>
                         <div
                           aria-labelledby="credentials.revokeSessions-label"
-                          class="MuiFormGroup-root emotion-97"
+                          class="MuiFormGroup-root emotion-98"
                           id="credentials.revokeSessions"
                         >
                           <label
-                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-98"
+                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-99"
                             id="credentials.revokeSessions-checkbox"
                           >
                             <span
-                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-99"
+                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-100"
                             >
                               <input
                                 aria-readonly="false"
-                                class="PrivateSwitchBase-input emotion-100"
+                                class="PrivateSwitchBase-input emotion-101"
                                 data-indeterminate="false"
                                 data-se="credentials.revokeSessions"
                                 name="credentials.revokeSessions"
@@ -677,7 +690,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-104"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-105"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -689,7 +702,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-106"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -203,7 +203,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -243,7 +243,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -283,7 +283,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -323,7 +323,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -521,7 +521,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"
@@ -756,7 +756,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -796,7 +796,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -836,7 +836,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -876,7 +876,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -916,7 +916,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1114,7 +1114,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
+                                aria-label="Requirement not met"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
                                 role="img"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -163,9 +163,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -202,9 +203,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -241,9 +243,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -280,9 +283,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -319,9 +323,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -353,12 +358,18 @@ exports[`authenticator-reset-password should render form 1`] = `
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-55"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-56"
+                        class="MuiBox-root emotion-57"
                         id="generated"
                         name="username"
                         type="text"
@@ -368,10 +379,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="generated"
@@ -381,7 +392,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-60"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
                           required="true"
                         >
                           <input
@@ -389,7 +400,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                             data-se="credentials.passcode"
                             id="generated"
                             name="credentials.passcode"
@@ -398,19 +409,19 @@ exports[`authenticator-reset-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-62"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-63"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-64"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -432,10 +443,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
                           data-shrink="false"
                           for="confirmPassword"
                           id="generated"
@@ -445,7 +456,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-60"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
                           required="true"
                         >
                           <input
@@ -453,7 +464,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                             data-se="confirmPassword"
                             id="generated"
                             name="confirmPassword"
@@ -462,19 +473,19 @@ exports[`authenticator-reset-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-62"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-63"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-64"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -500,8 +511,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-75"
+                          class="MuiBox-root emotion-76"
                           id="generated"
                         >
                           <li
@@ -511,13 +521,14 @@ exports[`authenticator-reset-password should render form 1`] = `
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-79"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-80"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -550,7 +561,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-83"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-84"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -562,7 +573,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-86"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -745,9 +756,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -784,9 +796,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -823,9 +836,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -862,9 +876,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -901,9 +916,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -935,12 +951,18 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-55"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-56"
+                        class="MuiBox-root emotion-57"
                         id="generated"
                         name="username"
                         type="text"
@@ -950,10 +972,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="generated"
@@ -963,7 +985,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-60"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
                           required="true"
                         >
                           <input
@@ -971,7 +993,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                             data-se="credentials.passcode"
                             id="generated"
                             name="credentials.passcode"
@@ -980,19 +1002,19 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-62"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-63"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-64"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1014,10 +1036,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-58"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-59"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
                           data-shrink="false"
                           for="confirmPassword"
                           id="generated"
@@ -1027,7 +1049,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-60"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
                           required="true"
                         >
                           <input
@@ -1035,7 +1057,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-61"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
                             data-se="confirmPassword"
                             id="generated"
                             name="confirmPassword"
@@ -1044,19 +1066,19 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-62"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-63"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-64"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1082,8 +1104,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          aria-hidden="true"
-                          class="MuiBox-root emotion-75"
+                          class="MuiBox-root emotion-76"
                           id="generated"
                         >
                           <li
@@ -1093,13 +1114,14 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               class="MuiBox-root emotion-26"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.notMet]"
                                 class="MuiBox-root emotion-27"
                                 data-se="passwordRequirementIcon-incomplete"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-79"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-80"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -1132,7 +1154,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-83"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-84"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1144,7 +1166,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-85"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-86"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -289,7 +289,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -329,7 +329,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -369,7 +369,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -409,7 +409,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -449,7 +449,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -489,7 +489,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -529,7 +529,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -569,7 +569,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1017,7 +1017,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1057,7 +1057,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1097,7 +1097,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1137,7 +1137,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1177,7 +1177,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1217,7 +1217,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1257,7 +1257,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1297,7 +1297,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1337,7 +1337,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1780,7 +1780,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1820,7 +1820,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1860,7 +1860,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1900,7 +1900,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1940,7 +1940,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -1980,7 +1980,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2020,7 +2020,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2060,7 +2060,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2100,7 +2100,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2553,7 +2553,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2593,7 +2593,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2633,7 +2633,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2673,7 +2673,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2713,7 +2713,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2753,7 +2753,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2793,7 +2793,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2833,7 +2833,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -2873,7 +2873,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -3316,7 +3316,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -3356,7 +3356,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -3396,7 +3396,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -3436,7 +3436,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -3476,7 +3476,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -3516,7 +3516,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -3556,7 +3556,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -3596,7 +3596,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -3636,7 +3636,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -4027,7 +4027,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -4067,7 +4067,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -4107,7 +4107,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -4147,7 +4147,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -4187,7 +4187,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -4227,7 +4227,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -4267,7 +4267,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -4307,7 +4307,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"
@@ -4347,7 +4347,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-label="L10N_ERROR[password.complexity.status.info]"
+                                aria-label="Information"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
                                 role="img"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -249,9 +249,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -288,9 +289,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -327,9 +329,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -366,9 +369,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -405,9 +409,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -444,9 +449,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -483,9 +489,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -522,9 +529,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -561,9 +569,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -595,6 +604,12 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-97"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-18"
@@ -613,7 +628,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-100"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
                           required="true"
                         >
                           <input
@@ -631,13 +646,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-102"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-103"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
                               tabindex="0"
                               type="button"
                             >
@@ -660,11 +675,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-105"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-106"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-106"
+                            class="MuiBox-root emotion-107"
                           >
                             Error:
                           </span>
@@ -673,15 +688,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-108"
+                              class="MuiList-root MuiList-dense emotion-109"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-109"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
                               >
                                 Does not include your first name
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-109"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
                               >
                                 Does not include your last name
                               </li>
@@ -694,7 +709,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-112"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-113"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -706,15 +721,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-114"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-115"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-115"
+                      class="MuiBox-root emotion-116"
                     >
                       <div
-                        class="MuiBox-root emotion-116"
+                        class="MuiBox-root emotion-117"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -729,10 +744,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-116"
+                        class="MuiBox-root emotion-117"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-120"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-121"
                           data-se="back"
                           role="link"
                           type="button"
@@ -1002,9 +1017,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1041,9 +1057,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1080,9 +1097,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1119,9 +1137,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1158,9 +1177,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1197,9 +1217,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1236,9 +1257,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1275,9 +1297,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1314,9 +1337,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1348,6 +1372,12 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-97"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-18"
@@ -1366,7 +1396,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-100"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
                           required="true"
                         >
                           <input
@@ -1384,13 +1414,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-102"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-103"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
                               tabindex="0"
                               type="button"
                             >
@@ -1413,11 +1443,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-105"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-106"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-106"
+                            class="MuiBox-root emotion-107"
                           >
                             Error:
                           </span>
@@ -1426,10 +1456,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-108"
+                              class="MuiList-root MuiList-dense emotion-109"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-109"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
                               >
                                 Maximum 3 consecutive repeating characters
                               </li>
@@ -1442,7 +1472,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-111"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-112"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1454,15 +1484,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-113"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-114"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-114"
+                      class="MuiBox-root emotion-115"
                     >
                       <div
-                        class="MuiBox-root emotion-115"
+                        class="MuiBox-root emotion-116"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -1477,10 +1507,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-115"
+                        class="MuiBox-root emotion-116"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-119"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-120"
                           data-se="back"
                           role="link"
                           type="button"
@@ -1750,9 +1780,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1789,9 +1820,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1828,9 +1860,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1867,9 +1900,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1906,9 +1940,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1945,9 +1980,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -1984,9 +2020,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2023,9 +2060,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2062,9 +2100,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2096,6 +2135,12 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-97"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-18"
@@ -2114,7 +2159,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-100"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
                           required="true"
                         >
                           <input
@@ -2132,13 +2177,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-102"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-103"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
                               tabindex="0"
                               type="button"
                             >
@@ -2161,11 +2206,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-105"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-106"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-106"
+                            class="MuiBox-root emotion-107"
                           >
                             Error:
                           </span>
@@ -2174,20 +2219,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-108"
+                              class="MuiList-root MuiList-dense emotion-109"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-109"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
                               >
                                 At least 8 characters
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-109"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
                               >
                                 An uppercase letter
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-109"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
                               >
                                 A symbol
                               </li>
@@ -2200,7 +2245,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-113"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-114"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -2212,15 +2257,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-115"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-116"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-116"
+                      class="MuiBox-root emotion-117"
                     >
                       <div
-                        class="MuiBox-root emotion-117"
+                        class="MuiBox-root emotion-118"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -2235,10 +2280,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-117"
+                        class="MuiBox-root emotion-118"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-121"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-122"
                           data-se="back"
                           role="link"
                           type="button"
@@ -2508,9 +2553,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2547,9 +2593,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2586,9 +2633,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2625,9 +2673,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2664,9 +2713,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2703,9 +2753,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2742,9 +2793,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2781,9 +2833,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2820,9 +2873,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -2854,6 +2908,12 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-97"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-18"
@@ -2872,7 +2932,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-100"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
                           required="true"
                         >
                           <input
@@ -2890,13 +2950,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-102"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-103"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
                               tabindex="0"
                               type="button"
                             >
@@ -2919,11 +2979,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-105"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-106"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-106"
+                            class="MuiBox-root emotion-107"
                           >
                             Error:
                           </span>
@@ -2932,10 +2992,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-108"
+                              class="MuiList-root MuiList-dense emotion-109"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-109"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
                               >
                                 No parts of your username
                               </li>
@@ -2948,7 +3008,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-111"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-112"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -2960,15 +3020,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-113"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-114"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-114"
+                      class="MuiBox-root emotion-115"
                     >
                       <div
-                        class="MuiBox-root emotion-115"
+                        class="MuiBox-root emotion-116"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -2983,10 +3043,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-115"
+                        class="MuiBox-root emotion-116"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-119"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-120"
                           data-se="back"
                           role="link"
                           type="button"
@@ -3256,9 +3316,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3295,9 +3356,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3334,9 +3396,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3373,9 +3436,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3412,9 +3476,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3451,9 +3516,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3490,9 +3556,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3529,9 +3596,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3568,9 +3636,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                               class="MuiBox-root emotion-44"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-45"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3602,6 +3671,12 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-97"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-18"
@@ -3620,7 +3695,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-100"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
                           required="true"
                         >
                           <input
@@ -3638,13 +3713,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-102"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-103"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
                               tabindex="0"
                               type="button"
                             >
@@ -3667,11 +3742,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-105"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-106"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-106"
+                            class="MuiBox-root emotion-107"
                           >
                             Error:
                           </span>
@@ -3687,7 +3762,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-109"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-110"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -3699,15 +3774,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-111"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-112"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-112"
+                      class="MuiBox-root emotion-113"
                     >
                       <div
-                        class="MuiBox-root emotion-113"
+                        class="MuiBox-root emotion-114"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -3722,10 +3797,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-113"
+                        class="MuiBox-root emotion-114"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-117"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-118"
                           data-se="back"
                           role="link"
                           type="button"
@@ -3952,9 +4027,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3991,9 +4067,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -4030,9 +4107,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -4069,9 +4147,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -4108,9 +4187,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -4147,9 +4227,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -4186,9 +4267,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -4225,9 +4307,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -4264,9 +4347,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               class="MuiBox-root emotion-37"
                             >
                               <div
-                                aria-hidden="true"
+                                aria-label="L10N_ERROR[password.complexity.status.info]"
                                 class="MuiBox-root emotion-38"
                                 data-se="passwordRequirementIcon-info"
+                                role="img"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -4298,6 +4382,12 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </li>
                         </ul>
                       </figure>
+                      <div
+                        class="MuiBox-root emotion-90"
+                        role="status"
+                      >
+                        
+                      </div>
                     </div>
                     <div
                       class="MuiBox-root emotion-11"
@@ -4316,7 +4406,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-93"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-94"
                           required="true"
                         >
                           <input
@@ -4333,19 +4423,19 @@ exports[`enroll-profile-with-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-95"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-96"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-96"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-97"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-97"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-98"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -4367,7 +4457,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-99"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-100"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -4379,15 +4469,15 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       class="MuiBox-root emotion-11"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-101"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-102"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-102"
+                      class="MuiBox-root emotion-103"
                     >
                       <div
-                        class="MuiBox-root emotion-103"
+                        class="MuiBox-root emotion-104"
                       >
                         <div
                           class="MuiBox-root emotion-12"
@@ -4402,10 +4492,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-103"
+                        class="MuiBox-root emotion-104"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-108"
                           data-se="back"
                           role="link"
                           type="button"


### PR DESCRIPTION
## Description:                                     
  
- Add a visually-hidden role="status" live region that announces password requirement status changes to screen readers as the user types (e.g., "Not met: A lowercase letter, A number" or "All password requirements met")
- Move the live region outside the <figure> element (via Fragment) so aria-describedby on the password input doesn't include dynamic announcements  
- Remove aria-hidden from the PasswordMatches confirm-password list so it's accessible to screen readers
- Add 2 i18n keys: password.complexity.status.allMet, password.complexity.status.notMetPrefix


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1156653](https://oktainc.atlassian.net/browse/OKTA-1156653)

### Reviewers:

### Screenshot/Video:

https://github.com/user-attachments/assets/5b6c24ab-76d7-48af-a07a-5cf09f8212dd



### Downstream Monolith Build:



