### PR TITLE
OKTA-1203670: Fix Classic widget logo overflow on narrow viewports

### DIFF
--- a/assets/sass/modules/_header.scss
+++ b/assets/sass/modules/_header.scss
@@ -7,6 +7,16 @@
   -moz-transition: padding-bottom 0.4s;
   -webkit-transition: padding-bottom 0.4s;
   transition: padding-bottom 0.4s;
+
+  @include device-mq(x-small) {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  @include max-width-mq($container-width - 50px) {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
 }
 
 /* Org Logo */


### PR DESCRIPTION
## Description:

In the gen2 widget (v1 Classic and v2 OIE-Backbone both render via `src/v1/views/shared/Header.ts` and share `_header.scss`), the org logo is pushed off-center and overflows the right edge of the auth header on viewports narrower than ~380px. The customer reported this on the user-enrollment / activation page, but the issue is in the shared header CSS so it affects every gen2 screen.

Root cause: `.auth-header` has fixed `padding: 30px 90px 75px` (180px total horizontal gutter) while `.auth-org-logo` has `max-width: 200px`. On a 320px viewport the inner span shrinks to 124px (304px container − 180px gutter), so the 200px logo cannot fit — `margin: 0 auto` can no longer center it and the image overflows ~76px to the right.

Fix: add responsive horizontal padding to `.auth-header`, mirroring the existing pattern already used by `.auth-content` in `_layout.scss:13-21` — reduce left/right padding to 20px on small devices (`device-mq(x-small)`, max-device-width 480px) and on narrow viewports (`max-width-mq($container-width - 50px)` = max-width 350px). Desktop and the default 400px-container case are unchanged.

The centering invariant (`inner-span ≥ logo-width`) now holds across viewport sizes: at 320px the inner span becomes 264px with 32px centering margins around the 200px logo.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1203670](https://oktainc.atlassian.net/browse/OKTA-1203670)

### Reviewers:

### Screenshot/Video:

Captured on the gen2 PrimaryAuth screen using the playground's default org logo (`logo_widgico.png`, 224×40).

**Regression check** — desktop and tablet renderings are byte-identical before vs after the fix (verified via SHA-256 of the screenshots), since neither media query fires above 480px device-width / 350px viewport:

| Viewport | Before | After | Result |
| --- | --- | --- | --- |
| Desktop 1200×800 | ![before-desktop](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1203670/before-desktop-1200.png) | ![after-desktop](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1203670/after-desktop-1200.png) | Byte-identical (no regression) |
| Tablet 768×1024 | ![before-tablet](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1203670/before-tablet-768.png) | ![after-tablet](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1203670/after-tablet-768.png) | Byte-identical (no regression) |
| Mobile 320×568 | ![before-mobile](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1203670/before-mobile-320.png) | ![after-mobile](https://raw.githubusercontent.com/okta/okta-signin-widget/pr-assets/OKTA-1203670/after-mobile-320.png) | Logo no longer overflows; centered in inner span |

> Note on the playground logo's visual lean: the `logo_widgico.png` test asset has a teal "O" mark on the right that gives the image asymmetric visual weight. The logo's bounding-box center is mathematically aligned to the container center (measured offset: −0.004px on desktop, 0.000px on mobile-after), but the design isn't symmetric — so "ICO" appears slightly right-of-center on every viewport, including desktop. A customer logo with a symmetric wordmark renders cleanly centered.

### Downstream Monolith Build:

