### PR TITLE
feat: adds support for alphanumeric passcodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "webpack-dev-server": "^4.15.2"
   },
   "dependencies": {
-    "@okta/okta-auth-js": "7.14.4",
+    "@okta/okta-auth-js": "7.14.5",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "@types/backbone": "^1.4.15",
     "@types/eslint-scope": "^3.7.3",

--- a/playground/mocks/data/idp/idx/authenticator-verification-email-alphanumeric.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-email-alphanumeric.json
@@ -1,0 +1,442 @@
+{
+    "version": "1.0.0",
+    "stateHandle": "mockValue",
+    "expiresAt": "2026-06-10T21:50:02.000Z",
+    "intent": "LOGIN",
+    "remediation": {
+        "type": "array",
+        "value": [
+            {
+                "rel": [
+                    "create-form"
+                ],
+                "name": "challenge-authenticator",
+                "relatesTo": [
+                    "$.currentAuthenticatorEnrollment"
+                ],
+                "href": "https://localhost/idp/idx/challenge/answer",
+                "method": "POST",
+                "produces": "application/ion+json; okta-version=1.0.0",
+                "value": [
+                    {
+                        "name": "credentials",
+                        "type": "object",
+                        "form": {
+                            "value": [
+                                {
+                                    "name": "passcode",
+                                    "label": "Enter code",
+                                    "minLength": 10,
+                                    "maxLength": 10,
+                                    "format": "alphanumeric"
+                                }
+                            ]
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "stateHandle",
+                        "required": true,
+                        "value": "mockValue",
+                        "visible": false,
+                        "mutable": false
+                    }
+                ],
+                "accepts": "application/json; okta-version=1.0.0"
+            },
+            {
+                "rel": [
+                    "create-form"
+                ],
+                "name": "select-authenticator-authenticate",
+                "href": "https://localhost/idp/idx/challenge",
+                "method": "POST",
+                "produces": "application/ion+json; okta-version=1.0.0",
+                "value": [
+                    {
+                        "name": "authenticator",
+                        "type": "object",
+                        "options": [
+                            {
+                                "label": "Email",
+                                "value": {
+                                    "form": {
+                                        "value": [
+                                            {
+                                                "name": "id",
+                                                "required": true,
+                                                "value": "aut154mqnlKDVnXeT0g4",
+                                                "mutable": false
+                                            },
+                                            {
+                                                "name": "methodType",
+                                                "required": false,
+                                                "value": "email",
+                                                "mutable": false
+                                            }
+                                        ]
+                                    }
+                                },
+                                "relatesTo": "$.authenticatorEnrollments.value[0]"
+                            },
+                            {
+                                "label": "Passkeys",
+                                "value": {
+                                    "form": {
+                                        "value": [
+                                            {
+                                                "name": "id",
+                                                "required": true,
+                                                "value": "aut156w0bsaxREByP0g4",
+                                                "mutable": false
+                                            },
+                                            {
+                                                "name": "methodType",
+                                                "required": false,
+                                                "value": "webauthn",
+                                                "mutable": false
+                                            }
+                                        ]
+                                    }
+                                },
+                                "relatesTo": "$.authenticators.value[1]"
+                            },
+                            {
+                                "label": "Password",
+                                "value": {
+                                    "form": {
+                                        "value": [
+                                            {
+                                                "name": "id",
+                                                "required": true,
+                                                "value": "aut154lmhj4WNnxoc0g4",
+                                                "mutable": false
+                                            },
+                                            {
+                                                "name": "methodType",
+                                                "required": false,
+                                                "value": "password",
+                                                "mutable": false
+                                            }
+                                        ]
+                                    }
+                                },
+                                "relatesTo": "$.authenticatorEnrollments.value[4]"
+                            },
+                            {
+                                "label": "Phone",
+                                "value": {
+                                    "form": {
+                                        "value": [
+                                            {
+                                                "name": "id",
+                                                "required": true,
+                                                "value": "aut154nxZP7ityuIh0g4",
+                                                "mutable": false
+                                            },
+                                            {
+                                                "name": "methodType",
+                                                "type": "string",
+                                                "required": false,
+                                                "options": [
+                                                    {
+                                                        "label": "SMS",
+                                                        "value": "sms"
+                                                    },
+                                                    {
+                                                        "label": "Voice call",
+                                                        "value": "voice"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "name": "enrollmentId",
+                                                "required": true,
+                                                "value": "sms15bsrcrvIo6NBT0g4",
+                                                "mutable": false
+                                            }
+                                        ]
+                                    }
+                                },
+                                "relatesTo": "$.authenticatorEnrollments.value[5]"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "stateHandle",
+                        "required": true,
+                        "value": "mockValue",
+                        "visible": false,
+                        "mutable": false
+                    }
+                ],
+                "accepts": "application/json; okta-version=1.0.0"
+            }
+        ]
+    },
+    "currentAuthenticatorEnrollment": {
+        "type": "object",
+        "value": {
+            "profile": {
+                "email": "a***n@okta.com"
+            },
+            "resend": {
+                "rel": [
+                    "create-form"
+                ],
+                "name": "resend",
+                "href": "https://localhost/idp/idx/challenge/resend",
+                "method": "POST",
+                "produces": "application/ion+json; okta-version=1.0.0",
+                "value": [
+                    {
+                        "name": "stateHandle",
+                        "required": true,
+                        "value": "mockValue",
+                        "visible": false,
+                        "mutable": false
+                    }
+                ],
+                "accepts": "application/json; okta-version=1.0.0"
+            },
+            "poll": {
+                "rel": [
+                    "create-form"
+                ],
+                "name": "poll",
+                "href": "https://localhost/idp/idx/challenge/poll",
+                "method": "POST",
+                "produces": "application/ion+json; okta-version=1.0.0",
+                "refresh": 4000,
+                "value": [
+                    {
+                        "name": "stateHandle",
+                        "required": true,
+                        "value": "mockValue",
+                        "visible": false,
+                        "mutable": false
+                    }
+                ],
+                "accepts": "application/json; okta-version=1.0.0"
+            },
+            "contextualData": {
+                "useEmailMagicLink": true
+            },
+            "type": "email",
+            "key": "okta_email",
+            "id": "eae15442ouXZNyErq0g4",
+            "displayName": "Email",
+            "methods": [
+                {
+                    "type": "email"
+                }
+            ]
+        }
+    },
+    "authenticators": {
+        "type": "array",
+        "value": [
+            {
+                "type": "email",
+                "key": "okta_email",
+                "id": "aut154mqnlKDVnXeT0g4",
+                "displayName": "Email",
+                "methods": [
+                    {
+                        "type": "email"
+                    }
+                ],
+                "allowedFor": "none"
+            },
+            {
+                "type": "security_key",
+                "key": "webauthn",
+                "id": "aut156w0bsaxREByP0g4",
+                "displayName": "Passkeys",
+                "methods": [
+                    {
+                        "type": "webauthn"
+                    }
+                ],
+                "allowedFor": "none"
+            },
+            {
+                "type": "password",
+                "key": "okta_password",
+                "id": "aut154lmhj4WNnxoc0g4",
+                "displayName": "Password",
+                "methods": [
+                    {
+                        "type": "password"
+                    }
+                ],
+                "allowedFor": "none"
+            },
+            {
+                "type": "phone",
+                "key": "phone_number",
+                "id": "aut154nxZP7ityuIh0g4",
+                "displayName": "Phone",
+                "methods": [
+                    {
+                        "type": "sms"
+                    },
+                    {
+                        "type": "voice"
+                    }
+                ],
+                "allowedFor": "none"
+            }
+        ]
+    },
+    "authenticatorEnrollments": {
+        "type": "array",
+        "value": [
+            {
+                "profile": {
+                    "email": "a***n@okta.com"
+                },
+                "type": "email",
+                "key": "okta_email",
+                "id": "eae15442ouXZNyErq0g4",
+                "displayName": "Email",
+                "methods": [
+                    {
+                        "type": "email"
+                    }
+                ]
+            },
+            {
+                "profile": {
+                    "aaguid": "adce0002-35bc-c60a-648b-0b25f1f05503",
+                    "transports": "internal"
+                },
+                "type": "security_key",
+                "key": "webauthn",
+                "id": "fwf15deuuBHEojh4w0g4",
+                "displayName": "Chrome on Mac",
+                "credentialId": "pHIa-SDTZV4Ca7bHCCPeVlzBW2njo3s-jpO3wH8TFJ0",
+                "methods": [
+                    {
+                        "type": "webauthn"
+                    }
+                ]
+            },
+            {
+                "profile": {
+                    "aaguid": "73bb0cd4-e502-49b8-9c6f-b59445bf720b",
+                    "transports": "usb"
+                },
+                "type": "security_key",
+                "key": "webauthn",
+                "id": "fwf1bdscMDOMuu4jt0g5",
+                "displayName": "YubiKey 5 FIPS",
+                "credentialId": "Cc7l0Kzszj1UC0g-T7z0V1IHaqvRbtpDZYVQ87639Hrj9e15SXaHv21xoWMTPW9S",
+                "methods": [
+                    {
+                        "type": "webauthn"
+                    }
+                ]
+            },
+            {
+                "profile": {
+                    "aaguid": "fbfc3007-154e-4ecc-8c0b-6e020557d7bd",
+                    "transports": "internal,hybrid"
+                },
+                "type": "security_key",
+                "key": "webauthn",
+                "id": "fwfybhzSQ0EhkxCfT0g4",
+                "displayName": "iCloud Keychain",
+                "credentialId": "YB2r-AK-U3_hw9GUAC649V5cWcA",
+                "methods": [
+                    {
+                        "type": "webauthn"
+                    }
+                ]
+            },
+            {
+                "type": "password",
+                "key": "okta_password",
+                "id": "lae5ls3CYziJDyyzo0g3",
+                "displayName": "Password",
+                "methods": [
+                    {
+                        "type": "password"
+                    }
+                ]
+            },
+            {
+                "profile": {
+                    "phoneNumber": "+1 XXX-XXX-0209"
+                },
+                "type": "phone",
+                "key": "phone_number",
+                "id": "sms15bsrcrvIo6NBT0g4",
+                "displayName": "Phone",
+                "methods": [
+                    {
+                        "type": "sms"
+                    },
+                    {
+                        "type": "voice"
+                    }
+                ]
+            }
+        ]
+    },
+    "user": {
+        "type": "object",
+        "value": {
+            "identifier": "admin@okta.com"
+        }
+    },
+    "cancel": {
+        "rel": [
+            "create-form"
+        ],
+        "name": "cancel",
+        "href": "https://localhost/idp/idx/cancel",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+            {
+                "name": "stateHandle",
+                "required": true,
+                "value": "mockValue",
+                "visible": false,
+                "mutable": false
+            }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+    },
+    "app": {
+        "type": "object",
+        "value": {
+            "name": "okta_enduser",
+            "label": "Okta Dashboard",
+            "id": "0oa150cwDt3UJgrBT0g4"
+        }
+    },
+    "authentication": {
+        "type": "object",
+        "value": {
+            "protocol": "OAUTH2.0",
+            "issuer": {
+                "name": "Passkeys Rebrand",
+                "uri": "https://localhost"
+            },
+            "request": {
+                "max_age": -1,
+                "scope": "openid profile email okta.users.read.self okta.users.manage.self okta.internal.enduser.read okta.internal.enduser.manage okta.enduser.dashboard.read okta.enduser.dashboard.manage okta.myAccount.sessions.manage okta.internal.navigation.enduser.read",
+                "display": "page",
+                "response_type": "code",
+                "redirect_uri": "https://localhost/enduser/callback",
+                "state": "Igc40BKbOX39CWNzq7oOhApsKlrXO8Zdn8bAwkKlRSFqH9tsfPhnh3pNo1chJz4N",
+                "code_challenge_method": "S256",
+                "nonce": "tyICnD3AdfI7H91sPFMqMFaz42SuWuYVBgjD849balh47t4R3Uvawj9CcZ46M6ep",
+                "code_challenge": "3GPUBD9muqvTqCGDw66RkJlN2XJN_IE1aX5V2XbKPtw",
+                "response_mode": "query"
+            }
+        }
+    }
+}

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -54,7 +54,7 @@
     "@mui/material": "^5.8.5",
     "@okta/odyssey-design-tokens": "1.44.0",
     "@okta/odyssey-react-mui": "1.44.0",
-    "@okta/okta-auth-js": "7.14.4",
+    "@okta/okta-auth-js": "7.14.5",
     "altcha": "^1.4.2",
     "chroma-js": "^2.4.2",
     "cross-fetch": "^3.1.5",

--- a/src/v3/src/transformer/field/attributes.test.ts
+++ b/src/v3/src/transformer/field/attributes.test.ts
@@ -102,4 +102,28 @@ describe('Attributes transformer', () => {
 
     expect(transformer(formfield)).toEqual(result);
   });
+
+  it('should not set inputmode when passcode field has format === "alphanumeric"', () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { userAgent: 'iPhone' } as unknown as Navigator,
+    );
+    const formfield: Input = { name: 'credentials.passcode', format: 'alphanumeric' };
+
+    const result = { attributes: { autocomplete: 'one-time-code' } };
+
+    expect(transformer(formfield)).toEqual(result);
+  });
+
+  it('should still set inputmode === "numeric" when passcode field has no format', () => {
+    const navigatorCredentials = jest.spyOn(global, 'navigator', 'get');
+    navigatorCredentials.mockReturnValue(
+      { userAgent: 'iPhone' } as unknown as Navigator,
+    );
+    const formfield: Input = { name: 'credentials.passcode' };
+
+    const result = { attributes: { autocomplete: 'one-time-code', inputmode: 'numeric' } };
+
+    expect(transformer(formfield)).toEqual(result);
+  });
 });

--- a/src/v3/src/transformer/field/attributes.test.ts
+++ b/src/v3/src/transformer/field/attributes.test.ts
@@ -110,9 +110,9 @@ describe('Attributes transformer', () => {
     );
     const formfield: Input = { name: 'credentials.passcode', format: 'alphanumeric' };
 
-    const result = { attributes: { autocomplete: 'one-time-code' } };
+    const result = transformer(formfield);
 
-    expect(transformer(formfield)).toEqual(result);
+    expect(result?.attributes?.inputmode).not.toBe('numeric');
   });
 
   it('should still set inputmode === "numeric" when passcode field has no format', () => {

--- a/src/v3/src/transformer/field/attributes.ts
+++ b/src/v3/src/transformer/field/attributes.ts
@@ -69,6 +69,10 @@ const inputModeValueTransformer = (input: Input): InputModeValue | null => {
   if (input.name === 'credentials.passcode' && input.secret) {
     return null;
   }
+  // Alphanumeric OTP must not restrict keyboard to numeric
+  if (input.name === 'credentials.passcode' && input.format === 'alphanumeric') {
+    return null;
+  }
   const key = getKeyFromMap(inputModeValueMap, input.name);
   return key ? inputModeValueMap.get(key) ?? null : null;
 };

--- a/src/v3/src/transformer/field/transform.test.ts
+++ b/src/v3/src/transformer/field/transform.test.ts
@@ -283,4 +283,45 @@ describe('transformStepInputs', () => {
       expect(result.data.nullField).toBe('');
     });
   });
+
+  describe('fieldsToTrim', () => {
+    it('should add numeric passcode to fieldsToTrim', () => {
+      const step: NextStep = {
+        name: 'challenge-authenticator',
+        inputs: [
+          {
+            name: 'credentials.passcode',
+            type: 'string',
+            required: true,
+            visible: true,
+            mutable: true,
+          } as Input,
+        ],
+      };
+
+      const result = transformStepInputs(formBag, widgetProps, step);
+
+      expect(result.dataSchema.fieldsToTrim).toContain('credentials.passcode');
+    });
+
+    it('should add alphanumeric passcode to fieldsToTrim', () => {
+      const step: NextStep = {
+        name: 'challenge-authenticator',
+        inputs: [
+          {
+            name: 'credentials.passcode',
+            type: 'string',
+            format: 'alphanumeric',
+            required: true,
+            visible: true,
+            mutable: true,
+          } as Input,
+        ],
+      };
+
+      const result = transformStepInputs(formBag, widgetProps, step);
+
+      expect(result.dataSchema.fieldsToTrim).toContain('credentials.passcode');
+    });
+  });
 });

