### PR TITLE
OKTA-1174752: Fix granular consent payload when scopes share a prefix

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -251,6 +251,7 @@ const consent = {
     // 'consent-admin',
     'consent-enduser',
     'consent-granular',
+    'consent-granular-prefix-collision',
   ],
   '/idp/idx/consent': [
     // note that the success 'href' is in reality a redirect (i.e. /login/token/redirect?stateToken={{stateToken}})

--- a/playground/mocks/data/idp/idx/consent-granular-prefix-collision.json
+++ b/playground/mocks/data/idp/idx/consent-granular-prefix-collision.json
@@ -1,0 +1,131 @@
+{
+  "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "expiresAt": "2018-09-17T23:08:56.000Z",
+  "version": "1.0.0",
+  "intent": "login",
+  "remediation": {
+    "type": "array",
+    "value": [{
+      "rel": [
+        "create-form"
+      ],
+      "name": "granular-consent",
+      "href": "http://localhost:3000/idp/idx/consent",
+      "method": "POST",
+      "accepts": "application/ion+json; okta-version=1.0.0",
+      "produces": "application/ion+json; okta-version=1.0.0",
+      "value": [
+        {
+          "name": "consent",
+          "type": "boolean",
+          "visible": false,
+          "required": true
+        },
+        {
+          "name": "optedScopes",
+          "form": {
+            "value": [
+              {
+                "name": "openid",
+                "type": "boolean",
+                "required": true,
+                "value": true,
+                "visible": true,
+                "mutable": false
+              },
+              {
+                "name": "custom1",
+                "label": "View your mobile phone data plan.",
+                "desc": "This allows the app to view your mobile phone data plan.",
+                "type": "boolean",
+                "required": true,
+                "value": true,
+                "visible": true,
+                "mutable": true
+              },
+              {
+                "name": "custom1.custom2",
+                "label": "View your mobile phone data plan sensitive details.",
+                "desc": "This allows the app to view your mobile phone data plan sensitive details.",
+                "type": "boolean",
+                "required": true,
+                "value": true,
+                "visible": true,
+                "mutable": true
+              },
+              {
+                "name": "profile",
+                "label": "View your profile information.",
+                "type": "boolean",
+                "required": true,
+                "value": true,
+                "visible": true,
+                "mutable": false
+              }
+            ]
+          }
+        },
+        {
+          "name": "stateHandle",
+          "required": true,
+          "value": "02tZJpxD03j1a3qaPcSsi16yDtqMZgfetf8OvWOepP",
+          "visible": false,
+          "mutable": false
+        }
+      ]
+    }
+    ]
+  },
+  "cancel": {
+    "rel": ["create-form"],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/ion+json; okta-version=1.0.0",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [{
+      "name": "stateHandle",
+      "value": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+      "visible": false
+    }]
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Native client",
+      "id": "0oa4mwdegX1GLIJy00g4",
+      "termsOfService": {
+        "href": "https://example.com/tos",
+        "rel": ["terms-of-service"]
+      },
+      "privacyPolicy": {
+        "href": "https://example.com/privacypolicy",
+        "rel": ["privacy-policy"]
+      },
+      "logo": {
+        "rel": ["icon"],
+        "alt": "Logo for the app"
+      },
+      "clientUri" : {
+        "href" : "https://client._funky-ch4rs.com"
+      }
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u4mufzdKWDb8hbC0g4",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "authentication":{
+    "type": "object",
+    "value" : {
+      "protocol":"OAUTH2.0",
+      "issuer":{
+        "uri":"http://localhost:3000"
+      }
+    }
+  }
+}

--- a/src/v2/ion/payloadTransformer.js
+++ b/src/v2/ion/payloadTransformer.js
@@ -12,47 +12,33 @@
 
 import { FORMS as RemediationForms } from './RemediationConstants';
 
-const flattenObj = (obj) => {
-  let result = {};
-
-  Object.keys(obj).forEach((key) => {
-    if (typeof obj[key] !== 'object') {
-      result[key] = obj[key];
-      return;
-    }
-
-    const tempObj = flattenObj(obj[key]);
-    Object.keys(tempObj).forEach((j) => {
-      result[key + '.' + j] = tempObj[j];
-    });
-  });
-  return result;
-};
+const OPTED_SCOPES_PREFIX = 'optedScopes.';
 
 /**
- * This function is for the Granular Consent remediation, scopes within the optedScopes
- * property can include a singular value or n values delimited by a "."
- * When they are delimited, BackBone's toJSON function will create a nested object, however,
- * these should not be nested and the delimited key names should stay as is. So this function will
- * flatten those nested proeprties to format it how the backend expects it. 
- * i.e. { optedScopes: { some: { scope: true }}} = { optedScopes: { 'some.scope': true }}
- * Currently, this is only used when the Granular Consent view form is saved see:
- * src/v2/view-builder/views/consent/GranularConsentView.js
- * 
+ * This function is for the Granular Consent remediation. The Granular Consent
+ * model uses `flat: false` (see GranularConsentView) so Courage's toJSON does
+ * not try to unflatten the optedScopes sub-form — that would crash when scope
+ * names share a dotted prefix (e.g. `custom1` and `custom1.custom2`). The
+ * flat `optedScopes.<scope>` keys are grouped here into the nested
+ * `optedScopes` object that the IDX backend expects, preserving dotted scope
+ * names verbatim.
+ * i.e. { 'optedScopes.custom1': true, 'optedScopes.custom1.custom2': false }
+ *      => { optedScopes: { 'custom1': true, 'custom1.custom2': false } }
+ *
  * @param {JSON} modelJSON JSON Equivalent of the Backbone Model's attributes/fields
- * @returns If the JSON contains the optedScopes Property, we will flatten the fields from
- * a nested object into K/V pair with dot notation for nested key names. Otherwise, we will return
- * the JSON as is.
+ * @returns A copy of modelJSON with `optedScopes.*` keys grouped into a single `optedScopes` object.
  */
 const transformOptedScopes = (modelJSON) => {
-  if (modelJSON.optedScopes && typeof modelJSON.optedScopes !== 'string') {
-    const data = {
-      ...modelJSON,
-      optedScopes: flattenObj(modelJSON.optedScopes),
-    };
-    return data;
-  }
-  return modelJSON;
+  const result = { ...modelJSON };
+  const optedScopes = {};
+  Object.keys(modelJSON).forEach((key) => {
+    if (key.indexOf(OPTED_SCOPES_PREFIX) === 0) {
+      optedScopes[key.slice(OPTED_SCOPES_PREFIX.length)] = modelJSON[key];
+      delete result[key];
+    }
+  });
+  result.optedScopes = optedScopes;
+  return result;
 };
 
 const FormNameToTransformerHandler = {
@@ -63,7 +49,7 @@ const FormNameToTransformerHandler = {
  * The purpose of this function is the transform the
  * Backbone Model's attributes/fields into a JSON equivalent before sending to IDX,
  * since the Model fields are all flattend when the UI Schema is transformed on consumption.
- * 
+ *
  * @param {string} formName Form name of the current remediation
  * @param {Model} model Backbone Model Class
  * @returns JSON equivalent of the Model

--- a/src/v2/view-builder/views/consent/GranularConsentView.js
+++ b/src/v2/view-builder/views/consent/GranularConsentView.js
@@ -66,6 +66,15 @@ export default BaseView.extend({
   Body: granularConsentViewForm,
   Footer: EnduserConsentViewFooter,
 
+  createModelClass() {
+    const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
+    // Disable Courage's flatten/unflatten round-trip for the granular-consent
+    // model. Scope names can collide on dotted prefixes (e.g. `custom1` and
+    // `custom1.custom2`) and would otherwise crash unflatten in
+    // Model.toJSON({verbose:true}) during BaseView.renderForm.
+    return ModelClass.extend({ flat: false });
+  },
+
   postRender() {
     const scopeList = this.$el.find('.o-form-fieldset-container');
 

--- a/src/v3/src/util/toNestedObject.test.ts
+++ b/src/v3/src/util/toNestedObject.test.ts
@@ -50,4 +50,44 @@ describe('toNestedObject', () => {
       },
     });
   });
+
+  // OKTA-1174752 / customer PR #4024 (Brex): gen2 Courage's `unflatten` mishandled
+  // a plain scope sharing its prefix with a dotted scope. Gen3 doesn't go through
+  // Courage at all (React form state -> useOnSubmit -> toNestedObject with
+  // keysWithoutNesting=['optedScopes']), so there is no render-time analog of
+  // the gen2 crash. The submit-time grouping below pins gen3's correct behavior
+  // for both customer scenarios.
+
+  // Customer scenario 1: plain scope is `true`. Gen2's unflatten threw
+  // "Cannot create property 'custom2' on boolean 'true'".
+  it('keeps a true plain key and a dotted key sharing its prefix as distinct siblings', () => {
+    expect(toNestedObject({
+      consent: true,
+      'optedScopes.custom1': true,
+      'optedScopes.custom1.custom2': false,
+    }, ['optedScopes'])).toEqual({
+      consent: true,
+      optedScopes: {
+        custom1: true,
+        'custom1.custom2': false,
+      },
+    });
+  });
+
+  // Customer scenario 2: plain scope is `false`. Gen2's unflatten check
+  // `if (!ref[part])` treated `false` as unset and silently overwrote it
+  // with an empty object, dropping the user's choice from the payload.
+  it('preserves a false plain key when a dotted key shares its prefix', () => {
+    expect(toNestedObject({
+      consent: true,
+      'optedScopes.custom1': false,
+      'optedScopes.custom1.custom2': true,
+    }, ['optedScopes'])).toEqual({
+      consent: true,
+      optedScopes: {
+        custom1: false,
+        'custom1.custom2': true,
+      },
+    });
+  });
 });

