### PR TITLE
OKTA-1215267: suppress /poll fired during /cancel in gen3 FastPass

### DIFF
--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -558,4 +558,91 @@ describe('LoopbackProbe', () => {
       }));
     });
   });
+
+  // When features.disablePollDuringCancel is on, LoopbackProbe.cancelHandler
+  // participates in the pollInFlightRef protocol as a writer using the
+  // "claim only if free, clear only what you claimed" pattern. Polls fired
+  // by usePolling during the /cancel proceed are then suppressed at the
+  // existing guard in usePolling.ts.
+  describe('disablePollDuringCancel guard', () => {
+    it('FF on, flag free: cancelHandler claims pollInFlightRef during /cancel proceed', async () => {
+      const pollInFlightRef = { current: false };
+      // proceedStub returns a pending Promise — cancel stays "in flight" so
+      // we can observe the flag while it's claimed
+      const cancelPending = new Promise(() => { /* never resolves */ });
+      const localProceedStub = jest.fn().mockReturnValue(cancelPending);
+      mockWidgetContextOverrides = {
+        widgetProps: { features: { disablePollDuringCancel: true } },
+        pollInFlightRef,
+        authClient: { idx: { proceed: localProceedStub } },
+      };
+      server.use(
+        rest.get('http://localhost:6512/probe', async (_, res, ctx) => res(ctx.status(500))),
+      );
+      const props: { uischema: LoopbackProbeElement } = {
+        uischema: {
+          type: 'LoopbackProbe',
+          options: {
+            deviceChallengePayload: {
+              ports: ['6512'],
+              domain: 'http://localhost',
+              challengeRequest: 'mockChallengeRequest',
+              probeTimeoutMillis: 100,
+            },
+            cancelStep: 'authenticatorChallenge-cancel',
+            step: 'device-challenge-poll',
+          },
+        },
+      };
+      render(<LoopbackProbe {...props} />);
+
+      await waitFor(() => expect(localProceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
+      // /cancel is on the wire (proceed hasn't resolved) → flag is claimed
+      expect(pollInFlightRef.current).toBe(true);
+    });
+
+    it('FF on, flag already held: cancelHandler does NOT clobber an in-flight /poll claim', async () => {
+      // Race A scenario: a /poll is already in flight (flag truthy) when
+      // cancelHandler fires. cancelHandler must not touch the flag — clearing
+      // it in our finally would re-enable polling while the original /poll is
+      // still on the wire, breaking the 7.46.2 invariant.
+      const pollInFlightRef = { current: true };
+      let resolveCancel: (value: unknown) => void;
+      const cancelPromise = new Promise((resolve) => { resolveCancel = resolve; });
+      const localProceedStub = jest.fn().mockReturnValue(cancelPromise);
+      mockWidgetContextOverrides = {
+        widgetProps: { features: { disablePollDuringCancel: true } },
+        pollInFlightRef,
+        authClient: { idx: { proceed: localProceedStub } },
+      };
+      server.use(
+        rest.get('http://localhost:6512/probe', async (_, res, ctx) => res(ctx.status(500))),
+      );
+      const props: { uischema: LoopbackProbeElement } = {
+        uischema: {
+          type: 'LoopbackProbe',
+          options: {
+            deviceChallengePayload: {
+              ports: ['6512'],
+              domain: 'http://localhost',
+              challengeRequest: 'mockChallengeRequest',
+              probeTimeoutMillis: 100,
+            },
+            cancelStep: 'authenticatorChallenge-cancel',
+            step: 'device-challenge-poll',
+          },
+        },
+      };
+      render(<LoopbackProbe {...props} />);
+
+      await waitFor(() => expect(localProceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
+      // Flag still held by the (mocked) in-flight /poll
+      expect(pollInFlightRef.current).toBe(true);
+      // Resolve /cancel and wait a microtask; cancelHandler's finally runs
+      resolveCancel!(undefined);
+      await new Promise((r) => { setTimeout(r, 50); });
+      // Flag STILL held — cancelHandler did not clear what it did not claim
+      expect(pollInFlightRef.current).toBe(true);
+    });
+  });
 });

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -33,6 +33,7 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
     authClient, idxTransaction, setIdxTransaction, widgetProps, pollInFlightRef,
   } = widgetContext;
   const disableConcurrentPolling = widgetProps?.features?.disableConcurrentPolling;
+  const disablePollDuringCancel = widgetProps?.features?.disablePollDuringCancel;
 
   const probeTimeoutMillis: number = typeof deviceChallengePayload.probeTimeoutMillis === 'undefined'
     ? 100 : deviceChallengePayload.probeTimeoutMillis;
@@ -52,10 +53,11 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
     }
 
     // When FF is on and another poll-step `proceed` is in flight (e.g.
