### PR TITLE
diagnostics: add logs to _handleErrorScroll

### DIFF
--- a/packages/@okta/courage-dist/esm/src/CourageForSigninWidget.js
+++ b/packages/@okta/courage-dist/esm/src/CourageForSigninWidget.js
@@ -142,7 +142,7 @@ const Form = BaseForm.extend({
       const isIOS = /iPad|iPhone|iPod/i.test(ua) || (ua.includes('Mac') && 'ontouchend' in document);
       if (isIOS) {
         const active = document.activeElement;
-        Logger.info({
+        console.log({
           tag: 'siw-scroll-diag:gate',
           ts: Date.now(),
           ua,

--- a/packages/@okta/courage-dist/esm/src/CourageForSigninWidget.js
+++ b/packages/@okta/courage-dist/esm/src/CourageForSigninWidget.js
@@ -132,6 +132,32 @@ const Form = BaseForm.extend({
       settings: settings
     } = this.options;
 
+    // OKTA-1104008 diagnostics: log every scroll-on-error gate evaluation so we can
+    // confirm whether iPadOS is firing this per keystroke. iOS-only (covers iPadOS 13+
+    // which reports as Mac). Wrapped in try/catch so a property-access failure never
+    // breaks the widget. Volume is bounded by the 100ms throttle on the underlying
+    // 'invalid error' listener. Remove together with PR #3974's behavioral fix.
+    try {
+      const ua = navigator.userAgent;
+      const isIOS = /iPad|iPhone|iPod/i.test(ua) || (ua.includes('Mac') && 'ontouchend' in document);
+      if (isIOS) {
+        const active = document.activeElement;
+        Logger.info({
+          tag: 'siw-scroll-diag:gate',
+          ts: Date.now(),
+          ua,
+          active: {
+            tag: active && active.tagName,
+            type: active && active.type,
+            readOnly: active && active.readOnly,
+          },
+          scrollY: window.scrollY,
+          visualViewportH: window.visualViewport && window.visualViewport.height,
+          scrollOnErrorSetting: settings.get('features.scrollOnError'),
+        });
+      }
+    } catch (_e) { /* diagnostics must never break the form */ }
+
     if (settings.get('features.scrollOnError') === false) {
       return false;
     }

--- a/packages/@okta/courage-dist/esm/src/courage/views/forms/BaseForm.js
+++ b/packages/@okta/courage-dist/esm/src/courage/views/forms/BaseForm.js
@@ -13,7 +13,6 @@ import InputFactory from './helpers/InputFactory.js';
 import InputLabel from './helpers/InputLabel.js';
 import InputWrapper from './helpers/InputWrapper.js';
 import SettingsModel from '../../util/SettingsModel.js';
-import Logger from '../../util/Logger.js';
 
 const template = _Handlebars2.template({
   "0": function (container, depth0, helpers, partials, data) {
@@ -995,7 +994,7 @@ var BaseForm = BaseView.extend(
           const active = document.activeElement;
           const offset = $el.offset();
           // eslint-disable-next-line no-console
-          Logger.info({
+          console.log({
             tag: 'siw-scroll-diag:animate',
             ts: Date.now(),
             ua: ua,

--- a/packages/@okta/courage-dist/esm/src/courage/views/forms/BaseForm.js
+++ b/packages/@okta/courage-dist/esm/src/courage/views/forms/BaseForm.js
@@ -13,6 +13,7 @@ import InputFactory from './helpers/InputFactory.js';
 import InputLabel from './helpers/InputLabel.js';
 import InputWrapper from './helpers/InputWrapper.js';
 import SettingsModel from '../../util/SettingsModel.js';
+import Logger from '../../util/Logger.js';
 
 const template = _Handlebars2.template({
   "0": function (container, depth0, helpers, partials, data) {
@@ -980,6 +981,36 @@ var BaseForm = BaseView.extend(
       } else {
         scrollTop = $scrollContext.scrollTop() + $el.offset().top - $scrollContext.offset().top;
       }
+
+      // OKTA-1104008 diagnostics: log every scroll animation so we can confirm
+      // whether the iPadOS auto-scroll is driven by this code path. iOS-only (covers
+      // iPadOS 13+ which reports as Mac). Wrapped in try/catch so a property-access
+      // failure (e.g. $el.offset() returning undefined in an unexpected DOM state)
+      // never breaks the form. Volume is bounded by the 100ms throttle on the
+      // underlying 'invalid error' listener. Remove together with PR #3974's fix.
+      try {
+        const ua = navigator.userAgent;
+        const isIOS = /iPad|iPhone|iPod/i.test(ua) || (ua.includes('Mac') && 'ontouchend' in document);
+        if (isIOS) {
+          const active = document.activeElement;
+          const offset = $el.offset();
+          // eslint-disable-next-line no-console
+          Logger.info({
+            tag: 'siw-scroll-diag:animate',
+            ts: Date.now(),
+            ua: ua,
+            targetScrollTop: scrollTop,
+            currentScrollTop: $scrollContext.scrollTop(),
+            errorContainerOffsetTop: offset && offset.top,
+            active: {
+              tag: active && active.tagName,
+              type: active && active.type,
+              readOnly: active && active.readOnly,
+            },
+            visualViewportH: window.visualViewport && window.visualViewport.height,
+          });
+        }
+      } catch (_e) { /* diagnostics must never break the form */ }
 
       $scrollContext.animate({
         scrollTop: scrollTop

--- a/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.ts
+++ b/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.ts
@@ -118,8 +118,35 @@ const PasswordBoxForSigninWidget = PasswordBox.extend({ events });
 
 const Form = BaseForm.extend({
   scrollOnError() {
-    // scrollOnError is true by default. Override to false if `scrollOnError` has been set to false in widget settings.
     const { settings } = this.options;
+
+    // OKTA-1104008 diagnostics: log every scroll-on-error gate evaluation so we can
+    // confirm whether iPadOS is firing this per keystroke. iOS-only (covers iPadOS 13+
+    // which reports as Mac). Wrapped in try/catch so a property-access failure never
+    // breaks the widget. Volume is bounded by the 100ms throttle on the underlying
+    // 'invalid error' listener. Remove together with PR #3974's behavioral fix.
+    try {
+      const ua = navigator.userAgent;
+      const isIOS = /iPad|iPhone|iPod/i.test(ua) || (ua.includes('Mac') && 'ontouchend' in document);
+      if (isIOS) {
+        const active = document.activeElement as (HTMLInputElement & HTMLTextAreaElement) || null;
+        Logger.info({
+          tag: 'siw-scroll-diag:gate',
+          ts: Date.now(),
+          ua,
+          active: {
+            tag: active?.tagName,
+            type: active?.type,
+            readOnly: active?.readOnly,
+          },
+          scrollY: window.scrollY,
+          visualViewportH: window.visualViewport?.height,
+          scrollOnErrorSetting: settings.get('features.scrollOnError'),
+        });
+      }
+    } catch (_e) { /* diagnostics must never break the form */ }
+
+    // scrollOnError is true by default. Override to false if `scrollOnError` has been set to false in widget settings.
     if (settings.get('features.scrollOnError') === false) {
       return false;
     }

--- a/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.ts
+++ b/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.ts
@@ -130,7 +130,7 @@ const Form = BaseForm.extend({
       const isIOS = /iPad|iPhone|iPod/i.test(ua) || (ua.includes('Mac') && 'ontouchend' in document);
       if (isIOS) {
         const active = document.activeElement as (HTMLInputElement & HTMLTextAreaElement) || null;
-        Logger.info({
+        console.log({
           tag: 'siw-scroll-diag:gate',
           ts: Date.now(),
           ua,


### PR DESCRIPTION
## Description:

This is a pre-check for PR https://github.com/okta/okta-signin-widget/pull/3974
Add console log to the path
key stroke -> invalidation error -> __showErrors --> _handleErrorScroll And scrollOnError

If we see a lot of logs like `siw-scroll-diag:gate` and `siw-scroll-diag:animate` accordingly on the customer side, we will be more confident to ship the fix #3974

#### by pass the isIOS check and test locally

<img width="1588" height="824" alt="Screenshot 2026-05-26 at 1 34 47 PM" src="https://github.com/user-attachments/assets/a1a7d38d-94be-46f9-8e22-1b77c44e6358" />


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1187277](https://oktainc.atlassian.net/browse/OKTA-1187277)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



