### PR TITLE
chore: pin js-cookie to 3.0.5 to keep CI on Node 16 unblocked

### DIFF
--- a/test/package/cjs/package.json
+++ b/test/package/cjs/package.json
@@ -14,5 +14,8 @@
     "webpack": "^5.91.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.8.0"
+  },
+  "resolutions": {
+    "js-cookie": "3.0.5"
   }
 }

--- a/test/package/esm/package.json
+++ b/test/package/esm/package.json
@@ -19,5 +19,8 @@
     "webpack": "^5.91.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.8.0"
+  },
+  "resolutions": {
+    "js-cookie": "3.0.5"
   }
 }

--- a/test/package/tsc/package.json
+++ b/test/package/tsc/package.json
@@ -17,5 +17,8 @@
   "devDependencies": {
     "rimraf": "^2.6.2",
     "typescript": "~4.8.4"
+  },
+  "resolutions": {
+    "js-cookie": "3.0.5"
   }
 }


### PR DESCRIPTION
## Description:

js-cookie 3.0.6 (2026-05-15) and 3.0.7 (2026-05-16) added an `engines: node >= 20` field on the 3.x line for the first time. Bacon CI runs Node 16.19.1, so the verify-package suite started failing on every commit with:

  error js-cookie@3.0.7: The engine "node" is incompatible with this
        module. Expected version ">=20". Got "16.19.1"

The failure surfaces in `test/package/tsc/`, where a fresh `yarn install` (no lockfile) resolves the transitive `js-cookie@^3.0.1` constraint declared by `@okta/okta-auth-js@7.14.2` to the latest matching version (3.0.7) and fails the engines check.

Fix:
- Add `js-cookie: 3.0.5` as a direct dependency in the root `package.json` so it lands in the published `dist/package.json` and forces deduplication of the transitive `^3.0.1` from `@okta/okta-auth-js`. Without this, `yarn install` against the built widget still picks 3.0.7 for the transitive slot, since resolutions on a published package are not honored by consumers.



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