-    // usePolling's setTimeout already fired), suppress this one.
-    // cancelHandler is intentionally NOT guarded — user-initiated cancel
-    // must always go through.
-    const guarded = disableConcurrentPolling && isPollingStep(stepName);
+    // usePolling's setTimeout already fired), or a /cancel from
+    // cancelHandler is in flight, suppress this one. cancelHandler itself
+    // is intentionally NOT guarded — cancel must always go through.
+    const guarded = (disableConcurrentPolling || disablePollDuringCancel)
+      && isPollingStep(stepName);
     if (guarded && pollInFlightRef?.current) {
       return;
     }
@@ -82,8 +84,25 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
     if (typeof idxTransaction?.context.stateHandle !== 'undefined') {
       payload.stateHandle = idxTransaction.context.stateHandle;
     }
-    const newTransaction = await authClient?.idx.proceed(payload);
-    setIdxTransaction(newTransaction);
+    // When FF is on, claim the shared pollInFlightRef so any racing
+    // poll-step `proceed` (from usePolling's timer or submitHandler)
+    // is suppressed at the existing guard in usePolling.ts.
+    // "Claim only if free, clear only what you claimed" — if a /poll
+    // is already in flight, the flag is already true; we don't touch
+    // it, and its own `finally` will clear it.
+    const claimedPollFlag = !!(disablePollDuringCancel
+      && pollInFlightRef && !pollInFlightRef.current);
+    if (claimedPollFlag && pollInFlightRef) {
+      pollInFlightRef.current = true;
+    }
+    try {
+      const newTransaction = await authClient?.idx.proceed(payload);
+      setIdxTransaction(newTransaction);
+    } finally {
+      if (claimedPollFlag && pollInFlightRef) {
+        pollInFlightRef.current = false;
+      }
+    }
   };
 
   /* eslint-disable no-await-in-loop, no-continue */

