### PR TITLE
fix: Google Authenticator setup UI improvements

### DIFF
--- a/assets/sass/v2/_google-authenticator.scss
+++ b/assets/sass/v2/_google-authenticator.scss
@@ -35,8 +35,14 @@
   }
 
   .shared-secret {
-    input {
-      text-align: center;
-    }
+    display: block;
+    text-align: center;
+    // Open up the gap between the setup instructions and the secret (per Figma).
+    margin-top: 20px;
+    // Visual spacing only — the secret stays a single string (no literal spaces)
+    // so it copies cleanly and a double-click selects the whole value.
+    letter-spacing: 0.3em;
+    // Compensate for the trailing letter-spacing so the text stays centered.
+    text-indent: 0.3em;
   }
 }

--- a/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
@@ -77,21 +77,28 @@ const Body = BaseForm.extend({
       }, {
         View: View.extend({
           className: 'o-form-fieldset o-form-label-top',
+          // Render the secret as plain, selectable text (not a readonly input, which
+          // looked disabled and let a double-click selection spill into the Next
+          // button). Keeping it a single contiguous string lets a double-click select
+          // the whole value; letter-spacing (see SCSS) provides the visual spacing.
+          // tabindex="0" keeps the secret in the tab order (as the previous readonly
+          // input was), and the aria-label spells out each character so screen readers
+          // announce the code one letter at a time on focus.
+          // https://oktainc.atlassian.net/browse/OKTA-1185578
           template: hbs`
             <div class="o-form-input">
-              <span class="o-form-input-name-sharedSecret o-form-control
-                okta-form-input-field input-fix shared-secret no-translate">
-                <input type="text"
-                  value="{{sharedSecret}}"
-                  readonly
-                  aria-label="{{sharedSecret}}"
-                  autocomplete="off" />
-              </span>
+              <span
+                class="shared-secret no-translate"
+                tabindex="0"
+                aria-label="{{sharedSecretSpaced}}"
+              >{{sharedSecret}}</span>
             </div>
           `,
           getTemplateData() {
+            const sharedSecret = this.options.appState.get('currentAuthenticator').contextualData.sharedSecret || '';
             return {
-              sharedSecret: this.options.appState.get('currentAuthenticator').contextualData.sharedSecret,
+              sharedSecret,
+              sharedSecretSpaced: sharedSecret.split('').join(' '),
             };
           },
         }),

--- a/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
@@ -90,7 +90,7 @@ const Body = BaseForm.extend({
               <span
                 class="shared-secret no-translate"
                 tabindex="0"
-                aria-label="{{sharedSecretSpaced}}"
+                aria-label="{{sharedSecretAriaLabel}}"
               >{{sharedSecret}}</span>
             </div>
           `,
@@ -98,7 +98,11 @@ const Body = BaseForm.extend({
             const sharedSecret = this.options.appState.get('currentAuthenticator').contextualData.sharedSecret || '';
             return {
               sharedSecret,
-              sharedSecretSpaced: sharedSecret.split('').join(' '),
+              sharedSecretAriaLabel: loc(
+                'oie.enroll.google_authenticator.sharedSecret.ariaLabel',
+                'login',
+                [sharedSecret.split('').join(' ')]
+              ),
             };
           },
         }),

--- a/src/v3/src/components/Widget/style.scss
+++ b/src/v3/src/components/Widget/style.scss
@@ -332,3 +332,9 @@ span.strong {
 span.no-translate {
   white-space: nowrap;
 }
+/* Google Authenticator manual-entry secret key (OKTA-1185578).
+ * Visual spacing only — the secret stays a single string (no literal spaces)
+ * so it copies cleanly and a double-click selects the whole value. */
+span.shared-secret {
+  letter-spacing: 0.3em;
+}

--- a/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorEnroll.test.ts.snap
+++ b/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorEnroll.test.ts.snap
@@ -102,7 +102,7 @@ Object {
                 "contentType": "subtitle",
                 "noTranslate": true,
                 "options": Object {
-                  "content": "<span tabindex=\\"0\\" aria-label=\\"A B C 1 2 3 D E F 4 5 6\\" style=\\"letter-spacing: 0.3em;\\">ABC123DEF456</span>",
+                  "content": "<span class=\\"shared-secret\\" tabindex=\\"0\\" aria-label=\\"oie.enroll.google_authenticator.sharedSecret.ariaLabel\\">ABC123DEF456</span>",
                 },
                 "type": "Description",
                 "viewIndex": 1,
@@ -263,7 +263,7 @@ Object {
                 "contentType": "subtitle",
                 "noTranslate": true,
                 "options": Object {
-                  "content": "<span tabindex=\\"0\\" aria-label=\\"A B C 1 2 3 D E F 4 5 6\\" style=\\"letter-spacing: 0.3em;\\">ABC123DEF456</span>",
+                  "content": "<span class=\\"shared-secret\\" tabindex=\\"0\\" aria-label=\\"oie.enroll.google_authenticator.sharedSecret.ariaLabel\\">ABC123DEF456</span>",
                 },
                 "type": "Description",
                 "viewIndex": 1,

--- a/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorEnroll.test.ts.snap
+++ b/src/v3/src/transformer/layout/googleAuthenticator/__snapshots__/transformGoogleAuthenticatorEnroll.test.ts.snap
@@ -102,7 +102,7 @@ Object {
                 "contentType": "subtitle",
                 "noTranslate": true,
                 "options": Object {
-                  "content": "A B C 1 2 3 D E F 4 5 6",
+                  "content": "<span tabindex=\\"0\\" aria-label=\\"A B C 1 2 3 D E F 4 5 6\\" style=\\"letter-spacing: 0.3em;\\">ABC123DEF456</span>",
                 },
                 "type": "Description",
                 "viewIndex": 1,
@@ -263,7 +263,7 @@ Object {
                 "contentType": "subtitle",
                 "noTranslate": true,
                 "options": Object {
-                  "content": "A B C 1 2 3 D E F 4 5 6",
+                  "content": "<span tabindex=\\"0\\" aria-label=\\"A B C 1 2 3 D E F 4 5 6\\" style=\\"letter-spacing: 0.3em;\\">ABC123DEF456</span>",
                 },
                 "type": "Description",
                 "viewIndex": 1,

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
@@ -69,7 +69,7 @@ describe('Google Authenticator Enroll Transformer Tests', () => {
     expect((layoutTwo.elements[1] as DescriptionElement).options.content)
       .toBe('oie.enroll.google_authenticator.manualSetupInstructions');
     expect((layoutTwo.elements[2] as DescriptionElement).options.content)
-      .toBe('<span tabindex="0" aria-label="A B C 1 2 3 D E F 4 5 6" style="letter-spacing: 0.3em;">ABC123DEF456</span>');
+      .toBe('<span class="shared-secret" tabindex="0" aria-label="oie.enroll.google_authenticator.sharedSecret.ariaLabel">ABC123DEF456</span>');
     expect((layoutTwo.elements[3] as StepperButtonElement).label)
       .toBe('oform.next');
     expect((layoutTwo.elements[3] as StepperButtonElement).options.nextStepIndex)

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.test.ts
@@ -69,7 +69,7 @@ describe('Google Authenticator Enroll Transformer Tests', () => {
     expect((layoutTwo.elements[1] as DescriptionElement).options.content)
       .toBe('oie.enroll.google_authenticator.manualSetupInstructions');
     expect((layoutTwo.elements[2] as DescriptionElement).options.content)
-      .toBe('A B C 1 2 3 D E F 4 5 6');
+      .toBe('<span tabindex="0" aria-label="A B C 1 2 3 D E F 4 5 6" style="letter-spacing: 0.3em;">ABC123DEF456</span>');
     expect((layoutTwo.elements[3] as StepperButtonElement).label)
       .toBe('oform.next');
     expect((layoutTwo.elements[3] as StepperButtonElement).options.nextStepIndex)

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.ts
@@ -60,11 +60,12 @@ export const transformGoogleAuthenticatorEnroll: IdxStepTransformer = ({
     noTranslate: true,
     options: {
       // Render the secret as a single contiguous string so that double-clicking
-      // selects the entire value (OKTA-1185578). letter-spacing keeps it legible,
-      // tabindex="0" puts it in the tab order, and the aria-label spells out each
-      // character so screen readers can speak the code one letter at a time on focus.
+      // selects the entire value (OKTA-1185578). The .shared-secret class adds the
+      // letter-spacing that keeps it legible, tabindex="0" puts it in the tab order,
+      // and the aria-label spells out each character so screen readers can speak the
+      // code one letter at a time on focus.
       content: sharedSecret
-        ? `<span tabindex="0" aria-label="${sharedSecret.split('').join(' ')}" style="letter-spacing: 0.3em;">${sharedSecret}</span>`
+        ? `<span class="shared-secret" tabindex="0" aria-label="${loc('oie.enroll.google_authenticator.sharedSecret.ariaLabel', 'login', [sharedSecret.split('').join(' ')])}">${sharedSecret}</span>`
         : '',
     },
   };

--- a/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/layout/googleAuthenticator/transformGoogleAuthenticatorEnroll.ts
@@ -53,13 +53,19 @@ export const transformGoogleAuthenticatorEnroll: IdxStepTransformer = ({
     },
   };
 
+  const sharedSecret = relatesTo.value.contextualData.sharedSecret || '';
   const manualKeyElement: DescriptionElement = {
     type: 'Description',
     contentType: 'subtitle',
     noTranslate: true,
     options: {
-      // spacing out the code so Screen reader can speak each letter individually
-      content: relatesTo.value.contextualData.sharedSecret?.split('').join(' ') || '',
+      // Render the secret as a single contiguous string so that double-clicking
+      // selects the entire value (OKTA-1185578). letter-spacing keeps it legible,
+      // tabindex="0" puts it in the tab order, and the aria-label spells out each
+      // character so screen readers can speak the code one letter at a time on focus.
+      content: sharedSecret
+        ? `<span tabindex="0" aria-label="${sharedSecret.split('').join(' ')}" style="letter-spacing: 0.3em;">${sharedSecret}</span>`
+        : '',
     },
   };
 

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -732,7 +732,13 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                             tabindex="-1"
                             translate="no"
                           >
-                            K A G W B I X A K O L P E F M Y
+                            <span
+                              aria-label="K A G W B I X A K O L P E F M Y"
+                              style="letter-spacing: 0.3em;"
+                              tabindex="0"
+                            >
+                              KAGWBIXAKOLPEFMY
+                            </span>
                           </p>
                         </div>
                       </div>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -733,8 +733,8 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                             translate="no"
                           >
                             <span
-                              aria-label="K A G W B I X A K O L P E F M Y"
-                              style="letter-spacing: 0.3em;"
+                              aria-label="Secret key: K A G W B I X A K O L P E F M Y"
+                              class="shared-secret"
                               tabindex="0"
                             >
                               KAGWBIXAKOLPEFMY

--- a/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
@@ -49,7 +49,7 @@ export default class EnrollGoogleAuthenticatorPageObject extends BasePageObject 
     if (userVariables.gen3) {
       return this.form.getSubtitle();
     }
-    return this.form.getElement('.shared-secret input').getAttribute('value');
+    return this.form.getElement('.shared-secret').textContent;
   }
 
   async goTomanualSetup() {


### PR DESCRIPTION
Resolves: OKTA-1185578

## Description:

Fixes an accessibility issue in the Google Authenticator enrollment flow (OKTA-1185578), figma: https://www.figma.com/design/G2kZ9WtlYLLd9q6ZfGJeXT/1--improvements?node-id=11249-257&t=7TU0T04YXbGal2RG-0

  Problem: The shared secret was rendered inside a readonly <input>, which:
  - Visually appeared disabled/greyed out
  - A double-click selection would spill into the "Next" button instead of selecting just the secret value

  Solution: Replace the readonly input with a plain <span> containing the unmodified secret string, with the following properties:
  - tabindex="0" keeps it in the keyboard tab order
  - aria-label spells out each character with spaces (e.g. "A B C 1 2 3") so screen readers announce the code one character at a time on focus
  - CSS letter-spacing: 0.3em provides visual separation between characters without inserting literal spaces, so a double-click still selects the entire value cleanly
  - text-indent: 0.3em compensates for the trailing letter-spacing to keep the text visually centered 

  Changes affect both the v2 (OIE Backbone) and v3 (Gen3 React) implementations. Tests and snapshots updated accordingly.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1185578](https://oktainc.atlassian.net/browse/OKTA-1185578)

### Reviewers:

### Screenshot/Video:

| Gen | Before fix | After fix |
| -------- | -------- | -------- |
| Gen2  | <img width="1221" height="850" alt="Screenshot 2026-07-17 at 5 23 29 PM" src="https://github.com/user-attachments/assets/5ab0adb2-03c5-44b7-acde-fc9e8fe459a0" /> |  <img width="1164" height="746" alt="Screenshot 2026-07-22 at 12 04 47 PM" src="https://github.com/user-attachments/assets/e434428c-a3b7-4fa2-ac76-aee889add398" /> |
| Gen3  | <img width="1001" height="709" alt="Screenshot 2026-07-17 at 5 26 16 PM" src="https://github.com/user-attachments/assets/c66fabc2-3362-424f-9633-2115e466cc58" />  |  <img width="1156" height="751" alt="Screenshot 2026-07-22 at 12 01 36 PM" src="https://github.com/user-attachments/assets/99009754-49a1-47cc-b295-1702d28a4dce" /> |


### Downstream Monolith Build:
https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=91e98dfcb583167e8c9510365732139f8ff4afc4&tab=main

#### IE11 verification
<img width="1142" height="718" alt="Screenshot 2026-07-22 at 12 36 12 PM" src="https://github.com/user-attachments/assets/3dda23e5-7c28-4c37-af4e-467a6ee88938" />

<img width="1095" height="724" alt="Screenshot 2026-07-22 at 12 32 34 PM" src="https://github.com/user-attachments/assets/9c5e6a3f-b5c6-44fa-a9b4-b5f8e3679c04" />