--- a/test/testcafe/spec/GranularConsentView_spec.js
+++ b/test/testcafe/spec/GranularConsentView_spec.js
@@ -5,6 +5,7 @@ import ConsentPageObject from '../framework/page-objects/ConsentPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 
 import xhrConsentGranular from '../../../playground/mocks/data/idp/idx/consent-granular';
+import xhrConsentGranularPrefixCollision from '../../../playground/mocks/data/idp/idx/consent-granular-prefix-collision';
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
 import terminalResetPasswordNotAllowed from '../../../playground/mocks/data/idp/idx/error-reset-password-not-allowed';
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
@@ -12,6 +13,14 @@ import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
 const consentGranularMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrConsentGranular)
+  .onRequestTo('http://localhost:3000/idp/idx/consent')
+  .respond(xhrSuccess)
+  .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
+  .respond(oktaDashboardContent);
+
+const consentGranularPrefixCollisionMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrConsentGranularPrefixCollision)
   .onRequestTo('http://localhost:3000/idp/idx/consent')
   .respond(xhrSuccess)
   .onRequestTo(/^http:\/\/localhost:3000\/app\/UserHome.*/)
@@ -135,6 +144,31 @@ test.requestHooks(requestLogger, consentGranularMock)('should send correct paylo
 
   await testRedirect(t);
 });
+
+test.requestHooks(requestLogger, consentGranularPrefixCollisionMock)(
+  'OKTA-1174752: preserves both scopes when scope names share a prefix (e.g. custom1 and custom1.custom2)',
+  async t => {
+    const consentPage = await setup(t);
+    await checkA11y(t);
+
+    // Initial mock state: custom1=true, custom1.custom2=true. Toggle only the
+    // dotted scope so we can verify both keys arrive in the payload distinctly
+    // (BaseFormObject.setCheckbox always clicks, so don't request a no-op).
+    await consentPage.setScopeCheckBox('optedScopes.custom1.custom2', false);
+
+    await consentPage.clickAllowButton();
+    const { request: { body } } = requestLogger.requests[requestLogger.requests.length - 1];
+    const jsonBody = JSON.parse(body);
+
+    await t.expect(jsonBody.consent).eql(true);
+    await t.expect(jsonBody.optedScopes.openid).eql(true);
+    await t.expect(jsonBody.optedScopes.custom1).eql(true);
+    await t.expect(jsonBody.optedScopes['custom1.custom2']).eql(false);
+    await t.expect(jsonBody.optedScopes.profile).eql(true);
+
+    await testRedirect(t);
+  }
+);
 
 test.requestHooks(requestLogger, consentGranularMock)('should send correct payload to /consent on "Cancel" click', async t => {
   const consentPage  = await setup(t);

--- a/test/unit/spec/v2/ion/payloadTransformer_spec.js
+++ b/test/unit/spec/v2/ion/payloadTransformer_spec.js
@@ -1,0 +1,102 @@
+import transformPayload from 'v2/ion/payloadTransformer';
+import { FORMS as RemediationForms } from 'v2/ion/RemediationConstants';
+
+const buildModel = (json) => ({
+  toJSON: jest.fn(() => ({ ...json })),
+});
+
+describe('v2/ion/payloadTransformer', function() {
+  describe('forms without a registered transformer', function() {
+    it('returns model.toJSON() unchanged', function() {
+      const model = buildModel({ identifier: 'user@example.com' });
+      const result = transformPayload('identify', model);
+
+      expect(model.toJSON).toHaveBeenCalled();
+      expect(result).toEqual({ identifier: 'user@example.com' });
+    });
+  });
+
+  describe('consent-granular', function() {
+    it('groups optedScopes.* keys into a nested optedScopes object', function() {
+      const model = buildModel({
+        consent: true,
+        'optedScopes.openid': true,
+        'optedScopes.email': false,
+      });
+
+      const result = transformPayload(RemediationForms.CONSENT_GRANULAR, model);
+
+      expect(result).toEqual({
+        consent: true,
+        optedScopes: {
+          openid: true,
+          email: false,
+        },
+      });
+    });
+
+    it('preserves dotted scope names without further nesting them', function() {
+      const model = buildModel({
+        consent: true,
+        'optedScopes.custom3.custom4.custom5': true,
+      });
+
+      const result = transformPayload(RemediationForms.CONSENT_GRANULAR, model);
+
+      expect(result.optedScopes).toEqual({
+        'custom3.custom4.custom5': true,
+      });
+    });
+
+    // Customer scenario 1 (PR #4024): plain scope is `true` — used to throw
+    // "Cannot create property 'custom2' on boolean 'true'" out of unflatten.
+    it('does not throw or drop scopes when a plain scope shares a prefix with a dotted scope (true case)', function() {
+      const model = buildModel({
+        consent: true,
+        'optedScopes.custom1': true,
+        'optedScopes.custom1.custom2': false,
+      });
+
+      const result = transformPayload(RemediationForms.CONSENT_GRANULAR, model);
+
+      expect(result).toEqual({
+        consent: true,
+        optedScopes: {
+          custom1: true,
+          'custom1.custom2': false,
+        },
+      });
+    });
+
+    // Customer scenario 2 (PR #4024): plain scope is `false` — used to be silently
+    // overwritten with an empty object by unflatten's `if (!ref[part])` check.
+    it('does not throw or drop scopes when a plain scope shares a prefix with a dotted scope (false case)', function() {
+      const model = buildModel({
+        consent: true,
+        'optedScopes.custom1': false,
+        'optedScopes.custom1.custom2': false,
+      });
+
+      const result = transformPayload(RemediationForms.CONSENT_GRANULAR, model);
+
+      expect(result).toEqual({
+        consent: true,
+        optedScopes: {
+          custom1: false,
+          'custom1.custom2': false,
+        },
+      });
+    });
+
+    it('returns an empty optedScopes object when no opted scope keys are present', function() {
+      const model = buildModel({ consent: true });
+
+      const result = transformPayload(RemediationForms.CONSENT_GRANULAR, model);
+
+      expect(result).toEqual({
+        consent: true,
+        optedScopes: {},
+      });
+    });
+  });
+});

--- a/test/unit/spec/v2/view-builder/views/consent/GranularConsentView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/consent/GranularConsentView_spec.js
@@ -1,0 +1,58 @@
+import GranularConsentView from 'v2/view-builder/views/consent/GranularConsentView';
+import insertUISchema from 'v2/ion/uiSchemaTransformer';
+import xhrConsentGranularPrefixCollision from '../../../../../../../playground/mocks/data/idp/idx/consent-granular-prefix-collision.json';
+
+const buildModel = (mock) => {
+  const remediation = mock.remediation.value.find((r) => r.name === 'granular-consent');
+  const transformed = { remediations: [{ ...remediation }] };
+  insertUISchema({}, transformed);
+
+  // Call createModelClass without constructing the full view (avoids appState dep).
+  const ModelClass = GranularConsentView.prototype.createModelClass.call(
+    {},
+    transformed.remediations[0],
+  );
+  return new ModelClass({ formName: 'granular-consent' });
+};
+
+describe('v2/view-builder/views/consent/GranularConsentView model', function() {
+  it('disables Courage flat/unflatten so toJSON keeps dotted scope keys flat', function() {
+    const model = buildModel(xhrConsentGranularPrefixCollision);
+    model.set('optedScopes.custom1.custom2', false);
+
+    // With flat: false, toJSON does not unflatten — dotted keys remain at top level.
+    // The submit path (transformOptedScopes) groups these into a nested optedScopes.
+    expect(model.toJSON()).toEqual({
+      'optedScopes.openid': true,
+      'optedScopes.custom1': true,
+      'optedScopes.custom1.custom2': false,
+      'optedScopes.profile': true,
+    });
+  });
+
+  // Customer-reported scenario 1 (PR #4024): plain scope is true → Courage's
+  // unflatten threw "Cannot create property 'custom2' on boolean 'true'",
+  // blocking BaseView.renderForm at the initial render call site
+  // (model.toJSON({verbose: true}) on line 78).
+  it('does not crash when toJSON({verbose: true}) runs against a true plain scope colliding with a dotted scope', function() {
+    const model = buildModel(xhrConsentGranularPrefixCollision);
+    model.set('optedScopes.custom1', true);
+    model.set('optedScopes.custom1.custom2', true);
+
+    expect(() => model.toJSON({ verbose: true })).not.toThrow();
+  });
+
+  // Customer-reported scenario 2 (PR #4024): plain scope is false → unflatten's
+  // `if (!ref[part])` treated false as unset and overwrote it with an empty
+  // object, silently dropping the user's "false" choice. Verify the false
+  // value is preserved on the flat model.
+  it('preserves a false plain scope when a dotted scope shares its prefix', function() {
+    const model = buildModel(xhrConsentGranularPrefixCollision);
+    model.set('optedScopes.custom1', false);
+    model.set('optedScopes.custom1.custom2', true);
+
+    const json = model.toJSON({ verbose: true });
+    expect(json['optedScopes.custom1']).toBe(false);
+    expect(json['optedScopes.custom1.custom2']).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description:

When a granular-consent form contains both a plain scope and a dotted scope sharing its prefix (e.g. `custom1` and `custom1.custom2`), Courage's `Model.toJSON()` `unflatten` pass either threw `Cannot create property 'custom2' on boolean 'true'` (blocking the form from rendering) or silently dropped the user's `false` selection from the payload — leaving the user unable to grant consent. Customer-reported by Brex (#4024).

The crash fires twice in gen2:
- **At render time** — `BaseView.renderForm` calls `model.toJSON({verbose: true})`, which invokes `unflatten`. With prefix-colliding scopes, `unflatten` either throws (truthy plain scope) or silently overwrites it with an empty object (falsy plain scope, since `if (!ref[part])` treats `false` as unset).
- **At submit time** — the same `toJSON()` round-trip used to be the only way the payload was built, so the same hazard reappeared on the wire.

This PR fixes both with two contained changes scoped to granular consent only:

1. **`GranularConsentView.createModelClass`** returns a `Model.extend({ flat: false })`. `flat` is an existing Courage feature that disables the `flatten`/`unflatten` round-trip on this one model class. With `flat: false`, `model.toJSON()` returns a plain shallow clone of `model.attributes` (flat dotted keys), so the render-time call no longer crashes. One-line change plus a comment explaining why.

2. **`payloadTransformer.transformOptedScopes`** is rewritten to operate on flat input. Instead of re-flattening a nested object that `unflatten` produced (which crashed/lost data on prefix collisions), it now groups the flat `optedScopes.<scope>` keys from `model.toJSON()` into the nested `optedScopes` object the IDX backend expects, preserving dotted scope names verbatim. The function signature, `transformPayload` dispatch, and `FormNameToTransformerHandler` registry are unchanged.

No Courage changes; no other forms affected. Gen3 was never broken (it goes through `toNestedObject` with `keysWithoutNesting=['optedScopes']`, which already handles prefix collisions correctly), but a defensive regression test was added there to lock in the behavior for both customer scenarios.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1174752](https://oktainc.atlassian.net/browse/OKTA-1174752)
- Customer-reported via #4024 (Brex)

### Test coverage:

- `test/unit/spec/v2/ion/payloadTransformer_spec.js` — both customer scenarios (true case + false case) at the submit boundary, plus dotted scope preservation
- `test/unit/spec/v2/view-builder/views/consent/GranularConsentView_spec.js` — verifies `flat: false` model: render-time `toJSON({verbose: true})` does not crash; flat shape preserved
- `test/testcafe/spec/GranularConsentView_spec.js` — end-to-end regression with the new prefix-collision mock (`playground/mocks/data/idp/idx/consent-granular-prefix-collision.json`)
- `src/v3/src/util/toNestedObject.test.ts` — defensive gen3 tests for both customer scenarios

### Reviewers:

### Screenshot/Video:

### Downstream Monolith Build:
