### PR TITLE
(gen3): Add aria labels for show password buttons

### DIFF
--- a/src/v3/src/components/InputPassword/InputPassword.test.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { render } from '@testing-library/preact';
+import { h } from 'preact';
+
+import { WidgetContextProvider } from '../../contexts';
+import { FieldElement, IWidgetContext } from '../../types';
+import InputPassword from './InputPassword';
+
+// The form-state HOC and value hooks are exercised elsewhere; stub them so this test
+// focuses on the visibility-toggle aria-label behavior.
+jest.mock('../../hooks', () => ({
+  useAutoFocus: () => ({ current: null }),
+  useValue: () => '',
+  useFormFieldValidation: () => jest.fn(),
+  useOnChange: () => jest.fn(),
+}));
+
+// Minimal stub mirroring Odyssey's PasswordField accessibility output: the input uses
+// id={name}, and the show/hide toggle IconButton carries aria-controls={id} with a single
+// hardcoded aria-label ("Show password") for every field — the behavior InputPassword overrides.
+jest.mock('@okta/odyssey-react-mui', () => ({
+  PasswordField: ({
+    id,
+    label,
+    hasShowPassword,
+  }: { id: string; label: string; hasShowPassword: boolean }) => (
+    <div>
+      <input id={id} aria-label={label} type="password" />
+      {hasShowPassword ? (
+        <button type="button" aria-controls={id} aria-label="Show password" aria-pressed="false">
+          toggle
+        </button>
+      ) : null}
+    </div>
+  ),
+}));
+
+const buildUischema = (name: string, visibilityToggleLabel: string): FieldElement => ({
+  type: 'Control',
+  options: {
+    inputMeta: { name, required: true, messages: {} },
+    attributes: {},
+  },
+  translations: [
+    { name: 'label', value: 'Password' },
+    { name: 'visibilityToggleLabel', value: visibilityToggleLabel },
+  ],
+} as unknown as FieldElement);
+
+const renderWithContext = (
+  ui: h.JSX.Element,
+  showPasswordToggleOnSignInPage = true,
+) => {
+  const widgetContext = {
+    loading: false,
+    widgetProps: { features: { showPasswordToggleOnSignInPage } },
+  } as unknown as IWidgetContext;
+
+  return render(<WidgetContextProvider value={widgetContext}>{ui}</WidgetContextProvider>);
+};
+
+describe('InputPassword visibility toggle aria-label', () => {
+  it('applies the per-field label to the confirm-password toggle', () => {
+    const { getByRole } = renderWithContext(
+      <InputPassword uischema={buildUischema('confirmPassword', 'Show re-entered password')} />,
+    );
+
+    expect(getByRole('button', { name: 'Show re-entered password' })).toBeInTheDocument();
+  });
+
+  it('labels the new-password toggle "Show password"', () => {
+    const { getByRole } = renderWithContext(
+      <InputPassword uischema={buildUischema('credentials.passcode', 'Show password')} />,
+    );
+
+    expect(getByRole('button', { name: 'Show password' })).toBeInTheDocument();
+  });
+
+  it('gives two password toggles on the same page distinct accessible names (WCAG 2.4.6)', () => {
+    const { getByRole } = renderWithContext(
+      <div>
+        <InputPassword uischema={buildUischema('credentials.passcode', 'Show password')} />
+        <InputPassword uischema={buildUischema('confirmPassword', 'Show re-entered password')} />
+      </div>,
+    );
+
+    // Distinct accessible names mean getByRole can resolve each toggle unambiguously.
+    expect(getByRole('button', { name: 'Show password' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Show re-entered password' })).toBeInTheDocument();
+  });
+
+  it('does not render or touch a toggle when the show-password feature is disabled', () => {
+    const { queryByRole } = renderWithContext(
+      <InputPassword uischema={buildUischema('credentials.passcode', 'Show password')} />,
+      false,
+    );
+
+    expect(queryByRole('button')).toBeNull();
+  });
+});

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -12,6 +12,7 @@
 
 import { PasswordField } from '@okta/odyssey-react-mui';
 import { h } from 'preact';
+import { useLayoutEffect } from 'preact/hooks';
 import { buildFieldLevelErrorMessages } from 'src/util/buildFieldLevelErrorMessages';
 
 import { useWidgetContext } from '../../contexts';
@@ -59,6 +60,22 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
   const focusRef = useAutoFocus<HTMLInputElement>(focus);
   const parsedExplainContent = parseHtmlContent(explain, parserOptions);
   const { errorMessage, errorMessageList } = buildFieldLevelErrorMessages(errors);
+  const toggleAriaLabel = getTranslation(translations, 'visibilityToggleLabel');
+
+  // Until SIW adopts Odyssey >= 1.65.0's `showPasswordToggleAriaLabel` prop
+  // (tracked in OKTA-1217904), override the rendered toggle's aria-label with the per-field
+  // label. Odyssey uses our `name` as the field id, so the toggle is `button[aria-controls=name]`.
+  // The name stays stable across show/hide (state is conveyed via aria-pressed), so React never
+  // rewrites the attribute on toggle and this override persists.
+  useLayoutEffect(() => {
+    if (!toggleAriaLabel || !showPasswordToggleOnSignInPage) {
+      return;
+    }
+    const toggleButton = document.querySelector<HTMLButtonElement>(
+      `button[aria-controls="${name}"]`,
+    );
+    toggleButton?.setAttribute('aria-label', toggleAriaLabel);
+  }, [toggleAriaLabel, name, showPasswordToggleOnSignInPage, loading]);
 
   return (
     <PasswordField

--- a/src/v3/src/transformer/i18n/transform.test.ts
+++ b/src/v3/src/transformer/i18n/transform.test.ts
@@ -25,7 +25,7 @@ jest.mock('./transformAuthenticatorButton', () => ({
   transformAuthenticatorButton: () => () => ({}),
 }));
 jest.mock('./transformInputPassword', () => ({
-  transformInputPassword: () => ({}),
+  transformInputPassword: () => () => ({}),
 }));
 jest.mock('./transformPhoneAuthenticator', () => ({
   transformPhoneAuthenticator: () => ({}),

--- a/src/v3/src/transformer/i18n/transform.ts
+++ b/src/v3/src/transformer/i18n/transform.ts
@@ -33,7 +33,7 @@ export const transformI18n: TransformStepFnWithOptions = (options) => (formbag) 
   transformField(options),
   transformGranularConsentFields(options),
   transformAuthenticatorButton(options),
-  transformInputPassword,
+  transformInputPassword(options),
   transformPhoneAuthenticator,
   transformQRCode,
   transformIdentifierHint(options),

--- a/src/v3/src/transformer/i18n/transformInputPassword.test.ts
+++ b/src/v3/src/transformer/i18n/transformInputPassword.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxAuthenticator, IdxTransaction } from '@okta/okta-auth-js';
+import { AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
+import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
+import { FieldElement, FormBag, WidgetProps } from 'src/types';
+
+import { transformInputPassword } from './transformInputPassword';
+
+const secretField = (name: string): FieldElement => ({
+  type: 'Field',
+  options: { inputMeta: { name, secret: true } },
+} as unknown as FieldElement);
+
+const getToggleLabelKey = (element: FieldElement): string | undefined => element.translations
+  ?.find(({ name }) => name === 'visibilityToggleLabel')?.i18nKey;
+
+const runTransform = (
+  formBag: FormBag,
+  transaction: IdxTransaction,
+): FormBag => transformInputPassword({
+  transaction,
+  widgetProps: {} as WidgetProps,
+  step: '',
+  isClientTransaction: false,
+  setMessage: () => {},
+})(formBag);
+
+describe('transformInputPassword visibility-toggle label selection', () => {
+  let transaction: IdxTransaction;
+  let formBag: FormBag;
+
+  beforeEach(() => {
+    transaction = getStubTransactionWithNextStep();
+    formBag = getStubFormBag();
+  });
+
+  it('labels the confirm-password toggle "re-entered password"', () => {
+    formBag.uischema.elements = [secretField('confirmPassword')];
+
+    const [confirmField] = runTransform(formBag, transaction).uischema.elements as FieldElement[];
+    expect(getToggleLabelKey(confirmField)).toBe('oie.password.showConfirmPassword');
+  });
+
+  it('labels the security-question answer toggle "answer"', () => {
+    formBag.uischema.elements = [secretField('credentials.answer')];
+
+    const [answerField] = runTransform(formBag, transaction).uischema.elements as FieldElement[];
+    expect(getToggleLabelKey(answerField)).toBe('oie.challenge.answer.showAnswer');
+  });
+
+  it('labels the enroll password/confirm pair "password" and "re-entered password"', () => {
+    formBag.uischema.elements = [
+      secretField('credentials.passcode'),
+      secretField('confirmPassword'),
+    ];
+
+    const [passcodeField, confirmField] = runTransform(formBag, transaction)
+      .uischema.elements as FieldElement[];
+    // Distinct names satisfy WCAG 2.4.6; the new-password field keeps the plain "Show password".
+    expect(getToggleLabelKey(passcodeField)).toBe('oie.password.showPassword');
+    expect(getToggleLabelKey(confirmField)).toBe('oie.password.showConfirmPassword');
+  });
+
+  it('labels the reset-password new-password toggle "new password"', () => {
+    formBag.uischema.elements = [
+      secretField('credentials.passcode'),
+      secretField('confirmPassword'),
+    ];
+    transaction.nextStep = { name: IDX_STEP.RESET_AUTHENTICATOR };
+
+    const [passcodeField, confirmField] = runTransform(formBag, transaction)
+      .uischema.elements as FieldElement[];
+    expect(getToggleLabelKey(passcodeField)).toBe('oie.password.showNewPassword');
+    expect(getToggleLabelKey(confirmField)).toBe('oie.password.showConfirmPassword');
+  });
+
+  it('labels the YubiKey passcode toggle "YubiKey verification code"', () => {
+    formBag.uischema.elements = [secretField('credentials.passcode')];
+    transaction.nextStep = {
+      name: IDX_STEP.ENROLL_AUTHENTICATOR,
+      relatesTo: { type: '', value: { key: AUTHENTICATOR_KEY.YUBIKEY } as IdxAuthenticator },
+    };
+
+    const [passcodeField] = runTransform(formBag, transaction).uischema.elements as FieldElement[];
+    expect(getToggleLabelKey(passcodeField)).toBe('oie.yubikey.passcode.show');
+  });
+
+  it('labels a sign-in password toggle "password" (no confirm field, not YubiKey)', () => {
+    formBag.uischema.elements = [secretField('credentials.passcode')];
+    transaction.nextStep = {
+      name: IDX_STEP.CHALLENGE_AUTHENTICATOR,
+      relatesTo: { type: '', value: { key: AUTHENTICATOR_KEY.PASSWORD } as IdxAuthenticator },
+    };
+
+    const [passcodeField] = runTransform(formBag, transaction).uischema.elements as FieldElement[];
+    expect(getToggleLabelKey(passcodeField)).toBe('oie.password.showPassword');
+  });
+});

--- a/src/v3/src/transformer/i18n/transformInputPassword.ts
+++ b/src/v3/src/transformer/i18n/transformInputPassword.ts
@@ -10,16 +10,20 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { AUTHENTICATOR_KEY, IDX_STEP } from '../../constants';
 import {
   FieldElement,
-  FormBag,
-  TransformStepFn,
+  TransformStepFnWithOptions,
 } from '../../types';
+import { getAuthenticatorKey } from '../../util';
 import { traverseLayout } from '../util';
 import { addTranslation } from './util';
 
-export const transformInputPassword: TransformStepFn = (formBag: FormBag) => {
+export const transformInputPassword: TransformStepFnWithOptions = ({
+  transaction,
+}) => (formBag) => {
   const { uischema } = formBag;
+  const authenticatorKey = getAuthenticatorKey(transaction);
 
   traverseLayout({
     layout: uischema,
@@ -36,12 +40,22 @@ export const transformInputPassword: TransformStepFn = (formBag: FormBag) => {
         i18nKey: 'sensitive.input.hide',
       });
 
+      // Odyssey's PasswordField hardcodes the show/hide toggle's accessible name to a single
+      // string for every field. Resolve a distinct, context-specific label per field so the
+      // toggles are distinguishable to screen readers (WCAG 2.4.6). See OKTA-1164538/-1164535/
+      // -1164537/-1164549. Applied to the rendered button in InputPassword.tsx.
       const { options: { inputMeta: { name: fieldName } } } = (element as FieldElement);
       let showLabelKey = 'oie.password.showPassword';
       if (fieldName === 'confirmPassword') {
         showLabelKey = 'oie.password.showConfirmPassword';
       } else if (fieldName === 'credentials.answer') {
         showLabelKey = 'oie.challenge.answer.showAnswer';
+      } else if (fieldName === 'credentials.passcode') {
+        if (authenticatorKey === AUTHENTICATOR_KEY.YUBIKEY) {
+          showLabelKey = 'oie.yubikey.passcode.show';
+        } else if (transaction.nextStep?.name === IDX_STEP.RESET_AUTHENTICATOR) {
+          showLabelKey = 'oie.password.showNewPassword';
+        }
       }
       addTranslation({
         element,

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-password-requirements-not-met.test.tsx.snap
@@ -574,7 +574,7 @@ exports[`authenticator-password-requirements-not-met should render form 1`] = `
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-76"
                               tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question-error.test.tsx.snap
@@ -328,7 +328,7 @@ exports[`authenticator-enroll-security-question-error custom question should sho
                             >
                               <button
                                 aria-controls="credentials.answer"
-                                aria-label="Show password"
+                                aria-label="Show answer"
                                 aria-pressed="false"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-54"
                                 tabindex="0"
@@ -859,7 +859,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                             >
                               <button
                                 aria-controls="credentials.answer"
-                                aria-label="Show password"
+                                aria-label="Show answer"
                                 aria-pressed="false"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-55"
                                 tabindex="0"
@@ -1390,7 +1390,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                             >
                               <button
                                 aria-controls="credentials.answer"
-                                aria-label="Show password"
+                                aria-label="Show answer"
                                 aria-pressed="false"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-55"
                                 tabindex="0"
@@ -1921,7 +1921,7 @@ exports[`authenticator-enroll-security-question-error predefined question should
                             >
                               <button
                                 aria-controls="credentials.answer"
-                                aria-label="Show password"
+                                aria-label="Show answer"
                                 aria-pressed="false"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-55"
                                 tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                             >
                               <button
                                 aria-controls="credentials.answer"
-                                aria-label="Show password"
+                                aria-label="Show answer"
                                 aria-pressed="false"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-57"
                                 tabindex="0"
@@ -701,7 +701,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                             >
                               <button
                                 aria-controls="credentials.answer"
-                                aria-label="Show password"
+                                aria-label="Show answer"
                                 aria-pressed="false"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-47"
                                 tabindex="0"
@@ -1172,7 +1172,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                             >
                               <button
                                 aria-controls="credentials.answer"
-                                aria-label="Show password"
+                                aria-label="Show answer"
                                 aria-pressed="false"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-48"
                                 tabindex="0"
@@ -1643,7 +1643,7 @@ exports[`authenticator-enroll-security-question predefined question should rende
                             >
                               <button
                                 aria-controls="credentials.answer"
-                                aria-label="Show password"
+                                aria-label="Show answer"
                                 aria-pressed="false"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-48"
                                 tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-yubikey-otp.test.tsx.snap
@@ -233,7 +233,7 @@ exports[`authenticator-enroll-yubikey-otp renders form 1`] = `
                           >
                             <button
                               aria-controls="credentials.passcode"
-                              aria-label="Show password"
+                              aria-label="Show YubiKey verification code"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-33"
                               tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-29"
                               tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -557,7 +557,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should pre
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-71"
                               tabindex="0"
@@ -1178,7 +1178,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-64"
                               tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -597,7 +597,7 @@ exports[`authenticator-expired-password should present field level error message
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-77"
                               tabindex="0"
@@ -1246,7 +1246,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -737,7 +737,7 @@ exports[`authenticator-expiry-warning-password should present field level error 
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-98"
                               tabindex="0"
@@ -1533,7 +1533,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-91"
                               tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password-revoke-sessions.test.tsx.snap
@@ -534,7 +534,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           >
                             <button
                               aria-controls="credentials.passcode"
-                              aria-label="Show password"
+                              aria-label="Show new password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-82"
                               tabindex="0"
@@ -598,7 +598,7 @@ exports[`authenticator-reset-password-revoke-sessions should render form 1`] = `
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-82"
                               tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -454,7 +454,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                           >
                             <button
                               aria-controls="credentials.passcode"
-                              aria-label="Show password"
+                              aria-label="Show new password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"
@@ -518,7 +518,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"
@@ -1088,7 +1088,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           >
                             <button
                               aria-controls="credentials.passcode"
-                              aria-label="Show password"
+                              aria-label="Show new password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"
@@ -1152,7 +1152,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           >
                             <button
                               aria-controls="confirmPassword"
-                              aria-label="Show password"
+                              aria-label="Show re-entered password"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-70"
                               tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                           >
                             <button
                               aria-controls="credentials.answer"
-                              aria-label="Show password"
+                              aria-label="Show answer"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-27"
                               tabindex="0"
@@ -414,7 +414,7 @@ exports[`authenticator-verification-security-question renders form when idx resp
                           >
                             <button
                               aria-controls="credentials.answer"
-                              aria-label="Show password"
+                              aria-label="Show answer"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-27"
                               tabindex="0"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-yubikey-otp.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`authenticator-verification-yubikey-otp renders form 1`] = `
                           >
                             <button
                               aria-controls="credentials.passcode"
-                              aria-label="Show password"
+                              aria-label="Show YubiKey verification code"
                               aria-pressed="false"
                               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium emotion-30"
                               tabindex="0"


### PR DESCRIPTION
## Description:

Fixes WCAG 2.4.6 issues (Deque audit) in the **Gen3 (v3)** widget where the show/hide password toggle didn't convey its purpose to screen readers.

**Root cause:** Odyssey's `PasswordField` hardcodes the toggle `aria-label` to "Show password" for every field, with no override prop in the version we ship (`@okta/odyssey-react-mui@1.44.0`). So duplicate toggles (new + re-enter password) are indistinguishable, and non-password secret fields (security answer, YubiKey) are mislabeled.

**Fix:**
1. `transformInputPassword` resolves a distinct label per field: `confirmPassword` → "Show re-entered password", `credentials.answer` → "Show answer", YubiKey → "Show YubiKey verification code", reset-password → "Show new password", everything else (incl. sign-in) → "Show password" (unchanged).
2. `InputPassword.tsx` applies that label to Odyssey's toggle (`button[aria-controls="<name>"]`); the name stays stable across show/hide (state via `aria-pressed`).

Sign-in flow is unaffected. All target i18n keys already existed.

### Why not upgrade Odyssey? (out of scope)

Odyssey added a `showPasswordToggleAriaLabel` prop in **1.65.0** (OKTA-1217904), which is the clean long-term fix. But bumping 1.44 → 1.65 is a **21-minor jump**, the widget runs Odyssey on **Preact**, and `theme.ts` heavily customizes Odyssey internals (+ design-tokens lockstep, dropped `react-i18next`) — high regression risk, its own VRT/parity effort. Too risky to bundle with a P1 a11y fix.

**This is a temporary workaround.** Once Odyssey ≥ 1.65.0 lands, remove the DOM override and pass `showPasswordToggleAriaLabel={getTranslation(translations, 'visibilityToggleLabel')}` instead — the transform logic stays identical. Code comments point to OKTA-1217904.

Downstream test: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=5343e4359d1afdd4bd2c9cf4120b94d5e099b142&tab=main

Gen 3 nightly downstream: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=c19821f20b10d76d14e16fd613e3f8df818e4f25&tab=main

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (No visual change — `aria-label` only.)

### Issue:

- [OKTA-1164538](https://oktainc.atlassian.net/browse/OKTA-1164538) — Password Setup
- [OKTA-1164535](https://oktainc.atlassian.net/browse/OKTA-1164535) — Reset password
- [OKTA-1164537](https://oktainc.atlassian.net/browse/OKTA-1164537) — Enroll Security Question
- [OKTA-1164549](https://oktainc.atlassian.net/browse/OKTA-1164549) — Set up YubiKey
- Related: [OKTA-1217904](https://oktainc.atlassian.net/browse/OKTA-1217904) (Odyssey prop for permanent fix)

### Reviewers:

### Screenshot/Video:

No visual change (accessible-name only).

### Downstream Monolith Build:
