### PR TITLE
OKTA-1185557: prevent concurrent /poll requests in gen3 FastPass

### DIFF
--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -19,6 +19,7 @@ import { LoopbackProbeElement } from 'src/types';
 import LoopbackProbe from './LoopbackProbe';
 
 const proceedStub = jest.fn();
+let mockWidgetContextOverrides: Record<string, unknown> = {};
 jest.mock('../../contexts', () => ({
   useWidgetContext: () => ({
     authClient: {
@@ -32,6 +33,7 @@ jest.mock('../../contexts', () => ({
       },
     },
     setIdxTransaction: jest.fn(),
+    ...mockWidgetContextOverrides,
   }),
 }));
 jest.mock('../../../../util/Logger');
@@ -47,6 +49,7 @@ describe('LoopbackProbe', () => {
   afterEach(() => {
     jest.clearAllMocks();
     server.resetHandlers();
+    mockWidgetContextOverrides = {};
   });
   afterAll(() => {
     server.close();
@@ -446,6 +449,113 @@ describe('LoopbackProbe', () => {
         },
       }],
       stateHandle: 'fake-state-handle',
+    });
+  });
+
+  // When features.disableConcurrentPolling is on and a poll-step proceed is
+  // already in flight (pollInFlightRef.current === true), submitHandler must
+  // suppress its own proceed. cancelHandler is unaffected.
+  describe('disableConcurrentPolling guard', () => {
+    it('suppresses submitHandler proceed when FF on and a poll is already in flight', async () => {
+      const pollInFlightRef = { current: true };
+      mockWidgetContextOverrides = {
+        widgetProps: { features: { disableConcurrentPolling: true } },
+        pollInFlightRef,
+      };
+      server.use(
+        rest.get('http://localhost:6512/probe', async (_, res, ctx) => res(ctx.status(200))),
+        rest.post('http://localhost:6512/challenge', async (_, res, ctx) => res(ctx.status(200))),
+      );
+      const props: { uischema: LoopbackProbeElement } = {
+        uischema: {
+          type: 'LoopbackProbe',
+          options: {
+            deviceChallengePayload: {
+              ports: ['6512'],
+              domain: 'http://localhost',
+              challengeRequest: 'mockChallengeRequest',
+              probeTimeoutMillis: 100,
+            },
+            cancelStep: 'authenticatorChallenge-cancel',
+            step: 'device-challenge-poll',
+          },
+        },
+      };
+      render(<LoopbackProbe {...props} />);
+
+      // wait for probe + challenge to complete; submitHandler would normally
+      // call proceed at this point but the FF guard suppresses it
+      await new Promise((r) => { setTimeout(r, 250); });
+      expect(proceedStub).not.toHaveBeenCalled();
+      // ref untouched (we did not toggle it from false→true→false)
+      expect(pollInFlightRef.current).toBe(true);
+    });
+
+    it('FF off: submitHandler proceed runs even if pollInFlightRef.current is true', async () => {
+      const pollInFlightRef = { current: true };
+      mockWidgetContextOverrides = {
+        widgetProps: { features: { disableConcurrentPolling: false } },
+        pollInFlightRef,
+      };
+      server.use(
+        rest.get('http://localhost:6512/probe', async (_, res, ctx) => res(ctx.status(200))),
+        rest.post('http://localhost:6512/challenge', async (_, res, ctx) => res(ctx.status(200))),
+      );
+      const props: { uischema: LoopbackProbeElement } = {
+        uischema: {
+          type: 'LoopbackProbe',
+          options: {
+            deviceChallengePayload: {
+              ports: ['6512'],
+              domain: 'http://localhost',
+              challengeRequest: 'mockChallengeRequest',
+              probeTimeoutMillis: 100,
+            },
+            cancelStep: 'authenticatorChallenge-cancel',
+            step: 'device-challenge-poll',
+          },
+        },
+      };
+      render(<LoopbackProbe {...props} />);
+
+      await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
+      expect(proceedStub).toHaveBeenCalledWith({
+        step: 'device-challenge-poll',
+        stateHandle: 'fake-state-handle',
+      });
+    });
+
+    it('FF on: cancelHandler is NOT guarded — user-initiated cancel still goes through', async () => {
+      const pollInFlightRef = { current: true };
+      mockWidgetContextOverrides = {
+        widgetProps: { features: { disableConcurrentPolling: true } },
+        pollInFlightRef,
+      };
+      // probe everywhere fails → cancelHandler fires with OV_UNREACHABLE_BY_LOOPBACK
+      server.use(
+        rest.get('http://localhost:6512/probe', async (_, res, ctx) => res(ctx.status(500))),
+      );
+      const props: { uischema: LoopbackProbeElement } = {
+        uischema: {
+          type: 'LoopbackProbe',
+          options: {
+            deviceChallengePayload: {
+              ports: ['6512'],
+              domain: 'http://localhost',
+              challengeRequest: 'mockChallengeRequest',
+              probeTimeoutMillis: 100,
+            },
+            cancelStep: 'authenticatorChallenge-cancel',
+            step: 'device-challenge-poll',
+          },
+        },
+      };
+      render(<LoopbackProbe {...props} />);
+
+      await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
+      expect(proceedStub).toHaveBeenCalledWith(expect.objectContaining({
+        actions: [expect.objectContaining({ name: 'authenticatorChallenge-cancel' })],
+      }));
     });
   });
 });

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -17,7 +17,7 @@ import { useEffect } from 'preact/hooks';
 import Logger from '../../../../util/Logger';
 import { useWidgetContext } from '../../contexts';
 import { ActionParams, LoopbackProbeElement } from '../../types';
