### PR TITLE
OKTA-1194394: Run before/after hooks on switchForm navigation

### DIFF
--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -19,6 +19,7 @@ import {
 } from '../ion/RemediationConstants';
 import transformPayload from '../ion/payloadTransformer';
 import Util from 'util/Util';
+import { executeHooksBefore, executeHooksAfter } from 'util/Hooks';
 import sessionStorageHelper from '../client/sessionStorageHelper';
 import { HttpResponse, IdxStatus, ProceedOptions } from '@okta/okta-auth-js';
 import { EventErrorContext } from 'types/events';
@@ -141,7 +142,7 @@ export default Controller.extend({
     return eventData;
   },
 
-  handleSwitchForm(formName) {
+  async handleSwitchForm(formName) {
     // trigger formName change to change view
     if (this.options.appState.get('messages')) {
       // Clear messages before calling switch form.
@@ -150,7 +151,17 @@ export default Controller.extend({
       // those error will show up on another screen that gets rendered after switchForm
       this.options.appState.unset('messages');
     }
+    // Run customer-registered before/after hooks for the target form. Without this,
+    // hooks fire only on renders driven by an IDX response (see AppState.setIonResponse),
+    // and any client-side switchForm navigation (e.g. "Verify with something else")
+    // would silently skip them.
+    const hook = this.options.appState.hooks?.getHook(formName);
+    await executeHooksBefore(hook);
+    // Backbone fires `change:currentFormName` and re-renders synchronously inside
+    // set(), so the DOM is fully updated by the time set() returns — which means
+    // executeHooksAfter below runs against the new form, not the old one.
     this.options.appState.set('currentFormName', formName);
+    await executeHooksAfter(hook);
   },
 
   // eslint-disable-next-line max-statements

--- a/test/unit/spec/v2/controllers/FormController_spec.js
+++ b/test/unit/spec/v2/controllers/FormController_spec.js
@@ -1,0 +1,83 @@
+import FormController from 'v2/controllers/FormController';
+
+describe('v2/controllers/FormController', () => {
+  describe('handleSwitchForm', () => {
+    let appState;
+    let beforeHook;
+    let afterHook;
+    let order;
+
+    beforeEach(() => {
+      order = [];
+      beforeHook = jest.fn(() => {
+        order.push('before');
+        return Promise.resolve();
+      });
+      afterHook = jest.fn(() => {
+        order.push('after');
+        return Promise.resolve();
+      });
+
+      appState = {
+        get: jest.fn(() => null),
+        unset: jest.fn(),
+        set: jest.fn(() => {
+          order.push('set:currentFormName');
+        }),
+        hooks: {
+          getHook: jest.fn(() => ({ before: [beforeHook], after: [afterHook] })),
+        },
+      };
+    });
+
+    function callHandler(formName) {
+      // Invoke the prototype method directly with a minimal fake `this` —
+      // handleSwitchForm only depends on `this.options.appState`, and this
+      // avoids spinning up Backbone routing/view machinery.
+      return FormController.prototype.handleSwitchForm.call(
+        { options: { appState } },
+        formName,
+      );
+    }
+
+    it('runs before/after hooks registered for the target form', async () => {
+      await callHandler('select-authenticator-authenticate');
+
+      expect(appState.hooks.getHook).toHaveBeenCalledWith('select-authenticator-authenticate');
+      expect(beforeHook).toHaveBeenCalledTimes(1);
+      expect(afterHook).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs the before hook, then changes currentFormName, then runs the after hook', async () => {
+      await callHandler('select-authenticator-authenticate');
+
+      expect(order).toEqual(['before', 'set:currentFormName', 'after']);
+      expect(appState.set).toHaveBeenCalledWith('currentFormName', 'select-authenticator-authenticate');
+    });
+
+    it('still changes currentFormName when no hook is registered for the target form', async () => {
+      appState.hooks.getHook.mockReturnValue(undefined);
+
+      await callHandler('select-authenticator-authenticate');
+
+      expect(appState.set).toHaveBeenCalledWith('currentFormName', 'select-authenticator-authenticate');
+      expect(beforeHook).not.toHaveBeenCalled();
+      expect(afterHook).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when appState has no hooks model', async () => {
+      delete appState.hooks;
+
+      await expect(callHandler('select-authenticator-authenticate')).resolves.not.toThrow();
+      expect(appState.set).toHaveBeenCalledWith('currentFormName', 'select-authenticator-authenticate');
+    });
+
+    it('clears existing messages before switching forms', async () => {
+      appState.get.mockImplementation((key) => (key === 'messages' ? [{}] : null));
+
+      await callHandler('select-authenticator-authenticate');
+
+      expect(appState.unset).toHaveBeenCalledWith('messages');
+    });
+  });
+});


### PR DESCRIPTION
## Description:

Customer-registered `oktaSignIn.before(formName, fn)` / `oktaSignIn.after(formName, fn)` hooks fired correctly on the first render of `select-authenticator-authenticate` (driven by an IDX server response), but were silently skipped on every subsequent render triggered by clicking "Verify with something else". The root cause was that `FormController.handleSwitchForm` set `currentFormName` directly, bypassing the hook-execution path that lives in `AppState.setIonResponse`.

The fix mirrors the `setIonResponse` ordering in `handleSwitchForm`: run `executeHooksBefore`, set `currentFormName` (which triggers re-render), then run `executeHooksAfter`. This applies to any client-side `switchForm` navigation, including repeated use of "Verify with something else" in the Forgot Password and Unlock Account flows. v2 (OIE) only; no UI changes.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1194394](https://oktainc.atlassian.net/browse/OKTA-1194394)

### Reviewers:

### Screenshot/Video:

### Downstream Monolith Build:
