### PR TITLE
OKTA-1016906: Fix uk-UA primary button text truncation

### DIFF
--- a/assets/sass/modules/_btns.scss
+++ b/assets/sass/modules/_btns.scss
@@ -43,6 +43,18 @@ $od-secondary-button-action-text-color: #124a94;
   text-align: center;
 }
 
+// Allow long localized strings (e.g. uk-UA "Надіслати повідомлення електронною
+// поштою") on the form's primary submit button to wrap onto multiple lines
+// instead of being clipped at the right edge of the fixed-width button.
+.o-form-button-bar .button.button-primary {
+  height: auto;
+  min-height: 50px;
+  line-height: 1.4;
+  padding-block: 14px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 .icon-button {
   display: block;
   width: 22px;

--- a/assets/sass/modules/_btns.scss
+++ b/assets/sass/modules/_btns.scss
@@ -52,7 +52,7 @@ $od-secondary-button-action-text-color: #124a94;
   line-height: 1.4;
   padding-block: 14px;
   white-space: normal;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
 }
 
 .icon-button {


### PR DESCRIPTION

## Description:

Long localized labels (e.g. uk-UA "Надіслати повідомлення електронною поштою" on oie.email.verify.primaryButton) were clipped at the right edge of the form's primary submit button, because .button-wide pinned the button to height: 50px / line-height: 48px with no white-space rule, and <input type="submit"> doesn't wrap by default.

Scope the fix to .o-form-button-bar .button.button-primary so the courage-rendered submit button can grow vertically and wrap when the text doesn't fit. .button-wide is left untouched so social/IDP/PIV buttons that intentionally use line-height: 50px keep their existing single-line layout.



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1016906](https://oktainc.atlassian.net/browse/OKTA-1016906)

### Reviewers:

### Screenshot/Video:

<img width="1200" height="901" alt="uk-after-fix" src="https://github.com/user-attachments/assets/9367f04b-0e3d-4616-9b86-dad77793c839" />


### Downstream Monolith Build:



