### PR TITLE
(fix): Prevent gen3 input labels from clipping over footer

### DIFF
--- a/src/v3/src/util/theme.ts
+++ b/src/v3/src/util/theme.ts
@@ -305,6 +305,9 @@ export const createThemeAndTokens = (
               // Odyssey sets position: "initial" which is not supported in IE11
               // "initial" uses browser default which is "static"
               position: 'static',
+              // MUI's outlined variant defaults this to 1, which causes the
+              // shrunk/transformed label to clip over the page footer on scroll.
+              zIndex: 0,
             }),
           }),
         },


### PR DESCRIPTION
## Description:

MUI's `.MuiInputLabel-outlined` rule sets `z-index: 1`, which causes shrunk/transformed text input labels to paint above the page footer when the form is scrolled. The existing `MuiInputLabel` theme override only switched `position` to `static`; add `zIndex: 0` for the formControl variant so the label stays in flow with the input.


**Before:**
<img width="1712" height="284" alt="image" src="https://github.com/user-attachments/assets/8f4cc1db-55d5-4579-b70c-d96654256c77" />


**After:**
<img width="599" height="295" alt="Screenshot 2026-06-09 at 3 35 29 PM" src="https://github.com/user-attachments/assets/e2042bf2-8c3e-4607-a42d-4e87a7dde925" />


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1016934](https://oktainc.atlassian.net/browse/OKTA-1016934)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



