### PR TITLE
add Secret key new i18n string

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1249,6 +1249,7 @@ oie.enroll.google_authenticator.scanBarcode.description = Launch Google Authenti
 oie.enroll.google_authenticator.scanBarcode.cannotScan = Can't scan?
 oie.enroll.google_authenticator.cannotScanBarcode.title = Can't scan QR code?
 oie.enroll.google_authenticator.manualSetupInstructions = To set up manually enter your Okta Account username and then input the following in the Secret Key Field
+oie.enroll.google_authenticator.sharedSecret.ariaLabel = Secret key: {0}
 oie.enroll.google_authenticator.enterCode.title = Enter code displayed from application
 oie.verify.google_authenticator.otp.title = Verify with Google Authenticator
 oie.verify.google_authenticator.otp.description = Enter the temporary code generated in your Google Authenticator app

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -949,6 +949,7 @@ oie.enroll.google_authenticator.scanBarcode.description = 》Ļåûñçĥ Ĝöö
 oie.enroll.google_authenticator.scanBarcode.cannotScan = 》Çåñ´ţ šçåñ¿ ئ䀕ヸ€홝한Ӝฐโ《
 oie.enroll.google_authenticator.cannotScanBarcode.title = 》Çåñ´ţ šçåñ ǪŔ çöðé¿ 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.enroll.google_authenticator.manualSetupInstructions = 》Ţö šéţ ûþ ɱåñûåļļý éñţéŕ ýöûŕ Öķţå Åççöûñţ ûšéŕñåɱé åñð ţĥéñ îñþûţ ţĥé ƒöļļöŵîñĝ îñ ţĥé Šéçŕéţ Ķéý Ƒîéļð โ⾼ئ䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+oie.enroll.google_authenticator.sharedSecret.ariaLabel = 》Šéçŕéţ ķéý∶ ئ䀕ヸ€홝한Ӝฐโ {0}《
 oie.enroll.google_authenticator.enterCode.title = 》Éñţéŕ çöðé ðîšþļåýéð ƒŕöɱ åþþļîçåţîöñ 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.verify.google_authenticator.otp.title = 》Ṽéŕîƒý ŵîţĥ Ĝööĝļé Åûţĥéñţîçåţöŕ Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.verify.google_authenticator.otp.description = 》Éñţéŕ ţĥé ţéɱþöŕåŕý çöðé ĝéñéŕåţéð îñ ýöûŕ Ĝööĝļé Åûţĥéñţîçåţöŕ åþþ ⾼ئ䀕ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《

--- a/packages/@okta/i18n/src/properties/login_ok_SK.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_SK.properties
@@ -949,6 +949,7 @@ oie.enroll.google_authenticator.scanBarcode.description = [[okta-signin-widget:l
 oie.enroll.google_authenticator.scanBarcode.cannotScan = [[okta-signin-widget:login: oie.enroll.google_authenticator.scanBarcode.cannotScan]]
 oie.enroll.google_authenticator.cannotScanBarcode.title = [[okta-signin-widget:login: oie.enroll.google_authenticator.cannotScanBarcode.title]]
 oie.enroll.google_authenticator.manualSetupInstructions = [[okta-signin-widget:login: oie.enroll.google_authenticator.manualSetupInstructions]]
+oie.enroll.google_authenticator.sharedSecret.ariaLabel = [[okta-signin-widget:login: oie.enroll.google_authenticator.sharedSecret.ariaLabel]]
 oie.enroll.google_authenticator.enterCode.title = [[okta-signin-widget:login: oie.enroll.google_authenticator.enterCode.title]]
 oie.verify.google_authenticator.otp.title = [[okta-signin-widget:login: oie.verify.google_authenticator.otp.title]]
 oie.verify.google_authenticator.otp.description = [[okta-signin-widget:login: oie.verify.google_authenticator.otp.description]]


### PR DESCRIPTION
Resolves: OKTA-1231285

## Description:
Prerequisite of https://oktainc.atlassian.net/browse/OKTA-1185578 
The idea is to add aria label to read Secret key

Details refer to slack: https://okta.slack.com/archives/C07FKNTTC58/p1784664050855539?thread_ts=1784649605.930569&cid=C07FKNTTC58 


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1231285](https://oktainc.atlassian.net/browse/OKTA-1231285)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



