### PR TITLE
fix: bump lodash to 4.18.1 for CVE-2026-4800

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,7 +291,9 @@
     "**/debug": "^4.3.4",
     "**/mout": "^1.2.4",
     "underscore": "1.13.8",
-    "**/axios": "^1.15.0"
+    "**/axios": "^1.15.0",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1"
   },
   "workspaces": {
     "packages": [

--- a/src/v3/licenses.txt
+++ b/src/v3/licenses.txt
@@ -1220,7 +1220,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - lodash@4.17.15
+ - lodash@4.18.1
 
 This package contains the following license and notice below:
 

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -61,7 +61,7 @@
     "duo_web_sdk": "https://github.com/duosecurity/duo_web_sdk.git",
     "html-react-parser": "^3.0.9",
     "js-cookie": "^3.0.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "preact": "^10.20.1",
     "react": "npm:@preact/compat",
     "react-dom": "npm:@preact/compat",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14952,10 +14952,10 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+lodash-es@4.18.1, lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -15067,10 +15067,10 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==
 
-"lodash@4.6.1 || ^4.16.1", lodash@4.x, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0, lodash@^4.9.0, lodash@~4.17.19, lodash@~4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@4.18.1, "lodash@4.6.1 || ^4.16.1", lodash@4.x, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.1, lodash@^4.7.0, lodash@^4.9.0, lodash@~4.17.19, lodash@~4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.0.0, log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary
Remediates **CVE-2026-4800** (CVSS 8.1) — a code-injection flaw in lodash's `_.template` via unvalidated `options.imports` key names. Affects `lodash`, `lodash-es`, `lodash-amd` for `>=4.0.0 <=4.17.23`; patched in **4.18.0**.

Jira: [OKTA-1216238](https://oktainc.atlassian.net/browse/OKTA-1216238)

## Context
A customer flagged a vulnerable lodash version in the hosted Sign-In Widget by looking at our license https://github.com/okta/okta-signin-widget/blob/0672fc1f4b196ac157318fbe6e8c58591f5db0bf/src/v3/licenses.txt#L1223
However, we are not bundling lodash template method in either Gen2 or Gen3
## Exploitability — not exploitable (verified against a release build)
The vulnerable code is **`_.template`**, and it is reachable only when a caller passes attacker-controlled **keys** in the `options.imports` map (they flow unvalidated into `Function(importsKeys, …)`; the pre-4.18 code only validated the `variable` option, not `imports` keys).

Evidence from a local `yarn build:release`:
- **lodash ships only in the Gen3 (`okta-sign-in.next.*`) bundle.** The default `okta-sign-in.min.js`, `.classic`, and `.oie` bundles contain **zero** lodash (0 `__lodash_hash_undefined__` markers).
- **lodash's `template` function is not bundled at all** in the Gen3 bundle. Webpack includes only the 8 functions Gen3 imports (`merge, union, flow, groupBy, isEmpty, escape, cloneDeep, omit`) and their dependency graph; `template.js` isn't reachable from them and is tree-shaken out. Fingerprint counts in `okta-sign-in.next.js`: `__p += ` = 0, `` Invalid `variable` option `` = 0, `` Invalid `imports` option `` = 0, `reForbiddenIdentifierChars` = 0.
- **No shipped source calls lodash `_.template`.** Gen3 (React/preact) has no string-template compilation; Gen2 uses `underscore` for `_` and Backbone/Handlebars for views (the one underscore-template call, courage `compileTemplate`, passes no `variable`/`imports` options and only compiles trusted developer strings; underscore has no `imports` option, so CVE-2026-4800 is N/A to it, and we ship the patched underscore 1.13.8).

So the vulnerable path is not present in the shipped runtime bundle. The scanner finding is a dependency-manifest / code-fingerprint match, not an exploitable condition.

But we will just update the lodash and lodash-es (used in yarn.lock) version anyway and update the license.txt

also double check on legacy browser in case of incompatibility
Gen2:
<img width="1874" height="888" alt="Screenshot 2026-07-08 at 3 41 41 PM" src="https://github.com/user-attachments/assets/8a1043de-a046-4189-9f3f-2349c22c1d75" />
Gen3:
<img width="1864" height="891" alt="Screenshot 2026-07-08 at 3 43 59 PM" src="https://github.com/user-attachments/assets/88d94c85-82bf-4bad-8d4e-575bb76deabc" />