--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -187,8 +187,12 @@ export const transformStepInputs = (
           },
         };
         acc.dataSchema.fieldsToValidate.push(name);
-        // Of the required fields, trim appropriately
-        if (uischema.options.attributes?.inputmode === 'numeric') {
+        // Of the required fields, trim appropriately.
+        // Alphanumeric passcodes have no inputmode set but still need trimming since
+        // the allowed charset (uppercase letters + digits) contains no spaces.
+        const isNumericInputMode = uischema.options.attributes?.inputmode === 'numeric';
+        const isAlphanumericPasscode = name === 'credentials.passcode' && input.format === 'alphanumeric';
+        if (isNumericInputMode || isAlphanumericPasscode) {
           acc.dataSchema.fieldsToTrim.push(name);
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4738,10 +4738,10 @@
     react-window "^1.8.10"
     word-wrap "^1.2.5"
 
-"@okta/okta-auth-js@7.14.4":
-  version "7.14.4"
-  resolved "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-7.14.4.tgz#e600bdd7474d03535b9743b4806068dedade325b"
-  integrity sha512-FiZPGU2lZ5i61SdZaLgaY9rhie9r7KuenA5QcztlUs1GgTqsQvAUAQTkNaciKt0IeokrqquE9p0excH9prxmCQ==
+"@okta/okta-auth-js@7.14.5":
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-7.14.5.tgz#698c2a97b13331fe8e2d2ec5ca0e5fd925d5bd1a"
+  integrity sha512-UPSm/bLgsWOMnAUQnlepcH3S143u1Fzg/mUa8yTXJEjnFZbovMEVsmVCjvFTshTtSANb8Orjp1bzmQavlya6rg==
   dependencies:
     "@babel/runtime" "^7.27.0"
     "@peculiar/webcrypto" "^1.4.0"


### PR DESCRIPTION
## Description:

Adds support for `alphanumeric` passcodes (being introduced at the moment with the Configurable Email OTP feature).
This is needed in order to not limit the mobile keyboard to numeric input, in case the Email OTP is set to `alphanumeric`.

Accompanying auth-js change to add the `format` property to types: https://github.com/okta/okta-auth-js/pull/1648

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1174808](https://oktainc.atlassian.net/browse/OKTA-1174808)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=da64fb422cab476bfa78086a6ebce78f9b8c208f&tab=main

