### PR TITLE
OKTA-1182955: gate post-AppLink redirect on focus, not just visibility

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -247,6 +247,16 @@ Util.executeOnVisiblePage = function(cb) {
   }
 };
 
+// OKTA-1182955: backend may attach a priorVerification descriptor to the success-redirect remediation
+// indicating the prior step was a successful Android AppLink (FastPass) verification. In that case the
+// SIW must not auto-redirect — the page can be `visible` before the window has regained focus and the
+// redirect lands on login.okta.com. The view renders a button instead; the user click guarantees focus
+// before the redirect fires.
+Util.isPostAppLinkVerification = function(viewStateOrLink) {
+  const pv = viewStateOrLink && viewStateOrLink.priorVerification;
+  return !!pv && pv.method === 'APP_LINK' && pv.success === true;
+};
+
 /**
  * Why redirect via Form get rather using `window.location.href`?
  * At the time of writing, Chrome (<72) in Android would block window location change

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -290,6 +290,13 @@ export default Controller.extend({
       sessionStorageHelper.removeStateHandle();
 
       const currentViewState = this.options.appState.getCurrentViewState();
+      // OKTA-1182955: when the backend signals a successful prior Android AppLink (FastPass)
+      // verification, do NOT auto-redirect. AutoRedirectView renders a button instead; the
+      // user click guarantees window focus before the redirect, avoiding the visible-but-not-
+      // focused race that lands on login.okta.com.
+      if (Util.isPostAppLinkVerification(currentViewState)) {
+        return;
+      }
       // OKTA-702402: redirect only if/when the page is visible
       Util.executeOnVisiblePage(() => {
         Util.redirectWithFormGet(currentViewState.href);

--- a/src/v2/ion/responseTransformer.js
+++ b/src/v2/ion/responseTransformer.js
@@ -69,6 +69,7 @@ const getRemediationValues = (idx) => {
       remediationValues.push({
         name: idx.context.success.name,
         href: idx.context.success.href,
+        priorVerification: idx.context.success.priorVerification,
         value: [],
       });
     } else if (idx.context.messages) {

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -1,6 +1,7 @@
-import { _, loc, createCallout } from '@okta/courage';
+import { _, loc, createButton, createCallout } from '@okta/courage';
 import { BaseForm, BaseView } from '../internals';
 import { INTERSTITIAL_REDIRECT_VIEW } from '../../ion/RemediationConstants';
+import Util from '../../../util/Util';
 import CustomAccessDeniedErrorMessage from '../views/shared/CustomAccessDeniedErrorMessage';
 const CUSTOM_ACCESS_DENIED_KEY = 'security.access_denied_custom_message';
 const UNLOCK_USER_SUCCESS_MESSAGE = 'oie.selfservice.unlock_user.landing.to.app.success.message';
@@ -68,6 +69,21 @@ const Body = BaseForm.extend({
 
   render() {
     BaseForm.prototype.render.apply(this, arguments);
+    const currentViewState = this.options.appState.getCurrentViewState();
+    // OKTA-1182955: render a Continue button instead of the auto-redirect spinner when the
+    // backend signaled a successful prior Android AppLink (FastPass) verification. A user click
+    // guarantees window focus before the redirect fires.
+    if (Util.isPostAppLinkVerification(currentViewState)) {
+      this.add(createButton({
+        className: 'button button-wide button-primary',
+        title: loc('oie.optional.authenticator.button.title', 'login'),
+        id: 'applink-continue-redirect',
+        click: () => {
+          Util.redirectWithFormGet(currentViewState.href);
+        }
+      }));
+      return;
+    }
     if (this.redirectView === INTERSTITIAL_REDIRECT_VIEW.DEFAULT) {
       this.add('<div class="okta-waiting-spinner"></div>');
     }

--- a/src/v3/src/components/Redirect/Redirect.test.tsx
+++ b/src/v3/src/components/Redirect/Redirect.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { fireEvent, render } from '@testing-library/preact';
+import { h } from 'preact';
+
+import { RedirectElement } from '../../types';
+import Redirect from './Redirect';
+
+const mockChangeLocation = jest.fn();
+const mockExecuteOnVisiblePage = jest.fn((cb: () => void) => cb());
+jest.mock('../../../../util/Util', () => ({
+  changeLocation: (url: string) => mockChangeLocation(url),
+  executeOnVisiblePage: (cb: () => void) => mockExecuteOnVisiblePage(cb),
+}));
+
+// Stub the Button component so we don't need to wire up WidgetContext / theme just to
+// test that Redirect renders a Continue button and its click reaches Util.changeLocation.
+jest.mock('../Button', () => ({
+  __esModule: true,
+  default: ({ uischema }: { uischema: { label: string; options: { onClick: () => void } } }) => (
+    <button
+      type="button"
+      data-se="applink-continue"
+      onClick={uischema.options.onClick}
+    >
+      {uischema.label}
+    </button>
+  ),
+}));
+
+describe('Redirect component', () => {
+  const REDIRECT_URL = 'https://example.okta.com/redirect';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('auto-redirects and renders nothing when priorVerification is absent', () => {
+    const uischema: RedirectElement = {
+      type: 'Redirect',
+      options: { url: REDIRECT_URL },
+    };
+    const { container } = render(<Redirect uischema={uischema} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(mockExecuteOnVisiblePage).toHaveBeenCalledTimes(1);
+    expect(mockChangeLocation).toHaveBeenCalledTimes(1);
+    expect(mockChangeLocation).toHaveBeenCalledWith(REDIRECT_URL);
+  });
+
+  it('renders Continue button and does NOT auto-redirect when APP_LINK verification succeeded', () => {
+    const uischema: RedirectElement = {
+      type: 'Redirect',
+      options: {
+        url: REDIRECT_URL,
+        priorVerification: { method: 'APP_LINK', success: true },
+      },
+    };
+    const { queryByTestId } = render(<Redirect uischema={uischema} />);
+
+    const button = queryByTestId('applink-continue');
+    expect(button).not.toBeNull();
+    // loc() returns the raw i18n key in tests; the key resolves to "Continue" at runtime.
+    expect(button?.textContent).toBe('oie.optional.authenticator.button.title');
+    expect(mockChangeLocation).not.toHaveBeenCalled();
+  });
+
+  it('clicking the Continue button calls Util.changeLocation with the redirect url', () => {
+    const uischema: RedirectElement = {
+      type: 'Redirect',
+      options: {
+        url: REDIRECT_URL,
+        priorVerification: { method: 'APP_LINK', success: true },
+      },
+    };
+    const { getByTestId } = render(<Redirect uischema={uischema} />);
+
+    fireEvent.click(getByTestId('applink-continue'));
+
+    expect(mockChangeLocation).toHaveBeenCalledTimes(1);
+    expect(mockChangeLocation).toHaveBeenCalledWith(REDIRECT_URL);
+  });
+
+  it('auto-redirects when method is APP_LINK but success is false', () => {
+    const uischema: RedirectElement = {
+      type: 'Redirect',
+      options: {
+        url: REDIRECT_URL,
+        priorVerification: { method: 'APP_LINK', success: false },
+      },
+    };
+    const { container } = render(<Redirect uischema={uischema} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(mockChangeLocation).toHaveBeenCalledWith(REDIRECT_URL);
+  });
+
+  it('auto-redirects when method is not APP_LINK', () => {
+    const uischema: RedirectElement = {
+      type: 'Redirect',
+      options: {
+        url: REDIRECT_URL,
+        priorVerification: { method: 'LOOPBACK', success: true },
+      },
+    };
+    const { container } = render(<Redirect uischema={uischema} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(mockChangeLocation).toHaveBeenCalledWith(REDIRECT_URL);
+  });
+
+  it('renders nothing when url is missing even with priorVerification present', () => {
+    const uischema: RedirectElement = {
+      type: 'Redirect',
+      // @ts-expect-error deliberately missing url to exercise the !options.url guard.
+      options: {
+        priorVerification: { method: 'APP_LINK', success: true },
+      },
+    };
+    const { container } = render(<Redirect uischema={uischema} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(mockChangeLocation).not.toHaveBeenCalled();
+  });
+});

--- a/src/v3/src/components/Redirect/Redirect.tsx
+++ b/src/v3/src/components/Redirect/Redirect.tsx
@@ -10,18 +10,35 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { h } from 'preact';
+import React from 'preact/compat';
 import { useEffect } from 'preact/hooks';
 
 import Util from '../../../../util/Util';
-import { RedirectElement, UISchemaElementComponent } from '../../types';
+import {
+  ButtonElement,
+  ButtonType,
+  RedirectElement,
+  UISchemaElementComponent,
+} from '../../types';
+import { loc } from '../../util';
+import Button from '../Button';
+
+const isPostAppLinkVerification = (
+  priorVerification: RedirectElement['options']['priorVerification'],
+): boolean => priorVerification?.method === 'APP_LINK' && priorVerification?.success === true;
 
 const Redirect: UISchemaElementComponent<{ uischema: RedirectElement }> = ({
   uischema: { options },
 }) => {
+  // OKTA-1182955: when the backend signaled a successful prior Android AppLink (FastPass) verification,
+  // render a Continue button instead of auto-redirecting. The user click guarantees window focus before
+  // the redirect, avoiding the visible-but-not-focused race that otherwise lands on login.okta.com.
+  const showAppLinkContinueButton = isPostAppLinkVerification(options?.priorVerification);
+
   useEffect(() => {
-    // we only want this to ever happen once (on initial component mount)
-    // and when document is visible
-    if (options?.url) {
+    // we only want this to ever happen once (on initial component mount) and when document is visible
+    if (options?.url && !showAppLinkContinueButton) {
       Util.executeOnVisiblePage(() => {
         Util.changeLocation(options.url);
       });
@@ -29,7 +46,28 @@ const Redirect: UISchemaElementComponent<{ uischema: RedirectElement }> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return null;
+  if (!showAppLinkContinueButton || !options?.url) {
+    return null;
+  }
+
+  const buttonUiSchema: ButtonElement = {
+    type: 'Button',
+    label: loc('oie.optional.authenticator.button.title', 'login'),
+    options: {
+      type: ButtonType.BUTTON,
+      variant: 'primary',
+      wide: true,
+      onClick: () => {
+        Util.changeLocation(options.url);
+      },
+    },
+  };
+
+  return (
+    <React.Fragment>
+      <Button uischema={buttonUiSchema} />
+    </React.Fragment>
+  );
 };
 
 export default Redirect;

--- a/src/v3/src/transformer/redirect/redirectTransformer.test.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.test.ts
@@ -107,6 +107,43 @@ describe('Success Redirect Transform Tests', () => {
     expect((formBag.uischema.elements[1] as RedirectElement).options?.url).toBe(REDIRECT_URL);
   });
 
+  it('should forward priorVerification to Redirect element when success.href matches url', () => {
+    // OKTA-1182955: when the backend attaches priorVerification (Android AppLink FastPass)
+    // to the success link, forward it to the Redirect component so it renders a Continue button.
+    // @ts-expect-error success is an additive field not in the okta-auth-js typing.
+    transaction.context.success = {
+      href: REDIRECT_URL,
+      priorVerification: { method: 'APP_LINK', success: true },
+    };
+    const formBag = redirectTransformer(transaction, REDIRECT_URL, widgetProps);
+
+    expect(formBag.uischema.elements[1].type).toBe('Redirect');
+    expect((formBag.uischema.elements[1] as RedirectElement).options?.priorVerification)
+      .toEqual({ method: 'APP_LINK', success: true });
+  });
+
+  it('should not forward priorVerification when success.href does not match url', () => {
+    // Guards against forwarding the AppLink signal on non-success-redirect paths.
+    // @ts-expect-error success is an additive field not in the okta-auth-js typing.
+    transaction.context.success = {
+      href: 'https://different-url.example.com',
+      priorVerification: { method: 'APP_LINK', success: true },
+    };
+    const formBag = redirectTransformer(transaction, REDIRECT_URL, widgetProps);
+
+    expect(formBag.uischema.elements[1].type).toBe('Redirect');
+    expect((formBag.uischema.elements[1] as RedirectElement).options?.priorVerification)
+      .toBeUndefined();
+  });
+
+  it('should leave priorVerification undefined when success is absent', () => {
+    const formBag = redirectTransformer(transaction, REDIRECT_URL, widgetProps);
+
+    expect(formBag.uischema.elements[1].type).toBe('Redirect');
+    expect((formBag.uischema.elements[1] as RedirectElement).options?.priorVerification)
+      .toBeUndefined();
+  });
+
   it('should add app name to description element for DEFAULT Interstitial view '
     + 'when identifier is missing from transaction', () => {
     const appInfo = { name: 'Okta Dashboard' };

--- a/src/v3/src/transformer/redirect/redirectTransformer.ts
+++ b/src/v3/src/transformer/redirect/redirectTransformer.ts
@@ -32,9 +32,17 @@ export const redirectTransformer = (
 
   const { uischema } = formBag;
 
+  // OKTA-1182955: forward the optional priorVerification descriptor (e.g. successful Android AppLink)
+  // from the IDX success link so the Redirect component can render a button instead of auto-redirecting.
+  // Only meaningful when this redirect IS the success-redirect path; for other paths the field is absent.
+  // @ts-expect-error priorVerification is an additive field not in the okta-auth-js IonLink typing.
+  const priorVerification = transaction.context?.success?.href === url
+    ? transaction.context?.success?.priorVerification
+    : undefined;
+
   uischema.elements.push({
     type: 'Redirect',
-    options: { url },
+    options: { url, priorVerification },
   } as RedirectElement);
 
   const appInfo = getAppInfo(transaction);

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -712,7 +712,12 @@ export interface StepperRadioElement extends UISchemaElement {
 
 export interface RedirectElement extends UISchemaElement {
   type: 'Redirect',
-  options: { url: string; },
+  options: {
+    url: string;
+    // OKTA-1182955: optional backend signal that the prior step was a successful Android AppLink
+    // verification. When present, the Redirect component renders a button instead of auto-redirecting.
+    priorVerification?: { method?: string; success?: boolean };
+  },
 }
 
 export interface AutoSubmitElement extends UISchemaElement {

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -400,4 +400,34 @@ describe('util/Util', () => {
       expect(Util.searchParamsToString(params)).toEqual(expected);
     });
   });
+
+  describe('isPostAppLinkVerification', () => {
+    it('returns false for undefined input', () => {
+      expect(Util.isPostAppLinkVerification(undefined)).toBe(false);
+    });
+
+    it('returns false for null input', () => {
+      expect(Util.isPostAppLinkVerification(null)).toBe(false);
+    });
+
+    it('returns false when priorVerification is missing', () => {
+      expect(Util.isPostAppLinkVerification({ href: 'http://example.com' })).toBe(false);
+    });
+
+    it('returns false when method is not APP_LINK', () => {
+      const viewState = { priorVerification: { method: 'LOOPBACK', success: true } };
+      expect(Util.isPostAppLinkVerification(viewState)).toBe(false);
+    });
+
+    it('returns false when success is not strictly true', () => {
+      expect(Util.isPostAppLinkVerification({ priorVerification: { method: 'APP_LINK', success: false } })).toBe(false);
+      expect(Util.isPostAppLinkVerification({ priorVerification: { method: 'APP_LINK' } })).toBe(false);
+      expect(Util.isPostAppLinkVerification({ priorVerification: { method: 'APP_LINK', success: 'true' } })).toBe(false);
+    });
+
+    it('returns true for method APP_LINK and success true', () => {
+      const viewState = { priorVerification: { method: 'APP_LINK', success: true } };
+      expect(Util.isPostAppLinkVerification(viewState)).toBe(true);
+    });
+  });
 });

--- a/test/unit/spec/v2/ion/responseTransformer_spec.js
+++ b/test/unit/spec/v2/ion/responseTransformer_spec.js
@@ -249,6 +249,25 @@ describe('v2/ion/responseTransformer', function() {
     });
   });
 
+  it('propagates priorVerification on success ion response', done => {
+    // OKTA-1182955: when the backend attaches a priorVerification descriptor to the
+    // success-redirect link (e.g. Android AppLink FastPass), it must be forwarded onto
+    // the transformed remediation value so views can render a Continue button.
+    const withPriorVerification = JSON.parse(JSON.stringify(XHRSuccess));
+    withPriorVerification.success.priorVerification = { method: 'APP_LINK', success: true };
+    MockUtil.mockIntrospect(done, withPriorVerification, idxResp => {
+      const result = transformResponse(testContext.settings, idxResp);
+      expect(result.remediations).toEqual([
+        {
+          name: 'success-redirect',
+          href: 'http://localhost:3000/app/UserHome?stateToken=mockedStateToken123',
+          priorVerification: { method: 'APP_LINK', success: true },
+          value: [],
+        },
+      ]);
+    });
+  });
+
   it('converts success ion response with app and user', done => {
     MockUtil.mockIntrospect(done, XHRSuccessWithAppUser, idxResp => {
       const result = transformResponse(testContext.settings, idxResp);

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -2,6 +2,7 @@ import { Model } from '@okta/courage';
 import AutoRedirectView from 'v2/view-builder/views/AutoRedirectView';
 import AppState from 'v2/models/AppState';
 import Settings from 'models/Settings';
+import Util from 'util/Util';
 import SuccessWithAppUser from '../../../../../../playground/mocks/data/idp/idx/success-with-app-user.json';
 import { INTERSTITIAL_REDIRECT_VIEW } from 'v2/ion/RemediationConstants';
 
@@ -93,5 +94,75 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
     testContext.view.render();
 
     expect(testContext.view.$el.html()).toMatchSnapshot();
+  });
+
+  describe('OKTA-1182955: post AppLink verification renders Continue button', function() {
+    const REDIRECT_HREF = 'http://localhost:3000/redirect-target';
+
+    const initWithViewState = (viewState) => {
+      const appState = new AppState({}, {});
+      appState.set('user', SuccessWithAppUser.user.value);
+      appState.set('app', SuccessWithAppUser.app.value);
+      appState.set('currentFormName', 'success-redirect');
+      appState.set('remediations', [viewState]);
+
+      testContext.view = new AutoRedirectView({
+        appState,
+        settings: new Settings({
+          baseUrl: 'http://localhost:3000',
+          'interstitialBeforeLoginRedirect': INTERSTITIAL_REDIRECT_VIEW.DEFAULT,
+        }),
+        currentViewState: {},
+        model: new Model(),
+      });
+      testContext.view.render();
+    };
+
+    it('renders the Continue button and hides the auto-redirect spinner', function() {
+      initWithViewState({
+        name: 'success-redirect',
+        href: REDIRECT_HREF,
+        priorVerification: { method: 'APP_LINK', success: true },
+      });
+
+      expect(testContext.view.$el.find('#applink-continue-redirect').length).toBe(1);
+      expect(testContext.view.$el.find('#applink-continue-redirect').text()).toBe('Continue');
+      expect(testContext.view.$el.find('.okta-waiting-spinner').length).toBe(0);
+    });
+
+    it('clicking the Continue button triggers Util.redirectWithFormGet with the success href', function() {
+      const redirectSpy = jest.spyOn(Util, 'redirectWithFormGet').mockImplementation(() => {});
+      initWithViewState({
+        name: 'success-redirect',
+        href: REDIRECT_HREF,
+        priorVerification: { method: 'APP_LINK', success: true },
+      });
+
+      testContext.view.$el.find('#applink-continue-redirect').click();
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(REDIRECT_HREF);
+    });
+
+    it('renders spinner (no Continue button) when priorVerification is absent', function() {
+      initWithViewState({
+        name: 'success-redirect',
+        href: REDIRECT_HREF,
+      });
+
+      expect(testContext.view.$el.find('#applink-continue-redirect').length).toBe(0);
+      expect(testContext.view.$el.find('.okta-waiting-spinner').length).toBe(1);
+    });
+
+    it('renders spinner (no Continue button) when method is not APP_LINK', function() {
+      initWithViewState({
+        name: 'success-redirect',
+        href: REDIRECT_HREF,
+        priorVerification: { method: 'LOOPBACK', success: true },
+      });
+
+      expect(testContext.view.$el.find('#applink-continue-redirect').length).toBe(0);
+      expect(testContext.view.$el.find('.okta-waiting-spinner').length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Description:
- Prior backend change https://github.com/atko-eng/okta-core/pull/133512
- Demo https://drive.google.com/file/d/1l5ipGvWUGd8VglvqyVjGo-X2ltMqrztl/view?usp=drive_link

**Root Cause**
 When Android FastPass authentication is invoked via AppLink (Okta Verify launched as a separate app), the user returns to the SIW tab with the page reported as visible briefly before the window has actually regained focus. The post-auth redirect today is gated only on `document.visibilityState` via `Util.executeOnVisiblePage` (added under OKTA-702402), which fires inside that "visible-but-not-focused" window and ands the user on login.okta.com instead of completing the auth flow.                                                                          
                                                                                                               
  Non-AppLink flows don't leave the browser, so they don't have this gap — universally tightening executeOnVisiblePage would risk regressing every other redirect, so the fix is scoped to the AppLink case.


**Fix**
   Rely on a backend-attached signal on the success-redirect remediation and require an explicit user click to trigger the final redirect — a click event inherently guarantees window focus, so it sidesteps the visible-but-not-focused race entirely.                                      
  1. Backend signal (from okta-core#133512): the success link on the IDX response carries an optional `priorVerification: { method: 'APP_LINK',  success: true}` descriptor when the prior step was a successful Android AppLink FastPass verification.       
  2. Shared helper `Util.isPostAppLinkVerification(viewStateOrLink)` in `src/util/Util.js` — returns true only for the strict `method === 'APP_LINK' && success === true` shape. Used from the gen2 sites; gen3 uses an equivalent inline check for the same shape.                                  
  3. Forward the signal onto the transformed remediation:
    - gen2: `src/v2/ion/responseTransformer.js` copies priorVerification onto the success remediation value.                                       
    - gen3: `src/v3/src/transformer/redirect/redirectTransformer.ts` copies it onto the RedirectElement (guarded by success.href === url so it only attaches on the actual success-redirect path).                                                                                                
  4. Suppress the auto-redirect and render a Continue button when the signal is present:                                                         
    - `gen2: FormController.ts` short-circuits handleSaveForm so no auto-redirect fires, and `AutoRedirectView.js` renders a createButton  (#applink-continue-redirect, label "Continue") in place of the spinner. Click calls `Util.redirectWithFormGet(currentViewState.href)`.           
    - gen3: `Redirect.tsx` skips the executeOnVisiblePage call and renders the shared <Button> component (variant primary, wide). Click calls Util.changeLocation(options.url).                                                                                                              
  5. Type update: RedirectElement.options.priorVerification added as optional in `src/v3/src/types/schema.ts`.   
                                                                                                                                                 
  All non-Android-AppLink paths are unchanged — without the backend field the behavior is identical to today. 

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1182955](https://oktainc.atlassian.net/browse/OKTA-1182955)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



