### PR TITLE
fix(gen3): keep app-login banner subtitle visible on short viewports

### DIFF
--- a/src/v3/src/components/Widget/style.scss
+++ b/src/v3/src/components/Widget/style.scss
@@ -196,9 +196,6 @@
     padding-block: 5px;
     padding-inline: 0;
   }
-  .okta-container .applogin-banner .applogin-container p {
-    display: none;
-  }
 }
 .okta-container .applogin-banner .applogin-container h1 {
   margin-block: 0;


### PR DESCRIPTION
## Description:

The app-login banner subtitle ("Sign in with your account to access...") disappears when the viewport height is ≤ 660px, making content unavailable at the 320px reflow breakpoint (WCAG 1.4.10).

The subtitle markup is emitted by okta-core's `loginpage_backbone.jsp` (i18n `sp.login.subtitle` / `sp.multibrand.login.subtitle`), but a CSS rule in the Gen3 widget stylesheet forces `display: none` on it below 660px height:

```scss
// src/v3/src/components/Widget/style.scss
@media only screen and (max-height: 660px) {
  .okta-container .applogin-banner .applogin-container p { display: none; }
}
```

This is **Gen3-only**. The identical rule existed in Classic/OIE (`assets/sass/modules/_app-login-banner.scss`) but was removed on 2023-04-13 as a bug fix under [OKTA-594775](https://oktainc.atlassian.net/browse/OKTA-594775) ("fix: O365 login screen app banner disappear issue", #3204). The long-running Odyssey 1.x migration ([OKTA-695838](https://oktainc.atlassian.net/browse/OKTA-695838), #3550) was branched from a pre-fix snapshot of the v1/v2 styles and silently reintroduced the rule into the new v3 `style.scss` — so this is effectively a regression of OKTA-594775.

**Fix:** remove the `p { display: none; }` block from the `max-height: 660px` media query. The padding tightening on short viewports is preserved; only the subtitle-hiding is dropped, restoring parity with the already-fixed Classic/OIE behavior.


**BEFORE:**

<img width="666" height="686" alt="image" src="https://github.com/user-attachments/assets/f3082fdf-ceb6-46ce-bae6-88a94985c0e1" />


**AFTER:**

<img width="655" height="779" alt="image" src="https://github.com/user-attachments/assets/ca7814b8-870d-46b8-84c3-6f8f785f7641" />


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1164555](https://oktainc.atlassian.net/browse/OKTA-1164555)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build: