### PR TITLE
OKTA-1024762: Add bottom padding to initial SIW spinner

### DIFF
--- a/src/v3/src/components/Spinner/InitialSpinner.tsx
+++ b/src/v3/src/components/Spinner/InitialSpinner.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Box } from '@mui/material';
+import { useOdysseyDesignTokens } from '@okta/odyssey-react-mui';
+import { FunctionComponent, h } from 'preact';
+
+import Spinner from './Spinner';
+
+const InitialSpinner: FunctionComponent = () => {
+  const tokens = useOdysseyDesignTokens();
+
+  return (
+    <Box paddingBlockEnd={tokens.Spacing7}>
+      <Spinner />
+    </Box>
+  );
+};
+
+export default InitialSpinner;

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -85,7 +85,7 @@ import AuthContent from '../AuthContent/AuthContent';
 import AuthHeader from '../AuthHeader/AuthHeader';
 import ConsentHeader from '../ConsentHeader';
 import Form from '../Form';
-import Spinner from '../Spinner';
+import InitialSpinner from '../Spinner/InitialSpinner';
 import GlobalStyles from './GlobalStyles';
 
 export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
@@ -558,7 +558,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
             {
               uischema.elements.length > 0
                 ? <Form uischema={uischema as UISchemaLayout} />
-                : <Spinner />
+                : <InitialSpinner />
             }
           </AuthContent>
         </AuthContainer>

--- a/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent-without-logo.test.tsx.snap
@@ -66,28 +66,32 @@ exports[`enduser-consent-without-logo should render form 1`] = `
                 </div>
                 <div
                   class="MuiBox-root emotion-14"
-                  role="status"
                 >
-                  <span
-                    aria-label="Processing..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-15"
-                    role="progressbar"
-                    style="width: 1.71428571rem; height: 1.71428571rem;"
+                  <div
+                    class="MuiBox-root emotion-15"
+                    role="status"
                   >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-16"
-                      viewBox="22 22 44 44"
+                    <span
+                      aria-label="Processing..."
+                      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-16"
+                      role="progressbar"
+                      style="width: 1.71428571rem; height: 1.71428571rem;"
                     >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-17"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="17"
-                        stroke-width="10"
-                      />
-                    </svg>
-                  </span>
+                      <svg
+                        class="MuiCircularProgress-svg emotion-17"
+                        viewBox="22 22 44 44"
+                      >
+                        <circle
+                          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-18"
+                          cx="44"
+                          cy="44"
+                          fill="none"
+                          r="17"
+                          stroke-width="10"
+                        />
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enduser-consent.test.tsx.snap
@@ -106,28 +106,32 @@ exports[`enduser-consent should render form with logo 1`] = `
                 </div>
                 <div
                   class="MuiBox-root emotion-18"
-                  role="status"
                 >
-                  <span
-                    aria-label="Processing..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-19"
-                    role="progressbar"
-                    style="width: 1.71428571rem; height: 1.71428571rem;"
+                  <div
+                    class="MuiBox-root emotion-19"
+                    role="status"
                   >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-20"
-                      viewBox="22 22 44 44"
+                    <span
+                      aria-label="Processing..."
+                      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-20"
+                      role="progressbar"
+                      style="width: 1.71428571rem; height: 1.71428571rem;"
                     >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-21"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="17"
-                        stroke-width="10"
-                      />
-                    </svg>
-                  </span>
+                      <svg
+                        class="MuiCircularProgress-svg emotion-21"
+                        viewBox="22 22 44 44"
+                      >
+                        <circle
+                          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-22"
+                          cx="44"
+                          cy="44"
+                          fill="none"
+                          r="17"
+                          stroke-width="10"
+                        />
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/granular-consent.test.tsx.snap
@@ -102,28 +102,32 @@ exports[`granular-consent should render form with logo 1`] = `
                 </div>
                 <div
                   class="MuiBox-root emotion-17"
-                  role="status"
                 >
-                  <span
-                    aria-label="Processing..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-18"
-                    role="progressbar"
-                    style="width: 1.71428571rem; height: 1.71428571rem;"
+                  <div
+                    class="MuiBox-root emotion-18"
+                    role="status"
                   >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-19"
-                      viewBox="22 22 44 44"
+                    <span
+                      aria-label="Processing..."
+                      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-19"
+                      role="progressbar"
+                      style="width: 1.71428571rem; height: 1.71428571rem;"
                     >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-20"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="17"
-                        stroke-width="10"
-                      />
-                    </svg>
-                  </span>
+                      <svg
+                        class="MuiCircularProgress-svg emotion-20"
+                        viewBox="22 22 44 44"
+                      >
+                        <circle
+                          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-21"
+                          cx="44"
+                          cy="44"
+                          fill="none"
+                          r="17"
+                          stroke-width="10"
+                        />
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -1463,28 +1463,32 @@ exports[`identify-with-password renders the loading state first 1`] = `
               >
                 <div
                   class="MuiBox-root emotion-9"
-                  role="status"
                 >
-                  <span
-                    aria-label="Processing..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-10"
-                    role="progressbar"
-                    style="width: 1.71428571rem; height: 1.71428571rem;"
+                  <div
+                    class="MuiBox-root emotion-10"
+                    role="status"
                   >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-11"
-                      viewBox="22 22 44 44"
+                    <span
+                      aria-label="Processing..."
+                      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-11"
+                      role="progressbar"
+                      style="width: 1.71428571rem; height: 1.71428571rem;"
                     >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-12"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="17"
-                        stroke-width="10"
-                      />
-                    </svg>
-                  </span>
+                      <svg
+                        class="MuiCircularProgress-svg emotion-12"
+                        viewBox="22 22 44 44"
+                      >
+                        <circle
+                          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-13"
+                          cx="44"
+                          cy="44"
+                          fill="none"
+                          r="17"
+                          stroke-width="10"
+                        />
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Description:

Fixes the visual imbalance of the initial loading spinner in the SIW card. Previously, when the widget bootstraps, `AuthContent` rendered the spinner with 40px of padding above and ~12px below, leaving the spinner pinned to the bottom of the card.

This change wraps the bootstrap-only spinner in a small `InitialSpinner` component that adds `paddingBlockEnd={tokens.Spacing7}` (40px) so the spinner is vertically centered inside the card. `AuthContent` and the shared `Spinner` component (used by buttons, `ActionPending`, etc.) are intentionally left unchanged so this fix does not affect any other surface.

This is a v3 (gen3)-only issue — the v1 spinner is for poll/wait flows, not the initial bootstrap.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1024762](https://oktainc.atlassian.net/browse/OKTA-1024762)

### Reviewers:

### Screenshot/Video:

**Before** — spinner crammed near the bottom of the card:

![before](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1024762/before.png)

**After** — spinner vertically centered inside the card:

![after](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1024762/after.png)

Captured against the local SIW playground (`yarn dev`) with the IDX bootstrap request blocked so the spinner state stays visible.

### Downstream Monolith Build:

