### PR TITLE
OKTA-1135857 Check LNA permission after loopback failure instead of upfront

### DIFF
--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -2,6 +2,7 @@
 import { $ } from '@okta/courage';
 import BaseFormWithPolling from '../internals/BaseFormWithPolling';
 import Logger from 'util/Logger';
+import { ChromeLNADeniedError } from 'util/Errors';
 import {
   AUTHENTICATOR_CANCEL_ACTION,
   AUTHENTICATION_CANCEL_REASONS,
@@ -12,6 +13,7 @@ import {
   doChallenge,
   cancelPollingWithParams,
   createInvisibleIFrame,
+  renderLNAError,
 } from '../utils/ChallengeViewUtil';
 
 const request = (opts) => {
@@ -64,6 +66,48 @@ const Body = BaseFormWithPolling.extend({
 
   getDeviceChallengePayload() {
     throw new Error('getDeviceChallengePayload needs to be implemented');
+  },
+
+  cancelLoopbackPolling() {
+    cancelPollingWithParams(
+      this.options.appState,
+      this.pollingCancelAction,
+      AUTHENTICATION_CANCEL_REASONS.LOOPBACK_FAILURE,
+      null,
+      !this.removed,
+    );
+  },
+
+  // Called when the loopback probe has failed to reach Okta Verify on any port.
+  // Rather than gating on the LNA permission upfront, we attempt the loopback
+  // first and only surface Local Network Access remediation here, when the
+  // connection has genuinely failed AND the browser reports the LNA permission
+  // as blocked. This avoids falsely failing auth in environments (e.g. an
+  // iframe within WebView2) that report 'denied' but do not actually enforce
+  // LNA, where the loopback would otherwise have succeeded.
+  handleLoopbackFailure(deviceChallenge) {
+    const chromeLocalNetworkAccessDetails = deviceChallenge?.chromeLocalNetworkAccessDetails;
+    // If there is no previous form name, it is a silent probe triggered by the
+    // registered condition; never show a terminal LNA error for a silent probe.
+    const isRegisteredConditionSilentProbe = this.options?.appState?.get('previousFormName') === undefined;
+
+    // LNA remediation only applies to interactive challenges where the server
+    // flagged LNA as relevant. Otherwise treat this as a normal loopback failure.
+    if (!chromeLocalNetworkAccessDetails || isRegisteredConditionSilentProbe) {
+      this.cancelLoopbackPolling();
+      return;
+    }
+
+    BrowserFeatures.getChromeLNAPermissionState((currPermissionState) => {
+      if (currPermissionState === 'denied') {
+        this.stopPolling();
+        renderLNAError(this, chromeLocalNetworkAccessDetails?.chromeLNAHelpLink);
+        // Log error for Sentry monitoring
+        throw new ChromeLNADeniedError('Chrome Local Network Access permission was denied for FastPass.');
+      }
+      // Loopback genuinely failed for another reason; proceed with normal cancel.
+      this.cancelLoopbackPolling();
+    });
   },
 
   doLoopback(deviceChallenge) {
@@ -150,13 +194,7 @@ const Body = BaseFormWithPolling.extend({
                 // when challenge is responded by the wrong OS profile and
                 // all the ports are exhausted,
                 // cancel the polling like the probing has failed
-                cancelPollingWithParams(
-                  this.options.appState,
-                  this.pollingCancelAction,
-                  AUTHENTICATION_CANCEL_REASONS.LOOPBACK_FAILURE,
-                  null,
-                  !this.removed,
-                );
+                this.handleLoopbackFailure(deviceChallenge);
               }
             });
         })
@@ -182,13 +220,7 @@ const Body = BaseFormWithPolling.extend({
             // This is to avoid concurrency issue where /poll/cancel takes long time to complete
             // and SIW will receive 400 error if the polling continues
             this.stopPolling();
-            cancelPollingWithParams(
-              this.options.appState,
-              this.pollingCancelAction,
-              AUTHENTICATION_CANCEL_REASONS.LOOPBACK_FAILURE,
-              null,
-              !this.removed,
-            );
+            this.handleLoopbackFailure(deviceChallenge);
           }
         });
     };

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -12,7 +12,6 @@
 import { loc, View, createButton, createCallout, _ } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
 import Enums from 'util/Enums';
