### PR TITLE
OKTA-1142182: Render password history requirement in gen3 SIW

### DIFF
--- a/src/v3/src/constants/passwordConstants.ts
+++ b/src/v3/src/constants/passwordConstants.ts
@@ -24,6 +24,8 @@ export const PASSWORD_REQUIREMENTS_KEYS: Record<'complexity' | 'age', { [key: st
     maxConsecutiveRepeatingCharacters: 'password.complexity.maxConsecutiveRepeatingCharacters.description',
   },
   age: {
+    historyCountOne: 'password.complexity.history.one.description',
+    historyCount: 'password.complexity.history.description',
     minAgeMinutes: 'password.complexity.minAgeMinutes.description',
     minAgeHours: 'password.complexity.minAgeHours.description',
     minAgeDays: 'password.complexity.minAgeDays.description',

--- a/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.test.ts
@@ -11,8 +11,12 @@
  */
 
 import { PASSWORD_REQUIREMENTS_KEYS } from '../../constants';
-import { ComplexityRequirements } from '../../types';
-import { getComplexityItems } from './passwordSettingsUtils';
+import { AgeRequirements, ComplexityRequirements, PasswordSettings } from '../../types';
+import {
+  buildPasswordRequirementListItems,
+  getAgeItems,
+  getComplexityItems,
+} from './passwordSettingsUtils';
 
 jest.mock('util/loc', () => ({
   loc: jest.fn().mockImplementation(
@@ -112,5 +116,92 @@ describe('getComplexityItems', () => {
 
     const result = getComplexityItems(complexity);
     expect(result).toEqual([{ ruleKey: 'maxConsecutiveRepeatingCharacters', label: PASSWORD_REQUIREMENTS_KEYS.complexity.maxConsecutiveRepeatingCharacters }]);
+  });
+});
+
+describe('getAgeItems', () => {
+  it('should return empty list when age is undefined', () => {
+    expect(getAgeItems(undefined)).toEqual([]);
+  });
+
+  it('should not return historyCount item when historyCount is 0', () => {
+    const age = { historyCount: 0 } as unknown as AgeRequirements;
+    expect(getAgeItems(age)).toEqual([]);
+  });
+
+  it('should return one-password historyCount item when historyCount is 1', () => {
+    const age = { historyCount: 1 } as unknown as AgeRequirements;
+    expect(getAgeItems(age)).toEqual([
+      { ruleKey: 'historyCount', label: PASSWORD_REQUIREMENTS_KEYS.age.historyCountOne },
+    ]);
+  });
+
+  it('should return many-password historyCount item when historyCount is greater than 1', () => {
+    const age = { historyCount: 4 } as unknown as AgeRequirements;
+    expect(getAgeItems(age)).toEqual([
+      { ruleKey: 'historyCount', label: PASSWORD_REQUIREMENTS_KEYS.age.historyCount },
+    ]);
+  });
+
+  it('should return minutes label for minAgeMinutes under one hour', () => {
+    const age = { minAgeMinutes: 30 } as unknown as AgeRequirements;
+    expect(getAgeItems(age)).toEqual([
+      { ruleKey: 'minAgeMinutes', label: PASSWORD_REQUIREMENTS_KEYS.age.minAgeMinutes },
+    ]);
+  });
+
+  it('should return hours label for minAgeMinutes between one hour and one day', () => {
+    const age = { minAgeMinutes: 90 } as unknown as AgeRequirements;
+    expect(getAgeItems(age)).toEqual([
+      { ruleKey: 'minAgeMinutes', label: PASSWORD_REQUIREMENTS_KEYS.age.minAgeHours },
+    ]);
+  });
+
+  it('should return days label for minAgeMinutes greater than one day', () => {
+    const age = { minAgeMinutes: 60 * 25 } as unknown as AgeRequirements;
+    expect(getAgeItems(age)).toEqual([
+      { ruleKey: 'minAgeMinutes', label: PASSWORD_REQUIREMENTS_KEYS.age.minAgeDays },
+    ]);
+  });
+
+  it('should not return minAgeMinutes item when minAgeMinutes is 0', () => {
+    const age = { historyCount: 4, minAgeMinutes: 0 } as unknown as AgeRequirements;
+    expect(getAgeItems(age)).toEqual([
+      { ruleKey: 'historyCount', label: PASSWORD_REQUIREMENTS_KEYS.age.historyCount },
+    ]);
+  });
+
+  it('should return both historyCount and minAgeMinutes items in order when both are set', () => {
+    const age = { historyCount: 4, minAgeMinutes: 10 } as unknown as AgeRequirements;
+    expect(getAgeItems(age)).toEqual([
+      { ruleKey: 'historyCount', label: PASSWORD_REQUIREMENTS_KEYS.age.historyCount },
+      { ruleKey: 'minAgeMinutes', label: PASSWORD_REQUIREMENTS_KEYS.age.minAgeMinutes },
+    ]);
+  });
+});
+
+describe('buildPasswordRequirementListItems', () => {
+  it('should concatenate complexity items followed by age items', () => {
+    const settings = {
+      complexity: { minLength: 8 },
+      age: { historyCount: 4, minAgeMinutes: 10 },
+    } as unknown as PasswordSettings;
+
+    expect(buildPasswordRequirementListItems(settings)).toEqual([
+      { ruleKey: 'minLength', label: PASSWORD_REQUIREMENTS_KEYS.complexity.minLength },
+      { ruleKey: 'historyCount', label: PASSWORD_REQUIREMENTS_KEYS.age.historyCount },
+      { ruleKey: 'minAgeMinutes', label: PASSWORD_REQUIREMENTS_KEYS.age.minAgeMinutes },
+    ]);
+  });
+
+  it('should return only complexity items when age has no positive values', () => {
+    const settings = {
+      complexity: { minLength: 8 },
+      age: { historyCount: 0, minAgeMinutes: 0 },
+    } as unknown as PasswordSettings;
+
+    expect(buildPasswordRequirementListItems(settings)).toEqual([
+      { ruleKey: 'minLength', label: PASSWORD_REQUIREMENTS_KEYS.complexity.minLength },
+    ]);
   });
 });

--- a/src/v3/src/transformer/password/passwordSettingsUtils.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.ts
@@ -12,6 +12,7 @@
 
 import { PASSWORD_REQUIREMENTS_KEYS } from '../../constants';
 import {
+  AgeRequirements,
   ComplexityKeys,
   ComplexityRequirements,
   GetAgeFromMinutes,
@@ -83,6 +84,38 @@ export const getComplexityItems = (complexity?: ComplexityRequirements): ListIte
   return items;
 };
 
+export const getAgeItems = (age?: AgeRequirements): ListItem[] => {
+  const items: ListItem[] = [];
+
+  if (!age) {
+    return items;
+  }
+
+  if (age.historyCount > 0) {
+    if (age.historyCount === 1) {
+      items.push({
+        ruleKey: 'historyCount',
+        label: loc(PASSWORD_REQUIREMENTS_KEYS.age.historyCountOne, 'login'),
+      });
+    } else {
+      items.push({
+        ruleKey: 'historyCount',
+        label: loc(PASSWORD_REQUIREMENTS_KEYS.age.historyCount, 'login', [age.historyCount]),
+      });
+    }
+  }
+
+  if (age.minAgeMinutes > 0) {
+    const { unitLabel, value } = getAgeFromMinutes(age.minAgeMinutes);
+    items.push({
+      ruleKey: 'minAgeMinutes',
+      label: loc(unitLabel, 'login', [value]),
+    });
+  }
+
+  return items;
+};
+
 export const buildPasswordRequirementListItems = (
   data: PasswordSettings,
-): ListItem[] => getComplexityItems(data.complexity);
+): ListItem[] => [...getComplexityItems(data.complexity), ...getAgeItems(data.age)];

--- a/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
+++ b/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
@@ -36,8 +36,19 @@ export const transformEnrollPasswordAuthenticator: IdxStepTransformer = ({
   transaction,
   formBag,
 }) => {
-  const { nextStep: { relatesTo } = {} } = transaction;
-  const passwordSettings = (relatesTo?.value?.settings || {}) as PasswordSettings;
+  const { context, nextStep: { relatesTo } = {} } = transaction;
+  // Mirror gen2 `ReEnrollAuthenticatorPasswordView.getPasswordPolicySettings`: for
+  // password-reset/expired flows IDX exposes the *current* password's policy via
+  // `nextStep.relatesTo` ($.currentAuthenticator), while the new-password policy lives
+  // on `recoveryAuthenticator` or `enrollmentAuthenticator`. Prefer those so requirements
+  // like "Password can't be the same as your last 4 passwords" surface in the UI.
+  const passwordSettings = (
+    // @ts-expect-error OKTA-1142182 - recoveryAuthenticator missing from IdxContext type
+    context?.recoveryAuthenticator?.value?.settings
+    || context?.enrollmentAuthenticator?.value?.settings
+    || relatesTo?.value?.settings
+    || {}
+  ) as PasswordSettings;
 
   const { uischema, dataSchema } = formBag;
   const userInfo = getUserInfo(transaction);

--- a/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
+++ b/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
@@ -12,6 +12,7 @@
 
 import { PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS } from '../../constants';
 import {
+  ExtendedIdxContext,
   FieldElement,
   FormBag,
   HiddenInputElement,
@@ -42,10 +43,10 @@ export const transformEnrollPasswordAuthenticator: IdxStepTransformer = ({
   // `nextStep.relatesTo` ($.currentAuthenticator), while the new-password policy lives
   // on `recoveryAuthenticator` or `enrollmentAuthenticator`. Prefer those so requirements
   // like "Password can't be the same as your last 4 passwords" surface in the UI.
+  const extendedContext = context as ExtendedIdxContext | undefined;
   const passwordSettings = (
-    // @ts-expect-error OKTA-1142182 - recoveryAuthenticator missing from IdxContext type
-    context?.recoveryAuthenticator?.value?.settings
-    || context?.enrollmentAuthenticator?.value?.settings
+    extendedContext?.recoveryAuthenticator?.value?.settings
+    || extendedContext?.enrollmentAuthenticator?.value?.settings
     || relatesTo?.value?.settings
     || {}
   ) as PasswordSettings;

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -12,6 +12,8 @@
 
 import {
   AuthApiError,
+  IdxAuthenticator,
+  IdxContext,
   IdxMessage,
   IdxTransaction,
   OAuthError,
@@ -21,6 +23,16 @@ import { MutableRef, StateUpdater } from 'preact/hooks';
 
 import { FormBag, LanguageDirection, UISchemaLayoutType } from './schema';
 import { WidgetProps } from './widget';
+
+// `recoveryAuthenticator` is exposed by IDX on password reset/expired flows but is
+// missing from `IdxContext` in our pinned `@okta/okta-auth-js`. Extend locally to
+// avoid a wholesale auth-js bump just for this field.
+export interface ExtendedIdxContext extends IdxContext {
+  recoveryAuthenticator?: {
+    type: string;
+    value: IdxAuthenticator;
+  };
+}
 
 export type IWidgetContext = {
   authClient: OktaAuthIdxInterface;

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -399,10 +399,50 @@ exports[`authenticator-expired-password should present field level error message
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-32"
+                          >
+                            <div
+                              class="MuiBox-root emotion-33"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-34"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-35"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-37"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-62"
+                        class="MuiBox-root emotion-68"
                         role="status"
                         translate="no"
                       >
@@ -413,7 +453,7 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-64"
+                        class="MuiBox-root emotion-70"
                         id="username"
                         name="username"
                         type="text"
@@ -423,10 +463,10 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-66"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-72"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-67"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-73"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -436,7 +476,7 @@ exports[`authenticator-expired-password should present field level error message
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-68"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-74"
                           required="true"
                         >
                           <input
@@ -445,7 +485,7 @@ exports[`authenticator-expired-password should present field level error message
                             aria-invalid="true"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-69"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-75"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             name="credentials.passcode"
@@ -454,13 +494,13 @@ exports[`authenticator-expired-password should present field level error message
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-70"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-76"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-71"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-77"
                               tabindex="0"
                               type="button"
                             >
@@ -483,11 +523,11 @@ exports[`authenticator-expired-password should present field level error message
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-73"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-79"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-74"
+                            class="MuiBox-root emotion-80"
                           >
                             Error:
                           </span>
@@ -496,20 +536,20 @@ exports[`authenticator-expired-password should present field level error message
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-76"
+                              class="MuiList-root MuiList-dense emotion-82"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-77"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-83"
                               >
                                 At least 8 characters
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-77"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-83"
                               >
                                 An uppercase letter
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-77"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-83"
                               >
                                 A number
                               </li>
@@ -522,10 +562,10 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-66"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-72"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-67"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-73"
                           data-shrink="false"
                           for="confirmPassword"
                           id="confirmPassword-label"
@@ -535,7 +575,7 @@ exports[`authenticator-expired-password should present field level error message
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-68"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-74"
                           required="true"
                         >
                           <input
@@ -544,7 +584,7 @@ exports[`authenticator-expired-password should present field level error message
                             aria-invalid="true"
                             aria-labelledby="confirmPassword-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-69"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-75"
                             data-se="confirmPassword"
                             id="confirmPassword"
                             name="confirmPassword"
@@ -553,13 +593,13 @@ exports[`authenticator-expired-password should present field level error message
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-70"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-76"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-71"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-77"
                               tabindex="0"
                               type="button"
                             >
@@ -582,11 +622,11 @@ exports[`authenticator-expired-password should present field level error message
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-73"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-79"
                           id="confirmPassword-error"
                         >
                           <span
-                            class="MuiBox-root emotion-74"
+                            class="MuiBox-root emotion-80"
                           >
                             Error:
                           </span>
@@ -606,7 +646,7 @@ exports[`authenticator-expired-password should present field level error message
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          class="MuiBox-root emotion-93"
+                          class="MuiBox-root emotion-99"
                           id="credentials.newPassword-list"
                         >
                           <li
@@ -623,7 +663,7 @@ exports[`authenticator-expired-password should present field level error message
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-97"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-103"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -656,7 +696,7 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-101"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-107"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -668,7 +708,7 @@ exports[`authenticator-expired-password should present field level error message
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-103"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-109"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -1044,10 +1084,50 @@ exports[`authenticator-expired-password should render form 1`] = `
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-25"
+                          >
+                            <div
+                              class="MuiBox-root emotion-26"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-27"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-28"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-30"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-55"
+                        class="MuiBox-root emotion-61"
                         role="status"
                         translate="no"
                       >
@@ -1058,7 +1138,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-57"
+                        class="MuiBox-root emotion-63"
                         id="generated"
                         name="username"
                         type="text"
@@ -1068,10 +1148,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="generated"
@@ -1081,7 +1161,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
                           required="true"
                         >
                           <input
@@ -1089,7 +1169,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
                             data-se="credentials.passcode"
                             id="generated"
                             name="credentials.passcode"
@@ -1098,19 +1178,19 @@ exports[`authenticator-expired-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-71"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1132,10 +1212,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
                           data-shrink="false"
                           for="confirmPassword"
                           id="generated"
@@ -1145,7 +1225,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
                           required="true"
                         >
                           <input
@@ -1153,7 +1233,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
                             data-se="confirmPassword"
                             id="generated"
                             name="confirmPassword"
@@ -1162,19 +1242,19 @@ exports[`authenticator-expired-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-71"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1200,7 +1280,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          class="MuiBox-root emotion-76"
+                          class="MuiBox-root emotion-82"
                           id="generated"
                         >
                           <li
@@ -1217,7 +1297,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-80"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-86"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -1250,7 +1330,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-84"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-90"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1262,7 +1342,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-86"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-92"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -534,10 +534,50 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-35"
+                          >
+                            <div
+                              class="MuiBox-root emotion-36"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-37"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-38"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-30"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-83"
+                        class="MuiBox-root emotion-89"
                         role="status"
                         translate="no"
                       >
@@ -548,7 +588,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-85"
+                        class="MuiBox-root emotion-91"
                         id="username"
                         name="username"
                         type="text"
@@ -558,10 +598,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-87"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-93"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-88"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-94"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -571,7 +611,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-89"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-95"
                           required="true"
                         >
                           <input
@@ -580,7 +620,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                             aria-invalid="true"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-90"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-96"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             name="credentials.passcode"
@@ -589,13 +629,13 @@ exports[`authenticator-expiry-warning-password should present field level error 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-91"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-97"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-92"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-98"
                               tabindex="0"
                               type="button"
                             >
@@ -618,11 +658,11 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-94"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-100"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-95"
+                            class="MuiBox-root emotion-101"
                           >
                             Error:
                           </span>
@@ -631,25 +671,25 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-97"
+                              class="MuiList-root MuiList-dense emotion-103"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-104"
                               >
                                 At least 8 characters
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-104"
                               >
                                 An uppercase letter
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-104"
                               >
                                 A number
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-98"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-104"
                               >
                                 A symbol
                               </li>
@@ -662,10 +702,10 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-87"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-93"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-88"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-94"
                           data-shrink="false"
                           for="confirmPassword"
                           id="confirmPassword-label"
@@ -675,7 +715,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-89"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-95"
                           required="true"
                         >
                           <input
@@ -684,7 +724,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                             aria-invalid="true"
                             aria-labelledby="confirmPassword-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-90"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-96"
                             data-se="confirmPassword"
                             id="confirmPassword"
                             name="confirmPassword"
@@ -693,13 +733,13 @@ exports[`authenticator-expiry-warning-password should present field level error 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-91"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-97"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-92"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-98"
                               tabindex="0"
                               type="button"
                             >
@@ -722,11 +762,11 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-94"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-100"
                           id="confirmPassword-error"
                         >
                           <span
-                            class="MuiBox-root emotion-95"
+                            class="MuiBox-root emotion-101"
                           >
                             Error:
                           </span>
@@ -746,7 +786,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          class="MuiBox-root emotion-115"
+                          class="MuiBox-root emotion-121"
                           id="credentials.newPassword-list"
                         >
                           <li
@@ -763,7 +803,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-119"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-125"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -796,7 +836,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-123"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-129"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -808,7 +848,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-125"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-131"
                         data-se="skip"
                         role="link"
                         type="button"
@@ -820,7 +860,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-125"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-131"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -1331,10 +1371,50 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-28"
+                          >
+                            <div
+                              class="MuiBox-root emotion-29"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-30"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-31"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-23"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-76"
+                        class="MuiBox-root emotion-82"
                         role="status"
                         translate="no"
                       >
@@ -1345,7 +1425,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-78"
+                        class="MuiBox-root emotion-84"
                         id="generated"
                         name="username"
                         type="text"
@@ -1355,10 +1435,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-80"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-86"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-81"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-87"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="generated"
@@ -1368,7 +1448,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-82"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-88"
                           required="true"
                         >
                           <input
@@ -1376,7 +1456,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-83"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-89"
                             data-se="credentials.passcode"
                             id="generated"
                             name="credentials.passcode"
@@ -1385,19 +1465,19 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-84"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-90"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-85"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-91"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-86"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-92"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1419,10 +1499,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-80"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-86"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-81"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-87"
                           data-shrink="false"
                           for="confirmPassword"
                           id="generated"
@@ -1432,7 +1512,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-82"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-88"
                           required="true"
                         >
                           <input
@@ -1440,7 +1520,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-83"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-89"
                             data-se="confirmPassword"
                             id="generated"
                             name="confirmPassword"
@@ -1449,19 +1529,19 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-84"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-90"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-85"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-91"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-86"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-92"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1487,7 +1567,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          class="MuiBox-root emotion-97"
+                          class="MuiBox-root emotion-103"
                           id="generated"
                         >
                           <li
@@ -1504,7 +1584,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-101"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-107"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -1537,7 +1617,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-105"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-111"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1549,7 +1629,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-113"
                         data-se="skip"
                         role="link"
                         type="button"
@@ -1561,7 +1641,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-113"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -436,10 +436,50 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-25"
+                          >
+                            <div
+                              class="MuiBox-root emotion-26"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-27"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-28"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-30"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-67"
+                        class="MuiBox-root emotion-73"
                         role="status"
                         translate="no"
                       >
@@ -450,7 +490,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-69"
+                        class="MuiBox-root emotion-75"
                         id="username"
                         name="username"
                         type="text"
@@ -460,10 +500,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-71"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-77"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-72"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-78"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -473,7 +513,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-73"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-79"
                           required="true"
                         >
                           <input
@@ -481,7 +521,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-80"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             name="credentials.passcode"
@@ -490,19 +530,19 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-75"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-81"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-76"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-82"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-83"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -524,10 +564,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-71"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-77"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-72"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-78"
                           data-shrink="false"
                           for="confirmPassword"
                           id="confirmPassword-label"
@@ -537,7 +577,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-73"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-79"
                           required="true"
                         >
                           <input
@@ -545,7 +585,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="confirmPassword-label"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-74"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-80"
                             data-se="confirmPassword"
                             id="confirmPassword"
                             name="confirmPassword"
@@ -554,19 +594,19 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-75"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-81"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-76"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-82"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-77"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-83"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -592,7 +632,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          class="MuiBox-root emotion-88"
+                          class="MuiBox-root emotion-94"
                           id="credentials.newPassword-list"
                         >
                           <li
@@ -609,7 +649,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-92"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-98"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -642,10 +682,10 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <fieldset
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-96"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-102"
                       >
                         <legend
-                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-97"
+                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-103"
                           id="credentials.revokeSessions-label"
                         >
                           
@@ -654,19 +694,19 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                         </legend>
                         <div
                           aria-labelledby="credentials.revokeSessions-label"
-                          class="MuiFormGroup-root emotion-98"
+                          class="MuiFormGroup-root emotion-104"
                           id="credentials.revokeSessions"
                         >
                           <label
-                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-99"
+                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-105"
                             id="credentials.revokeSessions-checkbox"
                           >
                             <span
-                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-100"
+                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-106"
                             >
                               <input
                                 aria-readonly="false"
-                                class="PrivateSwitchBase-input emotion-101"
+                                class="PrivateSwitchBase-input emotion-107"
                                 data-indeterminate="false"
                                 data-se="credentials.revokeSessions"
                                 name="credentials.revokeSessions"
@@ -691,7 +731,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-105"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-111"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -703,7 +743,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-107"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-113"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -356,10 +356,50 @@ exports[`authenticator-reset-password should render form 1`] = `
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-25"
+                          >
+                            <div
+                              class="MuiBox-root emotion-26"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-27"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-28"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-30"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-55"
+                        class="MuiBox-root emotion-61"
                         role="status"
                         translate="no"
                       >
@@ -370,7 +410,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-57"
+                        class="MuiBox-root emotion-63"
                         id="generated"
                         name="username"
                         type="text"
@@ -380,10 +420,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="generated"
@@ -393,7 +433,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
                           required="true"
                         >
                           <input
@@ -401,7 +441,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
                             data-se="credentials.passcode"
                             id="generated"
                             name="credentials.passcode"
@@ -410,19 +450,19 @@ exports[`authenticator-reset-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-71"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -444,10 +484,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
                           data-shrink="false"
                           for="confirmPassword"
                           id="generated"
@@ -457,7 +497,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
                           required="true"
                         >
                           <input
@@ -465,7 +505,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
                             data-se="confirmPassword"
                             id="generated"
                             name="confirmPassword"
@@ -474,19 +514,19 @@ exports[`authenticator-reset-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-71"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -512,7 +552,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          class="MuiBox-root emotion-76"
+                          class="MuiBox-root emotion-82"
                           id="generated"
                         >
                           <li
@@ -529,7 +569,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-80"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-86"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -562,7 +602,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-84"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-90"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -574,7 +614,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-86"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-92"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -950,10 +990,50 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-25"
+                          >
+                            <div
+                              class="MuiBox-root emotion-26"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-27"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-28"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-30"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-55"
+                        class="MuiBox-root emotion-61"
                         role="status"
                         translate="no"
                       >
@@ -964,7 +1044,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-2"
                     >
                       <input
-                        class="MuiBox-root emotion-57"
+                        class="MuiBox-root emotion-63"
                         id="generated"
                         name="username"
                         type="text"
@@ -974,10 +1054,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="generated"
@@ -987,7 +1067,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
                           required="true"
                         >
                           <input
@@ -995,7 +1075,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
                             data-se="credentials.passcode"
                             id="generated"
                             name="credentials.passcode"
@@ -1004,19 +1084,19 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-71"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1038,10 +1118,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-59"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-65"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-60"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-66"
                           data-shrink="false"
                           for="confirmPassword"
                           id="generated"
@@ -1051,7 +1131,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-61"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-67"
                           required="true"
                         >
                           <input
@@ -1059,7 +1139,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             aria-invalid="false"
                             aria-labelledby="generated"
                             autocomplete="new-password"
-                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-62"
+                            class="MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-68"
                             data-se="confirmPassword"
                             id="generated"
                             name="confirmPassword"
@@ -1068,19 +1148,19 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-63"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-69"
                           >
                             <button
                               aria-controls="confirmPassword"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-65"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-71"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -1106,7 +1186,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         data-se="password-authenticator--matches"
                       >
                         <ul
-                          class="MuiBox-root emotion-76"
+                          class="MuiBox-root emotion-82"
                           id="generated"
                         >
                           <li
@@ -1123,7 +1203,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-80"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-86"
                                   fill="none"
                                   focusable="false"
                                   viewBox="0 0 24 24"
@@ -1156,7 +1236,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-84"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-90"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1168,7 +1248,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-86"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-92"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-with-password.test.tsx.snap
@@ -602,10 +602,50 @@ exports[`enroll-profile-with-password should display field level error when pass
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              class="MuiBox-root emotion-44"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-45"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-46"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-23"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-97"
+                        class="MuiBox-root emotion-103"
                         role="status"
                         translate="no"
                       >
@@ -629,7 +669,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-107"
                           required="true"
                         >
                           <input
@@ -647,13 +687,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-109"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-110"
                               tabindex="0"
                               type="button"
                             >
@@ -676,11 +716,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-106"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-112"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-107"
+                            class="MuiBox-root emotion-113"
                           >
                             Error:
                           </span>
@@ -689,15 +729,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-109"
+                              class="MuiList-root MuiList-dense emotion-115"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-116"
                               >
                                 Does not include your first name
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-116"
                               >
                                 Does not include your last name
                               </li>
@@ -710,7 +750,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-113"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-119"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -722,15 +762,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-115"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-121"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-116"
+                      class="MuiBox-root emotion-122"
                     >
                       <div
-                        class="MuiBox-root emotion-117"
+                        class="MuiBox-root emotion-123"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -745,10 +785,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-117"
+                        class="MuiBox-root emotion-123"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-121"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-127"
                           data-se="back"
                           role="link"
                           type="button"
@@ -1371,10 +1411,50 @@ exports[`enroll-profile-with-password should display field level error when pass
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              class="MuiBox-root emotion-44"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-45"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-46"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-23"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-97"
+                        class="MuiBox-root emotion-103"
                         role="status"
                         translate="no"
                       >
@@ -1398,7 +1478,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-107"
                           required="true"
                         >
                           <input
@@ -1416,13 +1496,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-109"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-110"
                               tabindex="0"
                               type="button"
                             >
@@ -1445,11 +1525,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-106"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-112"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-107"
+                            class="MuiBox-root emotion-113"
                           >
                             Error:
                           </span>
@@ -1458,10 +1538,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-109"
+                              class="MuiList-root MuiList-dense emotion-115"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-116"
                               >
                                 Maximum 3 consecutive repeating characters
                               </li>
@@ -1474,7 +1554,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-112"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-118"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -1486,15 +1566,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-114"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-120"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-115"
+                      class="MuiBox-root emotion-121"
                     >
                       <div
-                        class="MuiBox-root emotion-116"
+                        class="MuiBox-root emotion-122"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -1509,10 +1589,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-116"
+                        class="MuiBox-root emotion-122"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-120"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-126"
                           data-se="back"
                           role="link"
                           type="button"
@@ -2135,10 +2215,50 @@ exports[`enroll-profile-with-password should display field level error when pass
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              class="MuiBox-root emotion-44"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-45"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-46"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-23"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-97"
+                        class="MuiBox-root emotion-103"
                         role="status"
                         translate="no"
                       >
@@ -2162,7 +2282,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-107"
                           required="true"
                         >
                           <input
@@ -2180,13 +2300,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-109"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-110"
                               tabindex="0"
                               type="button"
                             >
@@ -2209,11 +2329,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-106"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-112"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-107"
+                            class="MuiBox-root emotion-113"
                           >
                             Error:
                           </span>
@@ -2222,20 +2342,20 @@ exports[`enroll-profile-with-password should display field level error when pass
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-109"
+                              class="MuiList-root MuiList-dense emotion-115"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-116"
                               >
                                 At least 8 characters
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-116"
                               >
                                 An uppercase letter
                               </li>
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-116"
                               >
                                 A symbol
                               </li>
@@ -2248,7 +2368,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-114"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-120"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -2260,15 +2380,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-116"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-122"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-117"
+                      class="MuiBox-root emotion-123"
                     >
                       <div
-                        class="MuiBox-root emotion-118"
+                        class="MuiBox-root emotion-124"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -2283,10 +2403,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-118"
+                        class="MuiBox-root emotion-124"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-122"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-128"
                           data-se="back"
                           role="link"
                           type="button"
@@ -2909,10 +3029,50 @@ exports[`enroll-profile-with-password should display field level error when pass
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              class="MuiBox-root emotion-44"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-45"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-46"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-23"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-97"
+                        class="MuiBox-root emotion-103"
                         role="status"
                         translate="no"
                       >
@@ -2936,7 +3096,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-107"
                           required="true"
                         >
                           <input
@@ -2954,13 +3114,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-109"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-110"
                               tabindex="0"
                               type="button"
                             >
@@ -2983,11 +3143,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-106"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-filled emotion-112"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-107"
+                            class="MuiBox-root emotion-113"
                           >
                             Error:
                           </span>
@@ -2996,10 +3156,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                           >
                             Password requirements were not met:
                             <ul
-                              class="MuiList-root MuiList-dense emotion-109"
+                              class="MuiList-root MuiList-dense emotion-115"
                             >
                               <li
-                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-110"
+                                class="MuiListItem-root MuiListItem-dense MuiListItem-gutters emotion-116"
                               >
                                 No parts of your username
                               </li>
@@ -3012,7 +3172,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-112"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-118"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -3024,15 +3184,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-114"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-120"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-115"
+                      class="MuiBox-root emotion-121"
                     >
                       <div
-                        class="MuiBox-root emotion-116"
+                        class="MuiBox-root emotion-122"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -3047,10 +3207,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-116"
+                        class="MuiBox-root emotion-122"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-120"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-126"
                           data-se="back"
                           role="link"
                           type="button"
@@ -3673,10 +3833,50 @@ exports[`enroll-profile-with-password should display field level error when pass
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-43"
+                          >
+                            <div
+                              class="MuiBox-root emotion-44"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-45"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-46"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-23"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-97"
+                        class="MuiBox-root emotion-103"
                         role="status"
                         translate="no"
                       >
@@ -3700,7 +3900,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-101"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedEnd emotion-107"
                           required="true"
                         >
                           <input
@@ -3718,13 +3918,13 @@ exports[`enroll-profile-with-password should display field level error when pass
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-103"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-109"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-104"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-110"
                               tabindex="0"
                               type="button"
                             >
@@ -3747,11 +3947,11 @@ exports[`enroll-profile-with-password should display field level error when pass
                           </div>
                         </div>
                         <div
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-106"
+                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium emotion-112"
                           id="credentials.passcode-error"
                         >
                           <span
-                            class="MuiBox-root emotion-107"
+                            class="MuiBox-root emotion-113"
                           >
                             Error:
                           </span>
@@ -3767,7 +3967,7 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-110"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-116"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -3779,15 +3979,15 @@ exports[`enroll-profile-with-password should display field level error when pass
                       class="MuiBox-root emotion-18"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-112"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-118"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-113"
+                      class="MuiBox-root emotion-119"
                     >
                       <div
-                        class="MuiBox-root emotion-114"
+                        class="MuiBox-root emotion-120"
                       >
                         <div
                           class="MuiBox-root emotion-19"
@@ -3802,10 +4002,10 @@ exports[`enroll-profile-with-password should display field level error when pass
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-114"
+                        class="MuiBox-root emotion-120"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-118"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-124"
                           data-se="back"
                           role="link"
                           type="button"
@@ -4385,10 +4585,50 @@ exports[`enroll-profile-with-password should render form 1`] = `
                               </div>
                             </div>
                           </li>
+                          <li
+                            class="MuiBox-root emotion-36"
+                          >
+                            <div
+                              class="MuiBox-root emotion-37"
+                            >
+                              <div
+                                aria-label="Information"
+                                class="MuiBox-root emotion-38"
+                                data-se="passwordRequirementIcon-info"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-39"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18ZM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-3.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1 2.75a1 1 0 1 0-2 0v6h2v-6Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiBox-root emotion-2"
+                              >
+                                <p
+                                  class="MuiTypography-root MuiTypography-body1 emotion-16"
+                                  tabindex="-1"
+                                >
+                                  Password can't be the same as your last 4 passwords
+                                </p>
+                              </div>
+                            </div>
+                          </li>
                         </ul>
                       </figure>
                       <div
-                        class="MuiBox-root emotion-90"
+                        class="MuiBox-root emotion-96"
                         role="status"
                         translate="no"
                       >
@@ -4412,7 +4652,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-94"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedEnd emotion-100"
                           required="true"
                         >
                           <input
@@ -4429,19 +4669,19 @@ exports[`enroll-profile-with-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-96"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium emotion-102"
                           >
                             <button
                               aria-controls="credentials.passcode"
                               aria-label="Show password"
                               aria-pressed="false"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-97"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-103"
                               tabindex="0"
                               type="button"
                             >
                               <svg
                                 aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-98"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-104"
                                 fill="none"
                                 focusable="false"
                                 viewBox="0 0 24 24"
@@ -4463,7 +4703,7 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       class="MuiBox-root emotion-11"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-100"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-106"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -4475,15 +4715,15 @@ exports[`enroll-profile-with-password should render form 1`] = `
                       class="MuiBox-root emotion-11"
                     >
                       <hr
-                        class="MuiDivider-root MuiDivider-fullWidth emotion-102"
+                        class="MuiDivider-root MuiDivider-fullWidth emotion-108"
                         data-se="separation-line"
                       />
                     </div>
                     <div
-                      class="MuiBox-root emotion-103"
+                      class="MuiBox-root emotion-109"
                     >
                       <div
-                        class="MuiBox-root emotion-104"
+                        class="MuiBox-root emotion-110"
                       >
                         <div
                           class="MuiBox-root emotion-12"
@@ -4498,10 +4738,10 @@ exports[`enroll-profile-with-password should render form 1`] = `
                         </div>
                       </div>
                       <div
-                        class="MuiBox-root emotion-104"
+                        class="MuiBox-root emotion-110"
                       >
                         <button
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-108"
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-114"
                           data-se="back"
                           role="link"
                           type="button"

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -150,17 +150,12 @@ test.requestHooks(errorMock)('should show a callout when server-side field error
     await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your first name');
     await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your last name');
     await t.expect(enrollPasswordPage.getRequirements()).contains('Maximum 3 consecutive repeating characters');
-    // In V3, UX made a conscious decision to not include server side requirements in the UI
-    // to not confuse users. They are considering additional UI changes OKTA-533383 for server side requirements
-    // but for now, it does not display in v3
-    if (!userVariables.gen3) {
-      await t.expect(enrollPasswordPage.getRequirements()).contains('At least 2 hour(s) must have elapsed since you last changed your password');
+    await t.expect(enrollPasswordPage.getRequirements()).contains('At least 2 hour(s) must have elapsed since you last changed your password');
 
-      const historyCountMessage = isHistoryCountOne ? 
-        'Password can\'t be the same as your last password'
-        : 'Password can\'t be the same as your last 4 passwords';
-      await t.expect(enrollPasswordPage.getRequirements()).contains(historyCountMessage);
-    }
+    const historyCountMessage = isHistoryCountOne ?
+      'Password can\'t be the same as your last password'
+      : 'Password can\'t be the same as your last 4 passwords';
+    await t.expect(enrollPasswordPage.getRequirements()).contains(historyCountMessage);
     await t.expect(enrollPasswordPage.getRequirements()).contains('No parts of your username');
     await t.expect(enrollPasswordPage.getRequirements()).contains('A lowercase letter');
   });

--- a/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
@@ -93,15 +93,12 @@ async function setup(t) {
     await t.expect(expiredPasswordPage.getRequirements()).contains('No parts of your username');
     await t.expect(expiredPasswordPage.getRequirements()).contains('Maximum 3 consecutive repeating characters');
 
-    // Decision was made by design to exclude history and age password requirements in gen3
-    if (!userVariables.gen3) {
-      const historyCountMessage = isHistoryCountOne ? 
-        'Password can\'t be the same as your last password'
-        : 'Password can\'t be the same as your last 4 passwords';
-      await t.expect(expiredPasswordPage.getRequirements()).contains(historyCountMessage);
+    const historyCountMessage = isHistoryCountOne ?
+      'Password can\'t be the same as your last password'
+      : 'Password can\'t be the same as your last 4 passwords';
+    await t.expect(expiredPasswordPage.getRequirements()).contains(historyCountMessage);
 
-      await t.expect(expiredPasswordPage.getRequirements()).contains('At least 10 minute(s) must have elapsed since you last changed your password');
-    }
+    await t.expect(expiredPasswordPage.getRequirements()).contains('At least 10 minute(s) must have elapsed since you last changed your password');
   });
 });
 

--- a/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
@@ -67,14 +67,11 @@ async function setup(t) {
       await t.expect(resetPasswordPage.getRequirements()).contains('A symbol');
       await t.expect(resetPasswordPage.getRequirements()).contains('No parts of your username');
       await t.expect(resetPasswordPage.getRequirements()).contains('A lowercase letter');
-      // V3 does not display server side requirements
-      if (!userVariables.gen3) {
-        const historyCountMessage = isHistoryCountOne ? 
-          'Password can\'t be the same as your last password'
-          : 'Password can\'t be the same as your last 4 passwords';
-        await t.expect(resetPasswordPage.getRequirements()).contains(historyCountMessage);
-        await t.expect(resetPasswordPage.getRequirements()).contains('At least 10 minute(s) must have elapsed since you last changed your password');
-      }
+      const historyCountMessage = isHistoryCountOne ?
+        'Password can\'t be the same as your last password'
+        : 'Password can\'t be the same as your last 4 passwords';
+      await t.expect(resetPasswordPage.getRequirements()).contains(historyCountMessage);
+      await t.expect(resetPasswordPage.getRequirements()).contains('At least 10 minute(s) must have elapsed since you last changed your password');
     });
 });
 


### PR DESCRIPTION
## Description:

When an org's password policy enforces history (e.g. "Your password cannot be any of your last 4 passwords") or a minimum age between changes, gen2 SIW renders those rules in the password requirements list. Gen3 dropped both — the transformer ignored `data.age` — leaving customers like Vanguard with a generic "Password requirements were not met" error and no UI hint about which rule they violated.

This PR wires `age.historyCount` and `age.minAgeMinutes` through gen3's password requirements list, reusing the existing `getAgeFromMinutes` helper and existing i18n keys (`password.complexity.history.*`, `password.complexity.minAge*`). It also mirrors gen2's `ReEnrollAuthenticatorPasswordView.getPasswordPolicySettings` so the transformer prefers `recoveryAuthenticator` / `enrollmentAuthenticator` settings when present — on expired flows IDX exposes `currentAuthenticator` (the user's existing-password rules) via `relatesTo`. Gen2 behavior is unchanged.

The gen3 skip guards in three TestCafe specs that previously commented "decision was made by design to exclude history and age password requirements in gen3" are removed — the parity assertions now run on both engines.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1142182](https://oktainc.atlassian.net/browse/OKTA-1142182)

### Reviewers:

### Screenshot/Video:

**Your password has expired**

| Before | After |
|--------|-------|
| ![before-expired-password](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1142182/before-expired-password.png) | ![after-expired-password](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1142182/after-expired-password.png) |

**Reset your password**

| Before | After |
|--------|-------|
| ![before-reset-password](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1142182/before-reset-password.png) | ![after-reset-password](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1142182/after-reset-password.png) |

### Downstream Monolith Build:
