### PR TITLE
OKTA-1164533: Announce external links with "Opens in a new tab"

### DIFF
--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -17,6 +17,7 @@ import { h } from 'preact';
 import { useWidgetContext } from '../../contexts';
 import { useAutoFocus, useOnSubmit } from '../../hooks';
 import { ClickHandler, LinkElement, UISchemaElementComponent } from '../../types';
+import { loc } from '../../util';
 
 const Link: UISchemaElementComponent<{
   uischema: LinkElement
@@ -81,6 +82,9 @@ const Link: UISchemaElementComponent<{
           testId={dataSe}
           target={target}
           rel={(target === '_blank' && !rel) ? 'noopener noreferrer' : rel}
+          ariaLabel={target === '_blank'
+            ? `${label} ${loc('external.link.aria', 'login')}`
+            : undefined}
         >
           {label}
         </OdyLink>

--- a/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-apple-sso-extension.test.tsx.snap
@@ -162,6 +162,7 @@ exports[`authenticator-apple-sso-extension calls verify then cancels the transac
                       class="MuiBox-root emotion-11"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
                         data-se="help"
                         href="http://localhost:3000/help/login"
@@ -404,6 +405,7 @@ exports[`authenticator-apple-sso-extension cancels the transaction when sso exte
                       class="MuiBox-root emotion-11"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
                         data-se="help"
                         href="http://localhost:3000/help/login"
@@ -646,6 +648,7 @@ exports[`authenticator-apple-sso-extension opens the verify url with credential 
                       class="MuiBox-root emotion-11"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
                         data-se="help"
                         href="http://localhost:3000/help/login"

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -286,6 +286,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       class="MuiBox-root emotion-11"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-50"
                         data-se="help"
                         href="http://localhost:3000/help/login"
@@ -652,6 +653,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       class="MuiBox-root emotion-11"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-50"
                         data-se="help"
                         href="http://localhost:3000/help/login"
@@ -1018,6 +1020,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       class="MuiBox-root emotion-11"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-50"
                         data-se="help"
                         href="http://localhost:3000/help/login"

--- a/src/v3/test/integration/__snapshots__/granular-consent-without-logo.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/granular-consent-without-logo.test.tsx.snap
@@ -605,6 +605,7 @@ exports[`granular-consent-without-logo should render form 1`] = `
                       class="MuiBox-root emotion-15"
                     >
                       <a
+                        aria-label="Terms of Service Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-95"
                         data-se="terms-of-service"
                         href="https://example.com/tos"
@@ -638,6 +639,7 @@ exports[`granular-consent-without-logo should render form 1`] = `
                       class="MuiBox-root emotion-15"
                     >
                       <a
+                        aria-label="Privacy Policy Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-95"
                         data-se="privacy-policy"
                         href="https://example.com/privacypolicy"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -314,6 +314,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                       class="MuiBox-root emotion-18"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
                         data-se="help"
                         href="http://localhost:3000/help/login"
@@ -708,6 +709,7 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiBox-root emotion-18"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
                         data-se="help"
                         href="http://localhost:3000/help/login"
@@ -1025,6 +1027,7 @@ exports[`identify-with-password renders form with focus 1`] = `
                       class="MuiBox-root emotion-11"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"
                         data-se="help"
                         href="http://localhost:3000/help/login"
@@ -1342,6 +1345,7 @@ exports[`identify-with-password renders form without focus 1`] = `
                       class="MuiBox-root emotion-11"
                     >
                       <a
+                        aria-label="Help Opens in a new tab"
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"
                         data-se="help"
                         href="http://localhost:3000/help/login"


### PR DESCRIPTION

## Description:
Add a visually-hidden span inside the v3 Link component (OdyLink branch) so links with target="_blank" expose an accessible name of the form "{label} Opens in a new tab" to screen readers, without overriding the visible text or the Odyssey-rendered indicator icon. Covers the Help footer link and any custom help links wired through transformHelpLinks.

The i18n key external.link.aria is shipped in the base i18n PR so it can go through the translation cycle. Until login.json is regenerated post-merge, integration snapshots will contain L10N_ERROR placeholders for the new key (same pattern used by PR #4013 for #4022).


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1164533](https://oktainc.atlassian.net/browse/OKTA-1164533)
- [OKTA-1164558](https://oktainc.atlassian.net/browse/OKTA-1164558)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



