### PR TITLE
OKTA-1164552: Restore :focus-visible outline on v3 Link/StepperLink

### DIFF
--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Link as MuiLink } from '@mui/material';
-import { Link as OdyLink } from '@okta/odyssey-react-mui';
+import { Link as OdyLink, useOdysseyDesignTokens } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 
 import { useWidgetContext } from '../../contexts';
@@ -41,6 +41,7 @@ const Link: UISchemaElementComponent<{
   } = uischema;
   const onSubmitHandler = useOnSubmit();
   const focusRef = useAutoFocus<HTMLAnchorElement>(focus);
+  const tokens = useOdysseyDesignTokens();
 
   const onClick: ClickHandler = async (e) => {
     e.preventDefault();
@@ -70,6 +71,14 @@ const Link: UISchemaElementComponent<{
         onClick={onClick}
         ref={focusRef}
         data-se={dataSe}
+        sx={{
+          '&:focus-visible': {
+            outlineColor: tokens.PalettePrimaryMain,
+            outlineOffset: tokens.FocusOutlineOffsetMain,
+            outlineStyle: tokens.FocusOutlineStyle,
+            outlineWidth: tokens.FocusOutlineWidthMain,
+          },
+        }}
       >
         {label}
       </MuiLink>

--- a/src/v3/src/components/StepperLink/StepperLink.tsx
+++ b/src/v3/src/components/StepperLink/StepperLink.tsx
@@ -11,6 +11,7 @@
  */
 
 import { Link as LinkMui } from '@mui/material';
+import { useOdysseyDesignTokens } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
 
 import { useStepperContext, useWidgetContext } from '../../contexts';
@@ -33,6 +34,7 @@ const StepperLink: UISchemaElementComponent<{
 
   const focusRef = useAutoFocus<HTMLButtonElement>(focus);
   const widgetContext = useWidgetContext();
+  const tokens = useOdysseyDesignTokens();
 
   const handleClick = () => {
     if (typeof nextStepIndex === 'function') {
@@ -55,6 +57,12 @@ const StepperLink: UISchemaElementComponent<{
         '&:hover': {
           cursor: 'pointer',
           verticalAlign: 'baseline',
+        },
+        '&:focus-visible': {
+          outlineColor: tokens.PalettePrimaryMain,
+          outlineOffset: tokens.FocusOutlineOffsetMain,
+          outlineStyle: tokens.FocusOutlineStyle,
+          outlineWidth: tokens.FocusOutlineWidthMain,
         },
       }}
     >


### PR DESCRIPTION
## Description:

Add an Odyssey-token-based outline on :focus-visible to the shared Link component (MuiLink button variant) and StepperLink so keyboard users get a visible focus ring on Help-page links flagged in the Deque audit ("What should I do if I forget my username or password?", "Sign in to your Organization").


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