--- a/src/v3/src/components/LoopbackProbe/cancelDuringPoll.integration.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/cancelDuringPoll.integration.test.tsx
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/* eslint-disable react/prop-types */
+
+import { OktaAuth } from '@okta/okta-auth-js';
+import { render, waitFor } from '@testing-library/preact';
+import { FunctionComponent, h } from 'preact';
+import { useRef } from 'preact/hooks';
+
+// Mock makeRequest so probe resolves via microtasks (no msw, no real timers
+// needed). This mock has to be declared before the modules that import it.
+jest.mock('../../util', () => ({
+  ...jest.requireActual('../../util'),
+  makeRequest: jest.fn(),
+  isAndroid: () => false,
+}));
+
+// eslint-disable-next-line import/first
+import { WidgetContextProvider } from '../../contexts';
+// eslint-disable-next-line import/first
+import { usePolling } from '../../hooks/usePolling';
+// eslint-disable-next-line import/first
+import { IWidgetContext, LoopbackProbeElement, WidgetProps } from '../../types';
+// eslint-disable-next-line import/first
+import { makeRequest } from '../../util';
+// eslint-disable-next-line import/first
+import LoopbackProbe from './LoopbackProbe';
+
+const REFRESH_MS = 200;
+const STATE_HANDLE = 'fake-state-handle';
+const STEP = 'device-challenge-poll';
+const CANCEL_STEP = 'authenticatorChallenge-cancel';
+
+type HarnessProps = {
+  widgetProps: WidgetProps;
+};
+
+// Mirror Widget/index.tsx: own the shared ref, drive usePolling, render
+// LoopbackProbe inside WidgetContextProvider.
+const Harness: FunctionComponent<HarnessProps> = ({ widgetProps }) => {
+  const pollInFlightRef = useRef<boolean>(false);
+  const idxTransaction = {
+    nextStep: { name: STEP, refresh: REFRESH_MS },
+    context: { stateHandle: STATE_HANDLE },
+  } as unknown as Parameters<typeof usePolling>[0];
+
+  usePolling(idxTransaction, widgetProps, {}, pollInFlightRef);
+
+  const ctxValue = {
+    authClient: widgetProps.authClient,
+    widgetProps,
+    idxTransaction,
+    setIdxTransaction: jest.fn(),
+    setResponseError: jest.fn(),
+    setIsClientTransaction: jest.fn(),
+    stepToRender: undefined,
+    setStepToRender: jest.fn(),
+    message: undefined,
+    setMessage: jest.fn(),
+    data: {},
+    setData: jest.fn(),
+    dataSchemaRef: { current: undefined },
+    loading: false,
+    setLoading: jest.fn(),
+    setWidgetRendered: jest.fn(),
+    setloginHint: jest.fn(),
+    languageCode: 'en',
+    languageDirection: 'ltr',
+    setAbortController: jest.fn(),
+    abortController: undefined,
+    pollInFlightRef,
+  } as unknown as IWidgetContext;
+
+  const uischema: LoopbackProbeElement = {
+    type: 'LoopbackProbe',
+    options: {
+      deviceChallengePayload: {
+        ports: ['6512'],
+        domain: 'http://localhost',
+        challengeRequest: 'mockChallengeRequest',
+        probeTimeoutMillis: 100,
+      },
+      cancelStep: CANCEL_STEP,
+      step: STEP,
+    },
+  } as unknown as LoopbackProbeElement;
+
+  return (
+    <WidgetContextProvider value={ctxValue}>
+      <LoopbackProbe uischema={uischema} />
+    </WidgetContextProvider>
+  );
+};
+
+describe('disablePollDuringCancel — integration (LoopbackProbe.cancelHandler + usePolling)', () => {
+  let proceedMock: jest.Mock;
+
+  beforeEach(() => {
+    // never resolves — keeps /cancel in flight forever so the usePolling
+    // setTimeout has a chance to fire during the cancel window
+    proceedMock = jest.fn().mockImplementation(
+      () => new Promise(() => { /* pending */ }),
+    );
+    // /probe returns non-ok on every port → doLoopback finds no port →
+    // cancelHandler fires with reason 'OV_UNREACHABLE_BY_LOOPBACK'
+    (makeRequest as jest.Mock).mockImplementation(async () => (
+      { ok: false, status: 500 }
+    ));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const buildWidgetProps = (
+    disableConcurrentPolling: boolean,
+    disablePollDuringCancel: boolean,
+  ): WidgetProps => ({
+    stateToken: 'fake-state-token',
+    authClient: { idx: { proceed: proceedMock } } as unknown as OktaAuth,
+    features: { disableConcurrentPolling, disablePollDuringCancel },
+  } as unknown as WidgetProps);
+
+  it('FF on: cancelHandler claims the flag; usePolling timer is suppressed during /cancel', async () => {
+    render(<Harness widgetProps={buildWidgetProps(false, true)} />);
+
+    // 1. probe fails on all ports → cancelHandler fires /cancel
+    await waitFor(
+      () => expect(proceedMock).toHaveBeenCalledTimes(1),
+      { timeout: 1000 },
+    );
+    expect(proceedMock).toHaveBeenCalledWith(expect.objectContaining({
+      actions: [expect.objectContaining({
+        name: CANCEL_STEP,
+        params: expect.objectContaining({ reason: 'OV_UNREACHABLE_BY_LOOPBACK' }),
+      })],
+      stateHandle: STATE_HANDLE,
+    }));
+
+    // 2. wait long enough for usePolling's setTimeout(REFRESH_MS) to fire 2x
+    await new Promise((r) => { setTimeout(r, REFRESH_MS * 3); });
+
+    // 3. guard suppressed the racing /poll → still exactly 1 (the /cancel)
+    expect(proceedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('FF off (regression baseline): cancelHandler fires /cancel, usePolling fires racing /poll on same stateHandle', async () => {
+    render(<Harness widgetProps={buildWidgetProps(false, false)} />);
+
+    // cancelHandler fires /cancel
+    await waitFor(
+      () => expect(proceedMock).toHaveBeenCalledTimes(1),
+      { timeout: 1000 },
+    );
+
+    // usePolling's setTimeout fires /poll — no guard, race window open
+    await waitFor(
+      () => expect(proceedMock).toHaveBeenCalledTimes(2),
+      { timeout: 2000 },
+    );
+
+    // 1st call: /cancel
+    expect(proceedMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      actions: [expect.objectContaining({ name: CANCEL_STEP })],
+      stateHandle: STATE_HANDLE,
+    }));
+    // 2nd call: /poll on the same stateHandle as the in-flight /cancel —
+    // exactly the cancel-vs-poll race condition this fix targets
+    expect(proceedMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      step: STEP,
+      stateHandle: STATE_HANDLE,
+    }));
+  });
+
+  it('disableConcurrentPolling on but disablePollDuringCancel off: cancel-vs-poll race still open', async () => {
+    // Confirms the new FF is the one that closes the cancel-vs-poll race;
+    // the existing 7.46.2 FF alone doesn't (cancelHandler doesn't claim).
+    render(<Harness widgetProps={buildWidgetProps(true, false)} />);
+
+    await waitFor(
+      () => expect(proceedMock).toHaveBeenCalledTimes(1),
+      { timeout: 1000 },
+    );
+
+    await waitFor(
+      () => expect(proceedMock).toHaveBeenCalledTimes(2),
+      { timeout: 2000 },
+    );
+
+    expect(proceedMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      step: STEP,
+      stateHandle: STATE_HANDLE,
+    }));
+  });
+});

