### PR TITLE
fix(a11y): OKTA-1164540 Text content contrast ratio

### DIFF
--- a/src/v3/src/components/Widget/style.scss
+++ b/src/v3/src/components/Widget/style.scss
@@ -176,7 +176,7 @@
 }
 .okta-container .applogin-banner .applogin-container p {
   /* TODO: OKTA-586564 replace hardcoded value */
-  color: #6e6e78;
+  color: map.get($ods-tokens, 'typography', 'color', 'body');
   margin-block: 0;
 }
 


### PR DESCRIPTION
## Description:
- Updates the text color of the **"Sign in with your account to access Okta Dashboard"** banner subtitle in the Gen3 widget from the hardcoded **#6E6E78** to Odyssey's **typography.color.body** token **(#272727)**.
- The existing color **#6E6E78** on the semitransparent white banner background only achieves a 4.2:1 contrast ratio, failing WCAG 1.4.3 (minimum 4.5:1).

## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [X] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1164540](https://oktainc.atlassian.net/browse/OKTA-1164540)

### Reviewers:

### Screenshot/Video:

**Before**

<img width="1717" height="984" alt="Screenshot 2026-07-28 at 11 51 13 PM" src="https://github.com/user-attachments/assets/3d84a43d-46eb-4422-bb1f-7b5e9603c993" />

**After**

<img width="1705" height="1081" alt="Screenshot 2026-07-28 at 11 46 08 PM" src="https://github.com/user-attachments/assets/d6416b0b-609f-4359-9617-3ef1c6b196f8" />

### Test Plan
- Verify "Sign in with your account to access Okta Dashboard" text passes 4.5:1 contrast ratio on OIE org with Gen3 widget enabled
- No visual regression on other banner/container styles  

### Downstream Monolith Build:



