### PR TITLE
OKTA-1164534: Announce OR divider text to screen readers

### DIFF
--- a/src/v3/src/components/Divider/Divider.tsx
+++ b/src/v3/src/components/Divider/Divider.tsx
@@ -19,7 +19,7 @@ const Divider: UISchemaElementComponent<{ uischema: DividerElement }> = ({ uisch
   const { options } = uischema;
 
   return typeof options?.text !== 'undefined' ? (
-    <MuiDivider data-se="separation-line" aria-label={options.text}>
+    <MuiDivider data-se="separation-line" role="presentation">
       {options.text}
     </MuiDivider>
   ) : <MuiDivider data-se="separation-line" />;

--- a/src/v3/src/components/Divider/Divider.tsx
+++ b/src/v3/src/components/Divider/Divider.tsx
@@ -19,7 +19,10 @@ const Divider: UISchemaElementComponent<{ uischema: DividerElement }> = ({ uisch
   const { options } = uischema;
 
   return typeof options?.text !== 'undefined' ? (
-    <MuiDivider data-se="separation-line" role="presentation">
+    <MuiDivider
+      data-se="separation-line"
+      role="presentation"
+    >
       {options.text}
     </MuiDivider>
   ) : <MuiDivider data-se="separation-line" />;

--- a/src/v3/src/components/Divider/Divider.tsx
+++ b/src/v3/src/components/Divider/Divider.tsx
@@ -19,7 +19,9 @@ const Divider: UISchemaElementComponent<{ uischema: DividerElement }> = ({ uisch
   const { options } = uischema;
 
   return typeof options?.text !== 'undefined' ? (
-    <MuiDivider data-se="separation-line">{options.text}</MuiDivider>
+    <MuiDivider data-se="separation-line" aria-label={options.text}>
+      {options.text}
+    </MuiDivider>
   ) : <MuiDivider data-se="separation-line" />;
 };
 

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -89,10 +89,9 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        aria-label="OR"
                         class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren emotion-19"
                         data-se="separation-line"
-                        role="separator"
+                        role="presentation"
                       >
                         <span
                           class="MuiDivider-wrapper emotion-20"
@@ -456,10 +455,9 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        aria-label="OR"
                         class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren emotion-19"
                         data-se="separation-line"
-                        role="separator"
+                        role="presentation"
                       >
                         <span
                           class="MuiDivider-wrapper emotion-20"
@@ -959,10 +957,9 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       class="MuiBox-root emotion-11"
                     >
                       <div
-                        aria-label="OR"
                         class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren emotion-39"
                         data-se="separation-line"
-                        role="separator"
+                        role="presentation"
                       >
                         <span
                           class="MuiDivider-wrapper emotion-40"

--- a/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-piv-cac-verification.test.tsx.snap
@@ -89,6 +89,7 @@ exports[`authenticator-piv-cac-verification renders form with custom PIV/CAC But
                       class="MuiBox-root emotion-11"
                     >
                       <div
+                        aria-label="OR"
                         class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren emotion-19"
                         data-se="separation-line"
                         role="separator"
@@ -455,6 +456,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as PRIM
                       class="MuiBox-root emotion-11"
                     >
                       <div
+                        aria-label="OR"
                         class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren emotion-19"
                         data-se="separation-line"
                         role="separator"
@@ -957,6 +959,7 @@ exports[`authenticator-piv-cac-verification renders form with idpDisplay as SECO
                       class="MuiBox-root emotion-11"
                     >
                       <div
+                        aria-label="OR"
                         class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren emotion-39"
                         data-se="separation-line"
                         role="separator"

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -67,7 +67,7 @@ export default class IdentityPageObject extends BasePageObject {
 
   getSeparationLineText() {
     if (userVariables.gen3) {
-      return this.form.getElement('[role="separator"]').textContent;
+      return this.form.getElement('[data-se="separation-line"]').textContent;
     }
     return this.form.getElement('.sign-in-with-device-option .separation-line').textContent;
   }


### PR DESCRIPTION
## Description:

MUI Divider emits role="separator" by default, which causes VoiceOver and NVDA to skip the inner text node. Add an explicit aria-label that mirrors the visible text so the divider announces its label while retaining the separator semantics.

No new i18n keys — reuses the existing socialauth.divider.text string.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1164534](https://oktainc.atlassian.net/browse/OKTA-1164534)

### Reviewers:

### Screenshot/Video:

https://github.com/user-attachments/assets/78eb09df-8d1f-4443-ae73-dceb3bf0ec2a



### Downstream Monolith Build:



