### PR TITLE
fix: use "Set up" label for security question enroll button

### DIFF
--- a/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionEnroll.test.ts.snap
+++ b/src/v3/src/transformer/layout/securityQuestion/__snapshots__/securityQuestionEnroll.test.ts.snap
@@ -96,7 +96,7 @@ Object {
                 "viewIndex": 0,
               },
               Object {
-                "label": "mfa.challenge.verify",
+                "label": "oie.enroll.authenticator.button.text",
                 "options": Object {
                   "includeImmutableData": false,
                   "step": "",
@@ -164,7 +164,7 @@ Object {
                 "viewIndex": 1,
               },
               Object {
-                "label": "mfa.challenge.verify",
+                "label": "oie.enroll.authenticator.button.text",
                 "options": Object {
                   "actionParams": Object {
                     "credentials.questionKey": "custom",

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.test.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.test.ts
@@ -135,7 +135,7 @@ describe('SecurityQuestionEnroll Tests', () => {
     expect((layoutOne.elements[3] as FieldElement).noTranslate)
       .toBe(true);
     expect((layoutOne.elements[4] as ButtonElement).label)
-      .toBe('mfa.challenge.verify');
+      .toBe('oie.enroll.authenticator.button.text');
     expect((layoutOne.elements[4] as ButtonElement).options.includeImmutableData)
       .toBe(false);
     expect((layoutOne.elements[4] as ButtonElement).options.type)
@@ -162,7 +162,7 @@ describe('SecurityQuestionEnroll Tests', () => {
     expect((layoutOne.elements[3] as FieldElement).noTranslate)
       .toBe(true);
     expect((layoutTwo.elements[4] as ButtonElement).label)
-      .toBe('mfa.challenge.verify');
+      .toBe('oie.enroll.authenticator.button.text');
     expect((layoutTwo.elements[4] as ButtonElement).options.actionParams)
       .toEqual({ 'credentials.questionKey': 'custom' });
     expect((layoutTwo.elements[4] as ButtonElement).options.type)

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.ts
@@ -98,7 +98,7 @@ export const transformSecurityQuestionEnroll: IdxStepTransformer = ({ transactio
 
   const predefinedSubmitButton: ButtonElement = {
     type: 'Button',
-    label: loc('mfa.challenge.verify', 'login'),
+    label: loc('oie.enroll.authenticator.button.text', 'login'),
     options: {
       type: ButtonType.SUBMIT,
       step: transaction.nextStep!.name,
@@ -108,7 +108,7 @@ export const transformSecurityQuestionEnroll: IdxStepTransformer = ({ transactio
 
   const customQuestionSubmitButton: ButtonElement = {
     type: 'Button',
-    label: loc('mfa.challenge.verify', 'login'),
+    label: loc('oie.enroll.authenticator.button.text', 'login'),
     options: {
       type: ButtonType.SUBMIT,
       step: transaction.nextStep!.name,

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -378,7 +378,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                           tabindex="0"
                           type="submit"
                         >
-                          Verify
+                          Set up
                         </button>
                       </div>
                     </div>
@@ -909,7 +909,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           tabindex="0"
                           type="submit"
                         >
-                          Verify
+                          Set up
                         </button>
                       </div>
                     </div>
@@ -1440,7 +1440,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           tabindex="0"
                           type="submit"
                         >
-                          Verify
+                          Set up
                         </button>
                       </div>
                     </div>
@@ -1971,7 +1971,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                           tabindex="0"
                           type="submit"
                         >
-                          Verify
+                          Set up
                         </button>
                       </div>
                     </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -378,7 +378,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                           tabindex="0"
                           type="submit"
                         >
-                          Verify
+                          Set up
                         </button>
                       </div>
                     </div>
@@ -736,7 +736,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                           tabindex="0"
                           type="submit"
                         >
-                          Verify
+                          Set up
                         </button>
                       </div>
                     </div>
@@ -1207,7 +1207,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                           tabindex="0"
                           type="submit"
                         >
-                          Verify
+                          Set up
                         </button>
                       </div>
                     </div>
@@ -1678,7 +1678,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                           tabindex="0"
                           type="submit"
                         >
-                          Verify
+                          Set up
                         </button>
                       </div>
                     </div>

--- a/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question-error.test.tsx
@@ -66,7 +66,7 @@ describe('authenticator-enroll-security-question-error', () => {
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       expect(await findByText(/Set up security question/)).toBeInTheDocument();
-      const submitButton = await findByText('Verify', { selector: 'button' });
+      const submitButton = await findByText('Set up', { selector: 'button' });
       const answerEle = await findByLabelText('Answer') as HTMLInputElement;
 
       const answer = 'pi';
@@ -95,7 +95,7 @@ describe('authenticator-enroll-security-question-error', () => {
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       expect(await findByText(/Set up security question/)).toBeInTheDocument();
-      const submitButton = await findByText('Verify', { selector: 'button' });
+      const submitButton = await findByText('Set up', { selector: 'button' });
       const answerEle = await findByLabelText('Answer') as HTMLInputElement;
 
       const answer = 'pi';
@@ -112,7 +112,7 @@ describe('authenticator-enroll-security-question-error', () => {
         }),
       );
       await waitFor(() => expect(answerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/));
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
       expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
         ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
           credentials: {
@@ -133,7 +133,7 @@ describe('authenticator-enroll-security-question-error', () => {
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       expect(await findByText(/Set up security question/)).toBeInTheDocument();
-      const submitButton = await findByText('Verify', { selector: 'button' });
+      const submitButton = await findByText('Set up', { selector: 'button' });
       const answerEle = await findByLabelText('Answer') as HTMLInputElement;
 
       const answer = 'pi';
@@ -165,7 +165,7 @@ describe('authenticator-enroll-security-question-error', () => {
       expect(customQuestionEle.value).toBe(customQuestion);
       expect(customQuestionAnswerEle.value).toBe(answer);
 
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
       expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
         ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
           credentials: {
@@ -187,7 +187,7 @@ describe('authenticator-enroll-security-question-error', () => {
       await user.type(restoredAnswerEle, answer);
       expect(restoredAnswerEle.value).toEqual(answer);
 
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
       expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
         ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
           credentials: {
@@ -199,7 +199,7 @@ describe('authenticator-enroll-security-question-error', () => {
       expect((await findByLabelText('Answer') as HTMLInputElement).value).toBe(answer);
       await waitFor(() => expect(restoredAnswerEle).toHaveErrorMessage(/The security question answer must be at least 4 characters in length/));
       expect(container).toMatchSnapshot();
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
       expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
         ...createAuthJsPayloadArgs('POST', 'idp/idx/challenge/answer', {
           credentials: {
@@ -222,7 +222,7 @@ describe('authenticator-enroll-security-question-error', () => {
       // switch to custom question form
       await user.click(await findByLabelText(/Create my own security question/));
 
-      const submitButton = await findByText('Verify', { selector: 'button' });
+      const submitButton = await findByText('Set up', { selector: 'button' });
       const answerEle = await findByLabelText('Answer') as HTMLInputElement;
       const customQuestionEle = await findByRole('textbox', { name: 'Create my own security question' }) as HTMLInputElement;
 

--- a/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
@@ -47,7 +47,7 @@ describe('authenticator-enroll-security-question', () => {
 
       await findByText(/Set up security question/);
 
-      const submitButton = await findByText('Verify', { selector: 'button' });
+      const submitButton = await findByText('Set up', { selector: 'button' });
       const answerEle = await findByLabelText('Answer') as HTMLInputElement;
 
       const answer = 'pizza';
@@ -73,7 +73,7 @@ describe('authenticator-enroll-security-question', () => {
       } = await setup({ mockResponse });
 
       await findByText(/Set up security question/);
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
 
       // assert no network request
       expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
@@ -91,7 +91,7 @@ describe('authenticator-enroll-security-question', () => {
       } = await setup({ mockResponse });
 
       await findByText(/Set up security question/);
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
 
       // switch to custom question form
       user.click(await findByLabelText(/Create my own security question/));
@@ -132,7 +132,7 @@ describe('authenticator-enroll-security-question', () => {
 
       const customQuestionEle = await findByRole('textbox', { name: 'Create my own security question' }) as HTMLInputElement;
       const answerEle = await findByLabelText('Answer') as HTMLInputElement;
-      const submitButton = await findByText('Verify', { selector: 'button' });
+      const submitButton = await findByText('Set up', { selector: 'button' });
 
       const question = 'What is the meaning of life?';
       const answer = '42';
@@ -174,7 +174,7 @@ describe('authenticator-enroll-security-question', () => {
       await user.type(answerEle, answer);
       expect(answerEle.value).toBe(answer);
       expect(questionEle.value).toBe('');
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
 
       // assert no network request
       expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
@@ -204,7 +204,7 @@ describe('authenticator-enroll-security-question', () => {
       const question = 'What is the meaning of life?';
       await user.type(customQuestionEle, question);
       expect(customQuestionEle.value).toEqual(question);
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
 
       // assert no network request
       expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
@@ -230,7 +230,7 @@ describe('authenticator-enroll-security-question', () => {
       // switch to custom question form
       user.click(await findByLabelText(/Create my own security question/));
 
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
       expect(authClient.options.httpRequestClient).not.toHaveBeenCalled();
       // assert global alert
       const [globalError] = await findAllByRole('alert');
@@ -249,7 +249,7 @@ describe('authenticator-enroll-security-question', () => {
 
       // switch to custom question form
       user.click(await findByLabelText(/Create my own security question/));
-      await user.click(await findByText('Verify', { selector: 'button' }));
+      await user.click(await findByText('Set up', { selector: 'button' }));
 
       // switch to predefined question form
       user.click(await findByLabelText(/Choose a security question/));


### PR DESCRIPTION
## Description:

The submit button on the **Enroll Security Question** screen (Gen3/v3) used the `mfa.challenge.verify` i18n key, which resolves to **"Verify"**. "Verify" is a challenge/verification label and does not convey the enrollment purpose of the control, so screen reader users do not get the intended purpose of the button (WCAG 2.4.6, Deque audit).

This change switches both the predefined-question and custom-question submit buttons to `oie.enroll.authenticator.button.text`, which resolves to **"Set up"** — matching the label already used by other authenticators (Phone, Okta Verify, Symantec, Yubikey) on their enrollment screens, per the design proposal on the ticket.

No new i18n string is needed; the `oie.enroll.authenticator.button.text` key already exists.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1164547](https://oktainc.atlassian.net/browse/OKTA-1164547)

### Reviewers:

### Screenshot/Video:

The security question enrollment submit button now reads **"Set up"** instead of **"Verify"**.

### Downstream Monolith Build:


🤖 Generated with [Claude Code](https://claude.com/claude-code)