### PR TITLE
Fix granular consent payload corruption when scope names share a prefix

### DIFF
--- a/packages/@okta/courage-dist/esm/src/courage/framework/Model.js
+++ b/packages/@okta/courage-dist/esm/src/courage/framework/Model.js
@@ -90,8 +90,15 @@ function unflatten(data) {
     var parts = key.split('.');
 
     while ((part = parts.shift()) !== undefined) {
-      if (!ref[part]) {
-        ref[part] = parts.length ? {} : value;
+      if (parts.length) {
+        // Intermediate node — must be an object for traversal.
+        if (ref[part] != null && typeof ref[part] !== 'object') {
+          return;
+        } else if (!ref[part]) {
+          ref[part] = {};
+        }
+      } else if (!ref[part]) {
+        ref[part] = value;
       }
 
       ref = ref[part];

--- a/playground/mocks/data/idp/idx/consent-granular.json
+++ b/playground/mocks/data/idp/idx/consent-granular.json
@@ -44,6 +44,16 @@
                 "mutable": true
               },
               {
+                "name": "custom1.custom2",
+                "label": "View your mobile phone data plan sensitive details.",
+                "desc": "This allows the app to view your mobile phone data plan sensitive details.",
+                "type": "boolean",
+                "required": true,
+                "value": true,
+                "visible": true,
+                "mutable": true
+              },
+              {
                 "name": "custom2",
                 "label": "View your internet search history.",
                 "type": "boolean",

--- a/src/v2/ion/payloadTransformer.js
+++ b/src/v2/ion/payloadTransformer.js
@@ -34,11 +34,13 @@ const flattenObj = (obj) => {
  * property can include a singular value or n values delimited by a "."
  * When they are delimited, BackBone's toJSON function will create a nested object, however,
  * these should not be nested and the delimited key names should stay as is. So this function will
- * flatten those nested proeprties to format it how the backend expects it. 
+ * flatten those nested proeprties to format it how the backend expects it.
  * i.e. { optedScopes: { some: { scope: true }}} = { optedScopes: { 'some.scope': true }}
+ * Also handles the case where a dotted scope name shares a prefix with a plain scope name
+ * (e.g. 'card' and 'card.pan'), which unflatten leaves as unexpanded top-level keys.
  * Currently, this is only used when the Granular Consent view form is saved see:
  * src/v2/view-builder/views/consent/GranularConsentView.js
- * 
+ *
  * @param {JSON} modelJSON JSON Equivalent of the Backbone Model's attributes/fields
  * @returns If the JSON contains the optedScopes Property, we will flatten the fields from
  * a nested object into K/V pair with dot notation for nested key names. Otherwise, we will return
@@ -46,11 +48,24 @@ const flattenObj = (obj) => {
  */
 const transformOptedScopes = (modelJSON) => {
   if (modelJSON.optedScopes && typeof modelJSON.optedScopes !== 'string') {
-    const data = {
-      ...modelJSON,
-      optedScopes: flattenObj(modelJSON.optedScopes),
+    const OPTED_SCOPES_PREFIX = 'optedScopes.';
+    const remainingDottedScopes = {};
+    const cleanJSON = {};
+    Object.keys(modelJSON).forEach(key => {
+      if (key.startsWith(OPTED_SCOPES_PREFIX)) {
+        remainingDottedScopes[key.slice(OPTED_SCOPES_PREFIX.length)] = modelJSON[key];
+      } else {
+        cleanJSON[key] = modelJSON[key];
+      }
+    });
+
+    return {
+      ...cleanJSON,
+      optedScopes: {
+        ...flattenObj(cleanJSON.optedScopes),
+        ...remainingDottedScopes,
+      },
     };
-    return data;
   }
   return modelJSON;
 };

--- a/test/testcafe/spec/GranularConsentView_spec.js
+++ b/test/testcafe/spec/GranularConsentView_spec.js
@@ -50,6 +50,7 @@ test.requestHooks(requestLogger, consentGranularMock)('should show scopes list',
   if (userVariables.gen3) {
     await t.expect(consentPage.getScopeCheckBoxLabels()).eql([
       'View your mobile phone data plan.',
+      'View your mobile phone data plan sensitive details.',
       'View your internet search history.',
       'View your mobile phone call history.',
       'View your email address.',
@@ -60,6 +61,8 @@ test.requestHooks(requestLogger, consentGranularMock)('should show scopes list',
     await t.expect(consentPage.getScopeCheckBoxLabels()).eql([
       'View your mobile phone data plan.\n\n' +
         'This allows the app to view your mobile phone data plan.',
+      'View your mobile phone data plan sensitive details.\n\n' +
+        'This allows the app to view your mobile phone data plan sensitive details.',
       'View your internet search history.',
       'View your mobile phone call history.\n\n' +
         'This allows the app to view your mobile phone call history.',
@@ -117,6 +120,7 @@ test.requestHooks(requestLogger, consentGranularMock)('should send correct paylo
   await checkA11y(t);
 
   await consentPage.setScopeCheckBox('optedScopes.custom1', false);
+  await consentPage.setScopeCheckBox('optedScopes.custom1.custom2', false);
   await consentPage.setScopeCheckBox('optedScopes.email', false);
 
   await consentPage.clickAllowButton();
@@ -126,6 +130,7 @@ test.requestHooks(requestLogger, consentGranularMock)('should send correct paylo
   await t.expect(jsonBody.consent).eql(true);
   await t.expect(jsonBody.optedScopes.openid).eql(true);
   await t.expect(jsonBody.optedScopes.custom1).eql(false);
+  await t.expect(jsonBody.optedScopes['custom1.custom2']).eql(false);
   await t.expect(jsonBody.optedScopes.custom2).eql(true);
   await t.expect(jsonBody.optedScopes['custom3.custom4.custom5']).eql(true);
   await t.expect(jsonBody.optedScopes.email).eql(false);

--- a/test/unit/spec/v2/ion/payloadTransformer_spec.js
+++ b/test/unit/spec/v2/ion/payloadTransformer_spec.js
@@ -1,0 +1,48 @@
+import { Model } from '@okta/courage';
+import transformPayload from 'v2/ion/payloadTransformer';
+
+function createGranularConsentModel(scopeValues) {
+  const props = {};
+  Object.keys(scopeValues).forEach(key => {
+    props[key] = { type: 'boolean', value: scopeValues[key] };
+  });
+  const M = Model.extend({ props });
+  return new M();
+}
+
+describe('v2/ion/payloadTransformer', function() {
+  describe('granular-consent - prefix scope collision', function() {
+
+    it('does not throw when a plain scope is true and a dotted scope shares its prefix', function() {
+      const model = createGranularConsentModel({
+        'consent': true,
+        'optedScopes.custom1': true,
+        'optedScopes.custom1.custom2': true,
+      });
+      expect(() => transformPayload('granular-consent', model)).not.toThrow();
+    });
+
+    it('preserves both scopes in the payload when plain scope is true', function() {
+      const model = createGranularConsentModel({
+        'consent': true,
+        'optedScopes.custom1': true,
+        'optedScopes.custom1.custom2': true,
+      });
+      const payload = transformPayload('granular-consent', model);
+      expect(payload.optedScopes['custom1']).toBe(true);
+      expect(payload.optedScopes['custom1.custom2']).toBe(true);
+    });
+
+    it('preserves both scopes in the payload when plain scope is false', function() {
+      const model = createGranularConsentModel({
+        'consent': true,
+        'optedScopes.custom1': false,
+        'optedScopes.custom1.custom2': false,
+      });
+      const payload = transformPayload('granular-consent', model);
+      expect(payload.optedScopes['custom1']).toBe(false);
+      expect(payload.optedScopes['custom1.custom2']).toBe(false);
+    });
+
+  });
+});


### PR DESCRIPTION
## Description:

**Problem**

When an app requests both a plain scope and a dotted scope that shares its name as a prefix (e.g. `custom1` and `custom1.custom2`), the widget either throws a runtime error or silently drops the plain scope from the consent payload:

- If the plain scope is `true`: `unflatten` tries to set a property on a boolean, throwing `Cannot create property 'custom2' on boolean 'true'`
- If the plain scope is `false`: `unflatten` treats the falsy value as "not yet set" and overwrites it with a nested object, losing the value entirely

**Root cause**

`unflatten` in `Model.js` uses `if (!ref[part])` to decide whether to create an intermediate object node. This check is too coarse: it treats `false` (a valid unchecked scope value) the same as `undefined`, causing it to overwrite the existing boolean.

**Fix**

Two complementary changes:

1. **`Model.js`** — tightens the collision check in `unflatten` to `ref[part] != null && typeof ref[part] !== 'object'`. When a primitive already occupies an intermediate path node, the dotted key is left unexpanded rather than clobbering the existing value.

2. **`payloadTransformer.js`** — updates `transformOptedScopes` to collect any `optedScopes.*` top-level keys that `unflatten` intentionally left behind and merges them into the final flat payload.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, ~following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)~?
- [ ] ~Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?~
- [ ] ~Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)~
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below) 
   -  No. Just a bug fix. 

### Issue:

- N/A

### Reviewers:

### Screenshot/Video:

Running the tests below after expanding the test cases with an additional scope `custom1.custom2` complementary to `custom1`. (First two commits in this PR)

```sh
yarn test -t testcafe --fixture "GranularConsent"
```

| Before | After |
|--------|--------|
| <img width="1122" height="723" alt="Screenshot 2026-05-06 at 16 37 43" src="https://github.com/user-attachments/assets/b6fbf38f-0ccb-49f5-aa7f-3f13d636c70e" /> | <img width="577" height="201" alt="Screenshot 2026-05-06 at 16 51 32" src="https://github.com/user-attachments/assets/7dff4579-e5be-4c2b-9de6-48cace08a2d4" /> | 


```sh
yarn test -t jest test/unit/spec/v2/ion/payloadTransformer_spec.js
```

| Before | After |
|--------|--------|
| <img width="1121" height="416" alt="Screenshot 2026-05-06 at 16 44 50" src="https://github.com/user-attachments/assets/d40b9c29-3b65-4866-b087-f23ba6011db7" /> | <img width="724" height="212" alt="Screenshot 2026-05-06 at 16 45 52" src="https://github.com/user-attachments/assets/e0e0a106-bc23-46a9-9d7b-c1dded97d2da" /> | 


### Downstream Monolith Build:

