### PR TITLE
Move ALTCHA to use dist_external deployed to OKTA CDN

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,6 +102,12 @@ module.exports = function(grunt) {
           },
           {
             expand: true,
+            cwd: 'node_modules/altcha/dist_external',
+            src: ['altcha.js', 'altcha.css', 'worker.js'],
+            dest: DIST + '/altcha'
+          },
+          {
+            expand: true,
             cwd: 'polyfill',
             src: ['*.js'],
             dest: 'dist/polyfill'

--- a/assets/sass/widgets/_altcha.scss
+++ b/assets/sass/widgets/_altcha.scss
@@ -1,3 +1,5 @@
+@import 'altcha/dist_external/altcha';
+
 .altcha {
     background: #fff;
     border: 1px solid #a0a0a0;

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",
     "@zerollup/ts-transform-paths": "^1.7.18",
+    "altcha": "2.3.0",
     "autoprefixer": "^10.3.4",
     "axe-core": "^4.6.3",
     "axios": "^1.15.0",

--- a/src/util/Altcha.ts
+++ b/src/util/Altcha.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright (c) 2025-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+declare global {
+  interface Window {
+    altchaCreateWorker?: () => Worker;
+  }
+}
+
+let readyPromise: Promise<void> | undefined;
+
+// Public entry point. Idempotent via `readyPromise` so widget remounts reuse
+// the same load; resets on rejection so retries can succeed.
+export function loadAltcha(baseUrl: string): Promise<void> {
+  if (!readyPromise) {
+    readyPromise = load(baseUrl).catch((e) => {
+      readyPromise = undefined;
+      throw e;
+    });
+  }
+  return readyPromise;
+}
+
+// The actual work: fetch worker.js in parallel with the altcha.js script
+// load, then install a blob-URL factory so all parallel PoW workers share
+// one worker.js fetch. Best-effort — resolves even if the worker blob step
+// fails (altcha's own per-instance-fetch factory takes over).
+async function load(baseUrl: string): Promise<void> {
+  // eslint-disable-next-line compat/compat
+  const workerPromise = fetch(`${baseUrl}/worker.js`)
+    .then((r) => r.text())
+    .catch((): string | undefined => undefined);
+
+  await injectModule(`${baseUrl}/altcha.js`);
+
+  const workerSrc = await workerPromise;
+  if (workerSrc !== undefined) {
+    const blobUrl = URL.createObjectURL(
+      new Blob([workerSrc], { type: 'application/javascript' }),
+    );
+    window.altchaCreateWorker = () => new Worker(blobUrl);
+  }
+}
+
+// Promise-wraps a <script type="module"> injection. Resolves on onload,
+// rejects on onerror. Kept separate so the load flow reads linearly.
+function injectModule(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.src = src;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
+    document.head.appendChild(script);
+  });
+}

--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -11,7 +11,9 @@
  */
 
 import { View , loc } from '@okta/courage';
+import { loadAltcha } from 'util/Altcha';
 import Enums from 'util/Enums';
+import Logger from 'util/Logger';
 import Util from 'util/Util';
 import hbs from '@okta/handlebars-inline-precompile';
 import { WIDGET_FOOTER_CLASS } from '../../utils/Constants';
@@ -20,13 +22,6 @@ const OktaSignInWidgetOnCaptchaLoadedCallback = 'OktaSignInWidgetOnCaptchaLoaded
 const OktaSignInWidgetOnCaptchaSolvedCallback = 'OktaSignInWidgetOnCaptchaSolved';
 
 const HCAPTCHA_URL = 'https://hcaptcha.com/1/api.js';
-// ALTCHA_URL and ALTCHA_SRI_HASH must be updated together — changing one
-// without the other will silently break CAPTCHA.
-//
-// To regenerate the SRI hash after a version bump:
-//   echo "sha384-$(curl -s <new-url> | openssl dgst -sha384 -binary | openssl base64 -A)"
-const ALTCHA_URL = 'https://cdn.jsdelivr.net/gh/altcha-org/altcha@2.3.0/dist/altcha.min.js';
-const ALTCHA_SRI_HASH = 'sha384-lxB6k+TvdhSBKnLm6JqwAnW7QxKXj88yK1kq9g3MevDXlG9HdWtnShLgJzuYCUIw';
 const RECAPTCHAV2_URL = 'https://www.google.com/recaptcha/api.js';
 
 const ALTCHA_CHALLENGE_PATH = '/api/v1/altcha';
@@ -84,6 +79,10 @@ export default View.extend({
     } else if (this.captchaConfig.type === 'RECAPTCHA_V2') {
       window.grecaptcha = undefined;
     }
+  },
+
+  _getAltchaBase() {
+    return `${this.options.settings.get('assets.baseUrl')}/altcha`;
   },
 
   /**
@@ -199,7 +198,7 @@ export default View.extend({
         hidefooter: true,
         hidelogo: true,
         challengeurl: challengeUrlForm?.href ?? challengeUrlFallback,
-        strings: JSON.stringify(getAltchaWidgetStrings())
+        strings: JSON.stringify(getAltchaWidgetStrings()),
       }).forEach(([key, value]) => altEl.setAttribute(key, value));
 
       altEl.customfetch = altchaCustomFetch;
@@ -260,30 +259,22 @@ export default View.extend({
       this._loadCaptchaLib(this._getCaptchaUrl(HCAPTCHA_URL, 'hcaptcha'));
     } else if (this.captchaConfig.type === 'RECAPTCHA_V2') {
       this._loadCaptchaLib(this._getCaptchaUrl(RECAPTCHAV2_URL, 'recaptcha'));
-    } if (this.captchaConfig.type === 'ALTCHA') {
-      this._loadCaptchaLib(this._getCaptchaUrl(ALTCHA_URL, 'altcha'));
+    } else if (this.captchaConfig.type === 'ALTCHA') {
+      loadAltcha(this._getAltchaBase())
+        .then(onAltchaCaptchaLoaded)
+        .catch((e) => Logger.error('Failed to load ALTCHA script', e));
     }
   },
-  
+
   /**
    *  We dynamically inject <script> tag into our login container because in case the customer is hosting
    *  the SIW, we need to ensure we don't go out of scope when injecting the script.
-  * */ 
+  * */
   _loadCaptchaLib(url) {
     let scriptTag = document.createElement('script');
     scriptTag.src = url;
     scriptTag.async = true;
     scriptTag.defer = true;
-
-    if (url.indexOf('altcha') !== -1) {
-      scriptTag.type = 'module';
-      if (this.captchaConfig?.sriEnabled) {
-        scriptTag.integrity = ALTCHA_SRI_HASH;
-        scriptTag.crossOrigin = 'anonymous';
-      }
-      scriptTag.onload = window[OktaSignInWidgetOnCaptchaLoadedCallback];
-    }
-
     document.getElementById(Enums.WIDGET_CONTAINER_ID).appendChild(scriptTag);
   },
 

--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -55,7 +55,6 @@
     "@okta/odyssey-design-tokens": "1.44.0",
     "@okta/odyssey-react-mui": "1.44.0",
     "@okta/okta-auth-js": "7.14.5",
-    "altcha": "^1.4.2",
     "chroma-js": "^2.4.2",
     "cross-fetch": "^3.1.5",
     "dompurify": "^2.5.8",

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.test.ts
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.test.ts
@@ -13,6 +13,7 @@
 import { render, waitFor } from '@testing-library/preact';
 import { h } from 'preact';
 
+import { loadAltcha } from '../../../../util/Altcha';
 import Logger from '../../../../util/Logger';
 import CaptchaContainer from './CaptchaContainer';
 
@@ -20,20 +21,15 @@ jest.mock('../../../../util/Logger', () => ({
   error: jest.fn(),
 }));
 
+jest.mock('../../../../util/Altcha', () => ({
+  loadAltcha: jest.fn(),
+}));
+
 const mockOnSubmit = jest.fn();
 jest.mock('../../hooks', () => ({
   useOnSubmit: () => mockOnSubmit,
 }));
 
-/**
- * Mock custom element for altcha-widget that properly captures the `customfetch` property.
- *
- * When Preact renders `<altcha-widget customfetch={fn} />`, it sets the property directly
- * on the DOM element (e.g., `element.customfetch = fn`). A plain HTMLElement doesn't have
- * this property defined, so we need a custom class with an explicit getter/setter to:
- * 1. Allow Preact to set the function via the setter
- * 2. Allow tests to retrieve and invoke it via the getter
- */
 class MockAltchaWidget extends HTMLElement {
   private mockCustomFetch?: typeof window.fetch;
 
@@ -47,13 +43,10 @@ class MockAltchaWidget extends HTMLElement {
 }
 
 const mockLoadAltchaWidget = () => {
-  jest.mock(
-    'altcha',
-    () => {
-      window.customElements.define('altcha-widget', MockAltchaWidget);
-      return {};
-    },
-  );
+  if (!window.customElements.get('altcha-widget')) {
+    window.customElements.define('altcha-widget', MockAltchaWidget);
+  }
+  (loadAltcha as jest.Mock).mockResolvedValue(undefined);
 };
 
 jest.mock('../../contexts', () => ({
@@ -110,17 +103,12 @@ const recaptchaUischema = {
 describe('CaptchaContainer dynamic altcha import', () => {
   beforeEach(() => {
     (Logger.error as jest.Mock).mockClear();
+    (loadAltcha as jest.Mock).mockReset();
     mockOnSubmit.mockClear();
   });
 
   it('logs error when dynamic import of altcha fails', async () => {
-    jest.doMock(
-      'altcha',
-      () => {
-        throw new Error('dynamic import failed');
-      },
-      { virtual: true },
-    );
+    (loadAltcha as jest.Mock).mockRejectedValue(new Error('dynamic import failed'));
 
     render(h(CaptchaContainer, { uischema: altchaUischema }));
 
@@ -134,19 +122,12 @@ describe('CaptchaContainer dynamic altcha import', () => {
   });
 
   it('does not import altcha when captchaType is not ALTCHA', async () => {
-    jest.doMock(
-      'altcha',
-      () => {
-        throw new Error('should not load');
-      },
-      { virtual: true },
-    );
-
     const { container } = render(h(CaptchaContainer, { uischema: recaptchaUischema }));
 
     await waitFor(() => {
       expect(container.querySelector('altcha-widget')).toBeNull();
       expect(Logger.error).toHaveBeenCalledTimes(0);
+      expect(loadAltcha).not.toHaveBeenCalled();
     });
   });
 
@@ -242,11 +223,9 @@ describe('CaptchaContainer dynamic altcha import', () => {
   });
 
   it('does not render ALTCHA widget before script is loaded', () => {
-    // Delay the import to simulate loading state
-    jest.mock(
-      'altcha',
-      () => new Promise(() => {}),
-    );
+    // Never-settling Promise keeps loadAltcha "in flight" so setIsAltchaLoaded
+    // never fires and the widget stays unmounted.
+    (loadAltcha as jest.Mock).mockReturnValue(new Promise(() => {}));
 
     const { container } = render(h(CaptchaContainer, { uischema: altchaUischema }));
 

--- a/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
+++ b/src/v3/src/components/CaptchaContainer/CaptchaContainer.tsx
@@ -12,10 +12,12 @@
 
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Box } from '@mui/material';
+import type {} from 'altcha';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { useMemo } from 'react';
 import ReCAPTCHA from 'react-google-recaptcha';
 
+import { loadAltcha } from '../../../../util/Altcha';
 import Logger from '../../../../util/Logger';
 import { useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';
@@ -97,17 +99,14 @@ const CaptchaContainer: UISchemaElementComponent<{
   }
   // Effect to dynamically load ALTCHA script when needed
   useEffect(() => {
-    // If captchaType is ALTCHA and the script hasn't been loaded yet
-    if (captchaType === 'ALTCHA' && !isAltchaLoaded) {
-      import(/* webpackChunkName: "altcha" */ 'altcha')
-        .then(() => {
-          setIsAltchaLoaded(true);
-        })
-        .catch((err) => {
-          Logger.error('Failed to load ALTCHA script', err);
-        });
+    if (captchaType !== 'ALTCHA' || isAltchaLoaded) {
+      return;
     }
-  }, [captchaType, isAltchaLoaded]);
+    const altchaBase = `${widgetProps?.assets?.baseUrl}/altcha`;
+    loadAltcha(altchaBase)
+      .then(() => setIsAltchaLoaded(true))
+      .catch((e) => Logger.error('Failed to load ALTCHA script', e));
+  }, [captchaType, isAltchaLoaded, widgetProps]);
 
   useEffect(() => {
     // set the reference in dataSchema context to this captcha instance

--- a/src/v3/src/components/Widget/style.scss
+++ b/src/v3/src/components/Widget/style.scss
@@ -3,6 +3,8 @@
 @use 'sass:map';
 @import '@okta/odyssey-design-tokens/dist/index.scss';
 
+@import 'altcha/dist_external/altcha';
+
 @font-face {
   font-family: 'Inter';
   src: url('../font/inter-latin-400-normal.woff2') format('woff2');

--- a/test/unit/spec/util/Altcha_spec.ts
+++ b/test/unit/spec/util/Altcha_spec.ts
@@ -1,0 +1,174 @@
+/*!
+ * Copyright (c) 2025-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+describe('loadAltcha', () => {
+  let loadAltcha: (baseUrl: string) => Promise<void>;
+  let appendChildSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    appendChildSpy = jest.spyOn(document.head, 'appendChild').mockImplementation((node) => node);
+
+    // jsdom doesn't provide fetch — define it so the module can call it.
+    (window as any).fetch = jest.fn().mockResolvedValue({
+      text: () => Promise.resolve('/* worker source */'),
+    } as unknown as Response);
+
+    Object.defineProperty(window, 'Worker', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({})),
+    });
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: jest.fn().mockReturnValue('blob:https://okta.com/test-worker'),
+    });
+
+    // Fresh module per test — resets the module-scope readyPromise.
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      ({ loadAltcha } = require('../../../../src/util/Altcha'));
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (window as any).altchaCreateWorker;
+  });
+
+  function triggerScriptOnload() {
+    const script = appendChildSpy.mock.calls[0]?.[0] as HTMLScriptElement;
+    (script as any)?.onload?.(new Event('load'));
+  }
+
+  function triggerScriptOnerror() {
+    const script = appendChildSpy.mock.calls[0]?.[0] as HTMLScriptElement;
+    (script as any)?.onerror?.(new Event('error'));
+  }
+
+  it('injects a <script type="module"> tag into document.head', async () => {
+    const promise = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnload();
+    await promise;
+
+    const script = appendChildSpy.mock.calls[0][0] as HTMLScriptElement;
+    expect(script.tagName).toBe('SCRIPT');
+    expect(script.type).toBe('module');
+    expect(script.src).toBe('https://cdn.okta.com/altcha.js');
+  });
+
+  it('fetches worker.js from the same base URL', async () => {
+    const promise = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnload();
+    await promise;
+
+    expect((window as any).fetch).toHaveBeenCalledWith('https://cdn.okta.com/worker.js');
+  });
+
+  it('installs window.altchaCreateWorker after altcha.js loads', async () => {
+    const promise = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnload();
+    await promise;
+
+    expect(typeof window.altchaCreateWorker).toBe('function');
+  });
+
+  it('altchaCreateWorker returns a new Worker instance on each call', async () => {
+    const promise = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnload();
+    await promise;
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    window.altchaCreateWorker!();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    window.altchaCreateWorker!();
+
+    expect(window.Worker).toHaveBeenCalledTimes(2);
+  });
+
+  it('altchaCreateWorker passes the blob URL to Worker', async () => {
+    const promise = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnload();
+    await promise;
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    window.altchaCreateWorker!();
+
+    expect(window.Worker).toHaveBeenCalledWith('blob:https://okta.com/test-worker');
+  });
+
+  it('creates the blob URL from worker.js source text', async () => {
+    const promise = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnload();
+    await promise;
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'application/javascript' }),
+    );
+  });
+
+  it('is idempotent — returns the same Promise and does not re-fetch on second call', async () => {
+    const p1 = loadAltcha('https://cdn.okta.com');
+    const p2 = loadAltcha('https://cdn.okta.com');
+
+    expect(p1).toBe(p2);
+
+    triggerScriptOnload();
+    await p1;
+
+    expect((window as any).fetch).toHaveBeenCalledTimes(1);
+    expect(appendChildSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects if the script fails to load', async () => {
+    const promise = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnerror();
+
+    await expect(promise).rejects.toThrow('Failed to load script');
+  });
+
+  it('resets readyPromise on rejection so a subsequent call can retry', async () => {
+    const p1 = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnerror();
+    await expect(p1).rejects.toThrow();
+
+    appendChildSpy.mockClear();
+
+    const p2 = loadAltcha('https://cdn.okta.com');
+    expect(p1).not.toBe(p2);
+
+    triggerScriptOnload();
+    await p2;
+
+    expect(appendChildSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still resolves if worker.js fetch fails (best-effort blob build)', async () => {
+    (window as any).fetch = jest.fn().mockRejectedValue(new Error('network error'));
+
+    const promise = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnload();
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('does not install altchaCreateWorker if worker.js fetch fails', async () => {
+    (window as any).fetch = jest.fn().mockRejectedValue(new Error('network error'));
+
+    const promise = loadAltcha('https://cdn.okta.com');
+    triggerScriptOnload();
+    await promise;
+
+    // altcha's own default factory remains — we don't overwrite it
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(window.altchaCreateWorker).toBeUndefined();
+  });
+});

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -5,6 +5,11 @@ import Settings from 'models/Settings';
 import enrollProfileWithReCaptcha from '../../../../../../playground/mocks/data/idp/idx/enroll-profile-new-with-recaptcha-v2.json';
 import enrollProfileWithHCaptcha from '../../../../../../playground/mocks/data/idp/idx/enroll-profile-new-with-hcaptcha.json';
 import { WIDGET_FOOTER_CLASS } from 'v2/view-builder/utils/Constants';
+import { loadAltcha } from 'util/Altcha';
+
+jest.mock('../../../../../../src/util/Altcha', () => ({
+  loadAltcha: jest.fn(() => Promise.resolve()),
+}));
 
 const captchaAltchaObject = {
   captcha: {
@@ -14,19 +19,6 @@ const captchaAltchaObject = {
       name: 'altcha',
       siteKey: 'altcha-site-key',
       type: 'ALTCHA'
-    }
-  }
-};
-
-const captchaAltchaWithSri = {
-  captcha: {
-    type: 'object',
-    value: {
-      id: 'altcha',
-      name: 'altcha',
-      siteKey: 'altcha-site-key',
-      type: 'ALTCHA',
-      sriEnabled: true
     }
   }
 };
@@ -78,6 +70,9 @@ describe('v2/view-builder/views/CaptchaView', function() {
       testContext.view.render();
     };
     jest.spyOn(window.document, 'getElementById').mockReturnValue(document.createElement('div'));
+    // afterEach → jest.resetAllMocks() clears the loadAltcha mock's implementation.
+    // Re-arm it here so every test starts with a fresh no-op resolved Promise.
+    loadAltcha.mockResolvedValue(undefined);
   });
   afterEach(function() {
     jest.resetAllMocks();
@@ -212,10 +207,14 @@ describe('v2/view-builder/views/CaptchaView', function() {
       expect(testContext.view.el).toMatchSnapshot('with ALTCHA configuration');
     });
 
-    it('ALTCHA Captcha gets loaded with correct URL', function() {
-      const spy = jest.spyOn(CaptchaView.prototype, '_loadCaptchaLib');
+    it('ALTCHA Captcha invokes the shared loadAltcha with the assets-base-derived URL', function() {
       testContext.init(captchaAltchaObject.captcha.value);
-      expect(spy).toHaveBeenCalledWith('https://cdn.jsdelivr.net/gh/altcha-org/altcha@2.3.0/dist/altcha.min.js');
+      // URL is `${settings.get('assets.baseUrl')}/altcha`. assets.baseUrl is
+      // not set in the test settings, so the suffix is what we assert on —
+      // confirms _getAltchaBase() appends /altcha and that ALTCHA type is
+      // routed through the shared loader (not _loadCaptchaLib).
+      expect(loadAltcha).toHaveBeenCalledTimes(1);
+      expect(loadAltcha).toHaveBeenCalledWith(expect.stringMatching(/\/altcha$/));
     });
 
     it('ALTCHA uses altcha-captcha class in template', function() {
@@ -407,48 +406,6 @@ describe('v2/view-builder/views/CaptchaView', function() {
 
       const captchaObj = testContext.view._getCaptchaOject();
       expect(captchaObj).toBe(window.altcha);
-    });
-
-    it('ALTCHA script tag is loaded with type="module"', function() {
-      const appendChildSpy = jest.fn();
-      jest.spyOn(window.document, 'getElementById').mockReturnValue({
-        appendChild: appendChildSpy
-      });
-      
-      testContext.init(captchaAltchaObject.captcha.value);
-      
-      expect(appendChildSpy).toHaveBeenCalled();
-      const scriptTag = appendChildSpy.mock.calls[0][0];
-      expect(scriptTag.type).toBe('module');
-      expect(scriptTag.src).toContain('altcha');
-    });
-
-    it('ALTCHA script tag includes SRI integrity and crossorigin attributes when sriEnabled is true', function() {
-      const appendChildSpy = jest.fn();
-      jest.spyOn(window.document, 'getElementById').mockReturnValue({
-        appendChild: appendChildSpy
-      });
-
-      testContext.init(captchaAltchaWithSri.captcha.value);
-
-      expect(appendChildSpy).toHaveBeenCalled();
-      const scriptTag = appendChildSpy.mock.calls[0][0];
-      expect(scriptTag.integrity).toBe('sha384-lxB6k+TvdhSBKnLm6JqwAnW7QxKXj88yK1kq9g3MevDXlG9HdWtnShLgJzuYCUIw');
-      expect(scriptTag.crossOrigin).toBe('anonymous');
-    });
-
-    it('ALTCHA script tag does not include SRI attributes when sriEnabled is absent', function() {
-      const appendChildSpy = jest.fn();
-      jest.spyOn(window.document, 'getElementById').mockReturnValue({
-        appendChild: appendChildSpy
-      });
-
-      testContext.init(captchaAltchaObject.captcha.value);
-
-      expect(appendChildSpy).toHaveBeenCalled();
-      const scriptTag = appendChildSpy.mock.calls[0][0];
-      expect(scriptTag.getAttribute('integrity')).toBeNull();
-      expect(scriptTag.getAttribute('crossorigin')).toBeNull();
     });
   });
 });

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -170,7 +170,7 @@ module.exports = function({
               loader: 'sass-loader',
               options: {
                 sassOptions: {
-                  includePaths: ['target/sass'],
+                  includePaths: ['target/sass', './node_modules'],
                   outputStyle: 'expanded',
                 }
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6778,10 +6778,10 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-altcha@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/altcha/-/altcha-1.4.2.tgz#a7feb7a7e7eec35d1496e5980a57f304224f0c39"
-  integrity sha512-7UcWh4tHWqP5YHo+jC8vmm+sThYUi1R9qXsiiXtmdoOiimfA0LCLccSKqYSoDmYvqq+CBV79WpQVWafKQCKHmw==
+altcha@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/altcha/-/altcha-2.3.0.tgz#4433f0206ccc4207624821d1acad12292cecb016"
+  integrity sha512-vl8I0dQvSQB7/Mx09XuWZ1+LdSP7vEda6OLbg9kUQ2ZO2LT7MzgUyLK7Iips+GAV6c0ntVcS1XWOqhEPpwbDhQ==
   dependencies:
     "@altcha/crypto" "^0.0.1"
   optionalDependencies:


### PR DESCRIPTION
## Description:

### The problem
altcha 1.4.2's bundled build self-injects its CSS via `<style>` into `document.head` on module evaluation. Applying inline style violates CSP directive `'style-src 'unsafe-inline' 'nonce-...'` and the ALTCHA widget silently fails to render if enforcement is applied.

Both v2 and v3 were affected because both loaded the **bundled** altcha build. v2 via a `<script type="module">` from jsdelivr, v3 via a webpack dynamic-import chunk. Two different loading strategies with the same underlying build, and the same CSP failure.

### The fix
**Upgrade altcha 1.4.2 → 2.3.0** and switch from the bundled build to the split `dist_external/` build. `dist_external/altcha.js` in 2.3.0 is CSP-clean (verified: zero `document.head.appendChild(styleTag)` calls). Its CSS is a separate file (`dist_external/altcha.css`). We bundle it at SIW build time via SCSS `@import`, so it ships in `okta-sign-in.min.css` (v2) and `okta-sign-in.next.css` (v3) with no runtime style-tag injection.

All altcha assets will be served from `oktacdn.com/okta-signin-widget/{version}/altcha/` (same-origin, already in CSP allowlist for okta hosted pages).
- For v3, the mechanism remains similar since we were lazy loading ALTCHA from CDN. Instead, we now retrieve `altcha.js` and `worker.js` separately to comply with how ALTCHA splits files for strict CSP enforcement
- For v2, we stop using jsdelivr CDN and instead use our own Okta CDN directly with the same mechanism as v3
- For the ALTCHA library import, we installed a shared-blob Worker factory that collapses altcha's default N-worker/N-fetch pattern down to one `worker.js` fetch total.

We also modified build configurations:
  - webpack.common.config.js: Added './node_modules' to sassOptions.includePaths so _altcha.scss (and future SCSS) can use bare-package imports, mirroring v3's config
  - Gruntfile.js: Copy step for node_modules/altcha/dist_external/{altcha.js,altcha.css,worker.js} into dist/dist/altcha/
  - package.json: Added "altcha": "2.3.0" to root devDependencies (root Gruntfile is the actual consumer; source code doesn't import 'altcha')
  - src/v3/package.json: Removed altcha
  - yarn.lock: dependency resolution updated 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1217779](https://oktainc.atlassian.net/browse/OKTA-1217779)

### Reviewers:
@leemchale-okta

### Screenshot/Video:

https://github.com/user-attachments/assets/0b4b9af8-9821-49c0-ad1c-041c6d43839f

https://github.com/user-attachments/assets/93360b96-e28e-479b-a0d1-e1a51082e833

https://github.com/user-attachments/assets/564a0909-245d-4c05-87ab-26a459b288ea

### Downstream Monolith Build:
- https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-2f1ad35-6a4ba879-cdbae005b23d58454b2ba6dc0cc41d3ae7cc341f-Jul-06-185444-UTC&page=1&pageSize=6&tab=main
- https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&author=ahmed.alkoasmh%40okta.com&branch=d16t-okta-signin-widget-2f1ad35-6a4ba879&page=1&pageSize=6&tab=main