### PR TITLE
SIW README: Document correct way to enable features on the Okta-hosted sign-in page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1228,6 +1228,8 @@ transformUsername: (username, operation) => {
 
 ### Registration
 
+> **Note for Okta-hosted sign-in pages:** To enable the registration feature, see [Feature flags](#feature-flags) for the correct method of setting individual feature flags without removing Okta's runtime defaults.
+
 Callback functions can be provided which will be called at specific moments in the registration process.
 
 ```javascript
@@ -1395,6 +1397,15 @@ features: {
   rememberMe: true
 }
 ```
+
+> **Note for Okta-hosted sign-in pages:** If you are customizing the Okta-hosted sign-in page, do **not** override the entire `features` object (for example, `config.features = { registration: true }`). The Okta-hosted page injects runtime defaults required for certain flows, such as the password-reset email link. Set individual flags instead on the config object returned by `OktaUtil.getSignInWidgetConfig()`:
+>
+> ```javascript
+> var config = OktaUtil.getSignInWidgetConfig();
+> config['features.registration'] = true;
+> // or: config.features.registration = true;
+> // Then pass config to OktaSignIn as usual
+> ```
 
 #### features.showPasswordToggleOnSignInPage
 

--- a/docs/classic.md
+++ b/docs/classic.md
@@ -1509,6 +1509,15 @@ features: {
 }
 ```
 
+> **Note for Okta-hosted sign-in pages:** If you are customizing the Okta-hosted sign-in page, do **not** override the entire `features` object (for example, `config.features = { registration: true }`). The Okta-hosted page injects runtime defaults required for certain flows, such as the password-reset email link. Set individual flags instead on the config object returned by `OktaUtil.getSignInWidgetConfig()`:
+>
+> ```javascript
+> var config = OktaUtil.getSignInWidgetConfig();
+> config['features.registration'] = true;
+> // or: config.features.registration = true;
+> // Then pass config to OktaSignIn as usual
+> ```
+
 - **features.router** - Set to `true` if you want the widget to update the navigation bar when it transitions between pages. This is useful if you want the user to maintain their current state when refreshing the page, but requires that your server can handle the widget url paths. Defaults to `false`.
 
 - **features.rememberMe** - Display a checkbox to enable "Remember me" functionality at login. Defaults to `true`.


### PR DESCRIPTION
## Description

Adds a caution note to the `Feature flags` section of both the main README and `docs/classic.md`, and a cross-reference note to the `Registration` section, explaining that:

- On the Okta-hosted sign-in page, you must **not** override `config.features = { ... }` — doing so removes Okta's runtime defaults and can break flows such as the password-reset email link.
- Instead, set individual flags using `config['features.featureName'] = true` on the config returned by `OktaUtil.getSignInWidgetConfig()`.

This is a documentation-only change.

## Resolves

[OKTA-1210515](https://oktainc.atlassian.net/browse/OKTA-1210515)

## Related

- Companion dev-docs PR: okta/okta-developer-docs#6260

## Note

Cherry-picked from #4070 (original author @brentschaus-okta) to enable merge.
