### PR TITLE
FIX(Google Authenticator): OKTA-1169544 - allow for google authenticator code to be copyable in V2

### DIFF
--- a/assets/sass/v2/_google-authenticator.scss
+++ b/assets/sass/v2/_google-authenticator.scss
@@ -35,12 +35,8 @@
   }
 
   .shared-secret {
-    .o-form-input {
-      width: 100%;
-
-      input {
-        text-align: center;
-      }
+    input {
+      text-align: center;
     }
   }
 }

--- a/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
@@ -75,11 +75,27 @@ const Body = BaseForm.extend({
           viewToDisplay: viewToDisplayState.MANUAL,
         }
       }, {
-        label: false,
-        className: 'shared-secret no-translate',
-        type: 'text',
-        placeholder: this.options.appState.get('currentAuthenticator').contextualData.sharedSecret,
-        disabled: true,
+        View: View.extend({
+          className: 'o-form-fieldset o-form-label-top',
+          template: hbs`
+            <div class="o-form-input">
+              <span class="o-form-input-name-sharedSecret o-form-control
+                okta-form-input-field input-fix shared-secret no-translate">
+                <input type="text"
+                  value="{{sharedSecret}}"
+                  readonly
+                  aria-label="{{sharedSecret}}"
+                  autocomplete="off" />
+              </span>
+            </div>
+          `,
+          getTemplateData() {
+            return {
+              sharedSecret: this.options.appState.get('currentAuthenticator').contextualData.sharedSecret,
+            };
+          },
+        }),
+        selector: '.o-form-fieldset-container',
         showWhen: {
           viewToDisplay: viewToDisplayState.MANUAL,
         }

--- a/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
@@ -49,7 +49,7 @@ export default class EnrollGoogleAuthenticatorPageObject extends BasePageObject 
     if (userVariables.gen3) {
       return this.form.getSubtitle();
     }
-    return this.form.getElement('.shared-secret input').getAttribute('placeholder');
+    return this.form.getElement('.shared-secret input').getAttribute('value');
   }
 
   async goTomanualSetup() {


### PR DESCRIPTION
## Description:

- Allow for google authenticator secret to be copied in V2

- Before
<img width="650" height="682" alt="Screenshot 2026-06-01 at 3 11 56 PM" src="https://github.com/user-attachments/assets/69553dca-3447-422e-829c-415c52f8c5ca" />

- After

https://github.com/user-attachments/assets/c90269f9-1b79-47ca-9334-0bdab1f2c39b


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1169544](https://oktainc.atlassian.net/browse/OKTA-1169544)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&author=jake.bacher%40okta.com&branch=d16t-okta-signin-widget-950c1c3-6a1f0fe0&page=1&pageSize=6&tab=main



