### PR TITLE
OKTA-1172848: Ensure pseudo-loc tool sees /okta/okta-signin-widget/ in its cwd

### DIFF
--- a/packages/@okta/pseudo-loc/pseudo-loc.js
+++ b/packages/@okta/pseudo-loc/pseudo-loc.js
@@ -1,4 +1,29 @@
 const { execSync } = require('child_process');
+const {
+  mkdtempSync,
+  mkdirSync,
+  symlinkSync,
+  rmSync,
+} = require('fs');
+const { tmpdir } = require('os');
+const { join, resolve } = require('path');
+
+// @okta/tools.i18n.pseudo-loc derives the repo name from the cwd by splitting
+// on "/" and taking the segment after a literal "okta" segment (Okta's
+// internal /okta/<repo>/... clone convention). When the repo lives elsewhere
+// (e.g. ~/opensource/okta-signin-widget), that lookup returns undefined and
+// every SK entry is written as [[undefined:login: ...]]. Run the tool from
+// inside a temp symlink tree that always has /okta/okta-signin-widget/ in
+// the path, so the heuristic succeeds regardless of the real clone path.
+const prepareRunDir = () => {
+  const repoRoot = resolve(__dirname, '../../..');
+  const tmpRoot = mkdtempSync(join(tmpdir(), 'siw-pseudoloc-'));
+  const oktaDir = join(tmpRoot, 'okta');
+  const repoLink = join(oktaDir, 'okta-signin-widget');
+  mkdirSync(oktaDir, { recursive: true });
+  symlinkSync(repoRoot, repoLink, 'dir');
+  return { tmpRoot, runCwd: join(repoLink, 'packages/@okta/pseudo-loc') };
+};
 
 const generate = () => {
   console.log('================= Generating pseudo-loc properties =============');
@@ -6,27 +31,31 @@ const generate = () => {
     'country',
     'login',
   ];
-  const package = process.cwd();
-  bundles.forEach((bundle) => {
-    let pseudoLocCmd = `pseudo-loc generate --packageName ${package} --resourcePath ../i18n/src/properties --bundle ${bundle}`;
-    execSync(pseudoLocCmd, {
-      cwd: package,
-      stdio: 'inherit'
+
+  const { tmpRoot, runCwd } = prepareRunDir();
+  try {
+    bundles.forEach((bundle) => {
+      const pseudoLocCmd = `pseudo-loc generate --packageName ${runCwd} --resourcePath ../i18n/src/properties --bundle ${bundle}`;
+      execSync(pseudoLocCmd, {
+        cwd: runCwd,
+        stdio: 'inherit',
+      });
     });
-  });
 
-  // TODO: The pseudo-loc package assumes that all translation files live within a "properties/translations" directory
-  //       To keep the format consistent, we move them by hand here:
-  const fromDir = '../i18n/src/properties/translations';
-  const toDir = '../i18n/src/properties/';
-  const copyCmd = `mv ${fromDir}/** ${toDir} && rm -rf ${fromDir}`;
-  
-  console.log('======= Migrating files =======');
-  execSync(copyCmd, {
-    cwd: package,
-    stdio: 'inherit'
-  });
+    // TODO: The pseudo-loc package assumes that all translation files live within a "properties/translations" directory
+    //       To keep the format consistent, we move them by hand here:
+    const fromDir = '../i18n/src/properties/translations';
+    const toDir = '../i18n/src/properties/';
+    const copyCmd = `mv ${fromDir}/** ${toDir} && rm -rf ${fromDir}`;
 
+    console.log('======= Migrating files =======');
+    execSync(copyCmd, {
+      cwd: runCwd,
+      stdio: 'inherit',
+    });
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
 };
 
 generate();


### PR DESCRIPTION
## Description:

@okta/tools.i18n.pseudo-loc derives the consumer repo name by splitting the cwd path on "/" and taking the segment after a literal "okta" segment (Okta's /okta/<repo>/... clone convention). When the repo is cloned elsewhere (e.g. ~/opensource/okta-signin-widget), the lookup returns undefined and every SK entry is written as [[undefined:login: ...]], corrupting all ~1339 placeholder lines in *_ok_SK.properties.

Fix by running the tool from inside a temp symlink tree that always has /okta/okta-signin-widget/ in the path, so the tool's heuristic succeeds regardless of the real clone location. CI-compatible: the symlink resolves to the real repo for all file reads/writes, and CI checkouts under /okta/okta-signin-widget/ still work (the temp symlink just points to the same repo root).


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1172848](https://oktainc.atlassian.net/browse/OKTA-1172848)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



