### PR TITLE
OKTA-1152243: Persist flow reset to meta for KMSI after MFA step-up

### DIFF
--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -324,10 +324,18 @@ export default Controller.extend({
     // OKTA-1152243: After password reset, the server may return post-auth remediations
     // (e.g. keep-me-signed-in) that are not in PasswordRecoveryFlow. Reset to default flow
     // so auth-js does not throw when it encounters these in the recursive remediate() call.
+    // We also persist the change to the saved transaction meta — auth-js' proceed() falls
+    // back to meta.flow whenever a proceed call omits the flow option (e.g. the MFA
+    // step-up hop between reset-authenticator and post-auth keep-me-signed-in), and
+    // without this update it would re-read 'resetPassword' and throw on the KMSI step.
     const shouldResetFlow = formName === FORMS.RESET_AUTHENTICATOR
       && authClient.idx.getFlow?.() === 'resetPassword';
     if (shouldResetFlow) {
       authClient.idx.setFlow('default');
+      const savedMeta = authClient.idx.getSavedTransactionMeta?.();
+      if (savedMeta) {
+        authClient.idx.saveTransactionMeta?.({ ...savedMeta, flow: 'default' });
+      }
     }
 
     try {

--- a/test/testcafe/spec/ForgotPasswordWithKMSI_spec.js
+++ b/test/testcafe/spec/ForgotPasswordWithKMSI_spec.js
@@ -3,12 +3,14 @@ import BasePageObject from '../framework/page-objects/BasePageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import FactorEnrollPasswordPageObject from '../framework/page-objects/FactorEnrollPasswordPageObject';
 import PostAuthKeepMeSignedInPageObject from '../framework/page-objects/PostAuthKeepMeSignedInPageObject';
+import ChallengeEmailPageObject from '../framework/page-objects/ChallengeEmailPageObject';
 
 import xhrWellKnown from '../../../playground/mocks/data/oauth2/well-known-openid-configuration.json';
 import xhrInteract from '../../../playground/mocks/data/oauth2/interact.json';
 import xhrIdentifyWithPassword from '../../../playground/mocks/data/idp/idx/identify-with-password';
 import xhrIdentifyRecovery from '../../../playground/mocks/data/idp/idx/identify-recovery';
 import xhrResetPassword from '../../../playground/mocks/data/idp/idx/authenticator-reset-password';
+import xhrEmailChallenge from '../../../playground/mocks/data/idp/idx/authenticator-verification-email-without-emailmagiclink';
 import xhrPostAuthKeepMeSignedIn from '../../../playground/mocks/data/idp/idx/post-auth-keep-me-signed-in';
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
 import { oktaDashboardContent } from '../framework/a11y';
@@ -125,6 +127,93 @@ test
     await resetPasswordPage.clickResetPasswordButton();
 
     // Step 4: KMSI page should appear (this is where the gen2 bug manifested).
+    const kmsiPage = new PostAuthKeepMeSignedInPageObject(t);
+    await t.expect(kmsiPage.getFormTitle()).eql('Keep me signed in');
+    await t.expect(kmsiPage.getAcceptButtonText()).eql('Stay signed in');
+    await t.expect(kmsiPage.getRejectButtonText()).eql('Don\'t stay signed in');
+  });
+
+// -------------------------------------------------------------------------------------------
+// OKTA-1152243 / Case 02866134 customer repro ("Error-Reset-Password" scenario from the
+// customer HAR — user has MFA configured and gets KMSI after a post-reset MFA step-up).
+//
+// The customer reports that after 7.45.0 (fix ec62b9c8) they still hit
+// "No remediation can match current flow ... Remediations: [keep-me-signed-in]" when:
+//   identify-with-password -> Forgot password -> recovery -> reset-password ->
+//   MFA step-up -> Post-Auth KMSI
+//
+// Customer's post-reset factor is SMS; this test uses email to keep the mocks simple — the
+// auth-js code path is identical for any MFA factor because the bug is about meta.flow
+// fallback in proceed(), not the specific remediation that surfaces.
+//
+// Without the meta-persistence fix: auth-js throws "No remediation can match current flow"
+// because proceed() falls back to meta.flow = 'resetPassword' on the post-MFA hop, and
+// keep-me-signed-in is not in PasswordRecoveryFlow.
+// -------------------------------------------------------------------------------------------
+
+// challenge/answer is POSTed twice in the MFA case:
+//   1st: submit new password  -> server returns MFA challenge
+//   2nd: submit MFA OTP       -> server returns post-auth KMSI
+let challengeAnswerCount = 0;
+const challengeAnswerHandler = (req, res) => {
+  challengeAnswerCount++;
+  const response = challengeAnswerCount <= 1 ? xhrEmailChallenge : xhrPostAuthKeepMeSignedIn;
+  res.setBody(response);
+};
+
+const mockWithMfa = RequestMock()
+  .onRequestTo('http://localhost:3000/oauth2/default/.well-known/openid-configuration')
+  .respond(xhrWellKnown, 200)
+  .onRequestTo('http://localhost:3000/oauth2/default/v1/interact')
+  .respond(xhrInteract, 200)
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(introspectHandler)
+  .onRequestTo('http://localhost:3000/idp/idx/recover')
+  .respond(xhrIdentifyRecovery)
+  .onRequestTo('http://localhost:3000/idp/idx/identify')
+  .respond(xhrResetPassword)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
+  .respond(challengeAnswerHandler)
+  .onRequestTo('http://localhost:3000/idp/idx/keep-me-signed-in')
+  .respond(xhrSuccess)
+  .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
+  .respond(oktaDashboardContent);
+
+fixture('Forgot Password with MFA step-up then POST KMSI')
+  .beforeEach(() => {
+    introspectCount = 0;
+    challengeAnswerCount = 0;
+  });
+
+test
+  .requestHooks(logger, mockWithMfa)('should reach KMSI after forgot password reset + email MFA step-up', async t => {
+    const identityPage = await setup(t);
+
+    // Step 1: click Forgot password
+    await t.expect(await identityPage.hasForgotPasswordLinkText()).ok();
+    await t.click(Selector('[data-se="forgot-password"]'));
+
+    // Step 2: recovery page
+    const identityRecoveryPage = new IdentityPageObject(t);
+    await t.expect(identityRecoveryPage.formExists()).eql(true);
+    await identityRecoveryPage.fillIdentifierField('testUser@okta.com');
+    await identityRecoveryPage.clickNextButton();
+
+    // Step 3: reset password
+    const resetPasswordPage = new FactorEnrollPasswordPageObject(t);
+    await t.expect(resetPasswordPage.formExists()).eql(true);
+    await resetPasswordPage.fillPassword('Abcd1234!@');
+    await resetPasswordPage.fillConfirmPassword('Abcd1234!@');
+    await resetPasswordPage.clickResetPasswordButton();
+
+    // Step 4: MFA step-up (email challenge — customer used SMS; path is the same).
+    const emailChallengePage = new ChallengeEmailPageObject(t);
+    await t.expect(emailChallengePage.formExists()).eql(true);
+    await emailChallengePage.verifyFactor('credentials.passcode', '123456');
+    await emailChallengePage.clickNextButton('Verify');
+
+    // Step 5: KMSI should appear cleanly. If the fix does not cover this flow,
+    // we will instead see the "No remediation can match current flow" error here.
     const kmsiPage = new PostAuthKeepMeSignedInPageObject(t);
     await t.expect(kmsiPage.getFormTitle()).eql('Keep me signed in');
     await t.expect(kmsiPage.getAcceptButtonText()).eql('Stay signed in');


### PR DESCRIPTION
## Description:

The original fix only mutated authClient.options.flow via setFlow() and passed flow='default' on the reset-authenticator submit. Subsequent proceed calls from later forms (MFA selection, OTP verify) omit the flow option, so auth-js falls back to meta.flow — which was still 'resetPassword' from interact() — and re-loads PasswordRecoveryFlow. keep-me-signed-in is not in that flow, so auth-js throws "No remediation can match current flow".

Also persist flow='default' to the saved transaction meta so the fallback in proceed() reads 'default' on every hop after reset-authenticator.

Adds a testcafe scenario that inserts an MFA step-up between reset-password and POST KMSI (Case 02866134).


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1152243](https://oktainc.atlassian.net/browse/OKTA-1152243)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



