### PR TITLE
OKTA-1187372: Polyfill globalThis for older WebKit

### DIFF
--- a/polyfill/index.js
+++ b/polyfill/index.js
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 // core features
+// `globalThis` must be polyfilled before any module that imports @okta/courage —
+// handlebars 4.7.9's no-conflict module (bundled inside courage) ships an inline
+// `globalThis` polyfill that throws TypeError on older WebKit (Safari ≤12.0,
+// GlobalProtect's Linux embedded browser, certain WebView2 builds), aborting
+// widget bootstrap. With this polyfill loaded first, handlebars's typeof check
+// passes and its inline polyfill is skipped.
+require('core-js/features/global-this');
 require('core-js/features/object/set-prototype-of');
 require('core-js/features/object/assign');
 require('core-js/features/object/keys');


### PR DESCRIPTION
## Description:

The handlebars 4.7.9 bundled inside @okta/courage-dist (introduced by #4020 in 7.45) ships an inline `globalThis` polyfill that throws on older WebKit engines without native `globalThis` (Safari ≤12.0, GlobalProtect's Linux embedded browser). The throw aborts widget bootstrap, leaving SAML SP-initiated flows in a redirect-then-429 rate-limit loop.

Adding `core-js/features/global-this` to `polyfill/index.js` defines `globalThis` ahead of any @okta/courage import, so handlebars's typeof guard returns early and its inline polyfill is skipped. Affects `okta-sign-in.min.js` (default bundle) and `okta-sign-in.polyfill.min.js` (standalone polyfill bundle for embedded customers); the oie/classic/no-polyfill variants are deliberately polyfill-free and unchanged.

Verified on BrowserStack Safari 11.1 — the `__magic__.globalThis = __magic__` TypeError is gone and the widget bootstraps cleanly.



## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1187372](https://oktainc.atlassian.net/browse/OKTA-1187372)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