-import { isAndroid, makeRequest } from '../../util';
+import { isAndroid, isPollingStep, makeRequest } from '../../util';
 
 const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
   uischema: {
@@ -29,7 +29,10 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
   },
 }) => {
   const widgetContext = useWidgetContext();
-  const { authClient, idxTransaction, setIdxTransaction } = widgetContext;
+  const {
+    authClient, idxTransaction, setIdxTransaction, widgetProps, pollInFlightRef,
+  } = widgetContext;
+  const disableConcurrentPolling = widgetProps?.features?.disableConcurrentPolling;
 
   const probeTimeoutMillis: number = typeof deviceChallengePayload.probeTimeoutMillis === 'undefined'
     ? 100 : deviceChallengePayload.probeTimeoutMillis;
@@ -47,8 +50,26 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
     if (typeof idxTransaction?.context.stateHandle !== 'undefined') {
       payload.stateHandle = idxTransaction.context.stateHandle;
     }
-    const newTransaction = await authClient?.idx.proceed(payload);
-    setIdxTransaction(newTransaction);
+
+    // When FF is on and another poll-step `proceed` is in flight (e.g.
+    // usePolling's setTimeout already fired), suppress this one.
+    // cancelHandler is intentionally NOT guarded — user-initiated cancel
+    // must always go through.
+    const guarded = disableConcurrentPolling && isPollingStep(stepName);
+    if (guarded && pollInFlightRef?.current) {
+      return;
+    }
+    if (guarded && pollInFlightRef) {
+      pollInFlightRef.current = true;
+    }
+    try {
+      const newTransaction = await authClient?.idx.proceed(payload);
+      setIdxTransaction(newTransaction);
+    } finally {
+      if (guarded && pollInFlightRef) {
+        pollInFlightRef.current = false;
+      }
+    }
   };
 
   const cancelHandler = async (params?: ActionParams) => {

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -123,7 +123,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
   const [stepToRender, setStepToRender] = useState<string | undefined>(undefined);
   const prevIdxTransactionRef = useRef<IdxTransaction>();
   const [responseError, setResponseError] = useState<AuthApiError | OAuthError | null>(null);
-  const pollingTransaction = usePolling(idxTransaction, widgetProps, data);
+  // Shared poll-in-flight tracker (see IWidgetContext.pollInFlightRef)
+  const pollInFlightRef = useRef<boolean>(false);
+  const pollingTransaction = usePolling(idxTransaction, widgetProps, data, pollInFlightRef);
   const interactionCodeFlowFormBag = useInteractionCodeFlow(
     idxTransaction,
     widgetProps,
@@ -527,6 +529,7 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       languageDirection,
       setAbortController,
       abortController,
+      pollInFlightRef,
     }}
     >
       <OdysseyProvider

--- a/src/v3/src/hooks/usePolling.test.tsx
+++ b/src/v3/src/hooks/usePolling.test.tsx
@@ -13,6 +13,7 @@
 import { IdxTransaction, NextStep, OktaAuth } from '@okta/okta-auth-js';
 import { waitFor } from '@testing-library/preact';
 import { renderHook } from '@testing-library/preact-hooks';
+import { MutableRef } from 'preact/hooks';
 import { WidgetProps } from 'src/types';
 
 import { usePolling } from './usePolling';
@@ -226,6 +227,86 @@ describe('usePolling', () => {
       // expect to setup timer
       expect(setTimeout).toHaveBeenCalledTimes(1);
       expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 4000);
+    });
+  });
+
+  // When an external prop update arrives while a /poll request is still
+  // pending (e.g. LoopbackProbe.submitHandler → setIdxTransaction during a
+  // slow /challenge), usePolling reschedules its timer and would fire a
+  // second /poll with the same stateHandle while the first is in flight.
+  // IDX rejects the second request as "bad request" in production. Guard is
+  // gated behind features.disableConcurrentPolling.
+  describe('concurrent /poll requests when idxTransaction prop updates while a poll is in flight', () => {
+    type SetupArgs = {
+      disableConcurrentPolling?: boolean;
+      pollInFlightRef?: MutableRef<boolean>;
+    };
+    const setup = ({ disableConcurrentPolling, pollInFlightRef }: SetupArgs = {}) => {
+      // proceed never resolves during this test, so the 1st poll stays in flight
+      const slowProceed = jest.fn().mockImplementation(
+        () => new Promise(() => { /* never resolves */ }),
+      );
+      const props: Partial<WidgetProps> = {
+        stateToken: 'fake-state-token',
+        authClient: {
+          idx: { proceed: slowProceed },
+        } as unknown as OktaAuth,
+        features: { disableConcurrentPolling },
+      };
+
+      const idxTransaction1 = {
+        nextStep: { name: 'challenge-poll', refresh: 4000 },
+        context: { stateHandle: 'state-handle-abc' },
+      } as unknown as IdxTransaction;
+
+      const { rerender } = renderHook(
+        ({ tx }: { tx: IdxTransaction }) => usePolling(tx, props, mockData, pollInFlightRef),
+        { initialProps: { tx: idxTransaction1 } },
+      );
+
+      // 1st scheduled poll fires
+      jest.advanceTimersByTime(4000);
+
+      // simulate an external setIdxTransaction(...) — same stateHandle, same
+      // polling step, fresh object reference (e.g. LoopbackProbe.submitHandler
+      // resolving and updating idxTransaction).
+      const idxTransaction2 = {
+        nextStep: { name: 'challenge-poll', refresh: 4000 },
+        context: { stateHandle: 'state-handle-abc' },
+      } as unknown as IdxTransaction;
+      rerender({ tx: idxTransaction2 });
+
+      // advance past the next refresh window — the 1st proceed() is still pending
+      jest.advanceTimersByTime(4000);
+
+      return { slowProceed };
+    };
+
+    it('FF off (baseline): fires a 2nd proceed() concurrent with the 1st (the bug)', () => {
+      const { slowProceed } = setup({ disableConcurrentPolling: false });
+      // documents existing buggy behavior preserved when FF is off
+      expect(slowProceed).toHaveBeenCalledTimes(2);
+      expect(slowProceed).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        stateHandle: 'state-handle-abc',
+        step: 'challenge-poll',
+      }));
+      expect(slowProceed).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        stateHandle: 'state-handle-abc',
+        step: 'challenge-poll',
+      }));
+    });
+
+    it('FF on: suppresses the 2nd proceed() while the 1st is still pending', () => {
+      const pollInFlightRef = { current: false } as MutableRef<boolean>;
+      const { slowProceed } = setup({ disableConcurrentPolling: true, pollInFlightRef });
+      // only the 1st proceed() is dispatched; 2nd is suppressed by the guard
+      expect(slowProceed).toHaveBeenCalledTimes(1);
+      expect(slowProceed).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        stateHandle: 'state-handle-abc',
+        step: 'challenge-poll',
+      }));
+      // ref reflects that a poll is still in flight
+      expect(pollInFlightRef.current).toBe(true);
     });
   });
 });