--- a/src/v3/src/hooks/usePolling.test.tsx
+++ b/src/v3/src/hooks/usePolling.test.tsx
@@ -309,4 +309,64 @@ describe('usePolling', () => {
       expect(pollInFlightRef.current).toBe(true);
     });
   });
+
+  // features.disablePollDuringCancel extends the same shared-ref protocol:
+  // when ON, the reader OR's it into the guard so that a /cancel-claimed
+  // pollInFlightRef also suppresses a racing /poll. Production source of
+  // the truthy ref is LoopbackProbe.cancelHandler claiming the flag before
+  // its /cancel proceed; here we simulate that by pre-seeding the ref.
+  describe('concurrent /poll requests when /cancel has claimed the shared ref', () => {
+    type SetupArgs = {
+      disablePollDuringCancel?: boolean;
+      pollInFlightRef?: MutableRef<boolean>;
+    };
+    const setup = ({ disablePollDuringCancel, pollInFlightRef }: SetupArgs = {}) => {
+      const slowProceed = jest.fn().mockImplementation(
+        () => new Promise(() => { /* never resolves */ }),
+      );
+      const props: Partial<WidgetProps> = {
+        stateToken: 'fake-state-token',
+        authClient: {
+          idx: { proceed: slowProceed },
+        } as unknown as OktaAuth,
+        features: { disablePollDuringCancel },
+      };
+
+      const idxTransaction1 = {
+        nextStep: { name: 'challenge-poll', refresh: 4000 },
+        context: { stateHandle: 'state-handle-abc' },
+      } as unknown as IdxTransaction;
+
+      renderHook(
+        ({ tx }: { tx: IdxTransaction }) => usePolling(tx, props, mockData, pollInFlightRef),
+        { initialProps: { tx: idxTransaction1 } },
+      );
+
+      // advance past the next refresh window — the ref state determines
+      // whether the scheduled proceed() actually fires
+      jest.advanceTimersByTime(4000);
+
+      return { slowProceed };
+    };
+
+    it('FF on, ref pre-claimed (simulates /cancel in flight): suppresses /poll', () => {
+      const pollInFlightRef = { current: true } as MutableRef<boolean>;
+      const { slowProceed } = setup({ disablePollDuringCancel: true, pollInFlightRef });
+      // guard skips because pollInFlightRef.current is true and FF is on
+      expect(slowProceed).not.toHaveBeenCalled();
+      // ref untouched (we did not toggle it from true→true→true)
+      expect(pollInFlightRef.current).toBe(true);
+    });
+
+    it('FF off, ref pre-claimed: regression baseline — /poll still fires', () => {
+      const pollInFlightRef = { current: true } as MutableRef<boolean>;
+      const { slowProceed } = setup({ disablePollDuringCancel: false, pollInFlightRef });
+      // guard does not engage; /poll races with the in-flight /cancel
+      expect(slowProceed).toHaveBeenCalledTimes(1);
+      expect(slowProceed).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        stateHandle: 'state-handle-abc',
+        step: 'challenge-poll',
+      }));
+    });
+  });
 });

--- a/src/v3/src/hooks/usePolling.ts
+++ b/src/v3/src/hooks/usePolling.ts
@@ -99,10 +99,12 @@ export const usePolling = (
         payload = { actions: [{ name, params: payload }] };
       }
 
-      // When FF is on and another poll-step `proceed` is in flight, suppress
-      // this one. The recurring cycle resumes naturally after the in-flight
-      // call resolves and updates `transaction`.
-      const guarded = features?.disableConcurrentPolling && isPollingStep(name);
+      // When FF is on and another poll-step `proceed` (or a /cancel from
+      // LoopbackProbe.cancelHandler) is in flight, suppress this one. The
+      // recurring cycle resumes naturally after the in-flight call resolves
+      // and updates `transaction`.
+      const guarded = (features?.disableConcurrentPolling
+        || features?.disablePollDuringCancel) && isPollingStep(name);
       if (guarded && pollInFlightRef?.current) {
         return;
       }

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -286,6 +286,12 @@ export type OktaWidgetFeatures = {
   // request as "bad request" when /poll is slow (e.g. DBSSO-elongated
   // /challenge in FastPass loopback). FF delivered from monolith.
   disableConcurrentPolling?: boolean;
+  // When true, have LoopbackProbe.cancelHandler participate in the
+  // pollInFlightRef protocol so that a /poll fired during /cancel is
+  // suppressed by the existing guard in usePolling. Closes the
+  // gen3 cancel-vs-poll race (poll setTimeout firing while /cancel is
+  // on the wire). FF delivered from monolith.
+  disablePollDuringCancel?: boolean;
 };
 
 interface ProxyIdxResponse {


### PR DESCRIPTION
## Description:

Follow-up to #4046 (OKTA-1185557). Add `disablePollDuringCancel` feature flag (gen3 only, off by default). When enabled, `LoopbackProbe.cancelHandler` participates in the same `pollInFlightRef` protocol so that a racing `/poll` fired during `/cancel` is suppressed by the existing guard in `usePolling`.

The 7.46.2 fix (`disableConcurrentPolling`) closed the poll-vs-poll race. The remaining 400 tail on McKinsey is driven by a **poll-vs-cancel** race: `LoopbackProbe`'s auto-cancel (`OV_UNREACHABLE_BY_LOOPBACK` or `OV_RETURNED_ERROR`) and `usePolling`'s recurring `/poll` can fire simultaneously, with `/cancel` landing first and deleting the transaction before `/poll` arrives.

Two windows:
- **Race A** — `usePolling`'s `setTimeout` already fired `/poll` when `cancelHandler` runs. Both on the wire, `/cancel` lands first → `/poll` 400s. *Not closed by this PR* — would require AbortController on IDX `proceed` in okta-auth-js. Mitigated by the parallel monolith leniency fix in OKTA-1212904.
- **Race B** — `cancelHandler` is awaiting its `proceed`; the next `setTimeout` fires `/poll` before React re-renders post-cancel. *Closed by this PR.*

`cancelHandler` uses the "claim only if free, clear only what you claimed" pattern on the shared `pollInFlightRef` to avoid clobbering an in-flight `/poll`'s claim (Race A's invariant). Reader guards in `usePolling` and `LoopbackProbe.submitHandler` are OR'd with the new FF so it's self-contained.

Brings gen3 to parity with gen2's `stopPolling()` pre-cancel (`BaseOktaVerifyChallengeView.js:184`, explicit "avoid /poll/cancel concurrency" comment).

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1215267](https://oktainc.atlassian.net/browse/OKTA-1215267)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:


