### PR TITLE
fix(a11y): per-platform accessible label on OV download badges

### DIFF
--- a/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
+++ b/src/v3/src/transformer/oktaVerify/__snapshots__/transformOktaVerifyEnrollPoll.test.ts.snap
@@ -193,7 +193,7 @@ Object {
               Object {
                 "options": Object {
                   "alignment": "center",
-                  "altText": "enroll.oda.step3",
+                  "altText": "enroll.oda.download.android",
                   "dataSe": "app-store-link",
                   "href": "https://apps.test.com/us/app/okta-verify/id490179405",
                   "marginBlockStart": "20px",

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.test.ts
@@ -483,4 +483,38 @@ describe('TransformOktaVerifyEnrollPoll Tests', () => {
       expect((sameDeviceEnrollmentLayout.elements[4] as OpenOktaVerifyFPButtonElement).options.challengeMethod)
         .toBe(CHALLENGE_METHOD.APP_LINK);
     });
+
+  it.each([
+    ['ios', 'enroll.oda.download.ios'],
+    ['android', 'enroll.oda.download.android'],
+    ['windows', 'enroll.oda.download.windows'],
+    ['osx', 'enroll.oda.download.osx'],
+  ])('download badge for platform %s uses its own accessible label', (platform, expectedLabel) => {
+    transaction.context = {
+      // TODO: OKTA-503490 temporary sln access missing relatesTo obj
+      currentAuthenticator: {
+        value: {
+          contextualData: {
+            samedevice: {
+              orgUrl: 'okta.okta.com',
+              setupOVUrl: 'www.testSetupUrl.com',
+              downloadHref: 'https://apps.test.com/download/okta-verify',
+              platform,
+            },
+            selectedChannel: 'samedevice',
+          },
+        },
+      },
+    } as unknown as IdxContext;
+
+    const updatedFormBag = transformOktaVerifyEnrollPoll({ transaction, formBag, widgetProps });
+
+    const [stepperLayout] = updatedFormBag.uischema.elements;
+    const imageLink = (stepperLayout as StepperLayout).elements
+      .flatMap((layout) => layout.elements)
+      .find((element) => element.type === 'ImageLink') as ImageLinkElement;
+
+    expect(imageLink.options.dataSe).toBe('app-store-link');
+    expect(imageLink.options.altText).toBe(expectedLabel);
+  });
 });

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
@@ -234,21 +234,26 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
     if (deviceMap.platformLC) {
       let platformSupported = true;
       let svgIcon;
+      let altText = loc('enroll.oda.step3', 'login');
       switch (deviceMap.platformLC) {
         case 'android':
           svgIcon = GoogleStoreIcon;
+          altText = loc('enroll.oda.download.android', 'login');
           break;
 
         case 'ios':
           svgIcon = AppleStoreIcon;
+          altText = loc('enroll.oda.download.ios', 'login');
           break;
 
         case 'windows':
           svgIcon = WindowsStoreIcon;
+          altText = loc('enroll.oda.download.windows', 'login');
           break;
 
         case 'osx':
           svgIcon = OSXStoreIcon;
+          altText = loc('enroll.oda.download.osx', 'login');
           break;
 
         default:
@@ -260,7 +265,7 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
             type: 'ImageLink',
             options: {
               href: deviceMap.downloadHref,
-              altText: loc('enroll.oda.step3', 'login'),
+              altText,
               alignment: 'center',
               svgIcon,
               dataSe: 'app-store-link',


### PR DESCRIPTION
## Description:

The Okta Verify same-device enrollment download badges (Gen3) announced a generic accessible name — *"Download the Okta Verify app."* — via the SVG `<title>`, which did **not** match the visible text baked into each store-badge image. This is a **WCAG 2.5.3 (Label in Name)** violation flagged by a Deque audit.

This PR wires each platform's badge to its own accessible-name key so screen readers announce the badge's visible label:

| Platform | Visible badge text | Accessible-name key |
| --- | --- | --- |
| iOS | Download on the App Store | `enroll.oda.download.ios` |
| Android | Get it on Google Play | `enroll.oda.download.android` |
| Windows | Download 64-bit | `enroll.oda.download.windows` |
| macOS | Download on the Mac App Store | `enroll.oda.download.osx` |

The generic label remains as a safe fallback for unknown platforms. The keys and their translations already landed separately via **OKTA-1219241** (#4078), so this change only consumes them — no English-leak risk.

## PR Checklist

- [x] Have you verified the basic functionality for this change? — Verified via unit tests (per-platform `altText` assertions) and the `authenticator-enroll-ov-same-device` playground mock.
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)? — Added an `it.each` covering all four platform labels; updated the affected snapshot.
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)? — No security-relevant change.
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? — N/A.
- [ ] Does this PR include noticeable changes to the UI? — No visual change; screen-reader-only (accessible name now matches each badge's visible text).

### Issue:

- [OKTA-1164553](https://oktainc.atlassian.net/browse/OKTA-1164553)
- Keys + translations (prerequisite): [OKTA-1219241](https://oktainc.atlassian.net/browse/OKTA-1219241) (#4078)

### Reviewers:

### Screenshot/Video:

No visual change — the fix updates the SVG `<title>` (accessible name) only. For reference, the visible badge text each accessible name now mirrors: "Download on the App Store", "Get it on Google Play", "Download (64-bit)", "Download on the Mac App Store".

### Downstream Monolith Build:
