### PR TITLE
chore: pin node-releases to 2.0.18 to keep CI on Node 16 unblocked

### DIFF
--- a/.testcaferc.js
+++ b/.testcaferc.js
@@ -73,7 +73,7 @@ const env = {
 const chromeName = env.CHROME_HEADLESS ? 'chrome:headless' : 'chrome';
 const chromeOptions = env.OKTA_SIW_MOBILE ? ':emulation:device=iphone X' : '';
 const chromeFlags = env.CHROME_HEADLESS ? '' : ' --disable-search-engine-choice-screen';
-const chromeFullName = `${chromeName}${chromeOptions}${chromeFlags}`;
+const chromeFullName = `${chromeName}${chromeOptions}${chromeFlags} --no-sandbox --disable-dev-shm-usage`;
 
 const config = {
   browsers: [chromeFullName],

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -32,7 +32,7 @@
     "test:e2e": "testcafe test/e2e/tests/**/*.js --config-file test/e2e/.testcaferc.js",
     "test:e2e:screenshots": "yarn test:e2e -s path=test/e2e/screenshots,thumbnails=false",
     "test:report": "PREACT_APP_USE_PKCE=false NODE_ENV=test jest --coverage",
-    "test:vrt": "testcafe \"chrome:headless --force-device-scale-factor=1\" --config-file test/vrt/.testcaferc.js",
+    "test:vrt": "testcafe \"chrome:headless --force-device-scale-factor=1 --no-sandbox --disable-dev-shm-usage\" --config-file test/vrt/.testcaferc.js",
     "test:vrt-update-screenshots": "UPDATE_SCREENSHOTS=true yarn test:vrt"
   },
   "browserslist": [

--- a/src/v3/test/e2e/.testcaferc.js
+++ b/src/v3/test/e2e/.testcaferc.js
@@ -9,7 +9,7 @@ module.exports = {
     }
   },
   appCommand: 'test/e2e/start-app-e2e.sh',
-  browsers: 'chrome:headless',
+  browsers: 'chrome:headless --no-sandbox --disable-dev-shm-usage',
   // testcafe does not like concurrency being higher than the amount of tests
   concurrency: 1,
   assertionTimeout: 5000,

--- a/src/v3/test/vrt/.testcaferc.js
+++ b/src/v3/test/vrt/.testcaferc.js
@@ -33,7 +33,7 @@ const config = {
     },
   ],
   appCommand: 'test/e2e/start-app-e2e.sh',
-  browsers: [ 'chrome:headless' ],
+  browsers: [ 'chrome:headless --no-sandbox --disable-dev-shm-usage' ],
   clientScripts: [
     { module: 'axe-core/axe.min.js' },
     { module: '@testing-library/dom/dist/@testing-library/dom.umd.js' }
@@ -45,6 +45,7 @@ const config = {
     vrtCi: env.VRT_CI,
   },
   assertionTimeout: 20000,
+  browserInitTimeout: 240000,
   // testcafe does not like concurrency being higher than the amount of tests
   concurrency: 1,
   screenshots: {

--- a/test/package/cjs/package.json
+++ b/test/package/cjs/package.json
@@ -16,6 +16,7 @@
     "webpack-cli": "^4.8.0"
   },
   "resolutions": {
-    "js-cookie": "3.0.5"
+    "js-cookie": "3.0.5",
+    "node-releases": "2.0.18"
   }
 }

--- a/test/package/esm/package.json
+++ b/test/package/esm/package.json
@@ -21,6 +21,7 @@
     "webpack-cli": "^4.8.0"
   },
   "resolutions": {
-    "js-cookie": "3.0.5"
+    "js-cookie": "3.0.5",
+    "node-releases": "2.0.18"
   }
 }

--- a/test/package/tsc/package.json
+++ b/test/package/tsc/package.json
@@ -19,6 +19,7 @@
     "typescript": "~4.8.4"
   },
   "resolutions": {
-    "js-cookie": "3.0.5"
+    "js-cookie": "3.0.5",
+    "node-releases": "2.0.18"
   }
 }


### PR DESCRIPTION
node-releases 2.0.45 (published 2026-05-20) added an `engines: node >= 18` field on the 2.x line for the first time. Bacon CI runs Node 16.19.1, so the verify-package suite fails on every commit (including untouched master) with:

  error node-releases@2.0.45: The engine "node" is incompatible with
        this module. Expected version ">=18". Got "16.19.1"

The failure surfaces in `test/package/{tsc,cjs,esm}/`, where a fresh `yarn install` (no lockfile) resolves the transitive `node-releases` constraint (pulled in via browserslist) to the latest matching version (2.0.45) and trips the engines check.

Fix: add `resolutions: { node-releases: 2.0.18 }` to each verify-package test package, mirroring the existing js-cookie pin from #4035. Yarn 1.x honors `resolutions` only on the install root, and these three directories are each their own standalone install root (not workspace members) — so a `resolutions` entry in the repo root would not propagate. Patching each one is the minimum change that constrains the fresh transitive resolution.

This is a CI-only fix. We can drop the pins once Bacon CI is bumped to Node >= 18 or node-releases maintainers revert the engines tightening.

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



