### PR TITLE
fix(a11y): ReminderPrompt uses aria-live polite to avoid interrupting screen readers

### DIFF
--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
@@ -13,7 +13,7 @@
 import '@testing-library/jest-dom';
 
 import {
-  cleanup, fireEvent, render, within,
+  cleanup, fireEvent, render,
 } from '@testing-library/preact';
 import { HTMLReactParserOptions } from 'html-react-parser';
 import { h } from 'preact';
@@ -66,9 +66,9 @@ describe('ReminderPrompt', () => {
       },
     };
 
-    const { container, getByRole } = render(<ReminderPrompt {...props} />);
+    const { container, queryByText, findByText } = render(<ReminderPrompt {...props} />);
 
-    expect(container.firstChild).toBeNull();
+    expect(queryByText('Send again?')).not.toBeInTheDocument();
     act(() => {
       // @ts-expect-error setSystemTime does not exist on type 'typeof jest'
       jest.setSystemTime(Date.now() + DEFAULT_TIMEOUT_MS);
@@ -77,8 +77,7 @@ describe('ReminderPrompt', () => {
 
     expect(container.firstChild).not.toBeNull();
 
-    const box = getByRole('alert');
-    const sendAgainLink = await within(box).findByText('Send again?');
+    const sendAgainLink = await findByText('Send again?');
 
     expect(container).toMatchSnapshot();
 
@@ -111,9 +110,9 @@ describe('ReminderPrompt', () => {
       },
     };
 
-    const { container, getByRole } = render(<ReminderPrompt {...props} />);
+    const { container, queryByText, findByText } = render(<ReminderPrompt {...props} />);
 
-    expect(container.firstChild).toBeNull();
+    expect(queryByText('send again')).not.toBeInTheDocument();
 
     act(() => {
       // @ts-expect-error setSystemTime does not exist on type 'typeof jest'
@@ -123,8 +122,7 @@ describe('ReminderPrompt', () => {
 
     expect(container.firstChild).not.toBeNull();
 
-    const box = getByRole('alert');
-    const sendAgainLink = await within(box).findByText('send again');
+    const sendAgainLink = await findByText('send again');
 
     expect(container).toMatchSnapshot();
 

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -131,18 +131,26 @@ const ReminderPrompt: UISchemaElementComponent<{
     );
   };
 
-  return show ? (
-    <Box marginBlockEnd={tokens.Spacing4}>
-      <Callout
-        severity="warning"
-        // visually-hidden severity text is not translated
-        translate="no"
-      >
-        {renderAlertContent()}
-        {renderActionLink()}
-      </Callout>
+  return (
+    <Box
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {show && (
+        <Box marginBlockEnd={tokens.Spacing4}>
+          <Callout
+            severity="warning"
+            role={"presentation" as unknown as "status"}
+            // visually-hidden severity text is not translated
+            translate="no"
+          >
+            {renderAlertContent()}
+            {renderActionLink()}
+          </Callout>
+        </Box>
+      )}
     </Box>
-  ) : null;
+  );
 };
 
 export default ReminderPrompt;

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -137,10 +137,13 @@ const ReminderPrompt: UISchemaElementComponent<{
       aria-atomic="true"
     >
       {show && (
-        <Box marginBlockEnd={tokens.Spacing4}>
+        <Box
+          marginBlockEnd={tokens.Spacing4}
+          data-se="reminder-prompt"
+        >
           <Callout
             severity="warning"
-            role={"presentation" as unknown as "status"}
+            role={'presentation' as unknown as 'status'}
             // visually-hidden severity text is not translated
             translate="no"
           >

--- a/src/v3/src/components/ReminderPrompt/__snapshots__/ReminderPrompt.test.tsx.snap
+++ b/src/v3/src/components/ReminderPrompt/__snapshots__/ReminderPrompt.test.tsx.snap
@@ -1,53 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ReminderPrompt should show prompt after custom timeout passes 1`] = `<div />`;
+exports[`ReminderPrompt should show prompt after custom timeout passes 1`] = `
+<div>
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    class="MuiBox-root emotion-0"
+  />
+</div>
+`;
 
 exports[`ReminderPrompt should show prompt with working link after default timeout passes 1`] = `
 <div>
   <div
+    aria-atomic="true"
+    aria-live="polite"
     class="MuiBox-root emotion-0"
   >
     <div
-      aria-label="warning"
-      aria-labelledby="82mvyq"
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-1"
-      role="alert"
+      class="MuiBox-root emotion-1"
     >
       <div
-        class="MuiAlert-icon emotion-2"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-3"
-          data-testid="ReportProblemOutlinedIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-          />
-        </svg>
-      </div>
-      <div
-        class="MuiAlert-message emotion-4"
+        aria-label="warning"
+        aria-labelledby="82mvyq"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-2"
+        role="presentation"
       >
         <div
-          class="emotion-5"
+          class="MuiAlert-icon emotion-3"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-4"
+            data-testid="ReportProblemOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+            />
+          </svg>
+        </div>
+        <div
+          class="MuiAlert-message emotion-5"
         >
           <div
-            class="MuiBox-root emotion-6"
+            class="emotion-6"
           >
             <div
-              class="MuiBox-root emotion-7"
+              class="MuiBox-root emotion-0"
             >
-              Didnt receive the email?
+              <div
+                class="MuiBox-root emotion-8"
+              >
+                Didnt receive the email?
+              </div>
+              <a
+                class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-9"
+                href="#"
+              >
+                Send again?
+              </a>
             </div>
-            <a
-              class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-8"
-              href="#"
-            >
-              Send again?
-            </a>
           </div>
         </div>
       </div>
@@ -59,48 +73,54 @@ exports[`ReminderPrompt should show prompt with working link after default timeo
 exports[`ReminderPrompt should show prompt with working link after default timeout passes where ctaText contains HTML 1`] = `
 <div>
   <div
+    aria-atomic="true"
+    aria-live="polite"
     class="MuiBox-root emotion-0"
   >
     <div
-      aria-label="warning"
-      aria-labelledby="82mvyq"
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-1"
-      role="alert"
+      class="MuiBox-root emotion-1"
     >
       <div
-        class="MuiAlert-icon emotion-2"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-3"
-          data-testid="ReportProblemOutlinedIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-          />
-        </svg>
-      </div>
-      <div
-        class="MuiAlert-message emotion-4"
+        aria-label="warning"
+        aria-labelledby="82mvyq"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-2"
+        role="presentation"
       >
         <div
-          class="emotion-5"
+          class="MuiAlert-icon emotion-3"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-4"
+            data-testid="ReportProblemOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+            />
+          </svg>
+        </div>
+        <div
+          class="MuiAlert-message emotion-5"
         >
           <div
-            class="MuiBox-root emotion-6"
+            class="emotion-6"
           >
             <div
-              class="MuiBox-root emotion-6"
+              class="MuiBox-root emotion-0"
             >
-              Didn't receive the email? Click 
-              <a
-                class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways send-again emotion-8"
-                href="#"
+              <div
+                class="MuiBox-root emotion-0"
               >
-                send again
-              </a>
+                Didn't receive the email? Click 
+                <a
+                  class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways send-again emotion-9"
+                  href="#"
+                >
+                  send again
+                </a>
+              </div>
             </div>
           </div>
         </div>

--- a/src/v3/src/components/ReminderPrompt/__snapshots__/ReminderPrompt.test.tsx.snap
+++ b/src/v3/src/components/ReminderPrompt/__snapshots__/ReminderPrompt.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`ReminderPrompt should show prompt with working link after default timeo
   >
     <div
       class="MuiBox-root emotion-1"
+      data-se="reminder-prompt"
     >
       <div
         aria-label="warning"
@@ -79,6 +80,7 @@ exports[`ReminderPrompt should show prompt with working link after default timeo
   >
     <div
       class="MuiBox-root emotion-1"
+      data-se="reminder-prompt"
     >
       <div
         aria-label="warning"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email-magic-link-false.test.tsx.snap
@@ -140,7 +140,13 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                     </div>
                     <div
                       class="MuiBox-root emotion-12"
-                    />
+                    >
+                      <div
+                        aria-atomic="true"
+                        aria-live="polite"
+                        class="MuiBox-root emotion-2"
+                      />
+                    </div>
                     <div
                       class="MuiBox-root emotion-12"
                     >
@@ -148,7 +154,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -166,10 +172,10 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-27"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-28"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -179,14 +185,14 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-29"
                           required="true"
                         >
                           <input
                             aria-invalid="false"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
-                            class="MuiInputBase-input emotion-29"
+                            class="MuiInputBase-input emotion-30"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             inputmode="numeric"
@@ -201,7 +207,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-31"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-32"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -213,7 +219,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -225,7 +231,7 @@ exports[`Email authenticator enroll when magic link = false Tests should render 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-email.test.tsx.snap
@@ -143,7 +143,13 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                       </div>
                       <div
                         class="MuiBox-root emotion-12"
-                      />
+                      >
+                        <div
+                          aria-atomic="true"
+                          aria-live="polite"
+                          class="MuiBox-root emotion-2"
+                        />
+                      </div>
                       <div
                         class="MuiBox-root emotion-12"
                       >
@@ -151,7 +157,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-26"
                             data-se="o-form-explain"
                             tabindex="-1"
                           >
@@ -169,7 +175,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                         class="MuiBox-root emotion-12"
                       >
                         <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-27"
+                          class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-28"
                           tabindex="0"
                           type="button"
                         >
@@ -181,7 +187,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -193,7 +199,7 @@ exports[`Email authenticator enroll when email magic link = true Tests should re
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -786,7 +786,13 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     </div>
                     <div
                       class="MuiBox-root emotion-12"
-                    />
+                    >
+                      <div
+                        aria-atomic="true"
+                        aria-live="polite"
+                        class="MuiBox-root emotion-2"
+                      />
+                    </div>
                     <div
                       class="MuiBox-root emotion-12"
                     >
@@ -794,7 +800,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -809,7 +815,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -821,10 +827,10 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-30"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-31"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -834,14 +840,14 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-32"
                           required="true"
                         >
                           <input
                             aria-invalid="false"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
-                            class="MuiInputBase-input emotion-32"
+                            class="MuiInputBase-input emotion-33"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             inputmode="numeric"
@@ -856,7 +862,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-35"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -868,7 +874,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -880,7 +886,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -150,7 +150,13 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     </div>
                     <div
                       class="MuiBox-root emotion-12"
-                    />
+                    >
+                      <div
+                        aria-atomic="true"
+                        aria-live="polite"
+                        class="MuiBox-root emotion-2"
+                      />
+                    </div>
                     <div
                       class="MuiBox-root emotion-12"
                     >
@@ -158,7 +164,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -173,7 +179,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -185,10 +191,10 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-30"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-31"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -198,14 +204,14 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-32"
                           required="true"
                         >
                           <input
                             aria-invalid="false"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
-                            class="MuiInputBase-input emotion-32"
+                            class="MuiInputBase-input emotion-33"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             inputmode="numeric"
@@ -220,7 +226,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-35"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -232,7 +238,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -244,7 +250,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email-magic-link-false.test.tsx.snap
@@ -140,7 +140,13 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                     </div>
                     <div
                       class="MuiBox-root emotion-12"
-                    />
+                    >
+                      <div
+                        aria-atomic="true"
+                        aria-live="polite"
+                        class="MuiBox-root emotion-2"
+                      />
+                    </div>
                     <div
                       class="MuiBox-root emotion-12"
                     >
@@ -148,7 +154,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -166,10 +172,10 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-27"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-27"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-28"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -179,14 +185,14 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-28"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-29"
                           required="true"
                         >
                           <input
                             aria-invalid="false"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
-                            class="MuiInputBase-input emotion-29"
+                            class="MuiInputBase-input emotion-30"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             inputmode="numeric"
@@ -201,7 +207,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-31"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-32"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -213,7 +219,7 @@ exports[`Email authenticator verification when email magic link = false Tests sh
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-33"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -143,7 +143,13 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       </div>
                       <div
                         class="MuiBox-root emotion-12"
-                      />
+                      >
+                        <div
+                          aria-atomic="true"
+                          aria-live="polite"
+                          class="MuiBox-root emotion-2"
+                        />
+                      </div>
                       <div
                         class="MuiBox-root emotion-12"
                       >
@@ -151,7 +157,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-26"
                             data-se="o-form-explain"
                             tabindex="-1"
                           >
@@ -169,7 +175,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-12"
                       >
                         <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-27"
+                          class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-28"
                           tabindex="0"
                           type="button"
                         >
@@ -181,7 +187,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-29"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-30"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -346,53 +352,60 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-12"
                       >
                         <div
-                          class="MuiBox-root emotion-12"
+                          aria-atomic="true"
+                          aria-live="polite"
+                          class="MuiBox-root emotion-2"
                         >
                           <div
-                            aria-label="warning"
-                            aria-labelledby="82mvyq"
-                            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-24"
-                            role="alert"
+                            class="MuiBox-root emotion-12"
+                            data-se="reminder-prompt"
                           >
                             <div
-                              class="MuiAlert-icon emotion-25"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-26"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M9.342 2.918c1.123-2.144 4.192-2.144 5.315 0l7.695 14.69C23.398 19.605 21.95 22 19.695 22H4.305c-2.255 0-3.703-2.395-2.657-4.392l7.694-14.69ZM12 14a1 1 0 0 1-1-1V8h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiAlert-message emotion-27"
+                              aria-label="warning"
+                              aria-labelledby="82mvyq"
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-25"
+                              role="presentation"
                             >
                               <div
-                                class="emotion-28"
+                                class="MuiAlert-icon emotion-26"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-27"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M9.342 2.918c1.123-2.144 4.192-2.144 5.315 0l7.695 14.69C23.398 19.605 21.95 22 19.695 22H4.305c-2.255 0-3.703-2.395-2.657-4.392l7.694-14.69ZM12 14a1 1 0 0 1-1-1V8h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiAlert-message emotion-28"
                               >
                                 <div
-                                  class="MuiBox-root emotion-2"
+                                  class="emotion-29"
                                 >
                                   <div
-                                    class="MuiBox-root emotion-30"
+                                    class="MuiBox-root emotion-2"
                                   >
-                                    Haven't received an email?
+                                    <div
+                                      class="MuiBox-root emotion-31"
+                                    >
+                                      Haven't received an email?
+                                    </div>
+                                    <a
+                                      class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-32"
+                                      href="#"
+                                    >
+                                      Send again
+                                    </a>
                                   </div>
-                                  <a
-                                    class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-31"
-                                    href="#"
-                                  >
-                                    Send again
-                                  </a>
                                 </div>
                               </div>
                             </div>
@@ -406,7 +419,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-34"
+                            class="MuiTypography-root MuiTypography-body1 emotion-35"
                             data-se="o-form-explain"
                             tabindex="-1"
                           >
@@ -424,7 +437,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-12"
                       >
                         <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth Mui-focusVisible MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-36"
+                          class="MuiButtonBase-root MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth Mui-focusVisible MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-37"
                           tabindex="0"
                           type="button"
                         >
@@ -436,7 +449,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-38"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-39"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -599,7 +612,13 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       </div>
                       <div
                         class="MuiBox-root emotion-12"
-                      />
+                      >
+                        <div
+                          aria-atomic="true"
+                          aria-live="polite"
+                          class="MuiBox-root emotion-2"
+                        />
+                      </div>
                       <div
                         class="MuiBox-root emotion-12"
                       >
@@ -607,7 +626,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-26"
                             data-se="o-form-explain"
                             tabindex="-1"
                           >
@@ -625,10 +644,10 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-12"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-27"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-28"
                         >
                           <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-28"
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-29"
                             data-shrink="false"
                             for="credentials.passcode"
                             id="credentials.passcode-label"
@@ -638,14 +657,14 @@ exports[`Email authenticator verification when email magic link = undefined rend
                             </span>
                           </label>
                           <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-29"
+                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-30"
                             required="true"
                           >
                             <input
                               aria-invalid="false"
                               aria-labelledby="credentials.passcode-label"
                               autocomplete="off"
-                              class="MuiInputBase-input emotion-30"
+                              class="MuiInputBase-input emotion-31"
                               data-se="credentials.passcode"
                               id="credentials.passcode"
                               inputmode="numeric"
@@ -660,7 +679,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-12"
                       >
                         <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-32"
+                          class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-33"
                           data-se="save"
                           tabindex="0"
                           type="submit"
@@ -673,7 +692,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -879,7 +898,13 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       </div>
                       <div
                         class="MuiBox-root emotion-19"
-                      />
+                      >
+                        <div
+                          aria-atomic="true"
+                          aria-live="polite"
+                          class="MuiBox-root emotion-2"
+                        />
+                      </div>
                       <div
                         class="MuiBox-root emotion-19"
                       >
@@ -887,7 +912,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                           class="MuiBox-root emotion-27"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-32"
+                            class="MuiTypography-root MuiTypography-body1 emotion-33"
                             data-se="o-form-explain"
                             tabindex="-1"
                           >
@@ -905,10 +930,10 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-19"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-34"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-35"
                         >
                           <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-35"
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-36"
                             data-shrink="false"
                             for="credentials.passcode"
                             id="credentials.passcode-label"
@@ -918,7 +943,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                             </span>
                           </label>
                           <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-36"
+                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-37"
                             required="true"
                           >
                             <input
@@ -927,7 +952,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                               aria-invalid="true"
                               aria-labelledby="credentials.passcode-label"
                               autocomplete="off"
-                              class="MuiInputBase-input emotion-37"
+                              class="MuiInputBase-input emotion-38"
                               data-se="credentials.passcode"
                               id="credentials.passcode"
                               inputmode="numeric"
@@ -937,11 +962,11 @@ exports[`Email authenticator verification when email magic link = undefined rend
                             />
                           </div>
                           <div
-                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-38"
+                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-39"
                             id="credentials.passcode-error"
                           >
                             <span
-                              class="MuiBox-root emotion-39"
+                              class="MuiBox-root emotion-40"
                             >
                               Error:
                             </span>
@@ -957,7 +982,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-19"
                       >
                         <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-42"
+                          class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-43"
                           data-se="save"
                           tabindex="0"
                           type="submit"
@@ -970,7 +995,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-45"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -982,7 +1007,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-44"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-45"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -1190,53 +1215,60 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-19"
                       >
                         <div
-                          class="MuiBox-root emotion-19"
+                          aria-atomic="true"
+                          aria-live="polite"
+                          class="MuiBox-root emotion-2"
                         >
                           <div
-                            aria-label="warning"
-                            aria-labelledby="82mvyq"
-                            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-31"
-                            role="alert"
+                            class="MuiBox-root emotion-19"
+                            data-se="reminder-prompt"
                           >
                             <div
-                              class="MuiAlert-icon emotion-32"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-14"
-                                fill="none"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  clip-rule="evenodd"
-                                  d="M9.342 2.918c1.123-2.144 4.192-2.144 5.315 0l7.695 14.69C23.398 19.605 21.95 22 19.695 22H4.305c-2.255 0-3.703-2.395-2.657-4.392l7.694-14.69ZM12 14a1 1 0 0 1-1-1V8h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
-                                  fill="currentColor"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </div>
-                            <div
-                              class="MuiAlert-message emotion-15"
+                              aria-label="warning"
+                              aria-labelledby="82mvyq"
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-32"
+                              role="presentation"
                             >
                               <div
-                                class="emotion-16"
+                                class="MuiAlert-icon emotion-33"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-14"
+                                  fill="none"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    clip-rule="evenodd"
+                                    d="M9.342 2.918c1.123-2.144 4.192-2.144 5.315 0l7.695 14.69C23.398 19.605 21.95 22 19.695 22H4.305c-2.255 0-3.703-2.395-2.657-4.392l7.694-14.69ZM12 14a1 1 0 0 1-1-1V8h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="MuiAlert-message emotion-15"
                               >
                                 <div
-                                  class="MuiBox-root emotion-2"
+                                  class="emotion-16"
                                 >
                                   <div
-                                    class="MuiBox-root emotion-37"
+                                    class="MuiBox-root emotion-2"
                                   >
-                                    Haven't received an email?
+                                    <div
+                                      class="MuiBox-root emotion-38"
+                                    >
+                                      Haven't received an email?
+                                    </div>
+                                    <a
+                                      class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-39"
+                                      href="#"
+                                    >
+                                      Send again
+                                    </a>
                                   </div>
-                                  <a
-                                    class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways emotion-38"
-                                    href="#"
-                                  >
-                                    Send again
-                                  </a>
                                 </div>
                               </div>
                             </div>
@@ -1250,7 +1282,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                           class="MuiBox-root emotion-27"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-41"
+                            class="MuiTypography-root MuiTypography-body1 emotion-42"
                             data-se="o-form-explain"
                             tabindex="-1"
                           >
@@ -1268,10 +1300,10 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-19"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-43"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-44"
                         >
                           <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-44"
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-error MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-45"
                             data-shrink="false"
                             for="credentials.passcode"
                             id="credentials.passcode-label"
@@ -1281,7 +1313,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                             </span>
                           </label>
                           <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-45"
+                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-error Mui-focused MuiInputBase-formControl emotion-46"
                             required="true"
                           >
                             <input
@@ -1290,7 +1322,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                               aria-invalid="true"
                               aria-labelledby="credentials.passcode-label"
                               autocomplete="off"
-                              class="MuiInputBase-input emotion-46"
+                              class="MuiInputBase-input emotion-47"
                               data-se="credentials.passcode"
                               id="credentials.passcode"
                               inputmode="numeric"
@@ -1300,11 +1332,11 @@ exports[`Email authenticator verification when email magic link = undefined rend
                             />
                           </div>
                           <div
-                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-47"
+                            class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium Mui-focused MuiFormHelperText-filled emotion-48"
                             id="credentials.passcode-error"
                           >
                             <span
-                              class="MuiBox-root emotion-48"
+                              class="MuiBox-root emotion-49"
                             >
                               Error:
                             </span>
@@ -1320,7 +1352,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                         class="MuiBox-root emotion-19"
                       >
                         <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-51"
+                          class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-52"
                           data-se="save"
                           tabindex="0"
                           type="submit"
@@ -1333,7 +1365,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-53"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -1345,7 +1377,7 @@ exports[`Email authenticator verification when email magic link = undefined rend
                       class="MuiBox-root emotion-19"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-53"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-54"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -1629,7 +1661,13 @@ exports[`Email authenticator verification when email magic link = undefined shou
                       </div>
                       <div
                         class="MuiBox-root emotion-12"
-                      />
+                      >
+                        <div
+                          aria-atomic="true"
+                          aria-live="polite"
+                          class="MuiBox-root emotion-2"
+                        />
+                      </div>
                       <div
                         class="MuiBox-root emotion-12"
                       >
@@ -1637,7 +1675,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                           class="MuiBox-root emotion-20"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-25"
+                            class="MuiTypography-root MuiTypography-body1 emotion-26"
                             data-se="o-form-explain"
                             tabindex="-1"
                           >
@@ -1655,10 +1693,10 @@ exports[`Email authenticator verification when email magic link = undefined shou
                         class="MuiBox-root emotion-12"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-27"
+                          class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-28"
                         >
                           <label
-                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-28"
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-29"
                             data-shrink="false"
                             for="credentials.passcode"
                             id="credentials.passcode-label"
@@ -1668,14 +1706,14 @@ exports[`Email authenticator verification when email magic link = undefined shou
                             </span>
                           </label>
                           <div
-                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-29"
+                            class="MuiInputBase-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl emotion-30"
                             required="true"
                           >
                             <input
                               aria-invalid="false"
                               aria-labelledby="credentials.passcode-label"
                               autocomplete="one-time-code"
-                              class="MuiInputBase-input emotion-30"
+                              class="MuiInputBase-input emotion-31"
                               data-se="credentials.passcode"
                               id="credentials.passcode"
                               inputmode="numeric"
@@ -1690,7 +1728,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                         class="MuiBox-root emotion-12"
                       >
                         <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-32"
+                          class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-33"
                           data-se="save"
                           tabindex="0"
                           type="submit"
@@ -1703,7 +1741,7 @@ exports[`Email authenticator verification when email magic link = undefined shou
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-34"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -138,53 +138,60 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                       class="MuiBox-root emotion-2"
                     >
                       <div
-                        class="MuiBox-root emotion-12"
+                        aria-atomic="true"
+                        aria-live="polite"
+                        class="MuiBox-root emotion-2"
                       >
                         <div
-                          aria-label="warning"
-                          aria-labelledby="82mvyq"
-                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-23"
-                          role="alert"
+                          class="MuiBox-root emotion-12"
+                          data-se="reminder-prompt"
                         >
                           <div
-                            class="MuiAlert-icon emotion-24"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-25"
-                              fill="none"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M9.342 2.918c1.123-2.144 4.192-2.144 5.315 0l7.695 14.69C23.398 19.605 21.95 22 19.695 22H4.305c-2.255 0-3.703-2.395-2.657-4.392l7.694-14.69ZM12 14a1 1 0 0 1-1-1V8h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </div>
-                          <div
-                            class="MuiAlert-message emotion-26"
+                            aria-label="warning"
+                            aria-labelledby="82mvyq"
+                            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-calloutWarning MuiAlert-callout emotion-24"
+                            role="presentation"
                           >
                             <div
-                              class="emotion-27"
+                              class="MuiAlert-icon emotion-25"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-26"
+                                fill="none"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M9.342 2.918c1.123-2.144 4.192-2.144 5.315 0l7.695 14.69C23.398 19.605 21.95 22 19.695 22H4.305c-2.255 0-3.703-2.395-2.657-4.392l7.694-14.69ZM12 14a1 1 0 0 1-1-1V8h2v5a1 1 0 0 1-1 1Zm0 1.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="MuiAlert-message emotion-27"
                             >
                               <div
-                                class="MuiBox-root emotion-2"
+                                class="emotion-28"
                               >
                                 <div
                                   class="MuiBox-root emotion-2"
                                 >
-                                  Haven't received a push notification yet? Try opening the Okta Verify app on your device, or 
-                                  <a
-                                    class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways resend-number-challenge emotion-30"
-                                    href="#"
+                                  <div
+                                    class="MuiBox-root emotion-2"
                                   >
-                                    resend the push notification
-                                  </a>
-                                  .
+                                    Haven't received a push notification yet? Try opening the Okta Verify app on your device, or 
+                                    <a
+                                      class="MuiTypography-root MuiTypography-monochrome MuiLink-root MuiLink-underlineAlways resend-number-challenge emotion-31"
+                                      href="#"
+                                    >
+                                      resend the push notification
+                                    </a>
+                                    .
+                                  </div>
                                 </div>
                               </div>
                             </div>
@@ -196,10 +203,10 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                       class="MuiBox-root emotion-12"
                     >
                       <fieldset
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-32"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-33"
                       >
                         <legend
-                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-33"
+                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
                           id="autoChallenge-label"
                         >
                           
@@ -208,19 +215,19 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                         </legend>
                         <div
                           aria-labelledby="autoChallenge-label"
-                          class="MuiFormGroup-root emotion-34"
+                          class="MuiFormGroup-root emotion-35"
                           id="autoChallenge"
                         >
                           <label
-                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-35"
+                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-36"
                             id="autoChallenge-checkbox"
                           >
                             <span
-                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-36"
+                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-37"
                             >
                               <input
                                 aria-readonly="false"
-                                class="PrivateSwitchBase-input emotion-37"
+                                class="PrivateSwitchBase-input emotion-38"
                                 data-indeterminate="false"
                                 data-se="autoChallenge"
                                 name="autoChallenge"
@@ -228,10 +235,10 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                               />
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-38"
+                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-39"
                             >
                               <span
-                                class="MuiTypography-root MuiTypography-body1 emotion-38"
+                                class="MuiTypography-root MuiTypography-body1 emotion-39"
                                 tabindex="-1"
                               >
                                 Send push automatically
@@ -248,7 +255,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-38"
+                          class="MuiTypography-root MuiTypography-body1 emotion-39"
                           data-se="numberchallenge-instr-value"
                           tabindex="-1"
                         >
@@ -266,11 +273,11 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiBox-root emotion-44"
+                        class="MuiBox-root emotion-45"
                         id="code"
                       >
                         <div
-                          class="MuiBox-root emotion-45"
+                          class="MuiBox-root emotion-46"
                           data-se="icon-code"
                         >
                           <svg
@@ -319,7 +326,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-49"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -331,7 +338,7 @@ exports[`authenticator-verification-okta-verify-push-code Polling should display
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-49"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-50"
                         data-se="cancel"
                         role="link"
                         type="button"
@@ -487,15 +494,21 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
-                    />
+                    >
+                      <div
+                        aria-atomic="true"
+                        aria-live="polite"
+                        class="MuiBox-root emotion-2"
+                      />
+                    </div>
                     <div
                       class="MuiBox-root emotion-12"
                     >
                       <fieldset
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-23"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-24"
                       >
                         <legend
-                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-24"
+                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-25"
                           id="autoChallenge-label"
                         >
                           
@@ -504,19 +517,19 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                         </legend>
                         <div
                           aria-labelledby="autoChallenge-label"
-                          class="MuiFormGroup-root emotion-25"
+                          class="MuiFormGroup-root emotion-26"
                           id="autoChallenge"
                         >
                           <label
-                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-26"
+                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-27"
                             id="autoChallenge-checkbox"
                           >
                             <span
-                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-27"
+                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-28"
                             >
                               <input
                                 aria-readonly="false"
-                                class="PrivateSwitchBase-input emotion-28"
+                                class="PrivateSwitchBase-input emotion-29"
                                 data-indeterminate="false"
                                 data-se="autoChallenge"
                                 name="autoChallenge"
@@ -524,10 +537,10 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                               />
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-29"
+                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-30"
                             >
                               <span
-                                class="MuiTypography-root MuiTypography-body1 emotion-29"
+                                class="MuiTypography-root MuiTypography-body1 emotion-30"
                                 tabindex="-1"
                               >
                                 Send push automatically
@@ -544,7 +557,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-29"
+                          class="MuiTypography-root MuiTypography-body1 emotion-30"
                           data-se="numberchallenge-instr-value"
                           tabindex="-1"
                         >
@@ -562,11 +575,11 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiBox-root emotion-35"
+                        class="MuiBox-root emotion-36"
                         id="code"
                       >
                         <div
-                          class="MuiBox-root emotion-36"
+                          class="MuiBox-root emotion-37"
                           data-se="icon-code"
                         >
                           <svg
@@ -615,7 +628,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -627,7 +640,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-40"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-41"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -136,7 +136,13 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                     </div>
                     <div
                       class="MuiBox-root emotion-2"
-                    />
+                    >
+                      <div
+                        aria-atomic="true"
+                        aria-live="polite"
+                        class="MuiBox-root emotion-2"
+                      />
+                    </div>
                     <div
                       class="MuiBox-root emotion-12"
                     >
@@ -144,7 +150,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -156,10 +162,10 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                       class="MuiBox-root emotion-12"
                     >
                       <fieldset
-                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-26"
+                        class="MuiFormControl-root MuiFormControl-marginNormal emotion-27"
                       >
                         <legend
-                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-27"
+                          class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-28"
                           id="autoChallenge-label"
                         >
                           
@@ -168,19 +174,19 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                         </legend>
                         <div
                           aria-labelledby="autoChallenge-label"
-                          class="MuiFormGroup-root emotion-28"
+                          class="MuiFormGroup-root emotion-29"
                           id="autoChallenge"
                         >
                           <label
-                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-29"
+                            class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-30"
                             id="autoChallenge-checkbox"
                           >
                             <span
-                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-30"
+                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall emotion-31"
                             >
                               <input
                                 aria-readonly="false"
-                                class="PrivateSwitchBase-input emotion-31"
+                                class="PrivateSwitchBase-input emotion-32"
                                 data-indeterminate="false"
                                 data-se="autoChallenge"
                                 name="autoChallenge"
@@ -188,10 +194,10 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                               />
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                              class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-25"
                             >
                               <span
-                                class="MuiTypography-root MuiTypography-body1 emotion-24"
+                                class="MuiTypography-root MuiTypography-body1 emotion-25"
                                 tabindex="-1"
                               >
                                 Send push automatically
@@ -205,7 +211,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -217,7 +223,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-35"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms-required.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms-required.test.tsx.snap
@@ -150,7 +150,13 @@ exports[`authenticator-verification-phone-sms-required should render form 1`] = 
                     </div>
                     <div
                       class="MuiBox-root emotion-12"
-                    />
+                    >
+                      <div
+                        aria-atomic="true"
+                        aria-live="polite"
+                        class="MuiBox-root emotion-2"
+                      />
+                    </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
@@ -158,7 +164,7 @@ exports[`authenticator-verification-phone-sms-required should render form 1`] = 
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -179,7 +185,7 @@ exports[`authenticator-verification-phone-sms-required should render form 1`] = 
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -191,10 +197,10 @@ exports[`authenticator-verification-phone-sms-required should render form 1`] = 
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-30"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-31"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -204,14 +210,14 @@ exports[`authenticator-verification-phone-sms-required should render form 1`] = 
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-32"
                           required="true"
                         >
                           <input
                             aria-invalid="false"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
-                            class="MuiInputBase-input emotion-32"
+                            class="MuiInputBase-input emotion-33"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             inputmode="numeric"
@@ -226,7 +232,7 @@ exports[`authenticator-verification-phone-sms-required should render form 1`] = 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-35"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -238,7 +244,7 @@ exports[`authenticator-verification-phone-sms-required should render form 1`] = 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -250,7 +256,7 @@ exports[`authenticator-verification-phone-sms-required should render form 1`] = 
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -150,7 +150,13 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     </div>
                     <div
                       class="MuiBox-root emotion-12"
-                    />
+                    >
+                      <div
+                        aria-atomic="true"
+                        aria-live="polite"
+                        class="MuiBox-root emotion-2"
+                      />
+                    </div>
                     <div
                       class="MuiBox-root emotion-2"
                     >
@@ -158,7 +164,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -179,7 +185,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                         class="MuiBox-root emotion-19"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body1 emotion-24"
+                          class="MuiTypography-root MuiTypography-body1 emotion-25"
                           data-se="o-form-explain"
                           tabindex="-1"
                         >
@@ -191,10 +197,10 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-29"
+                        class="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth emotion-30"
                       >
                         <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-30"
+                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-31"
                           data-shrink="false"
                           for="credentials.passcode"
                           id="credentials.passcode-label"
@@ -204,14 +210,14 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                           </span>
                         </label>
                         <div
-                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-31"
+                          class="MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-32"
                           required="true"
                         >
                           <input
                             aria-invalid="false"
                             aria-labelledby="credentials.passcode-label"
                             autocomplete="off"
-                            class="MuiInputBase-input emotion-32"
+                            class="MuiInputBase-input emotion-33"
                             data-se="credentials.passcode"
                             id="credentials.passcode"
                             inputmode="numeric"
@@ -226,7 +232,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-34"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-fullWidth emotion-35"
                         data-se="save"
                         tabindex="0"
                         type="submit"
@@ -238,7 +244,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="switchAuthenticator"
                         role="link"
                         type="button"
@@ -250,7 +256,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                       class="MuiBox-root emotion-12"
                     >
                       <button
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-36"
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button emotion-37"
                         data-se="cancel"
                         role="link"
                         type="button"

--- a/test/testcafe/framework/page-objects/ChallengeCustomAppPushPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeCustomAppPushPageObject.js
@@ -77,7 +77,10 @@ export default class ChallengeCustomAppPushPageObject extends ChallengeFactorPag
   }
 
   getWarningBox() {
-    return this.form.getElement('[data-se="reminder-prompt"]');
+    if (userVariables.gen3) {
+      return this.form.getElement('[data-se="reminder-prompt"]');
+    }
+    return this.form.getAlertBox();
   }
 
   async autoChallengeInputExists() {

--- a/test/testcafe/framework/page-objects/ChallengeCustomAppPushPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeCustomAppPushPageObject.js
@@ -77,7 +77,7 @@ export default class ChallengeCustomAppPushPageObject extends ChallengeFactorPag
   }
 
   getWarningBox() {
-    return this.form.getAlertBox();
+    return this.form.getElement('[data-se="reminder-prompt"]');
   }
 
   async autoChallengeInputExists() {

--- a/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
@@ -10,12 +10,12 @@ export default class ChallengeEmailPageObject extends ChallengeFactorPageObject 
 
   resendEmailViewText() {
     if (userVariables.gen3) {
-      return this.form.getErrorBoxText();
+      return this.form.getElement('[data-se="reminder-prompt"]').innerText;
     }
     return this.form.getElement(RESEND_EMAIL_VIEW_SELECTOR).innerText;
   }
 
-  async resendEmailExists(index = 0) {
+  async resendEmailExists() {
     if (userVariables.gen3) {
       return this.form.elementExist('[data-se="reminder-prompt"]');
     }

--- a/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
@@ -17,7 +17,7 @@ export default class ChallengeEmailPageObject extends ChallengeFactorPageObject 
 
   async resendEmailExists(index = 0) {
     if (userVariables.gen3) {
-      return this.form.hasAlertBox(index);
+      return this.form.elementExist('[data-se="reminder-prompt"]');
     }
 
     const isHidden = await this.form.getElement(RESEND_EMAIL_VIEW_SELECTOR).hasClass('hide');

--- a/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
@@ -64,7 +64,7 @@ export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPa
 
   getWarningBox() {
     if (userVariables.gen3) {
-      return this.form.getAlertBox();
+      return this.form.getElement('[data-se="reminder-prompt"]');
     }
 
     return this.form.getElement(FORM_INFOBOX_WARNING);

--- a/test/testcafe/framework/page-objects/ChallengePhonePageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengePhonePageObject.js
@@ -38,10 +38,7 @@ export default class ChallengePhonePageObject extends ChallengeFactorPageObject 
 
   async resendCodeExists(index) {
     if (userVariables.gen3) {
-      if (index === undefined) {
-        index = 0;
-      }
-      return this.form.hasAlertBox(index);
+      return this.form.elementExist('[data-se="reminder-prompt"]');
     }
 
     const isHidden = await this.form.getElement(RESEND_VIEW_SELECTOR).hasClass('hide');

--- a/test/testcafe/framework/page-objects/ChallengePhonePageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengePhonePageObject.js
@@ -19,12 +19,9 @@ export default class ChallengePhonePageObject extends ChallengeFactorPageObject 
     return this.form.clickElement('.phone-authenticator-challenge__link');
   }
 
-  resendCodeText(index) {
+  resendCodeText() {
     if (userVariables.gen3) {
-      if (index === undefined) {
-        index = 0;
-      }
-      return this.form.getErrorBoxTextByIndex(index);
+      return this.form.getElement('[data-se="reminder-prompt"]').innerText;
     }
     return this.form.getElement(RESEND_VIEW_SELECTOR).innerText;
   }
@@ -36,7 +33,7 @@ export default class ChallengePhonePageObject extends ChallengeFactorPageObject 
     return this.getTextContent('.phone-authenticator-challenge__link');
   }
 
-  async resendCodeExists(index) {
+  async resendCodeExists() {
     if (userVariables.gen3) {
       return this.form.elementExist('[data-se="reminder-prompt"]');
     }

--- a/test/testcafe/framework/page-objects/EnrollEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollEmailPageObject.js
@@ -42,7 +42,7 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
 
   async resendEmailExists() {
     if (userVariables.gen3) {
-      return this.form.hasErrorBox();
+      return this.form.elementExist('[data-se="reminder-prompt"]');
     }
 
     const isHidden = await Selector(RESEND_EMAIL).hasClass('hide');
@@ -51,7 +51,7 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
 
   resendEmailText() {
     if (userVariables.gen3) {
-      return this.form.el.find('[role="alert"]').textContent;
+      return this.form.getElement('[data-se="reminder-prompt"]').textContent;
     }
     return this.form.el.find(RESEND_EMAIL).textContent;
   }

--- a/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
@@ -184,14 +184,14 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
 
   resendView() {
     if (userVariables.gen3) {
-      return this.form.getAlertBox();
+      return this.form.getElement('[data-se="reminder-prompt"]');
     }
     return this.form.getElement('.resend-ov-link-view');
   }
 
   resendViewExists() {
     if (userVariables.gen3) {
-      return this.form.hasAlertBox();
+      return this.form.elementExist('[data-se="reminder-prompt"]');
     }
     return this.form.getElement('.resend-ov-link-view').visible;
   }

--- a/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
@@ -81,22 +81,16 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
     return this.form.getTextBoxErrorMessage(PASSCODE_FIELD_NAME);
   }
   
-  resendCodeText(index) {
+  resendCodeText() {
     if (userVariables.gen3) {
-      if (index === undefined) {
-        index = 0;
-      }
-      return this.form.getErrorBoxTextByIndex(index);
+      return this.form.getElement('[data-se="reminder-prompt"]').innerText;
     }
     return this.form.getElement(RESEND_VIEW_SELECTOR).innerText;
   }
 
-  async resendCodeExists(index) {
+  async resendCodeExists() {
     if (userVariables.gen3) {
-      if (index === undefined) {
-        index = 0;
-      }
-      return this.form.hasAlertBox(index);
+      return this.form.elementExist('[data-se="reminder-prompt"]');
     }
 
     const isHidden = await this.form.getElement(RESEND_VIEW_SELECTOR).hasClass('hide');


### PR DESCRIPTION
## Description:

- The resend reminder prompt (`ReminderPrompt`) previously rendered inside Odyssey's `<Callout severity="warning">`, which defaults to `role="alert"` (`aria-live="assertive"`). This caused screen readers to **immediately interrupt** any ongoing announcement (e.g., a validation error) to read the reminder which is the wrong priority for a non-critical resend prompt. 
- **Fix:** Wrap the callout in a `<Box aria-live="polite" aria-atomic="true">` container and set `role="presentation"` on the inner `<Callout>` to neutralize its built-in live region. The outer `aria-live="polite"` box announces the reminder only after the screen reader finishes its current announcement.
-  The `role="alert"` was removed from the Callout, so the existing e2e selectors that relied on                queryAllByRole('alert') could no longer find the reminder. Added `data-se="reminder-prompt"` as a stable test selector instead, following the existing gen3 convention.
- No visual change. only the ARIA announcement priority changes.                                 
  
**Tested with:**  Verified the fix works correctly on VoiceOver (macOS).

## PR Checklist

- [X] Have you verified the basic functionality for this change?
- [X] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-1227828](https://oktainc.atlassian.net/browse/OKTA-1227828)

### Reviewers:

### Screenshot/Video:

**Fix a11y before/after**

**Before**:

https://github.com/user-attachments/assets/3f922a0b-58dc-4f76-b3e4-4cf242675086

**After**:

https://github.com/user-attachments/assets/00ee301b-38a7-4aff-b20b-320ed0d6b4d5

**No UI change before/after**

**Before** 

https://github.com/user-attachments/assets/275fbfcf-4754-4134-86d1-ab8a6eebd8ce 

**After**

https://github.com/user-attachments/assets/75e6b43f-bc8f-4e88-aeec-7b9bf87c21e6


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=bdac8b1c6a60f4dac0e79acb7e43d53f57913f53&tab=main