--- a/src/v3/src/hooks/usePolling.ts
+++ b/src/v3/src/hooks/usePolling.ts
@@ -102,15 +102,10 @@ export const usePolling = (
       // When FF is on and another poll-step `proceed` is in flight, suppress
       // this one. The recurring cycle resumes naturally after the in-flight
       // call resolves and updates `transaction`.
-      if (
-        features?.disableConcurrentPolling
-        && isPollingStep(name)
-        && pollInFlightRef?.current
-      ) {
+      const guarded = features?.disableConcurrentPolling && isPollingStep(name);
+      if (guarded && pollInFlightRef?.current) {
         return;
       }
-
-      const guarded = features?.disableConcurrentPolling && isPollingStep(name);
       if (guarded && pollInFlightRef) {
         // eslint-disable-next-line no-param-reassign
         pollInFlightRef.current = true;

--- a/src/v3/src/hooks/usePolling.ts
+++ b/src/v3/src/hooks/usePolling.ts
@@ -13,7 +13,7 @@
 import { IdxActionParams, IdxTransaction, NextStep } from '@okta/okta-auth-js';
 import cloneDeep from 'lodash/cloneDeep';
 import {
-  useEffect, useMemo, useRef, useState,
+  MutableRef, useEffect, useMemo, useRef, useState,
 } from 'preact/hooks';
 
 import { TERMINAL_KEY } from '../constants';
@@ -58,8 +58,9 @@ export const usePolling = (
   idxTransaction: IdxTransaction | undefined,
   widgetProps: Partial<WidgetOptions>,
   data: Record<string, unknown>,
+  pollInFlightRef?: MutableRef<boolean>,
 ): IdxTransaction | undefined => {
-  const { stateToken, authClient } = widgetProps;
+  const { stateToken, authClient, features } = widgetProps;
   const [transaction, setTransaction] = useState<IdxTransaction | undefined>();
   const timerRef = useRef<NodeJS.Timeout>();
 
@@ -97,29 +98,53 @@ export const usePolling = (
       } else {
         payload = { actions: [{ name, params: payload }] };
       }
-      // TODO: Revert to use action once this fix is completed OKTA-512706
-      const newTransaction = await authClient?.idx.proceed({
-        stateHandle: stateToken && idxTransaction?.context?.stateHandle,
-        ...payload,
-      });
 
-      // error code E0000047 is from a standard API error (unhandled)
-      // TERMINAL_KEY.TOO_MANY_REQUESTS is error key from IDX API error message
-      // check that there is no errorIntent to make sure it is not a standard IDX message error
-      // @ts-expect-error OKTA-585869 errorCode & errorIntent properties missing from context type
-      if ((newTransaction?.context?.errorCode === 'E0000047' && !newTransaction?.context?.errorIntent)
-        || containsMessageKey(TERMINAL_KEY.TOO_MANY_REQUESTS, newTransaction?.messages)) {
-        // When polling encounter rate limit error, wait 60 sec for rate limit bucket to reset before polling again
-        const clonedTransaction = cloneDeep(idxTransaction);
-        const clonedPollingStep = getPollingStep(clonedTransaction);
-        if (clonedPollingStep !== undefined) {
-          clonedPollingStep.refresh = 60000;
-        }
-        setTransaction(clonedTransaction);
+      // When FF is on and another poll-step `proceed` is in flight, suppress
+      // this one. The recurring cycle resumes naturally after the in-flight
+      // call resolves and updates `transaction`.
+      if (
+        features?.disableConcurrentPolling
+        && isPollingStep(name)
+        && pollInFlightRef?.current
+      ) {
         return;
       }
 
-      setTransaction(newTransaction);
+      const guarded = features?.disableConcurrentPolling && isPollingStep(name);
+      if (guarded && pollInFlightRef) {
+        // eslint-disable-next-line no-param-reassign
+        pollInFlightRef.current = true;
+      }
+      try {
+        // TODO: Revert to use action once this fix is completed OKTA-512706
+        const newTransaction = await authClient?.idx.proceed({
+          stateHandle: stateToken && idxTransaction?.context?.stateHandle,
+          ...payload,
+        });
+
+        // error code E0000047 is from a standard API error (unhandled)
+        // TERMINAL_KEY.TOO_MANY_REQUESTS is error key from IDX API error message
+        // check that there is no errorIntent to make sure it is not a standard IDX message error
+        // @ts-expect-error OKTA-585869 errorCode & errorIntent properties missing from context type
+        if ((newTransaction?.context?.errorCode === 'E0000047' && !newTransaction?.context?.errorIntent)
+          || containsMessageKey(TERMINAL_KEY.TOO_MANY_REQUESTS, newTransaction?.messages)) {
+          // When polling encounter rate limit error, wait 60 sec for rate limit bucket to reset before polling again
+          const clonedTransaction = cloneDeep(idxTransaction);
+          const clonedPollingStep = getPollingStep(clonedTransaction);
+          if (clonedPollingStep !== undefined) {
+            clonedPollingStep.refresh = 60000;
+          }
+          setTransaction(clonedTransaction);
+          return;
+        }
+
+        setTransaction(newTransaction);
+      } finally {
+        if (guarded && pollInFlightRef) {
+          // eslint-disable-next-line no-param-reassign
+          pollInFlightRef.current = false;
+        }
+      }
     }, refresh);
 
     return () => {

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -47,6 +47,10 @@ export type IWidgetContext = {
   languageDirection: LanguageDirection;
   setAbortController: StateUpdater<AbortController | undefined>;
   abortController: AbortController | undefined;
+  // Shared in-flight tracker for poll-step `proceed` calls. Read/written by
+  // usePolling and LoopbackProbe.submitHandler when
+  // features.disableConcurrentPolling is enabled.
+  pollInFlightRef: MutableRef<boolean>;
 };
 
 // Stepper context

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -281,6 +281,11 @@ export type OktaWidgetFeatures = {
   showPasswordRequirementsAsHtmlList?: boolean;
   disableAutocomplete?: boolean;
   setPageTitle?: boolean | string | PageTitleCallback;
+  // When true, suppress a poll-step `proceed` while another poll-step
+  // `proceed` is already in flight. Prevents IDX from rejecting the 2nd
+  // request as "bad request" when /poll is slow (e.g. DBSSO-elongated
+  // /challenge in FastPass loopback). FF delivered from monolith.
+  disableConcurrentPolling?: boolean;
 };
 
 interface ProxyIdxResponse {


### PR DESCRIPTION
## Description:

Add disableConcurrentPolling feature flag (gen3 only, off by default). When enabled, suppress a poll-step `proceed` while another poll-step `proceed` is already in flight. Fixes IDX rejecting the 2nd request as "bad request" when /poll is slow (e.g. DBSSO-elongated /challenge in FastPass loopback).

Shared in-flight tracker (pollInFlightRef on IWidgetContext) covers both producers: usePolling timer-driven proceed and LoopbackProbe.submitHandler. Non-poll proceeds (cancel, back, select-different-authenticator) bypass the guard. FF delivered from monolith.




## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1185557](https://oktainc.atlassian.net/browse/OKTA-1185557)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