-import { ChromeLNADeniedError } from 'util/Errors';
 import Util from 'util/Util';
 import {
   FASTPASS_FALLBACK_SPINNER_TIMEOUT,
@@ -23,7 +22,6 @@ import {
   OV_UV_ENABLE_BIOMETRICS_FASTPASS_WINDOWS,
   REQUEST_PARAM_AUTHENTICATION_CANCEL_REASON,
 } from '../utils/Constants';
-import BrowserFeatures from '../../../util/BrowserFeatures';
 
 export function appendLoginHint(deviceChallengeUrl, loginHint) {
   if (deviceChallengeUrl && loginHint) {
@@ -78,50 +76,30 @@ function updateChromeLNATitle(view, newTitle) {
   }
 }
 
-function handlePermissionState(view, currPermissionState, deviceChallenge) {
+// Replaces the loopback spinner with the Local Network Access (LNA) remediation
+// error view. Called only after a loopback probe has actually failed and the
+// browser reports the LNA permission as blocked (see handleLoopbackFailure in
+// BaseOktaVerifyChallengeView).
+export function renderLNAError(view, chromeLNAHelpLink) {
   view.removeChildren();
-  switch(currPermissionState) {
-  case 'prompt':
-  case 'granted':
-    updateChromeLNATitle(view, loc('deviceTrust.sso.redirectText', 'login'));
-    addLoopbackView(view, deviceChallenge);
-    break;
-  case 'denied': {
-    // If there is no previous form name, it is a silent probe triggered by the registered condition
-    const isRegisteredConditionSilentProbe = view.options?.appState?.get('previousFormName') === undefined;
-    if (isRegisteredConditionSilentProbe) {
-      updateChromeLNATitle(view, loc('deviceTrust.sso.redirectText', 'login'));
-      addLoopbackView(view, deviceChallenge);
-    } else {
-      updateChromeLNATitle(view, loc('chrome.lna.fastpass.requires.permission.title', 'login'));
-      addLNAErrorView(view, deviceChallenge.chromeLocalNetworkAccessDetails?.chromeLNAHelpLink);
-      // Log error for Sentry monitoring
-      throw new ChromeLNADeniedError('Chrome Local Network Access permission was denied for FastPass.');
-    }
-    break;
-  }
-  default:
-    updateChromeLNATitle(view, loc('deviceTrust.sso.redirectText', 'login'));
-    addLoopbackView(view, deviceChallenge);
-    break;
-  }
+  updateChromeLNATitle(view, loc('chrome.lna.fastpass.requires.permission.title', 'login'));
+  addLNAErrorView(view, chromeLNAHelpLink);
 }
 
 export function doChallenge(view, fromView) {
   const deviceChallenge = view.getDeviceChallengePayload();
-  const { chromeLocalNetworkAccessDetails } = deviceChallenge || {};
   const loginHint = view.options?.settings?.get('identifier');
   const HIDE_CLASS = 'hide';
   switch (deviceChallenge.challengeMethod) {
   case Enums.LOOPBACK_CHALLENGE: {
+    // Always attempt the loopback first. The LNA permission state is no longer
+    // used as an upfront gate: an iframe within WebView2 (e.g. the Teams thick
+    // client) reports the LNA permission as 'denied' by default even though
+    // loopback is not actually enforced, which previously failed auth before
+    // the connection was ever attempted. LNA remediation is now surfaced only
+    // if the loopback genuinely fails (see handleLoopbackFailure).
     view.title = loc('deviceTrust.sso.redirectText', 'login');
-    if (chromeLocalNetworkAccessDetails) {
-      BrowserFeatures.getChromeLNAPermissionState(
-        (currPermissionState) => handlePermissionState(view, currPermissionState, deviceChallenge)
-      );
-    } else {
-      addLoopbackView(view, deviceChallenge);
-    }
+    addLoopbackView(view, deviceChallenge);
     break;
   }
   case Enums.CUSTOM_URI_CHALLENGE:

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.test.tsx
@@ -16,9 +16,12 @@ import { SetupServer, setupServer } from 'msw/node';
 import { h } from 'preact';
 import { LoopbackProbeElement } from 'src/types';
 
+import * as browserUtils from '../../util/browserUtils';
 import LoopbackProbe from './LoopbackProbe';
 
 const proceedStub = jest.fn();
+const setIdxTransactionStub = jest.fn();
+const setIsClientTransactionStub = jest.fn();
 let mockWidgetContextOverrides: Record<string, unknown> = {};
 jest.mock('../../contexts', () => ({
   useWidgetContext: () => ({
@@ -32,7 +35,8 @@ jest.mock('../../contexts', () => ({
         stateHandle: 'fake-state-handle',
       },
     },
-    setIdxTransaction: jest.fn(),
+    setIdxTransaction: setIdxTransactionStub,
+    setIsClientTransaction: setIsClientTransactionStub,
     ...mockWidgetContextOverrides,
   }),
 }));
@@ -643,6 +647,103 @@ describe('LoopbackProbe', () => {
       await new Promise((r) => { setTimeout(r, 50); });
       // Flag STILL held — cancelHandler did not clear what it did not claim
       expect(pollInFlightRef.current).toBe(true);
+    });
+  });
+
+  describe('Local Network Access (LNA) remediation on loopback failure', () => {
+    const buildProps = (
+      showLNARemediationOnFailure?: boolean,
+    ): { uischema: LoopbackProbeElement } => ({
+      uischema: {
+        type: 'LoopbackProbe',
+        options: {
+          deviceChallengePayload: {
+            ports: ['2000', '6511', '6512', '6513'],
+            domain: 'http://localhost',
+            challengeRequest: 'mockChallengeRequest',
+            probeTimeoutMillis: 100,
+            chromeLocalNetworkAccessDetails: {
+              chromeLNAHelpLink: 'https://okta.com',
+            },
+          },
+          cancelStep: 'authenticatorChallenge-cancel',
+          step: 'device-challenge-poll',
+          showLNARemediationOnFailure,
+        },
+      },
+    });
+
+    beforeEach(() => {
+      // All ports fail to probe so the loopback attempt fails.
+      server.use(
+        rest.get(/http:\/\/localhost:\d{4}\/probe/, async (_, res, ctx) => res(ctx.status(500))),
+      );
+    });
+
+    it('renders the LNA remediation view (client-side) and stops polling when the permission is denied', async () => {
+      // getChromeLNAPermissionState resolves to 'denied'. The ChromeLNADeniedError thrown for
+      // Sentry monitoring is swallowed here so it does not surface as an unhandled rejection.
+      jest.spyOn(browserUtils, 'getChromeLNAPermissionState').mockImplementation(async (cb) => {
+        try {
+          cb('denied');
+        } catch {
+          /* ChromeLNADeniedError is monitoring-only */
+        }
+      });
+
+      render(<LoopbackProbe {...buildProps(true)} />);
+
+      await waitFor(
+        () => expect(setIsClientTransactionStub).toHaveBeenCalledWith(true),
+        { timeout: 300 },
+      );
+      // Transaction is marked so the transformer renders the error layout and usePolling stops
+      expect(setIdxTransactionStub).toHaveBeenCalledWith(
+        expect.objectContaining({ chromeLNADenied: true }),
+      );
+      // No cancel/proceed round-trip is made
+      expect(proceedStub).not.toHaveBeenCalled();
+    });
+
+    it.each(['granted', 'prompt'])('cancels for "%s" permission (no remediation)', async (permissionState) => {
+      jest.spyOn(browserUtils, 'getChromeLNAPermissionState').mockImplementation(async (cb) => {
+        cb(permissionState as PermissionState);
+      });
+
+      render(<LoopbackProbe {...buildProps(true)} />);
+
+      await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
+      expect(proceedStub).toHaveBeenCalledWith({
+        actions: [{
+          name: 'authenticatorChallenge-cancel',
+          params: {
+            reason: 'OV_UNREACHABLE_BY_LOOPBACK',
+            statusCode: null,
+          },
+        }],
+        stateHandle: 'fake-state-handle',
+      });
+      expect(setIsClientTransactionStub).not.toHaveBeenCalled();
+    });
+
+    it('cancels without checking the permission when showLNARemediationOnFailure is false (silent probe)', async () => {
+      const lnaSpy = jest.spyOn(browserUtils, 'getChromeLNAPermissionState');
+
+      render(<LoopbackProbe {...buildProps(false)} />);
+
+      await waitFor(() => expect(proceedStub).toHaveBeenCalledTimes(1), { timeout: 300 });
+      expect(proceedStub).toHaveBeenCalledWith({
+        actions: [{
+          name: 'authenticatorChallenge-cancel',
+          params: {
+            reason: 'OV_UNREACHABLE_BY_LOOPBACK',
+            statusCode: null,
+          },
+        }],
+        stateHandle: 'fake-state-handle',
+      });
+      expect(lnaSpy).not.toHaveBeenCalled();
+      expect(setIsClientTransactionStub).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
+++ b/src/v3/src/components/LoopbackProbe/LoopbackProbe.tsx
@@ -14,10 +14,12 @@ import { IdxActionParams } from '@okta/okta-auth-js';
 import { FunctionComponent } from 'preact';
 import { useEffect } from 'preact/hooks';
 
+import { ChromeLNADeniedError } from '../../../../util/Errors';
 import Logger from '../../../../util/Logger';
 import { useWidgetContext } from '../../contexts';
 import { ActionParams, LoopbackProbeElement } from '../../types';
 import { isAndroid, isPollingStep, makeRequest } from '../../util';
+import { getChromeLNAPermissionState, markChromeLNADeniedTransaction } from '../../util/browserUtils';
 
 const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
   uischema: {
@@ -25,12 +27,18 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
       deviceChallengePayload,
       cancelStep,
       step,
+      showLNARemediationOnFailure,
     },
   },
 }) => {
   const widgetContext = useWidgetContext();
   const {
-    authClient, idxTransaction, setIdxTransaction, widgetProps, pollInFlightRef,
+    authClient,
+    idxTransaction,
+    setIdxTransaction,
+    setIsClientTransaction,
+    widgetProps,
+    pollInFlightRef,
   } = widgetContext;
   const disableConcurrentPolling = widgetProps?.features?.disableConcurrentPolling;
   const disablePollDuringCancel = widgetProps?.features?.disablePollDuringCancel;
@@ -103,6 +111,33 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
         pollInFlightRef.current = false;
       }
     }
+  };
+
+  // Called when the loopback probe fails to reach Okta Verify on any port. The loopback
+  // is always attempted first (see doLoopback below); Local Network Access remediation is
+  // surfaced only here, when the failure coincides with a blocked LNA permission on an
+  // interactive challenge. This avoids falsely failing auth in environments (e.g. an
+  // iframe within WebView2) that report the LNA permission as 'denied' but do not actually
+  // enforce it, where the loopback would otherwise have succeeded.
+  const handleLoopbackFailure = () => {
+    if (!showLNARemediationOnFailure || !idxTransaction) {
+      cancelHandler({ reason: 'OV_UNREACHABLE_BY_LOOPBACK', statusCode: null });
+      return;
+    }
+    getChromeLNAPermissionState((currPermissionState) => {
+      if (currPermissionState !== 'denied') {
+        // Loopback genuinely failed for another reason; cancel polling as usual.
+        cancelHandler({ reason: 'OV_UNREACHABLE_BY_LOOPBACK', statusCode: null });
+        return;
+      }
+      // Render the LNA remediation view client-side with no server round-trip: marking the
+      // transaction makes the loopback transformer emit the error layout on re-render and
+      // makes usePolling stop polling (so the probe is not re-mounted / re-run).
+      setIsClientTransaction(true);
+      setIdxTransaction(markChromeLNADeniedTransaction(idxTransaction));
+      // Log error for Sentry monitoring
+      throw new ChromeLNADeniedError('Chrome Local Network Access permission was denied for FastPass.');
+    });
   };
 
   /* eslint-disable no-await-in-loop, no-continue */
@@ -183,13 +218,11 @@ const LoopbackProbe: FunctionComponent<{ uischema: LoopbackProbeElement }> = ({
         // for the next ongoing polling to be triggered to make the authentication flow go faster
         submitHandler(step);
       } else {
-        // no more ports to probe: cancel polling and return
+        // no more ports to probe: surface LNA remediation if the failure is due to a
+        // blocked LNA permission, otherwise cancel polling and return
         Logger.error('No available ports. Loopback server failed and polling is cancelled.');
 
-        cancelHandler({
-          reason: 'OV_UNREACHABLE_BY_LOOPBACK',
-          statusCode: null,
-        });
+        handleLoopbackFailure();
       }
     };
 

--- a/src/v3/src/hooks/usePolling.ts
+++ b/src/v3/src/hooks/usePolling.ts
@@ -19,6 +19,7 @@ import {
 import { TERMINAL_KEY } from '../constants';
 import { FormBag, WidgetOptions } from '../types';
 import { containsMessageKey, isPollingStep } from '../util';
+import { isChromeLNADeniedTransaction } from '../util/browserUtils';
 
 const DEFAULT_TIMEOUT = 4000;
 
@@ -28,6 +29,14 @@ const getPollingStep = (
   // auth-js preserves polling object (cache) in transaction when back to authenticators list
   // stop polling in this scenario
   if (!transaction || transaction.nextStep?.name.startsWith('select-authenticator')) {
+    return undefined;
+  }
+
+  // Stop polling once a FastPass loopback failure has been attributed to a blocked
+  // Local Network Access permission — the widget renders a terminal LNA remediation
+  // view client-side (no server round-trip), so continuing to poll would re-mount the
+  // probe and flicker. See LoopbackProbe.tsx / transformOktaVerifyFPLoopbackPoll.
+  if (isChromeLNADeniedTransaction(transaction)) {
     return undefined;
   }
 

--- a/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyFPLoopbackPoll.test.ts.snap
+++ b/src/v3/src/transformer/layout/oktaVerify/__snapshots__/transformOktaVerifyFPLoopbackPoll.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Transform Okta Verify FP Loopback Poll where chromeLocalNetworkAccessDetails are defined should create Loopback Poll elements for display when permission state is "denied" and loopback is triggered by registered condition silent probe 1`] = `
+exports[`Transform Okta Verify FP Loopback Poll where chromeLocalNetworkAccessDetails are defined creates Loopback Poll elements with showLNARemediationOnFailure=false for a registered condition silent probe 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -36,6 +36,7 @@ Object {
               "6513",
             ],
           },
+          "showLNARemediationOnFailure": false,
           "step": "device-challenge-poll",
         },
         "type": "LoopbackProbe",
@@ -59,7 +60,7 @@ Object {
 }
 `;
 
-exports[`Transform Okta Verify FP Loopback Poll where chromeLocalNetworkAccessDetails are defined should create Loopback Poll elements for display when permission state is "granted" 1`] = `
+exports[`Transform Okta Verify FP Loopback Poll where chromeLocalNetworkAccessDetails are defined creates Loopback Poll elements with showLNARemediationOnFailure=true for an interactive challenge 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -95,6 +96,7 @@ Object {
               "6513",
             ],
           },
+          "showLNARemediationOnFailure": true,
           "step": "device-challenge-poll",
         },
         "type": "LoopbackProbe",
@@ -118,66 +120,7 @@ Object {
 }
 `;
 
-exports[`Transform Okta Verify FP Loopback Poll where chromeLocalNetworkAccessDetails are defined should create Loopback Poll elements for display when permission state is "prompt" 1`] = `
-Object {
-  "data": Object {},
-  "dataSchema": Object {
-    "fieldsToExclude": [Function],
-    "fieldsToTrim": Array [],
-    "fieldsToValidate": Array [],
-    "submit": Object {
-      "step": "challenge-authenticator",
-    },
-  },
-  "schema": Object {},
-  "uischema": Object {
-    "elements": Array [
-      Object {
-        "options": Object {
-          "content": "deviceTrust.sso.redirectText",
-        },
-        "type": "ActionPending",
-      },
-      Object {
-        "options": Object {
-          "cancelStep": "authenticatorChallenge-cancel",
-          "deviceChallengePayload": Object {
-            "challengeRequest": "mockChallengeRequest",
-            "chromeLocalNetworkAccessDetails": Object {
-              "chromeLNAHelpLink": "https://okta.com",
-            },
-            "domain": "http://localhost",
-            "ports": Array [
-              "2000",
-              "6511",
-              "6512",
-              "6513",
-            ],
-          },
-          "step": "device-challenge-poll",
-        },
-        "type": "LoopbackProbe",
-      },
-      Object {
-        "contentType": "footer",
-        "options": Object {
-          "actionParams": Object {
-            "reason": "USER_CANCELED",
-            "statusCode": null,
-          },
-          "isActionStep": true,
-          "label": "goback",
-          "step": "authenticatorChallenge-cancel",
-        },
-        "type": "Link",
-      },
-    ],
-    "type": "VerticalLayout",
-  },
-}
-`;
-
-exports[`Transform Okta Verify FP Loopback Poll where chromeLocalNetworkAccessDetails are defined should create error remediation elements when permission state is "denied" and loopback is not triggered by registered condition silent probe 1`] = `
+exports[`Transform Okta Verify FP Loopback Poll where chromeLocalNetworkAccessDetails are defined creates error remediation elements when the transaction is marked as LNA-denied 1`] = `
 Object {
   "data": Object {},
   "dataSchema": Object {
@@ -281,6 +224,7 @@ Object {
               "6513",
             ],
           },
+          "showLNARemediationOnFailure": false,
           "step": "challenge-poll",
         },
         "type": "LoopbackProbe",
@@ -346,6 +290,7 @@ Object {
               "6513",
             ],
           },
+          "showLNARemediationOnFailure": false,
           "step": "device-challenge-poll",
         },
         "type": "LoopbackProbe",

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.test.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.test.ts
@@ -12,7 +12,6 @@
 
 import { IDX_STEP } from 'src/constants';
 import { getStubFormBag, getStubTransactionWithNextStep } from 'src/mocks/utils/utils';
-import { ChromeLNADeniedError } from 'util/Errors';
 
 import {
   ActionPendingElement,
@@ -22,7 +21,7 @@ import {
   TitleElement,
   WidgetProps,
 } from '../../../types';
-import * as browserUtils from '../../../util/browserUtils';
+import { markChromeLNADeniedTransaction } from '../../../util/browserUtils';
 import * as idxUtils from '../../../util/idxUtils';
 import { transformOktaVerifyFPLoopbackPoll } from './transformOktaVerifyFPLoopbackPoll';
 
@@ -72,6 +71,7 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
           },
           cancelStep: 'authenticatorChallenge-cancel',
           step: 'device-challenge-poll',
+          showLNARemediationOnFailure: false,
         });
       expect((updatedFormBag.uischema.elements[2] as LinkElement).options.label)
         .toBe('oie.verification.switch.authenticator');
@@ -129,6 +129,7 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
           },
           cancelStep: 'currentAuthenticator-cancel',
           step: 'challenge-poll',
+          showLNARemediationOnFailure: false,
         });
       expect((updatedFormBag.uischema.elements[2] as LinkElement).options.label)
         .toBe('oie.verification.switch.authenticator');
@@ -141,13 +142,6 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
 
   describe('where chromeLocalNetworkAccessDetails are defined', () => {
     const prevTransaction = getStubTransactionWithNextStep();
-
-    const mockChromeLNAPermissionState = (permissionState: PermissionState) => {
-      jest.spyOn(browserUtils, 'getChromeLNAPermissionState').mockImplementation((handlePermissionState) => {
-        handlePermissionState(permissionState);
-        return Promise.resolve();
-      });
-    };
 
     beforeEach(() => {
       transaction.nextStep = {
@@ -167,10 +161,18 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
       transaction.availableSteps = [{ name: IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE }];
     });
 
-    it.each(['prompt', 'granted'])('should create Loopback Poll elements for display when permission state is "%s"', (permissionState) => {
-      mockChromeLNAPermissionState(permissionState as PermissionState);
+    // The LNA permission is no longer checked upfront in the transformer. The loopback is
+    // always attempted; the LoopbackProbe surfaces LNA remediation only after a genuine
+    // failure with a blocked permission, then marks the transaction so this transformer
+    // renders the error layout (see the marked-transaction test below).
+    it('creates Loopback Poll elements with showLNARemediationOnFailure=true for an interactive challenge', () => {
+      // A defined prevTransaction.nextStep.name means this is not a registered-condition silent probe
+      prevTransaction.nextStep = {
+        name: IDX_STEP.IDENTIFY,
+      };
 
       const updatedFormBag = transformOktaVerifyFPLoopbackPoll({
+        prevTransaction,
         transaction,
         formBag,
         widgetProps,
@@ -195,19 +197,19 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
           },
           cancelStep: 'authenticatorChallenge-cancel',
           step: 'device-challenge-poll',
+          showLNARemediationOnFailure: true,
         });
       expect(updatedFormBag.uischema.elements[2].type).toBe('Link');
       expect((updatedFormBag.uischema.elements[2] as LinkElement).options.label)
         .toBe('goback');
     });
 
-    it('should create Loopback Poll elements for display when permission state is "denied" and loopback is triggered by registered condition silent probe', () => {
-      // Explicitly mock no previous transaction through an undefined prevTransaction.nextStep.name, which happens when
-      // a silent loopback probe is triggered by the registered condition
+    it('creates Loopback Poll elements with showLNARemediationOnFailure=false for a registered condition silent probe', () => {
+      // An undefined prevTransaction.nextStep.name means this is a silent probe triggered by
+      // the registered condition; a silent probe must never show the terminal LNA error
       prevTransaction.nextStep = {
         name: undefined as unknown as string,
       };
-      mockChromeLNAPermissionState('denied');
 
       const updatedFormBag = transformOktaVerifyFPLoopbackPoll({
         prevTransaction,
@@ -234,36 +236,31 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
           },
           cancelStep: 'authenticatorChallenge-cancel',
           step: 'device-challenge-poll',
+          showLNARemediationOnFailure: false,
         });
       expect(updatedFormBag.uischema.elements[2].type).toBe('Link');
       expect((updatedFormBag.uischema.elements[2] as LinkElement).options.label)
         .toBe('goback');
     });
 
-    it('should create error remediation elements when permission state is "denied" and loopback is not triggered by registered condition silent probe', () => {
-      // Explicitly mock a previous transaction with a defined prevTransaction.nextStep.name, which happens when
-      // a loopback probe is not triggered by the registered condition
-      prevTransaction.nextStep = {
-        name: IDX_STEP.IDENTIFY,
-      };
-      mockChromeLNAPermissionState('denied');
+    it('creates error remediation elements when the transaction is marked as LNA-denied', () => {
+      // LoopbackProbe marks the transaction once a loopback failure is attributed to a
+      // blocked LNA permission; the transformer then renders the remediation view.
+      const deniedTransaction = markChromeLNADeniedTransaction(transaction);
 
-      expect(() => {
-        transformOktaVerifyFPLoopbackPoll({
-          prevTransaction,
-          transaction,
-          formBag,
-          widgetProps,
-        });
-      }).toThrowError(ChromeLNADeniedError);
+      const updatedFormBag = transformOktaVerifyFPLoopbackPoll({
+        transaction: deniedTransaction,
+        formBag,
+        widgetProps,
+      });
 
-      expect(formBag).toMatchSnapshot();
-      expect(formBag.uischema.elements.length).toBe(3);
-      expect(formBag.uischema.elements[0].type).toBe('Title');
-      expect((formBag.uischema.elements[0] as TitleElement).options.content).toBe('chrome.lna.fastpass.requires.permission.title');
-      expect(formBag.uischema.elements[1].type).toBe('InfoBox');
+      expect(updatedFormBag).toMatchSnapshot();
+      expect(updatedFormBag.uischema.elements.length).toBe(3);
+      expect(updatedFormBag.uischema.elements[0].type).toBe('Title');
+      expect((updatedFormBag.uischema.elements[0] as TitleElement).options.content).toBe('chrome.lna.fastpass.requires.permission.title');
+      expect(updatedFormBag.uischema.elements[1].type).toBe('InfoBox');
       expect((
-        formBag.uischema.elements[1] as InfoboxElement
+        updatedFormBag.uischema.elements[1] as InfoboxElement
       ).options?.message).toEqual(
         [
           {
@@ -294,10 +291,10 @@ describe('Transform Okta Verify FP Loopback Poll', () => {
         ],
       );
       expect((
-        formBag.uischema.elements[1] as InfoboxElement
+        updatedFormBag.uischema.elements[1] as InfoboxElement
       ).options?.class).toBe('ERROR');
-      expect(formBag.uischema.elements[2].type).toBe('Link');
-      expect((formBag.uischema.elements[2] as LinkElement).options.label).toBe('goback');
+      expect(updatedFormBag.uischema.elements[2].type).toBe('Link');
+      expect((updatedFormBag.uischema.elements[2] as LinkElement).options.label).toBe('goback');
     });
   });
 });

--- a/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
+++ b/src/v3/src/transformer/layout/oktaVerify/transformOktaVerifyFPLoopbackPoll.ts
@@ -12,7 +12,6 @@
 
 import { NextStep } from '@okta/okta-auth-js';
 
-import { ChromeLNADeniedError } from '../../../../../util/Errors';
 import { IDX_STEP } from '../../../constants';
 import {
   ActionPendingElement,
@@ -26,11 +25,11 @@ import {
   UISchemaLayout,
 } from '../../../types';
 import {
-  getChromeLNAPermissionState,
   hasMinAuthenticatorOptions,
   loc,
   updateTransactionWithNextStep,
 } from '../../../util';
+import { isChromeLNADeniedTransaction } from '../../../util/browserUtils';
 
 export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
   prevTransaction,
@@ -158,12 +157,22 @@ export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
     cancelLink,
   ];
 
+  // The LNA permission is no longer used as an upfront gate: an iframe within WebView2
+  // (e.g. the Teams thick client) reports the LNA permission as 'denied' by default even
+  // though loopback is not actually enforced, which previously failed auth before the
+  // connection was ever attempted. Instead we always probe and let LoopbackProbe surface
+  // LNA remediation only if the probe genuinely fails and the permission is blocked.
+  // Silent probes never show the terminal error.
+  const showLNARemediationOnFailure = Boolean(chromeLocalNetworkAccessDetails)
+    && !isRegisteredConditionSilentProbe;
+
   const loopbackProbeElement : LoopbackProbeElement = {
     type: 'LoopbackProbe',
     options: {
       deviceChallengePayload,
       cancelStep,
       step: transaction.nextStep?.name,
+      showLNARemediationOnFailure,
     },
   } as LoopbackProbeElement;
 
@@ -179,29 +188,11 @@ export const transformOktaVerifyFPLoopbackPoll: IdxStepTransformer = ({
     ...linkElements,
   ];
 
-  if (chromeLocalNetworkAccessDetails) {
-    getChromeLNAPermissionState((currPermissionState) => {
-      switch (currPermissionState) {
-        case 'prompt':
-          uischema.elements = loopbackProbeElements;
-          break;
-        case 'granted':
-          uischema.elements = loopbackProbeElements;
-          break;
-        case 'denied':
-          if (isRegisteredConditionSilentProbe) {
-            uischema.elements = loopbackProbeElements;
-          } else {
-            uischema.elements = chromeLNAErrorCalloutElements;
-            // Log error for Sentry monitoring
-            throw new ChromeLNADeniedError('Chrome Local Network Access permission was denied for FastPass.');
-          }
-          break;
-        default:
-          uischema.elements = loopbackProbeElements;
-          break;
-      }
-    });
+  // LoopbackProbe marks the (client-side) transaction once a loopback failure is
+  // confirmed to be caused by a blocked LNA permission. On that render we show the
+  // remediation view instead of re-mounting the probe.
+  if (chromeLocalNetworkAccessDetails && isChromeLNADeniedTransaction(transaction)) {
+    uischema.elements = chromeLNAErrorCalloutElements;
   } else {
     uischema.elements = loopbackProbeElements;
   }

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -497,6 +497,11 @@ export interface LoopbackProbeElement extends UISchemaElement {
     deviceChallengePayload: DeviceChallengePayload;
     step: string;
     cancelStep: string;
+    // When true, a loopback failure should surface the Local Network Access (LNA)
+    // remediation view if the browser reports the LNA permission as blocked, rather
+    // than immediately cancelling. Only set for interactive challenges where the
+    // server flagged LNA as relevant (chromeLocalNetworkAccessDetails present).
+    showLNARemediationOnFailure?: boolean;
   };
 }
 

--- a/src/v3/src/util/browserUtils.ts
+++ b/src/v3/src/util/browserUtils.ts
@@ -10,6 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { IdxTransaction } from '@okta/okta-auth-js';
+
 import { ChromeLNADeniedError } from '../../../util/Errors';
 
 export const isAndroid = (): boolean => (
@@ -54,3 +56,25 @@ export const getChromeLNAPermissionState = async (
 };
 
 export const isAndroidOrIOS = (): boolean => isAndroid() || isIOS();
+
+// Marker property set on a client-side (cloned) transaction to signal that a FastPass
+// loopback attempt failed while the browser reported the Local Network Access (LNA)
+// permission as blocked. When present:
+//  - transformOktaVerifyFPLoopbackPoll renders the LNA remediation view instead of the
+//    LoopbackProbe (so it does not re-probe), and
+//  - usePolling stops polling (getPollingStep returns undefined),
+// giving a stable terminal error with no server round-trip. See LoopbackProbe.tsx.
+const CHROME_LNA_DENIED_MARKER = 'chromeLNADenied';
+
+type ChromeLNADeniedMarked = { [CHROME_LNA_DENIED_MARKER]?: boolean };
+
+export const markChromeLNADeniedTransaction = (
+  transaction: IdxTransaction,
+): IdxTransaction => ({
+  ...transaction,
+  [CHROME_LNA_DENIED_MARKER]: true,
+} as IdxTransaction);
+
+export const isChromeLNADeniedTransaction = (transaction?: unknown): boolean => (
+  !!transaction && (transaction as ChromeLNADeniedMarked)[CHROME_LNA_DENIED_MARKER] === true
+);

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -473,7 +473,44 @@ const loopbackLNADeniedRemediationViewMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
   .respond(identifyWithDeviceProbingLoopbackAndChromeLNA)
   .onRequestTo(/\/idp\/idx\/authenticators\/poll$/)
-  .respond(identifyWithDeviceProbingLoopbackAndChromeLNA);
+  .respond(identifyWithDeviceProbingLoopbackAndChromeLNA)
+  // The loopback is now always attempted before remediation; fail every probe so the
+  // loopback genuinely fails, which is what triggers the LNA remediation view.
+  .onRequestTo(/(2000|6511|6512|6513)\/probe/)
+  .respond(null, 500, { 'access-control-allow-origin': '*' });
+
+// Chrome LNA permission is 'denied' but the loopback still succeeds — e.g. an iframe within
+// WebView2, which reports the LNA permission as 'denied' by default but does not actually
+// enforce LNA. Auth should proceed and the remediation view should NOT be shown.
+const loopbackLNADeniedLoopbackSucceedsLogger = RequestLogger(/introspect|probe|challenge|poll/, { logRequestBody: true, stringifyRequestBody: true });
+const loopbackLNADeniedLoopbackSucceedsMock = RequestMock()
+  .onRequestTo(/\/idp\/idx\/introspect/)
+  .respond(loopbackChallengeNotReceived)
+  .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
+  .respond(identifyWithDeviceProbingLoopbackAndChromeLNA)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll$/)
+  .respond(identifyWithDeviceProbingLoopbackAndChromeLNA)
+  .onRequestTo({ url: /2000\/probe/, method: 'OPTIONS' })
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo({ url: /2000\/probe/, method: 'GET' })
+  .respond(null, 500, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6511\/probe/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6511\/challenge/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
+    'access-control-allow-methods': 'POST, GET, OPTIONS'
+  });
 
 fixture('Device Challenge Polling View with the Loopback Server, Custom URI, App Link, and Universal Link approaches');
 
@@ -1072,13 +1109,21 @@ test
   });
 
 test
-  .requestHooks(loopbackLNADeniedRemediationViewLogger, loopbackLNADeniedRemediationViewMock)('in loopback server approach, when Chrome Local Network Access permission state is denied and loopback is not triggered by registered condition silent probe, error remediation view is shown', async t => {
+  .requestHooks(loopbackLNADeniedRemediationViewLogger, loopbackLNADeniedRemediationViewMock)('in loopback server approach, when Chrome Local Network Access permission state is denied and the loopback fails, the error remediation view is shown after the loopback is attempted', async t => {
     const deviceChallengeFallbackPage = await setupLoopbackFallback(t, undefined, 'denied');
     await t.expect(deviceChallengeFallbackPage.getFormTitle()).eql('Sign In');
 
+    // The ChromeLNADeniedError is thrown for Sentry monitoring once the loopback fails; the
+    // skip stays enabled through the assertions because the throw now happens asynchronously
+    // after the probes fail (not synchronously on click as before).
     await t.skipJsErrors({ message: 'Chrome Local Network Access permission was denied for FastPass.' });
     await deviceChallengeFallbackPage.clickOktaVerifyButton();
-    await t.skipJsErrors(false);
+
+    // The loopback is attempted first (probes are sent and fail) before the remediation view appears
+    await t.expect(loopbackLNADeniedRemediationViewLogger.count(
+      record => record.response.statusCode === 500 &&
+        record.request.url.match(/2000|6511|6512|6513/)
+    )).gte(1);
 
     await t.expect(deviceChallengeFallbackPage.getFormTitle()).eql('Okta FastPass requires network permission');
     const errorBox = userVariables.gen3 ? deviceChallengeFallbackPage.form.getErrorBox() : deviceChallengeFallbackPage.form.getErrorBoxCallout();
@@ -1089,5 +1134,34 @@ test
     await t.expect(errorBox.withText('Change the permission from “Block” to “Allow” and reload this page').exists).eql(true);
     await t.expect(errorBox.withText('For more information, follow the instructions on the Local app access page or contact your administrator for help.').exists).eql(true);
     await t.expect(errorBox.withText('Local app access').find('a[href="https://okta.com"]').exists).eql(true);
+    await t.skipJsErrors(false);
+  });
+
+test
+  .requestHooks(loopbackLNADeniedLoopbackSucceedsLogger, loopbackLNADeniedLoopbackSucceedsMock)('in loopback server approach, when Chrome Local Network Access permission state is denied but the loopback still succeeds (e.g. iframe within WebView2), authentication proceeds and the error remediation view is not shown', async t => {
+    const deviceChallengeFallbackPage = await setupLoopbackFallback(t, undefined, 'denied');
+    await t.expect(deviceChallengeFallbackPage.getFormTitle()).eql('Sign In');
+
+    await deviceChallengeFallbackPage.clickOktaVerifyButton();
+
+    // Despite the 'denied' permission, the loopback is attempted and succeeds, so auth proceeds
+    // to the polling view rather than surfacing the LNA remediation view.
+    await t.expect(deviceChallengeFallbackPage.getFormTitle()).eql('Verifying your identity');
+    await t.expect(loopbackLNADeniedLoopbackSucceedsLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.method === 'get' &&
+        record.request.url.match(/6511\/probe/)
+    )).gte(1);
+    await t.expect(loopbackLNADeniedLoopbackSucceedsLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/6511\/challenge/)
+    )).gte(1);
+
+    // No remediation view and no loopback-failure cancel were triggered
+    const errorBox = userVariables.gen3 ? deviceChallengeFallbackPage.form.getErrorBox() : deviceChallengeFallbackPage.form.getErrorBoxCallout();
+    await t.expect(errorBox.withText('Unable to sign in').exists).eql(false);
+    await t.expect(loopbackLNADeniedLoopbackSucceedsLogger.count(
+      record => record.request.url.match(/authenticators\/poll\/cancel/)
+    )).eql(0);
   });
   

--- a/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
@@ -1,10 +1,8 @@
-import {doChallenge, getBiometricsErrorOptions} from '../../../../../../src/v2/view-builder/utils/ChallengeViewUtil';
+import {doChallenge, getBiometricsErrorOptions, renderLNAError} from '../../../../../../src/v2/view-builder/utils/ChallengeViewUtil';
 import { loc, View, createButton } from '@okta/courage';
 import hbs from '@okta/handlebars-inline-precompile';
-import BrowserFeatures from '../../../../../../src/util/BrowserFeatures';
 import Enums from '../../../../../../src/util/Enums';
 import Util from '../../../../../../src/util/Util';
-import { ChromeLNADeniedError } from '../../../../../../src/util/Errors';
 
 describe('v2/utils/ChallengeViewUtil', function() {
   class TestView {
@@ -53,7 +51,6 @@ describe('v2/utils/ChallengeViewUtil', function() {
     let testView;
     let expectedAddArg = {};
     let deviceChallengeWithChromeLNADetails;
-    let originalGetChromeLNAPermissionState;
 
     beforeEach(function() {
       testView = new TestView();
@@ -76,58 +73,25 @@ describe('v2/utils/ChallengeViewUtil', function() {
         return extendArg;
       });
       testView.options = { appState: { get: () => undefined } };
-
-      // Save original implementation to restore after tests
-      originalGetChromeLNAPermissionState = BrowserFeatures.getChromeLNAPermissionState;
     });
 
-    afterEach(function() {
-      // Restore original implementation
-      BrowserFeatures.getChromeLNAPermissionState = originalGetChromeLNAPermissionState;
-    });
-
-    function mockChromeLNAPermissionState(currPermissionState) {
-      BrowserFeatures.getChromeLNAPermissionState = function(callback) {
-        callback(currPermissionState);
-      };
-    }
-
-    it.each(['prompt', 'granted'])('shows loopback view for "%s" permission state', function(permissionState) {
-      mockChromeLNAPermissionState(permissionState);
+    // The LNA permission is no longer checked upfront: doChallenge always attempts
+    // the loopback. LNA remediation is surfaced only after the loopback fails (see
+    // handleLoopbackFailure in BaseOktaVerifyChallengeView), which lets loopback
+    // succeed in environments (e.g. an iframe within WebView2) that report the LNA
+    // permission as 'denied' but do not actually enforce it.
+    it('always shows the loopback view when chromeLocalNetworkAccessDetails is present, without checking the LNA permission', function() {
       doChallenge(testView);
       expect(testView.title).toBe(loc('deviceTrust.sso.redirectText', 'login'));
       expect(expectedAddArg.className).toBe('loopback-content');
       expect(expectedAddArg.template.call()).toBe(hbs`<div class="spinner"></div>`.call());
+      expect(testView.doLoopback).toHaveBeenCalledWith(deviceChallengeWithChromeLNADetails);
     });
 
-    it('shows loopback view for "denied" permission state when loopback is triggered by registered condition silent probe', function() {
-      spyOn(testView.options.appState, 'get').and.callFake((key) => {
-        // Make it explicit that we expect 'previousFormName' to be undefined in this case
-        if (key === 'previousFormName') {
-          return undefined;
-        }
-        return undefined;
-      });
-      mockChromeLNAPermissionState('denied');
-      doChallenge(testView);
-      expect(testView.title).toBe(loc('deviceTrust.sso.redirectText', 'login'));
-      expect(expectedAddArg.className).toBe('loopback-content');
-      expect(expectedAddArg.template.call()).toBe(hbs`<div class="spinner"></div>`.call());
-    });
+    it('renderLNAError shows the remediation callout with the correct title and help link', function() {
+      renderLNAError(testView, deviceChallengeWithChromeLNADetails.chromeLocalNetworkAccessDetails.chromeLNAHelpLink);
 
-    it('shows remediation view for "denied" permission state when loopback is not triggered by registered condition silent probe', function() {
-      spyOn(testView.options.appState, 'get').and.callFake((key) => {
-        if (key === 'previousFormName') {
-          return 'somePreviousFormName';
-        }
-        return undefined;
-      });
-      mockChromeLNAPermissionState('denied');
-
-      expect(() => {
-        doChallenge(testView);
-      }).toThrowError(ChromeLNADeniedError);
-
+      expect(testView.removeChildren).toHaveBeenCalled();
       expect(testView.title).toBe(loc('chrome.lna.fastpass.requires.permission.title', 'login'));
       expect(expectedAddArg.options.title).toBe(loc('chrome.lna.error.title', 'login'));
       expect(expectedAddArg.options.content.options.chromeLNAHelpLink).toBe(deviceChallengeWithChromeLNADetails.chromeLocalNetworkAccessDetails.chromeLNAHelpLink);


### PR DESCRIPTION
## Description

FastPass interactive auth was failing with a Local Network Access (LNA) remediation error inside an iframe within WebView2 (e.g. the Microsoft Teams thick client, reported by BCG). Such iframes report the LNA permission as `denied` by default even though WebView2 does not actually enforce LNA, so the widget rendered the remediation view before ever attempting the loopback, even though the loopback would have succeeded.

This moves the LNA check from an upfront gate to a post-failure fallback in both engines:

- Always attempt the loopback first.
- Surface LNA remediation only when the loopback genuinely fails AND the permission is `denied` on an interactive challenge.
- Silent probes never show the terminal error.
- `ChromeLNADeniedError` (Sentry signal) now fires only on real LNA blocks.

### Background

The original LNA remediation (#3888, OKTA-998031) queried the permission up front and, on `denied`, rendered the remediation view without attempting the loopback. That assumption is wrong for an iframe without `allow="local-network-access"` in WebView2, where the permission reports `denied` but loopback is not enforced.

### Changes

Gen2 (OIE): `ChallengeViewUtil.js` always renders the loopback view; new `handleLoopbackFailure()` in `BaseOktaVerifyChallengeView.js` surfaces remediation only after a real failure with a blocked permission.

Gen3: `transformOktaVerifyFPLoopbackPoll.ts` always renders `LoopbackProbe` (new `showLNARemediationOnFailure` option). On failure, `LoopbackProbe.tsx` marks the transaction client-side so the transformer renders the error and `usePolling.ts` stops polling (no re-probe flicker). Shared marker helpers in `browserUtils.ts`.

Tests: updated Gen2/Gen3 unit tests (+ snapshots) and the shared TestCafe spec, including a new case for denied-permission-but-loopback-succeeds (the WebView2 scenario).

### Issue

- [OKTA-1135857](https://oktainc.atlassian.net/browse/OKTA-1135857)

### Notes for reviewers

- Backport? This targets `master`; the original LNA change landed on `7.35`.
- The `ChromeLNADeniedError` Sentry counter now fires only on genuine LNA blocks (previously also for falsely-blocked WebView2 users), so expect the count to decrease.

Generated with Claude Code